### PR TITLE
feat: Add configurable max package size limit to zipAppPackage action

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -889,7 +889,7 @@
   "error.teamsApp.InvalidAppIdError": "App ID %s is invalid, must be a GUID.",
   "error.teamsApp.createAppPackage.invalidFile": "%s is invalid, it should be in the same directory as manifest.json or a subdirectory of it.",
   "error.teamsApp.createAppPackage.packageSizeExceeded": "The generated app package (%s MB) exceeds the maximum allowed size of %s MB. Reduce the package contents or increase the maxPackageSizeInBytes limit.",
-  "error.m365.packageService.packageSizeExceeded": "The app package (%s MB) exceeds the maximum size supported by the MOS API (%s MB). Reduce the package contents before uploading.",
+  "error.m365.packageService.packageSizeExceeded": "The app package (%s MB) exceeds the maximum supported size (%s MB). Reduce the package contents before uploading.",
   "driver.botFramework.description": "creates or updates the bot registration on dev.botframework.com",
   "driver.botFramework.summary.create": "The bot registration has been created successfully (%s).",
   "driver.botFramework.summary.update": "The bot registration has been updated successfully (%s).",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -888,7 +888,7 @@
   "error.teamsApp.AppIdNotExistError": "App with ID %s does not exist in Developer Portal.",
   "error.teamsApp.InvalidAppIdError": "App ID %s is invalid, must be a GUID.",
   "error.teamsApp.createAppPackage.invalidFile": "%s is invalid, it should be in the same directory as manifest.json or a subdirectory of it.",
-  "error.teamsApp.createAppPackage.packageSizeExceeded": "The generated app package (%s MB) exceeds the maximum allowed size of %s MB. Reduce the package contents or increase the maxPackageSizeInBytes limit.",
+  "error.teamsApp.createAppPackage.packageSizeExceeded": "The generated app package (%s MB) exceeds the maximum allowed size of %s MB. Reduce the package contents before building.",
   "error.m365.packageService.packageSizeExceeded": "The app package (%s MB) exceeds the maximum supported size (%s MB). Reduce the package contents before uploading.",
   "driver.botFramework.description": "creates or updates the bot registration on dev.botframework.com",
   "driver.botFramework.summary.create": "The bot registration has been created successfully (%s).",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -888,6 +888,7 @@
   "error.teamsApp.AppIdNotExistError": "App with ID %s does not exist in Developer Portal.",
   "error.teamsApp.InvalidAppIdError": "App ID %s is invalid, must be a GUID.",
   "error.teamsApp.createAppPackage.invalidFile": "%s is invalid, it should be in the same directory as manifest.json or a subdirectory of it.",
+  "error.teamsApp.createAppPackage.packageSizeExceeded": "The generated app package (%s MB) exceeds the maximum allowed size of %s MB. Reduce the package contents or increase the maxPackageSizeInBytes limit.",
   "driver.botFramework.description": "creates or updates the bot registration on dev.botframework.com",
   "driver.botFramework.summary.create": "The bot registration has been created successfully (%s).",
   "driver.botFramework.summary.update": "The bot registration has been updated successfully (%s).",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -889,6 +889,7 @@
   "error.teamsApp.InvalidAppIdError": "App ID %s is invalid, must be a GUID.",
   "error.teamsApp.createAppPackage.invalidFile": "%s is invalid, it should be in the same directory as manifest.json or a subdirectory of it.",
   "error.teamsApp.createAppPackage.packageSizeExceeded": "The generated app package (%s MB) exceeds the maximum allowed size of %s MB. Reduce the package contents or increase the maxPackageSizeInBytes limit.",
+  "error.m365.packageService.packageSizeExceeded": "The app package (%s MB) exceeds the maximum size supported by the MOS API (%s MB). Reduce the package contents before uploading.",
   "driver.botFramework.description": "creates or updates the bot registration on dev.botframework.com",
   "driver.botFramework.summary.create": "The bot registration has been created successfully (%s).",
   "driver.botFramework.summary.update": "The bot registration has been updated successfully (%s).",

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -388,12 +388,11 @@ export class CreateAppPackageDriver implements StepDriver {
 
     zip.writeZip(zipFileName);
 
-    // Validate zip package size against configured limit
-    if (args.maxPackageSizeInBytes !== undefined && args.maxPackageSizeInBytes > 0) {
-      const zipStats = await fs.stat(zipFileName);
-      if (zipStats.size > args.maxPackageSizeInBytes) {
-        return err(new AppPackageSizeExceededError(zipStats.size, args.maxPackageSizeInBytes));
-      }
+    // Validate zip package size against 10 MB hard limit
+    const maxPackageSize = 10 * 1024 * 1024;
+    const zipStats = await fs.stat(zipFileName);
+    if (zipStats.size > maxPackageSize) {
+      return err(new AppPackageSizeExceededError(zipStats.size, maxPackageSize));
     }
 
     await this.writeJsonFile(teamsManifestJsonFileName, JSON.stringify(manifest, null, 4));

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -27,7 +27,7 @@ import { featureFlagManager, FeatureFlags } from "../../../common/featureFlags";
 import { ErrorContextMW } from "../../../common/globalVars";
 import { getLocalizedString } from "../../../common/localizeUtils";
 import { FileNotFoundError, InvalidActionInputError, JSONSyntaxError } from "../../../error/common";
-import { InvalidFileOutsideOfTheDirectotryError } from "../../../error/teamsApp";
+import { InvalidFileOutsideOfTheDirectotryError, AppPackageSizeExceededError } from "../../../error/teamsApp";
 import { getAbsolutePath } from "../../utils/common";
 import { expandVariableWithFunction, ManifestType } from "../../utils/envFunctionUtils";
 import { DriverContext } from "../interface/commonArgs";
@@ -387,6 +387,14 @@ export class CreateAppPackageDriver implements StepDriver {
     }
 
     zip.writeZip(zipFileName);
+
+    // Validate zip package size against configured limit
+    if (args.maxPackageSizeInBytes !== undefined && args.maxPackageSizeInBytes > 0) {
+      const zipStats = await fs.stat(zipFileName);
+      if (zipStats.size > args.maxPackageSizeInBytes) {
+        return err(new AppPackageSizeExceededError(zipStats.size, args.maxPackageSizeInBytes));
+      }
+    }
 
     await this.writeJsonFile(teamsManifestJsonFileName, JSON.stringify(manifest, null, 4));
 

--- a/packages/fx-core/src/component/driver/teamsApp/interfaces/CreateAppPackageArgs.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/interfaces/CreateAppPackageArgs.ts
@@ -21,11 +21,4 @@ export interface CreateAppPackageArgs {
    * Folder path where output files should be put.  This parameter is used when teamspp yaml version > 1.6
    */
   outputFolder?: string;
-
-  /**
-   * Maximum allowed size (in bytes) for the generated zip package.
-   * If set, the action will fail when the zip exceeds this limit.
-   * Useful for enforcing MOS/Titles API upload limits (e.g. 10 MB = 10485760).
-   */
-  maxPackageSizeInBytes?: number;
 }

--- a/packages/fx-core/src/component/driver/teamsApp/interfaces/CreateAppPackageArgs.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/interfaces/CreateAppPackageArgs.ts
@@ -21,4 +21,11 @@ export interface CreateAppPackageArgs {
    * Folder path where output files should be put.  This parameter is used when teamspp yaml version > 1.6
    */
   outputFolder?: string;
+
+  /**
+   * Maximum allowed size (in bytes) for the generated zip package.
+   * If set, the action will fail when the zip exceeds this limit.
+   * Useful for enforcing MOS/Titles API upload limits (e.g. 10 MB = 10485760).
+   */
+  maxPackageSizeInBytes?: number;
 }

--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -40,6 +40,9 @@ import { getResourceServiceEndpoint, ResourceServiceType } from "../../common/co
 const M365ErrorSource = "M365";
 const M365ErrorComponent = "PackageService";
 
+// MOS/Titles API maximum upload size (10 MB)
+const MOS_MAX_PACKAGE_SIZE_BYTES = 10 * 1024 * 1024;
+
 export enum AppScope {
   Personal = "Personal",
   Shared = "Shared",
@@ -126,6 +129,7 @@ export class PackageService {
   @hooks([ErrorContextMW({ source: M365ErrorSource, component: M365ErrorComponent })])
   public async sideLoadXmlManifest(token: string, manifestPath: string): Promise<[string, string]> {
     try {
+      this.validatePackageSize(manifestPath);
       const data = await fs.readFile(manifestPath);
       const content = new FormData();
       content.append("package", data);
@@ -198,6 +202,7 @@ export class PackageService {
     if (!manifest) {
       throw new Error("Invalid app package zip. manifest.json is missing");
     }
+    this.validatePackageSize(packagePath);
     const isDelcarativeAgentApp = IsDeclarativeAgentManifest(manifest);
     if (isDelcarativeAgentApp) {
       const res = await this.sideLoadingV2(token, packagePath, appScope);
@@ -902,6 +907,28 @@ export class PackageService {
     } catch (error: any) {
       this.logger?.debug(`Invalid input zip ${path}. ${error.message as string}`);
       this.logger?.warning(`Please make sure input path is a valid app package zip. ${path}`);
+    }
+  }
+
+  private validatePackageSize(packagePath: string) {
+    const stats = fs.statSync(packagePath);
+    if (stats.size > MOS_MAX_PACKAGE_SIZE_BYTES) {
+      const actualMB = (stats.size / (1024 * 1024)).toFixed(2);
+      const maxMB = (MOS_MAX_PACKAGE_SIZE_BYTES / (1024 * 1024)).toFixed(2);
+      throw new UserError({
+        source: M365ErrorSource,
+        name: "AppPackageSizeExceeded",
+        message: getDefaultString(
+          "error.m365.packageService.packageSizeExceeded",
+          actualMB,
+          maxMB
+        ),
+        displayMessage: getLocalizedString(
+          "error.m365.packageService.packageSizeExceeded",
+          actualMB,
+          maxMB
+        ),
+      });
     }
   }
 

--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -198,11 +198,11 @@ export class PackageService {
     packagePath: string,
     appScope = AppScope.Personal
   ): Promise<[string, string, string]> {
+    this.validatePackageSize(packagePath);
     const manifest = this.getManifestFromZip(packagePath);
     if (!manifest) {
       throw new Error("Invalid app package zip. manifest.json is missing");
     }
-    this.validatePackageSize(packagePath);
     const isDelcarativeAgentApp = IsDeclarativeAgentManifest(manifest);
     if (isDelcarativeAgentApp) {
       const res = await this.sideLoadingV2(token, packagePath, appScope);

--- a/packages/fx-core/src/error/teamsApp.ts
+++ b/packages/fx-core/src/error/teamsApp.ts
@@ -102,6 +102,28 @@ export class InvalidFileOutsideOfTheDirectotryError extends UserError {
   }
 }
 
+export class AppPackageSizeExceededError extends UserError {
+  constructor(actualSizeInBytes: number, maxSizeInBytes: number) {
+    const actualMB = (actualSizeInBytes / (1024 * 1024)).toFixed(2);
+    const maxMB = (maxSizeInBytes / (1024 * 1024)).toFixed(2);
+    const errorOptions: UserErrorOptions = {
+      source: Constants.PLUGIN_NAME,
+      message: getDefaultString(
+        "error.teamsApp.createAppPackage.packageSizeExceeded",
+        actualMB,
+        maxMB
+      ),
+      displayMessage: getLocalizedString(
+        "error.teamsApp.createAppPackage.packageSizeExceeded",
+        actualMB,
+        maxMB
+      ),
+      categories: [ErrorCategory.External],
+    };
+    super(errorOptions);
+  }
+}
+
 export class AppIdNotExist extends UserError {
   constructor(appId: string, source?: string) {
     super({

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -2276,8 +2276,8 @@ describe("teamsApp/createAppPackage", async () => {
     });
   });
 
-  describe("maxPackageSizeInBytes", () => {
-    it("should fail when zip exceeds maxPackageSizeInBytes", async () => {
+  describe("package size limit", () => {
+    it("should fail when zip exceeds 10 MB", async () => {
       const manifest = {
         manifestVersion: "1.16",
         icons: {
@@ -2300,7 +2300,6 @@ describe("teamsApp/createAppPackage", async () => {
         outputZipPath:
           "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
         outputFolder: "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage",
-        maxPackageSizeInBytes: 10 * 1024 * 1024,
       };
 
       const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
@@ -2312,7 +2311,7 @@ describe("teamsApp/createAppPackage", async () => {
       await fs.remove(args.outputZipPath);
     });
 
-    it("should succeed when zip is within maxPackageSizeInBytes", async () => {
+    it("should succeed when zip is within 10 MB", async () => {
       const manifest = {
         manifestVersion: "1.16",
         icons: {
@@ -2328,38 +2327,6 @@ describe("teamsApp/createAppPackage", async () => {
       sinon.stub(fs, "writeFile").callsFake(async () => {});
       // Stub fs.stat to return a small file size
       sinon.stub(fs, "stat").resolves({ size: 1024 * 1024, mode: 0o644 } as any);
-
-      const args: CreateAppPackageArgs = {
-        manifestPath:
-          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
-        outputZipPath:
-          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
-        outputFolder: "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage",
-        maxPackageSizeInBytes: 10 * 1024 * 1024,
-      };
-
-      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
-      if (result.isErr()) {
-        console.log(result.error);
-      }
-      chai.assert.isTrue(result.isOk());
-      await fs.remove(args.outputZipPath);
-    });
-
-    it("should skip size check when maxPackageSizeInBytes is not set", async () => {
-      const manifest = {
-        manifestVersion: "1.16",
-        icons: {
-          color: "resources/color.png",
-          outline: "resources/outline.png",
-        },
-      } as TeamsManifest;
-      sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
-      sinon.stub(fs, "chmod").callsFake(async () => {});
-      sinon.stub(fs, "existsSync").returns(false);
-      sinon.stub(fs, "pathExists").resolves(true);
-      sinon.stub(utils, "updateVersionForTeamsAppYamlFile").resolves();
-      sinon.stub(fs, "writeFile").callsFake(async () => {});
 
       const args: CreateAppPackageArgs = {
         manifestPath:

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -27,7 +27,7 @@ import * as utils from "../../../../src/component/driver/util/utils";
 import * as envFunctionUtils from "../../../../src/component/utils/envFunctionUtils";
 import { ManifestType } from "../../../../src/component/utils/envFunctionUtils";
 import { FileNotFoundError, JSONSyntaxError } from "../../../../src/error/common";
-import { InvalidFileOutsideOfTheDirectotryError } from "../../../../src/error/teamsApp";
+import { InvalidFileOutsideOfTheDirectotryError, AppPackageSizeExceededError } from "../../../../src/error/teamsApp";
 import { MockedM365Provider } from "../../../core/utils";
 import { MockedLogProvider, MockedUserInteraction } from "../../../plugins/solution/util";
 
@@ -2273,6 +2273,108 @@ describe("teamsApp/createAppPackage", async () => {
       if (result.isErr()) {
         chai.assert.isTrue(result.error instanceof FileNotFoundError);
       }
+    });
+  });
+
+  describe("maxPackageSizeInBytes", () => {
+    it("should fail when zip exceeds maxPackageSizeInBytes", async () => {
+      const manifest = {
+        manifestVersion: "1.16",
+        icons: {
+          color: "resources/color.png",
+          outline: "resources/outline.png",
+        },
+      } as TeamsManifest;
+      sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+      sinon.stub(fs, "chmod").callsFake(async () => {});
+      sinon.stub(fs, "existsSync").returns(false);
+      sinon.stub(fs, "pathExists").resolves(true);
+      sinon.stub(utils, "updateVersionForTeamsAppYamlFile").resolves();
+      sinon.stub(fs, "writeFile").callsFake(async () => {});
+      // Stub fs.stat to return a large file size
+      sinon.stub(fs, "stat").resolves({ size: 20 * 1024 * 1024, mode: 0o644 } as any);
+
+      const args: CreateAppPackageArgs = {
+        manifestPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+        outputZipPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+        outputFolder: "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage",
+        maxPackageSizeInBytes: 10 * 1024 * 1024,
+      };
+
+      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert.isTrue(result.error instanceof AppPackageSizeExceededError);
+        chai.assert.include(result.error.message, "exceeds the maximum allowed size");
+      }
+      await fs.remove(args.outputZipPath);
+    });
+
+    it("should succeed when zip is within maxPackageSizeInBytes", async () => {
+      const manifest = {
+        manifestVersion: "1.16",
+        icons: {
+          color: "resources/color.png",
+          outline: "resources/outline.png",
+        },
+      } as TeamsManifest;
+      sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+      sinon.stub(fs, "chmod").callsFake(async () => {});
+      sinon.stub(fs, "existsSync").returns(false);
+      sinon.stub(fs, "pathExists").resolves(true);
+      sinon.stub(utils, "updateVersionForTeamsAppYamlFile").resolves();
+      sinon.stub(fs, "writeFile").callsFake(async () => {});
+      // Stub fs.stat to return a small file size
+      sinon.stub(fs, "stat").resolves({ size: 1024 * 1024, mode: 0o644 } as any);
+
+      const args: CreateAppPackageArgs = {
+        manifestPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+        outputZipPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+        outputFolder: "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage",
+        maxPackageSizeInBytes: 10 * 1024 * 1024,
+      };
+
+      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+      if (result.isErr()) {
+        console.log(result.error);
+      }
+      chai.assert.isTrue(result.isOk());
+      await fs.remove(args.outputZipPath);
+    });
+
+    it("should skip size check when maxPackageSizeInBytes is not set", async () => {
+      const manifest = {
+        manifestVersion: "1.16",
+        icons: {
+          color: "resources/color.png",
+          outline: "resources/outline.png",
+        },
+      } as TeamsManifest;
+      sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+      sinon.stub(fs, "chmod").callsFake(async () => {});
+      sinon.stub(fs, "existsSync").returns(false);
+      sinon.stub(fs, "pathExists").resolves(true);
+      sinon.stub(utils, "updateVersionForTeamsAppYamlFile").resolves();
+      sinon.stub(fs, "writeFile").callsFake(async () => {});
+
+      const args: CreateAppPackageArgs = {
+        manifestPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+        outputZipPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+        outputFolder: "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage",
+      };
+
+      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+      if (result.isErr()) {
+        console.log(result.error);
+      }
+      chai.assert.isTrue(result.isOk());
+      await fs.remove(args.outputZipPath);
     });
   });
 });

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -2087,4 +2087,36 @@ describe("Package Service", () => {
     chai.assert.equal(result, "https://test-url");
     chai.assert.equal(callCount, 2);
   });
+
+  it("sideLoading should throw when package exceeds 10 MB", async () => {
+    sandbox.stub(fs, "statSync").returns({ size: 15 * 1024 * 1024 } as any);
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    let actualError: Error | undefined;
+    try {
+      await packageService.sideLoading("test-token", "test-path");
+    } catch (error: any) {
+      actualError = error;
+    }
+
+    chai.assert.isDefined(actualError);
+    chai.assert.instanceOf(actualError, UserError);
+    chai.assert.equal((actualError as UserError).name, "AppPackageSizeExceeded");
+  });
+
+  it("sideLoadXmlManifest should throw when package exceeds 10 MB", async () => {
+    sandbox.stub(fs, "statSync").returns({ size: 15 * 1024 * 1024 } as any);
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    let actualError: Error | undefined;
+    try {
+      await packageService.sideLoadXmlManifest("test-token", "test-path");
+    } catch (error: any) {
+      actualError = error;
+    }
+
+    chai.assert.isDefined(actualError);
+    chai.assert.instanceOf(actualError, UserError);
+    chai.assert.equal((actualError as UserError).name, "AppPackageSizeExceeded");
+  });
 });

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -80,6 +80,7 @@ describe("Package Service", () => {
     sandbox.stub(fs, "readFile").callsFake((file) => {
       return Promise.resolve(Buffer.from("test"));
     });
+    sandbox.stub(fs, "statSync").returns({ size: 1024 } as any);
     sandbox.stub(axios, "create").returns(testAxiosInstance);
 
     setTools({} as any);
@@ -2089,6 +2090,7 @@ describe("Package Service", () => {
   });
 
   it("sideLoading should throw when package exceeds 10 MB", async () => {
+    (fs.statSync as any).restore();
     sandbox.stub(fs, "statSync").returns({ size: 15 * 1024 * 1024 } as any);
 
     const packageService = new PackageService("https://test-endpoint", logger);
@@ -2105,6 +2107,7 @@ describe("Package Service", () => {
   });
 
   it("sideLoadXmlManifest should throw when package exceeds 10 MB", async () => {
+    (fs.statSync as any).restore();
     sandbox.stub(fs, "statSync").returns({ size: 15 * 1024 * 1024 } as any);
 
     const packageService = new PackageService("https://test-endpoint", logger);


### PR DESCRIPTION
## Summary

Adds a configurable \maxPackageSizeInBytes\ option to the \	eamsApp/zipAppPackage\ action that fails the build when the generated zip exceeds the configured size limit. MOS/Titles APIs enforce a 10 MB max upload — this prevents oversized packages from reaching that limit at build time.

## Changes

- **\CreateAppPackageArgs.maxPackageSizeInBytes\** — optional parameter (bytes). Fails the action when zip exceeds this limit.
- **\AppPackageSizeExceededError\** — new error class with human-readable MB in the message.
- **Localization string** in \package.nls.json\.
- **Unit tests** — exceeds limit, within limit, no limit set.

## Usage

\\\yaml
- uses: teamsApp/zipAppPackage
  with:
    manifestPath: ./appPackage/manifest.json
    outputZipPath: ./build/appPackage.zip
    outputFolder: ./build
    maxPackageSizeInBytes: 10485760  # 10 MB
\\\

Only enforced when explicitly set — no impact on existing projects.