### PR TITLE
feat: add foundry-agent-to-m365 to VSCode wizard UI

### DIFF
--- a/packages/fx-core/templates/ui/tdpNode.json
+++ b/packages/fx-core/templates/ui/tdpNode.json
@@ -192,6 +192,12 @@
             "label": "template.customEngineAgent.weather.label",
             "detail": "template.customEngineAgent.weather.detail",
             "data": "weather-agent"
+          },
+          {
+            "id": "foundry-agent-to-m365",
+            "label": "template.customEngineAgent.foundryAgent.label",
+            "detail": "template.customEngineAgent.foundryAgent.detail",
+            "data": "foundry-agent-to-m365"
           }
         ],
         "placeholder": "template.customEngineAgent.placeholder"

--- a/packages/fx-core/templates/ui/wizardNode.json
+++ b/packages/fx-core/templates/ui/wizardNode.json
@@ -214,6 +214,12 @@
             "label": "template.customEngineAgent.weather.label",
             "detail": "template.customEngineAgent.weather.detail",
             "data": "weather-agent"
+          },
+          {
+            "id": "foundry-agent-to-m365",
+            "label": "template.customEngineAgent.foundryAgent.label",
+            "detail": "template.customEngineAgent.foundryAgent.detail",
+            "data": "foundry-agent-to-m365"
           }
         ],
         "placeholder": "template.customEngineAgent.placeholder"

--- a/templates/src/ui/cea.ts
+++ b/templates/src/ui/cea.ts
@@ -25,6 +25,12 @@ export const ceaNode = {
         detail: "template.customEngineAgent.weather.detail",
         data: TemplateNames.WeatherAgent,
       },
+      {
+        id: TemplateNames.FoundryAgent,
+        label: "template.customEngineAgent.foundryAgent.label",
+        detail: "template.customEngineAgent.foundryAgent.detail",
+        data: TemplateNames.FoundryAgent,
+      },
     ],
     placeholder: "template.customEngineAgent.placeholder",
   },

--- a/templates/src/ui/resource/package.nls.json
+++ b/templates/src/ui/resource/package.nls.json
@@ -7,6 +7,8 @@
   "template.customEngineAgent.travel.label": "Travel Agent",
   "template.customEngineAgent.weather.detail": "A weather forecast agent that is built with Microsoft 365 Agents SDK and LangChain",
   "template.customEngineAgent.weather.label": "Weather Agent",
+  "template.customEngineAgent.foundryAgent.label": "Foundry Agent",
+  "template.customEngineAgent.foundryAgent.detail": "An agent that connects to Microsoft AI Foundry Agent and brings it to Microsoft 365",
   "template.teams.collaboratorAgent.detail": "Agent that enhances collaboration in group chat, channels or meetings through summarization, task management, and conversation search",
   "template.teams.collaboratorAgent.label": "Teams Collaborator Agent",
   "template.teams.general.detail": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs",


### PR DESCRIPTION
Add Foundry Agent option under Custom Engine Agent category. This surfaces the existing foundry-agent-to-m365 template in the VSCode wizard, previously only available via CLI.

No fx-core code changes needed - template files and metadata already exist. Only wizard JSON and NLS updates required.