### PR TITLE
fix(vscode-extension): skip inaccessible filesystem entries during activation scan

### DIFF
--- a/packages/vscode-extension/src/globalVariables.ts
+++ b/packages/vscode-extension/src/globalVariables.ts
@@ -111,17 +111,35 @@ export function checkIsMetaOSAddinProject(directory: string): boolean {
 }
 
 export function checkIsSPFx(directory: string): boolean {
-  const files = fs.readdirSync(directory);
+  let files: string[] = [];
+  try {
+    files = fs.readdirSync(directory);
+  } catch {
+    return false;
+  }
+
   for (const file of files) {
+    const fullPath = path.join(directory, file);
     if (file === ".yo-rc.json") {
-      const content = fs.readJsonSync(path.join(directory, file)) as Record<string, unknown>;
-      if (content["@microsoft/generator-sharepoint"]) {
-        return true;
+      try {
+        const content = fs.readJsonSync(fullPath) as Record<string, unknown>;
+        if (content["@microsoft/generator-sharepoint"]) {
+          return true;
+        }
+      } catch {
+        continue;
       }
-    } else if (fs.lstatSync(path.join(directory, file)).isDirectory()) {
-      if (checkIsSPFx(path.join(directory, file))) return true;
+    } else {
+      try {
+        if (fs.lstatSync(fullPath).isDirectory() && checkIsSPFx(fullPath)) {
+          return true;
+        }
+      } catch {
+        continue;
+      }
     }
   }
+
   return false;
 }
 

--- a/packages/vscode-extension/test/extension/globalVariables.test.ts
+++ b/packages/vscode-extension/test/extension/globalVariables.test.ts
@@ -86,6 +86,30 @@ describe("Global Variables", () => {
 
       chai.expect(globalVariables.isTeamsFxProject).equals(false);
     });
+
+    it("return false when readdirSync throws", () => {
+      sandbox.stub(fs, "readdirSync").throws(new Error("EACCES: permission denied"));
+
+      const res = globalVariables.checkIsSPFx("/test");
+      chai.expect(res).equals(false);
+    });
+
+    it("continue when readJsonSync throws", () => {
+      sandbox.stub(fs, "readdirSync").returns([".yo-rc.json", "other.json"] as any);
+      sandbox.stub(fs, "readJsonSync").throws(new Error("Failed to read JSON"));
+      sandbox.stub(fs, "lstatSync").returns({ isDirectory: () => false } as any);
+
+      const res = globalVariables.checkIsSPFx("/test");
+      chai.expect(res).equals(false);
+    });
+
+    it("continue when lstatSync throws", () => {
+      sandbox.stub(fs, "readdirSync").returns(["subdir"] as any);
+      sandbox.stub(fs, "lstatSync").throws(new Error("EACCES: permission denied"));
+
+      const res = globalVariables.checkIsSPFx("/test");
+      chai.expect(res).equals(false);
+    });
   });
 
   describe("isDeclarativeCopilotApp", () => {

--- a/packages/vscode-extension/test/extension/globalVariables.test.ts
+++ b/packages/vscode-extension/test/extension/globalVariables.test.ts
@@ -110,6 +110,32 @@ describe("Global Variables", () => {
       const res = globalVariables.checkIsSPFx("/test");
       chai.expect(res).equals(false);
     });
+
+    it("return false when .yo-rc.json exists without generator-sharepoint", () => {
+      sandbox.stub(fs, "readdirSync").returns([".yo-rc.json"] as any);
+      sandbox.stub(fs, "readJsonSync").returns({ someOtherKey: "value" });
+
+      const res = globalVariables.checkIsSPFx("/test");
+      chai.expect(res).equals(false);
+    });
+
+    it("return false when subdirectory exists but has no SPFx", () => {
+      const readdirStub = sandbox.stub(fs, "readdirSync");
+      readdirStub.onFirstCall().returns(["subdir"] as any);
+      readdirStub.onSecondCall().returns([] as any);
+      sandbox.stub(fs, "lstatSync").returns({ isDirectory: () => true } as any);
+
+      const res = globalVariables.checkIsSPFx("/test");
+      chai.expect(res).equals(false);
+    });
+
+    it("return false when file is not directory", () => {
+      sandbox.stub(fs, "readdirSync").returns(["somefile.txt"] as any);
+      sandbox.stub(fs, "lstatSync").returns({ isDirectory: () => false } as any);
+
+      const res = globalVariables.checkIsSPFx("/test");
+      chai.expect(res).equals(false);
+    });
   });
 
   describe("isDeclarativeCopilotApp", () => {


### PR DESCRIPTION
## Summary
This change prevents extension activation from failing when workspace scanning encounters inaccessible filesystem entries.

## Repro (Windows PowerShell)
```powershell
mkdir .repro-denied
echo "x" > .repro-denied\dummy.txt
icacls .repro-denied /inheritance:r
icacls .repro-denied /deny "(OI)(CI)RX"
code .
```
Then run Developer: Reload Window and check Log (Extension Host).

### Expected
Extension activates successfully and skips unreadable entries.

### Actual (before fix)
A single EACCES/EPERM during recursive traversal can abort activation.

## Fix
Add per-entry guards in recursive scanning logic:
- protect directory listing
- protect metadata checks
- protect optional JSON reads
- continue traversal on access errors

## Validation
- Reproduced activation failure with an unreadable directory (before fix).
- Verified activation continues after this change by skipping inaccessible entries.