### PR TITLE
feat: agent publish experience re-design

### DIFF
--- a/packages/fx-core/resource/yaml-schema/v1.12/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/v1.12/yaml.schema.json
@@ -748,6 +748,9 @@
           "properties": {
             "teamsAppId": {
               "$ref": "#/definitions/envVarName"
+            },
+            "teamsAppTenantId": {
+              "$ref": "#/definitions/envVarName"
             }
           }
         }

--- a/packages/fx-core/resource/yaml-schema/v1.12/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/v1.12/yaml.schema.json
@@ -2099,8 +2099,7 @@
             },
             "scope": {
               "type": "string",
-              "description": "Scope of the agent. 'personal' is only visible to the owners. 'shared' can be visible to other users in the tenant. 'tenant' is visible to all users in the tenant. Default is 'personal'.",
-              "enum": ["personal", "shared", "tenant"]
+              "description": "Scope of the agent. 'personal' is only visible to the owners. 'shared' can be visible to other users in the tenant. 'tenant' is visible to all users in the tenant. Default is 'personal'."
             }
           }
         },

--- a/packages/fx-core/resource/yaml-schema/v1.12/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/v1.12/yaml.schema.json
@@ -748,9 +748,6 @@
           "properties": {
             "teamsAppId": {
               "$ref": "#/definitions/envVarName"
-            },
-            "teamsAppTenantId": {
-              "$ref": "#/definitions/envVarName"
             }
           }
         }

--- a/packages/fx-core/resource/yaml-schema/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/yaml.schema.json
@@ -2102,8 +2102,7 @@
             },
             "scope": {
               "type": "string",
-              "description": "Scope of the agent. 'personal' is only visible to the owners. 'shared' can be visible to other users in the tenant. 'tenant' is visible to all users in the tenant. Default is 'personal'.",
-              "enum": ["personal", "shared", "tenant"]
+              "description": "Scope of the agent. 'personal' is only visible to the owners. 'shared' can be visible to other users in the tenant. 'tenant' is visible to all users in the tenant. Default is 'personal'."
             }
           }
         },

--- a/packages/fx-core/src/component/configManager/validator.ts
+++ b/packages/fx-core/src/component/configManager/validator.ts
@@ -20,6 +20,7 @@ const supportedVersions = [
   "v1.9",
   "v1.10",
   "v1.11",
+  "v1.12",
 ];
 
 export class Validator {

--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -807,10 +807,16 @@ class Coordinator {
         } else {
           const msg = getLocalizedString("core.common.LifecycleComplete.publish", steps, steps);
           const adminPortal = getLocalizedString("plugins.appstudio.adminPortal");
+          const isCopilotAgentPublish = projectModel.publish.driverDefs.some(
+            (def) => def.uses === "copilotAgent/publish"
+          );
+          const portalUrl = isCopilotAgentPublish
+            ? Constants.MICROSOFT_ADMIN_CENTER
+            : Constants.TEAMS_ADMIN_PORTAL;
           if (ctx.platform !== Platform.CLI) {
             ctx.ui?.showMessage("info", msg, false, adminPortal).then((value) => {
               if (value.isOk() && value.value === adminPortal) {
-                void ctx.ui!.openUrl(Constants.TEAMS_ADMIN_PORTAL);
+                void ctx.ui!.openUrl(portalUrl);
               }
             });
           } else {

--- a/packages/fx-core/src/component/driver/copilotAgent/interfaces/PublishArgs.ts
+++ b/packages/fx-core/src/component/driver/copilotAgent/interfaces/PublishArgs.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface CopilotAgentPublishArgs {
+  /**
+   * Zipped app package path
+   */
+  appPackagePath: string;
+
+  /**
+   * Publishing scope. Defaults to "Personal".
+   * - Personal: Publish to personal scope
+   * - Shared: Publish to shared scope
+   * - Tenant: Publish to tenant app catalog
+   */
+  scope?: string;
+}

--- a/packages/fx-core/src/component/driver/copilotAgent/publish.ts
+++ b/packages/fx-core/src/component/driver/copilotAgent/publish.ts
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as fs from "fs-extra";
+import { Service } from "typedi";
+import AdmZip from "adm-zip";
+
+import { hooks } from "@feathersjs/hooks/lib";
+import { FxError, Result, SystemError, TeamsAppManifest, UserError } from "@microsoft/teamsfx-api";
+
+import { getLocalizedString } from "../../../common/localizeUtils";
+import { FileNotFoundError, InvalidActionInputError, assembleError } from "../../../error/common";
+import { AppScope, PackageService } from "../../m365/packageService";
+import {
+  getResourceServiceEndpoint,
+  MosServiceScope,
+  ResourceServiceType,
+} from "../../../common/constants";
+import { getAbsolutePath, wrapRun } from "../../utils/common";
+import { logMessageKeys } from "../aad/utility/constants";
+import { DriverContext } from "../interface/commonArgs";
+import { ExecutionResult, StepDriver } from "../interface/stepDriver";
+import { addStartAndEndTelemetry } from "../middleware/addStartAndEndTelemetry";
+import { CopilotAgentPublishArgs } from "./interfaces/PublishArgs";
+import { Constants } from "../teamsApp/constants";
+import { verifyLocalMCPPluginCerts } from "../teamsApp/utils/McpCertVerification";
+import { AppStudioError } from "../teamsApp/errors";
+import { AppStudioResultFactory } from "../teamsApp/results";
+
+export const actionName = "copilotAgent/publish";
+const helpLink = "https://aka.ms/teamsfx-actions/copilotagent-publish";
+
+const outputKeys = {
+  titleId: "titleId",
+  appId: "appId",
+  shareLink: "shareLink",
+};
+
+@Service(actionName) // DO NOT MODIFY the service name
+export class CopilotAgentPublishDriver implements StepDriver {
+  description = getLocalizedString("driver.m365.acquire.description");
+  readonly progressTitle = getLocalizedString("driver.m365.acquire.progress.message");
+
+  @hooks([addStartAndEndTelemetry(actionName, actionName)])
+  public async run(
+    args: CopilotAgentPublishArgs,
+    context: DriverContext
+  ): Promise<Result<Map<string, string>, FxError>> {
+    return wrapRun(async () => {
+      const result = await this.handler(args, context);
+      return result.output;
+    }, actionName);
+  }
+
+  @hooks([addStartAndEndTelemetry(actionName, actionName)])
+  public async execute(
+    args: CopilotAgentPublishArgs,
+    ctx: DriverContext,
+    outputEnvVarNames?: Map<string, string>
+  ): Promise<ExecutionResult> {
+    let summaries: string[] = [];
+    const outputResult = await wrapRun(async () => {
+      const result = await this.handler(args, ctx, outputEnvVarNames);
+      summaries = result.summaries;
+      return result.output;
+    }, actionName);
+    return {
+      result: outputResult,
+      summaries,
+    };
+  }
+
+  private async handler(
+    args: CopilotAgentPublishArgs,
+    context: DriverContext,
+    outputEnvVarNames?: Map<string, string>
+  ): Promise<{
+    output: Map<string, string>;
+    summaries: string[];
+  }> {
+    try {
+      this.validateArgs(args);
+      this.validateOutputEnvVarNames(outputEnvVarNames);
+
+      const appPackagePath = getAbsolutePath(args.appPackagePath, context.projectPath);
+      if (!(await fs.pathExists(appPackagePath))) {
+        throw new FileNotFoundError(actionName, appPackagePath, helpLink);
+      }
+
+      // Verify MCP certs for declarative agents
+      const archivedFile = await fs.readFile(appPackagePath);
+      const zipEntries = new AdmZip(archivedFile).getEntries();
+
+      const manifestFile = zipEntries.find((x) => x.entryName === Constants.MANIFEST_FILE);
+      if (!manifestFile) {
+        throw new FileNotFoundError(actionName, Constants.MANIFEST_FILE, helpLink);
+      }
+      const manifestString = manifestFile.getData().toString();
+      const manifest = JSON.parse(manifestString) as TeamsAppManifest;
+
+      const declarativeAgents =
+        manifest.copilotExtensions?.declarativeCopilots ||
+        manifest.copilotAgents?.declarativeAgents;
+
+      if (declarativeAgents && declarativeAgents.length > 0) {
+        const declarativeAgentFile = zipEntries.find(
+          (x) => x.entryName === declarativeAgents[0].file
+        );
+
+        if (declarativeAgentFile) {
+          const declarativeAgentContent = declarativeAgentFile.getData().toString();
+          const declarativeAgentManifest = JSON.parse(declarativeAgentContent);
+
+          if (declarativeAgentManifest.actions) {
+            for (const action of declarativeAgentManifest.actions) {
+              const actionFile = zipEntries.find((x) => x.entryName === action.file);
+              if (actionFile) {
+                const isValid = await verifyLocalMCPPluginCerts(actionFile);
+                if (!isValid) {
+                  const message = getLocalizedString(
+                    "driver.teamsApp.error.localMcpCertVerificationFailed"
+                  );
+                  throw AppStudioResultFactory.UserError(
+                    AppStudioError.ValidationFailedError.name,
+                    [message, message]
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Get scope, default to Personal
+      const scope = this.parseScope(args.scope);
+
+      // Get MOS service settings
+      const sideloadingServiceEndpoint = getResourceServiceEndpoint(ResourceServiceType.MOS3);
+
+      const packageService = new PackageService(sideloadingServiceEndpoint, context.logProvider);
+      const sideloadingTokenRes = await context.m365TokenProvider.getAccessToken({
+        scopes: MosServiceScope(),
+      });
+      if (sideloadingTokenRes.isErr()) {
+        throw sideloadingTokenRes.error;
+      }
+      const sideloadingToken = sideloadingTokenRes.value;
+
+      // Use Builder API via publishAgent
+      const publishRes = await packageService.publishAgent(sideloadingToken, appPackagePath, scope);
+
+      const mapping = new Map<string, string>();
+      mapping.set(outputEnvVarNames!.get(outputKeys.titleId)!, publishRes[0]);
+      mapping.set(outputEnvVarNames!.get(outputKeys.appId)!, publishRes[1]);
+      const shareLinkKey = outputEnvVarNames?.get(outputKeys.shareLink);
+      if (shareLinkKey && publishRes[2]) {
+        mapping.set(shareLinkKey, publishRes[2]);
+      }
+
+      return {
+        output: mapping,
+        summaries: [getLocalizedString("driver.m365.acquire.summary", publishRes[0])],
+      };
+    } catch (error) {
+      if (error instanceof UserError || error instanceof SystemError) {
+        context.logProvider?.error(
+          getLocalizedString(
+            logMessageKeys.failExecuteDriver,
+            actionName,
+            error.displayMessage || error.message
+          )
+        );
+        throw error;
+      }
+
+      const message = JSON.stringify(error);
+      context.logProvider?.error(
+        getLocalizedString(logMessageKeys.failExecuteDriver, actionName, message)
+      );
+      throw assembleError(error as Error, actionName);
+    }
+  }
+
+  private validateArgs(args: CopilotAgentPublishArgs): void {
+    const invalidParameters: string[] = [];
+
+    if (!args.appPackagePath || typeof args.appPackagePath !== "string") {
+      invalidParameters.push("appPackagePath");
+    }
+
+    if (
+      args.scope &&
+      !Object.values(AppScope)
+        .map((v) => v.toLowerCase())
+        .includes(args.scope.toLowerCase())
+    ) {
+      invalidParameters.push("scope");
+    }
+
+    if (invalidParameters.length > 0) {
+      throw new InvalidActionInputError(actionName, invalidParameters, helpLink);
+    }
+  }
+
+  private validateOutputEnvVarNames(outputEnvVarNames?: Map<string, string>): void {
+    if (!outputEnvVarNames?.get(outputKeys.titleId) || !outputEnvVarNames.get(outputKeys.appId)) {
+      throw new InvalidActionInputError(actionName, ["writeToEnvironmentFile"], helpLink);
+    }
+  }
+
+  private parseScope(scope?: string): AppScope {
+    if (!scope) {
+      return AppScope.Personal;
+    }
+    const lowerScope = scope.toLowerCase();
+    if (lowerScope === "tenant") {
+      return AppScope.Tenant;
+    } else if (lowerScope === "shared") {
+      return AppScope.Shared;
+    }
+    return AppScope.Personal;
+  }
+}

--- a/packages/fx-core/src/component/driver/index.ts
+++ b/packages/fx-core/src/component/driver/index.ts
@@ -12,6 +12,7 @@ import "./apiKey/update";
 import "./arm/deploy";
 import "./botAadApp/create";
 import "./botFramework/createOrUpdateBot";
+import "./copilotAgent/publish";
 import "./deploy/azure/azureAppServiceDeployDriver";
 import "./deploy/azure/azureFunctionDeployDriver";
 import "./deploy/azure/azureStaticWebAppGetDeploymentTokenDriver";

--- a/packages/fx-core/src/component/driver/teamsApp/constants.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/constants.ts
@@ -294,6 +294,7 @@ export class Constants {
     "https://dev.teams.microsoft.com/apps/%s/app-package-editor?login_hint=%s";
   public static readonly PUBLISH_GUIDE = "https://aka.ms/teamsfx-publish";
   public static readonly TEAMS_ADMIN_PORTAL = "https://aka.ms/teamsfx-mtac";
+  public static readonly MICROSOFT_ADMIN_CENTER = "https://aka.ms/atk-mac";
   public static readonly TEAMS_MANAGE_APP_DOC = "https://aka.ms/teamsfx-mtac-doc";
   public static readonly TEAMS_APP_ID = "teamsAppId";
   public static readonly TEAMS_APP_UPDATED_AT = "teamsAppUpdatedAt";

--- a/packages/fx-core/src/component/driver/teamsApp/publishAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/publishAppPackage.ts
@@ -19,14 +19,11 @@ import { WrapDriverContext } from "../util/wrapUtil";
 import { Constants } from "./constants";
 import { PublishAppPackageArgs } from "./interfaces/PublishAppPackageArgs";
 import { TelemetryPropertyKey } from "./utils/telemetry";
-import { ODRProvider } from "../../utils/odrProvider";
-import { exec } from "child_process";
-import { promisify } from "util";
-import { LocalMcpPrefix } from "../../constants";
 import { AppStudioError } from "./errors";
 import { AppStudioResultFactory } from "./results";
 import { FeatureFlagName } from "../../../common/featureFlags";
 import { SovereignCloudEnvironment } from "../../../common/accountUtils";
+import { verifyLocalMCPPluginCerts } from "./utils/McpCertVerification";
 
 export const actionName = "teamsApp/publishAppPackage";
 
@@ -120,7 +117,7 @@ export class PublishAppPackageDriver implements StepDriver {
           for (const action of declarativeAgentManifest.actions) {
             const actionFile = zipEntries.find((x) => x.entryName === action.file);
             if (actionFile) {
-              const isValid = await this.verifyLocalMCPPluginCerts(actionFile);
+              const isValid = await verifyLocalMCPPluginCerts(actionFile);
               if (!isValid) {
                 const message = getLocalizedString(
                   "driver.teamsApp.error.localMcpCertVerificationFailed"
@@ -247,68 +244,6 @@ export class PublishAppPackageDriver implements StepDriver {
       );
     } else {
       return ok(undefined);
-    }
-  }
-
-  private async verifyLocalMCPPluginCerts(pluginFile: AdmZip.IZipEntry): Promise<boolean> {
-    const pluginContent = pluginFile.getData().toString();
-    const pluginManifest = JSON.parse(pluginContent);
-    if (!pluginManifest.runtimes || !Array.isArray(pluginManifest.runtimes)) {
-      return true;
-    }
-
-    const servers = await ODRProvider.listServers();
-
-    let allValidCerts = true;
-
-    const localPluginRuntimes = pluginManifest.runtimes.filter(
-      (runtime: { type: string }) => runtime.type === "LocalPlugin"
-    );
-
-    for (const runtime of localPluginRuntimes) {
-      const localEndpoint = (runtime as { spec?: { local_endpoint?: string } }).spec
-        ?.local_endpoint;
-
-      if (!localEndpoint || !localEndpoint.startsWith(LocalMcpPrefix)) {
-        continue;
-      }
-
-      const mcpIdentifier = localEndpoint.substring(LocalMcpPrefix.length);
-      const serverInfo = servers.find((x) => x.identifier === mcpIdentifier);
-
-      if (!serverInfo) {
-        continue;
-      }
-
-      const valid = await this.verifyPackageFamilyCertIsValid(serverInfo.packageFamily);
-
-      if (!valid) {
-        allValidCerts = false;
-        break;
-      }
-    }
-
-    return allValidCerts;
-  }
-
-  private async verifyPackageFamilyCertIsValid(packageName: string): Promise<boolean> {
-    const execAsync = promisify(exec);
-    const command = `powershell.exe -Command "& Get-AppxPackage | where { $_.PackageFamilyName -eq '${packageName}' } | select { $_.SignatureKind }"`;
-
-    try {
-      const { stdout } = await execAsync(command);
-
-      if (!stdout) {
-        return false;
-      }
-
-      if (stdout.toLowerCase().includes("developer")) {
-        return false;
-      }
-      return true;
-    } catch (error) {
-      console.error("Unable to get cert info for package name", error);
-      return false;
     }
   }
 }

--- a/packages/fx-core/src/component/driver/teamsApp/utils/McpCertVerification.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/McpCertVerification.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import AdmZip from "adm-zip";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { LocalMcpPrefix } from "../../../constants";
+import { ODRProvider } from "../../../utils/odrProvider";
+
+/**
+ * Verifies that all Local MCP plugin certificates in the plugin file are valid.
+ * Returns true if all certs are valid or no Local MCP plugins exist, false otherwise.
+ */
+export async function verifyLocalMCPPluginCerts(pluginFile: AdmZip.IZipEntry): Promise<boolean> {
+  const pluginContent = pluginFile.getData().toString();
+  const pluginManifest = JSON.parse(pluginContent);
+  if (!pluginManifest.runtimes || !Array.isArray(pluginManifest.runtimes)) {
+    return true;
+  }
+
+  const servers = await ODRProvider.listServers();
+
+  let allValidCerts = true;
+
+  const localPluginRuntimes = pluginManifest.runtimes.filter(
+    (runtime: { type: string }) => runtime.type === "LocalPlugin"
+  );
+
+  for (const runtime of localPluginRuntimes) {
+    const localEndpoint = (runtime as { spec?: { local_endpoint?: string } }).spec?.local_endpoint;
+
+    if (!localEndpoint || !localEndpoint.startsWith(LocalMcpPrefix)) {
+      continue;
+    }
+
+    const mcpIdentifier = localEndpoint.substring(LocalMcpPrefix.length);
+    const serverInfo = servers.find((x) => x.identifier === mcpIdentifier);
+
+    if (!serverInfo) {
+      continue;
+    }
+
+    const valid = await verifyPackageFamilyCertIsValid(serverInfo.packageFamily);
+
+    if (!valid) {
+      allValidCerts = false;
+      break;
+    }
+  }
+
+  return allValidCerts;
+}
+
+/**
+ * Verifies that a package family certificate is valid (not a developer/self-signed cert).
+ * Valid certs include: Store, System, Enterprise.
+ * Invalid certs include: Developer (self-signed).
+ */
+export async function verifyPackageFamilyCertIsValid(packageName: string): Promise<boolean> {
+  const execAsync = promisify(exec);
+  const command = `powershell.exe -Command "& Get-AppxPackage | where { $_.PackageFamilyName -eq '${packageName}' } | select { $_.SignatureKind }"`;
+
+  try {
+    const { stdout } = await execAsync(command);
+
+    if (!stdout) {
+      return false;
+    }
+
+    if (stdout.toLowerCase().includes("developer")) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error("Unable to get cert info for package name", error);
+    return false;
+  }
+}

--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -295,6 +295,29 @@ export class PackageService {
     }
   }
 
+  /**
+   * Publish agent using Builder API (sideLoadingV2) and get share link for shared scope.
+   * Returns [titleId, appId, shareLink]
+   */
+  @hooks([ErrorContextMW({ source: M365ErrorSource, component: M365ErrorComponent })])
+  public async publishAgent(
+    token: string,
+    packagePath: string,
+    appScope: AppScope = AppScope.Personal
+  ): Promise<[string, string, string]> {
+    const res = await this.sideLoadingV2(token, packagePath, appScope);
+    let shareLink = "";
+    if (appScope.toLowerCase() === AppScope.Shared.toLowerCase()) {
+      shareLink = await this.getShareLink(token, res[0]);
+    }
+    sendTelemetryEvent(Component.core, TelemetryEvent.MosSideloadEnd, {
+      [TelemetryProperty.MosTitleId]: res[0],
+      [TelemetryProperty.MosAppId]: res[1],
+      [TelemetryProperty.IsDeclarativeAgent]: "true",
+    });
+    return [res[0], res[1], shareLink];
+  }
+
   @hooks([ErrorContextMW({ source: M365ErrorSource, component: M365ErrorComponent })])
   public async sideLoadingV1(token: string, manifestPath: string): Promise<[string, string]> {
     try {

--- a/packages/fx-core/tests/component/coordinator/coordinator.publish.test.ts
+++ b/packages/fx-core/tests/component/coordinator/coordinator.publish.test.ts
@@ -371,4 +371,62 @@ describe("component coordinator test", () => {
     const res = await coordinator.publish(context, inputs);
     assert.isTrue(res.isErr() && res.error.name === "LifeCycleUndefinedError");
   });
+  it("publish happy path - copilotAgent/publish opens Microsoft Admin Center", async () => {
+    const mockProjectModel: ProjectModel = {
+      version: "1.0.0",
+      publish: {
+        name: "publish",
+        driverDefs: [{ uses: "copilotAgent/publish", with: {} }],
+        resolvePlaceholders: () => {
+          return [];
+        },
+        execute: async (ctx: DriverContext): Promise<ExecutionResult> => {
+          return { result: ok(new Map()), summaries: [] };
+        },
+        resolveDriverInstances: mockedResolveDriverInstances,
+      },
+    };
+    sandbox.stub(metadataUtil, "parse").resolves(ok(mockProjectModel));
+    sandbox.stub(envUtil, "listEnv").resolves(ok(["dev", "prod"]));
+    sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+    sandbox.stub(envUtil, "writeEnv").resolves(ok(undefined));
+    sandbox.stub(tools.ui, "selectOption").callsFake(async (config) => {
+      if (config.name === "env") {
+        return ok({ type: "success", result: "dev" });
+      } else {
+        return ok({ type: "success", result: "" });
+      }
+    });
+    const progressStartStub = sandbox.stub();
+    const progressEndStub = sandbox.stub();
+    sandbox.stub(tools.ui, "createProgressBar").returns({
+      start: progressStartStub,
+      end: progressEndStub,
+    } as any as IProgressHandler);
+    const showMessageStub = sandbox
+      .stub(tools.ui, "showMessage")
+      .callsFake(async (level, msg, modal, ...items) => {
+        if (items.length > 0 && items[0].includes("admin portal")) {
+          return ok(items[0]);
+        }
+        return ok("");
+      });
+    const openUrlStub = sandbox.stub(tools.ui, "openUrl").resolves(ok(true));
+    sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok("."));
+    sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+    sandbox.stub(fs, "pathExistsSync").onFirstCall().returns(false).onSecondCall().returns(true);
+    const inputs: Inputs = {
+      platform: Platform.VSCode,
+      projectPath: ".",
+      ignoreLockByUT: true,
+    };
+    const fxCore = new FxCore(tools);
+    const res = await fxCore.publishApplication(inputs);
+    assert.isTrue(res.isOk());
+    assert.isTrue(showMessageStub.calledOnce);
+    assert.isTrue(progressStartStub.calledOnce);
+    assert.isTrue(progressEndStub.calledOnceWithExactly(true));
+    assert.isTrue(openUrlStub.calledOnce);
+    assert.isTrue(openUrlStub.calledWith("https://aka.ms/atk-mac"));
+  });
 });

--- a/packages/fx-core/tests/component/driver/copilotAgent/publish.test.ts
+++ b/packages/fx-core/tests/component/driver/copilotAgent/publish.test.ts
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { err, ok, TeamsAppManifest } from "@microsoft/teamsfx-api";
+import AdmZip from "adm-zip";
+import chai from "chai";
+import fs from "fs-extra";
+import "mocha";
+import * as sinon from "sinon";
+import { v4 as uuid } from "uuid";
+import { CopilotAgentPublishDriver } from "../../../../src/component/driver/copilotAgent/publish";
+import { CopilotAgentPublishArgs } from "../../../../src/component/driver/copilotAgent/interfaces/PublishArgs";
+import { AppStudioError } from "../../../../src/component/driver/teamsApp/errors";
+import { Constants } from "../../../../src/component/driver/teamsApp/constants";
+import { UserCancelError } from "../../../../src/error/common";
+import { MockedLogProvider, MockedUserInteraction } from "../../../plugins/solution/util";
+import { MockedM365Provider } from "../../../core/utils";
+import { PackageService } from "../../../../src/component/m365/packageService";
+
+describe("copilotAgent/publish", async () => {
+  const driver = new CopilotAgentPublishDriver();
+  const mockedDriverContext: any = {
+    m365TokenProvider: new MockedM365Provider(),
+    logProvider: new MockedLogProvider(),
+    ui: new MockedUserInteraction(),
+    projectPath: "./",
+  };
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should throw error if file not exists", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_PUBLISHED_TITLE_ID"],
+      ["appId", "M365_PUBLISHED_APP_ID"],
+    ]);
+
+    const result = (await driver.execute(args, mockedDriverContext, outputEnvVarNames)).result;
+    chai.assert(result.isErr());
+    if (result.isErr()) {
+      chai.assert.equal(AppStudioError.FileNotFoundError.name, result.error.name);
+    }
+  });
+
+  it("invalid param error - empty appPackagePath", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_PUBLISHED_TITLE_ID"],
+      ["appId", "M365_PUBLISHED_APP_ID"],
+    ]);
+
+    const result = (await driver.execute(args, mockedDriverContext, outputEnvVarNames)).result;
+    chai.assert(result.isErr());
+    if (result.isErr()) {
+      chai.assert.equal("InvalidActionInputError", result.error.name);
+    }
+  });
+
+  it("invalid param error - invalid scope", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+      scope: "invalid",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_PUBLISHED_TITLE_ID"],
+      ["appId", "M365_PUBLISHED_APP_ID"],
+    ]);
+
+    sinon.stub(fs, "pathExists").resolves(true);
+
+    const result = (await driver.execute(args, mockedDriverContext, outputEnvVarNames)).result;
+    chai.assert(result.isErr());
+    if (result.isErr()) {
+      chai.assert.equal("InvalidActionInputError", result.error.name);
+    }
+  });
+
+  it("invalid param error - missing writeToEnvironmentFile", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+
+    sinon.stub(fs, "pathExists").resolves(true);
+
+    const result = (await driver.execute(args, mockedDriverContext)).result;
+    chai.assert(result.isErr());
+    if (result.isErr()) {
+      chai.assert.equal("InvalidActionInputError", result.error.name);
+    }
+  });
+
+  it("happy path - default scope (Personal)", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, ""]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
+    if (result.result.isOk()) {
+      chai.assert.equal(result.result.value.get("M365_TITLE_ID"), titleId);
+      chai.assert.equal(result.result.value.get("M365_APP_ID"), appId);
+    }
+  });
+
+  it("happy path - tenant scope", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+      scope: "tenant",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_PUBLISHED_TITLE_ID"],
+      ["appId", "M365_PUBLISHED_APP_ID"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, ""]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
+    if (result.result.isOk()) {
+      chai.assert.equal(result.result.value.get("M365_PUBLISHED_TITLE_ID"), titleId);
+      chai.assert.equal(result.result.value.get("M365_PUBLISHED_APP_ID"), appId);
+    }
+  });
+
+  it("happy path - shared scope", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+      scope: "Shared",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, ""]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
+    if (result.result.isOk()) {
+      chai.assert.equal(result.result.value.get("M365_TITLE_ID"), titleId);
+      chai.assert.equal(result.result.value.get("M365_APP_ID"), appId);
+    }
+  });
+
+  it("should return token error when getAccessToken fails", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      const manifest = new TeamsAppManifest();
+      manifest.id = uuid();
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
+      return zip.toBuffer();
+    });
+
+    const tokenError = new UserCancelError();
+    sinon.stub(mockedDriverContext.m365TokenProvider, "getAccessToken").resolves(err(tokenError));
+
+    const result = (await driver.execute(args, mockedDriverContext, outputEnvVarNames)).result;
+    chai.assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      chai.assert.equal(result.error, tokenError);
+    }
+  });
+
+  it("should return error when publishAgent throws", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      const manifest = new TeamsAppManifest();
+      manifest.id = uuid();
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").rejects(new Error("publish failed"));
+
+    const result = (await driver.execute(args, mockedDriverContext, outputEnvVarNames)).result;
+    chai.assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      chai.assert.include(result.error.message, "publish failed");
+    }
+  });
+
+  it("run method should work", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+
+    const titleId = uuid();
+    const appId = uuid();
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, ""]);
+
+    const result = await driver.run(args, mockedDriverContext);
+    chai.assert.isTrue(result.isErr());
+  });
+});

--- a/packages/fx-core/tests/component/driver/copilotAgent/publish.test.ts
+++ b/packages/fx-core/tests/component/driver/copilotAgent/publish.test.ts
@@ -16,8 +16,16 @@ import { UserCancelError } from "../../../../src/error/common";
 import { MockedLogProvider, MockedUserInteraction } from "../../../plugins/solution/util";
 import { MockedM365Provider } from "../../../core/utils";
 import { PackageService } from "../../../../src/component/m365/packageService";
+import * as McpCertVerification from "../../../../src/component/driver/teamsApp/utils/McpCertVerification";
 
 describe("copilotAgent/publish", async () => {
+  const createManifestWithDA = (declarativeAgentFile: string) => {
+    const manifest = new TeamsAppManifest();
+    manifest.copilotAgents = {
+      declarativeAgents: [{ id: "da1", file: declarativeAgentFile }],
+    };
+    return manifest;
+  };
   const driver = new CopilotAgentPublishDriver();
   const mockedDriverContext: any = {
     m365TokenProvider: new MockedM365Provider(),
@@ -264,5 +272,246 @@ describe("copilotAgent/publish", async () => {
 
     const result = await driver.run(args, mockedDriverContext);
     chai.assert.isTrue(result.isErr());
+  });
+
+  it("should throw error if manifest.json not found in package", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      zip.addFile("other.json", Buffer.from("{}"));
+      return zip.toBuffer();
+    });
+
+    const result = (await driver.execute(args, mockedDriverContext, outputEnvVarNames)).result;
+    chai.assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      chai.assert.equal(AppStudioError.FileNotFoundError.name, result.error.name);
+    }
+  });
+
+  it("should return shareLink when published with shared scope", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+      scope: "Shared",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+      ["shareLink", "SHARE_LINK"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+    const shareLink = "https://fake.sharelink.com";
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, shareLink]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
+    if (result.result.isOk()) {
+      chai.assert.equal(result.result.value.get("M365_TITLE_ID"), titleId);
+      chai.assert.equal(result.result.value.get("M365_APP_ID"), appId);
+      chai.assert.equal(result.result.value.get("SHARE_LINK"), shareLink);
+    }
+  });
+
+  it("should not set shareLink when shareLinkKey is not provided", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+      scope: "Shared",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+    const shareLink = "https://fake.sharelink.com";
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, shareLink]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
+    if (result.result.isOk()) {
+      chai.assert.equal(result.result.value.get("M365_TITLE_ID"), titleId);
+      chai.assert.equal(result.result.value.get("M365_APP_ID"), appId);
+      chai.assert.isUndefined(result.result.value.get("SHARE_LINK"));
+    }
+  });
+
+  it("should verify MCP certs for declarative agents with actions", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      const manifest = createManifestWithDA("declarativeAgent.json");
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
+      const daManifest = {
+        actions: [{ id: "action1", file: "plugin.json" }],
+      };
+      zip.addFile("declarativeAgent.json", Buffer.from(JSON.stringify(daManifest)));
+      zip.addFile("plugin.json", Buffer.from(JSON.stringify({ runtimes: [] })));
+      return zip.toBuffer();
+    });
+    sinon.stub(McpCertVerification, "verifyLocalMCPPluginCerts").resolves(true);
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, ""]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
+  });
+
+  it("should fail when MCP cert verification fails", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      const manifest = createManifestWithDA("declarativeAgent.json");
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
+      const daManifest = {
+        actions: [{ id: "action1", file: "plugin.json" }],
+      };
+      zip.addFile("declarativeAgent.json", Buffer.from(JSON.stringify(daManifest)));
+      zip.addFile("plugin.json", Buffer.from(JSON.stringify({ runtimes: [] })));
+      return zip.toBuffer();
+    });
+    sinon.stub(McpCertVerification, "verifyLocalMCPPluginCerts").resolves(false);
+
+    const result = (await driver.execute(args, mockedDriverContext, outputEnvVarNames)).result;
+    chai.assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      chai.assert.equal(AppStudioError.ValidationFailedError.name, result.error.name);
+    }
+  });
+
+  it("should skip MCP verification when declarative agent file not found", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      const manifest = createManifestWithDA("nonexistent.json");
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, ""]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
+  });
+
+  it("should skip action file verification when action file not found", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      const manifest = createManifestWithDA("declarativeAgent.json");
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
+      const daManifest = {
+        actions: [{ id: "action1", file: "nonexistent-plugin.json" }],
+      };
+      zip.addFile("declarativeAgent.json", Buffer.from(JSON.stringify(daManifest)));
+      return zip.toBuffer();
+    });
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, ""]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
+  });
+
+  it("should handle copilotExtensions.declarativeCopilots format", async () => {
+    const args: CopilotAgentPublishArgs = {
+      appPackagePath: "fakepath",
+    };
+    const outputEnvVarNames = new Map<string, string>([
+      ["titleId", "M365_TITLE_ID"],
+      ["appId", "M365_APP_ID"],
+    ]);
+
+    const titleId = uuid();
+    const appId = uuid();
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").callsFake(async () => {
+      const zip = new AdmZip();
+      const manifest = new TeamsAppManifest();
+      manifest.copilotExtensions = {
+        declarativeCopilots: [{ id: "dc1", file: "declarativeAgent.json" }],
+      };
+      zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
+      const daManifest = {
+        actions: [{ id: "action1", file: "plugin.json" }],
+      };
+      zip.addFile("declarativeAgent.json", Buffer.from(JSON.stringify(daManifest)));
+      zip.addFile("plugin.json", Buffer.from(JSON.stringify({ runtimes: [] })));
+      return zip.toBuffer();
+    });
+    sinon.stub(McpCertVerification, "verifyLocalMCPPluginCerts").resolves(true);
+    sinon.stub(PackageService.prototype, "getTitleServiceUrl").resolves("https://fake.url");
+    sinon.stub(PackageService.prototype, "publishAgent").resolves([titleId, appId, ""]);
+
+    const result = await driver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert.isTrue(result.result.isOk());
   });
 });

--- a/packages/fx-core/tests/component/driver/teamsApp/publishAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/publishAppPackage.test.ts
@@ -22,6 +22,7 @@ import { MockedLogProvider, MockedUserInteraction } from "../../../plugins/solut
 import { Constants } from "./../../../../src/component/driver/teamsApp/constants";
 import { MockedM365Provider } from "../../../core/utils";
 import { ODRProvider } from "../../../../src/component/utils/odrProvider";
+import * as McpCertVerification from "../../../../src/component/driver/teamsApp/utils/McpCertVerification";
 
 describe("teamsApp/publishAppPackage", async () => {
   const teamsAppDriver = new PublishAppPackageDriver();
@@ -513,9 +514,7 @@ describe("teamsApp/publishAppPackage", async () => {
           tools: [],
         },
       ]);
-      sinon
-        .stub(PublishAppPackageDriver.prototype as any, "verifyPackageFamilyCertIsValid")
-        .resolves(true);
+      sinon.stub(McpCertVerification, "verifyLocalMCPPluginCerts").resolves(true);
       sinon.stub(GraphClient.prototype, "getStagedApp").resolves(undefined);
       sinon.stub(GraphClient.prototype, "publishTeamsApp").resolves(uuid());
 
@@ -576,9 +575,7 @@ describe("teamsApp/publishAppPackage", async () => {
           tools: [],
         },
       ]);
-      sinon
-        .stub(PublishAppPackageDriver.prototype as any, "verifyPackageFamilyCertIsValid")
-        .resolves(false);
+      sinon.stub(McpCertVerification, "verifyLocalMCPPluginCerts").resolves(false);
 
       const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
       chai.assert.isTrue(result.isErr());
@@ -640,9 +637,7 @@ describe("teamsApp/publishAppPackage", async () => {
           tools: [],
         },
       ]);
-      sinon
-        .stub(PublishAppPackageDriver.prototype as any, "verifyPackageFamilyCertIsValid")
-        .resolves(false);
+      sinon.stub(McpCertVerification, "verifyLocalMCPPluginCerts").resolves(false);
 
       const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
       chai.assert.isTrue(result.isErr());
@@ -722,9 +717,7 @@ describe("teamsApp/publishAppPackage", async () => {
           tools: [],
         },
       ]);
-      sinon
-        .stub(PublishAppPackageDriver.prototype as any, "verifyPackageFamilyCertIsValid")
-        .resolves(true);
+      sinon.stub(McpCertVerification, "verifyLocalMCPPluginCerts").resolves(true);
       sinon.stub(GraphClient.prototype, "getStagedApp").resolves(undefined);
       sinon.stub(GraphClient.prototype, "publishTeamsApp").resolves(uuid());
 
@@ -735,7 +728,6 @@ describe("teamsApp/publishAppPackage", async () => {
 
   // eslint-disable-next-line no-secrets/no-secrets
   describe("verifyPackageFamilyCertIsValid", () => {
-    const teamsAppDriver = new PublishAppPackageDriver();
     let execStub: sinon.SinonStub;
 
     beforeEach(() => {
@@ -760,10 +752,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isTrue(result);
     });
 
@@ -780,10 +769,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isTrue(result);
     });
 
@@ -800,10 +786,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
 
@@ -820,10 +803,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
 
@@ -840,10 +820,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
 
@@ -861,10 +838,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
 
@@ -882,10 +856,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
 
@@ -900,10 +871,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
 
@@ -920,8 +888,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid(
         "NonExistentPackage_99999"
       );
       chai.assert.isFalse(result);
@@ -940,10 +907,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isTrue(result);
     });
 
@@ -960,10 +924,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isTrue(result);
     });
 
@@ -982,8 +943,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(packageName);
+      await McpCertVerification.verifyPackageFamilyCertIsValid(packageName);
       chai.assert.isTrue(execStub.calledOnce);
     });
 
@@ -1000,10 +960,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
 
@@ -1021,10 +978,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
 
@@ -1041,10 +995,7 @@ describe("teamsApp/publishAppPackage", async () => {
         }
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await (teamsAppDriver as any).verifyPackageFamilyCertIsValid(
-        "TestPackage_12345"
-      );
+      const result = await McpCertVerification.verifyPackageFamilyCertIsValid("TestPackage_12345");
       chai.assert.isFalse(result);
     });
   });

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -2087,4 +2087,102 @@ describe("Package Service", () => {
     chai.assert.equal(result, "https://test-url");
     chai.assert.equal(callCount, 2);
   });
+
+  it("publishAgent happy path with Personal scope", async () => {
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "https://test-url",
+      },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      status: 201,
+      data: {
+        titlePreview: {
+          titleId: "test-title-id",
+          appId: "test-app-id",
+        },
+      },
+    };
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    const result = await packageService.publishAgent("test-token", "test-path", AppScope.Personal);
+    chai.assert.equal(result[0], "test-title-id");
+    chai.assert.equal(result[1], "test-app-id");
+    chai.assert.equal(result[2], "");
+  });
+
+  it("publishAgent with Shared scope should get shareLink", async () => {
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "https://test-url",
+      },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      status: 201,
+      data: {
+        titlePreview: {
+          titleId: "test-title-id",
+          appId: "test-app-id",
+        },
+      },
+    };
+    axiosGetResponses["/marketplace/v1/users/titles/test-title-id/sharingInfo"] = {
+      status: 200,
+      data: {
+        unifiedStoreLink: "https://test-share-link.com",
+      },
+    };
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    const result = await packageService.publishAgent("test-token", "test-path", AppScope.Shared);
+    chai.assert.equal(result[0], "test-title-id");
+    chai.assert.equal(result[1], "test-app-id");
+    chai.assert.equal(result[2], "https://test-share-link.com");
+  });
+
+  it("publishAgent with Tenant scope should not get shareLink", async () => {
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "https://test-url",
+      },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      status: 201,
+      data: {
+        titlePreview: {
+          titleId: "test-title-id",
+          appId: "test-app-id",
+        },
+      },
+    };
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    const result = await packageService.publishAgent("test-token", "test-path", AppScope.Tenant);
+    chai.assert.equal(result[0], "test-title-id");
+    chai.assert.equal(result[1], "test-app-id");
+    chai.assert.equal(result[2], "");
+  });
+
+  it("publishAgent defaults to Personal scope", async () => {
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "https://test-url",
+      },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      status: 201,
+      data: {
+        titlePreview: {
+          titleId: "test-title-id",
+          appId: "test-app-id",
+        },
+      },
+    };
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    const result = await packageService.publishAgent("test-token", "test-path");
+    chai.assert.equal(result[0], "test-title-id");
+    chai.assert.equal(result[1], "test-app-id");
+    chai.assert.equal(result[2], "");
+  });
 });

--- a/templates/vs/csharp/declarative-agent-basic/m365agents.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-basic/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.9/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -32,7 +32,7 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
   # Extend your Teams app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -58,13 +58,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID

--- a/templates/vs/csharp/declarative-agent-with-action-from-existing-api/m365agents.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-existing-api/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.9/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -75,7 +75,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your Teams app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.9/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates a Teams app

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
@@ -85,7 +85,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your Teams app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/m365agents.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.9/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -81,7 +81,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your Teams app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
@@ -148,7 +148,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your Teams app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.9/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates a new Microsoft Entra app to authenticate users if

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/m365agents.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.9/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -137,7 +137,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your Teams app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
@@ -43,7 +43,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your Teams app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.9/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates a Teams app

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch/m365agents.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.9/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -65,7 +65,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your Teams app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/common/declarative-agent-basic/m365agents.local.yml.tpl
+++ b/templates/vsc/common/declarative-agent-basic/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.10/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates an app

--- a/templates/vsc/common/declarative-agent-basic/m365agents.local.yml.tpl
+++ b/templates/vsc/common/declarative-agent-basic/m365agents.local.yml.tpl
@@ -38,7 +38,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/common/declarative-agent-basic/m365agents.yml.tpl
+++ b/templates/vsc/common/declarative-agent-basic/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -36,7 +36,7 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -69,13 +69,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID

--- a/templates/vsc/common/declarative-agent-typespec/m365agents.local.yml.tpl
+++ b/templates/vsc/common/declarative-agent-typespec/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.10/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates an app

--- a/templates/vsc/common/declarative-agent-typespec/m365agents.local.yml.tpl
+++ b/templates/vsc/common/declarative-agent-typespec/m365agents.local.yml.tpl
@@ -60,7 +60,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/common/declarative-agent-typespec/m365agents.yml.tpl
+++ b/templates/vsc/common/declarative-agent-typespec/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -61,7 +61,7 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -111,13 +111,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID

--- a/templates/vsc/common/declarative-agent-with-action-from-existing-api/m365agents.local.yml.tpl
+++ b/templates/vsc/common/declarative-agent-with-action-from-existing-api/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.10/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates an app

--- a/templates/vsc/common/declarative-agent-with-action-from-existing-api/m365agents.local.yml.tpl
+++ b/templates/vsc/common/declarative-agent-with-action-from-existing-api/m365agents.local.yml.tpl
@@ -71,7 +71,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/common/declarative-agent-with-action-from-existing-api/m365agents.yml.tpl
+++ b/templates/vsc/common/declarative-agent-with-action-from-existing-api/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -70,7 +70,7 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -103,13 +103,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID

--- a/templates/vsc/common/declarative-agent-with-action-from-mcp/m365agents.yml.tpl
+++ b/templates/vsc/common/declarative-agent-with-action-from-mcp/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -37,7 +37,7 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -68,13 +68,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates an app

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
@@ -72,7 +72,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/m365agents.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -82,7 +82,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -142,13 +142,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates a new Microsoft Entra app to authenticate users if

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
@@ -136,7 +136,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/m365agents.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -138,7 +138,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -193,13 +193,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates an app

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
@@ -45,7 +45,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/m365agents.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -66,7 +66,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -121,13 +121,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates an app

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
@@ -72,7 +72,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/m365agents.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -82,7 +82,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -143,14 +143,14 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID
 

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates a new Microsoft Entra app to authenticate users if

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
@@ -136,7 +136,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/m365agents.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -138,7 +138,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -199,14 +199,14 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID
 

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 provision:
   # Creates an app

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
@@ -45,7 +45,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/m365agents.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/m365agents.yml.tpl
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.11/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/m365-agents-toolkits/v1.12/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: v1.11
+version: v1.12
 
 environmentFolderPath: ./env
 
@@ -66,7 +66,7 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
   # Extend your app to Outlook and the Microsoft 365 app
-  - uses: teamsApp/extendToM365
+  - uses: copilotAgent/publish
     with:
       # Relative path to the build app package.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
@@ -127,13 +127,13 @@ publish:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  # Publish the app to
-  # Teams Admin Center (https://admin.teams.microsoft.com/policies/manage-apps)
-  # for review and approval
-  - uses: teamsApp/publishAppPackage
+  # Publish the agent to tenant app catalog
+  - uses: copilotAgent/publish
     with:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      scope: tenant
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
-      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
+      titleId: M365_PUBLISHED_TITLE_ID
+      appId: M365_PUBLISHED_APP_ID


### PR DESCRIPTION
IntelliSense 
<img width="1478" height="444" alt="image" src="https://github.com/user-attachments/assets/5af4ed5c-5b36-4ba4-ae6d-78b2b7c2d3cf" />

When provision, the messages keep the same for new action:
<img width="1347" height="390" alt="image" src="https://github.com/user-attachments/assets/153e532d-be52-45ca-b656-e8377aa3f526" />
When publish, the messages for action execution keep the same, differences are:
1> Agent info with new env names prefixed PUBLISHED_ is printed
2> When user clicks the button, it will redirect user to MAC instead of TAC
<img width="1744" height="563" alt="image" src="https://github.com/user-attachments/assets/473bb1b8-c317-49bd-b387-396bb8aa5936" />
<img width="815" height="238" alt="image" src="https://github.com/user-attachments/assets/fc94f0dc-a5b6-4ae4-93f8-9466e8d9d32c" />
check publish status:
<img width="1481" height="427" alt="image" src="https://github.com/user-attachments/assets/2cbcc965-03e6-4ec8-bc37-9afeeb627305" />

