### PR TITLE
fix(fx-core): propagate x-ai-adaptive-card / x-openai-isConsequential through Kiota plugin generation (#15731)

### DIFF
--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -108,7 +108,7 @@
     "@microsoft/dev-tunnels-contracts": "1.1.9",
     "@microsoft/dev-tunnels-management": "1.1.9",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@microsoft/kiota": "1.29.0",
+    "@microsoft/kiota": "1.31.1",
     "@microsoft/m365-spec-parser": "workspace:^",
     "@microsoft/teamsfx-api": "workspace:*",
     "adm-zip": "^0.5.10",

--- a/packages/fx-core/pnpm-lock.yaml
+++ b/packages/fx-core/pnpm-lock.yaml
@@ -45,8 +45,8 @@ dependencies:
     specifier: 1.1.9
     version: 1.1.9
   '@microsoft/kiota':
-    specifier: 1.29.0
-    version: 1.29.0
+    specifier: 1.31.1
+    version: 1.31.1
   '@microsoft/m365-spec-parser':
     specifier: workspace:^
     version: link:../spec-parser
@@ -1545,8 +1545,8 @@ packages:
       - supports-color
     dev: false
 
-  /@microsoft/kiota@1.29.0:
-    resolution: {integrity: sha512-qqIlTz48OJ5ZMRoTA/uQA70B7ltS4lPSs9atG5PUn+dKZcgXny3LzQPe12B1LsKoBJYbwhaU3fD8/C1DsLW6Cw==}
+  /@microsoft/kiota@1.31.1:
+    resolution: {integrity: sha512-YlAI2jC0grK2p2fvxDV9Hin5EtRXL6yOMhLKqtjRVlH8Q0+hI9UWFl7RhLWSZjsbDyl+0LIlI2HjlcbsUhXGsQ==}
     dependencies:
       adm-zip: 0.5.17
       original-fs: 1.2.0

--- a/packages/fx-core/src/common/daSpecParser.ts
+++ b/packages/fx-core/src/common/daSpecParser.ts
@@ -321,8 +321,52 @@ export async function patchOpenApiExtensionsIntoPluginManifest(
   }
 
   const manifest = (await fs.readJSON(pluginManifestPath)) as PluginManifestSchema;
+  const pluginManifestDir = path.dirname(pluginManifestPath);
   const functions = manifest.functions ?? [];
   let modified = false;
+
+  // Try several base directories when resolving an Adaptive Card file
+  // reference. The path in `x-ai-adaptive-card.file` (and the placeholder
+  // emitted by Kiota) is authored relative to the appPackage directory, but
+  // the plugin manifest lives in `appPackage/.generated/` and the spec lives
+  // in `appPackage/.generated/specs/`. Walk a few candidate base dirs so
+  // either layout works.
+  const candidateBaseDirs = [
+    pluginManifestDir,
+    path.dirname(pluginManifestDir),
+    path.dirname(path.dirname(pluginManifestDir)),
+    specDir,
+    path.dirname(specDir),
+  ];
+  const resolveCardJson = async (relOrAbs: string): Promise<any | undefined> => {
+    const candidates = path.isAbsolute(relOrAbs)
+      ? [relOrAbs]
+      : candidateBaseDirs.map((dir) => path.join(dir, relOrAbs));
+    for (const candidate of candidates) {
+      try {
+        if (await fs.pathExists(candidate)) {
+          return await fs.readJSON(candidate);
+        }
+      } catch {
+        // try next candidate
+      }
+    }
+    return undefined;
+  };
+
+  // Detect Kiota's placeholder shape: `static_template: { file: "..." }`.
+  // Real Adaptive Cards always have `type` and `$schema` (or `body`), so a
+  // bare `{ file }` object means Kiota left the card unresolved.
+  const isFilePlaceholder = (template: any): template is { file: string } => {
+    return (
+      template &&
+      typeof template === "object" &&
+      typeof template.file === "string" &&
+      template.type === undefined &&
+      template.$schema === undefined &&
+      template.body === undefined
+    );
+  };
 
   for (const fn of functions as any[]) {
     const ext = opExtensions.get(fn.name);
@@ -330,28 +374,39 @@ export async function patchOpenApiExtensionsIntoPluginManifest(
     fn.capabilities = fn.capabilities || {};
 
     // 1. response_semantics from x-ai-adaptive-card.
-    if (ext.adaptiveCard && !fn.capabilities.response_semantics) {
-      const responseSemantics: any = {};
-      if (ext.adaptiveCard.data_path) {
-        responseSemantics.data_path = ext.adaptiveCard.data_path;
-      }
-      if (ext.adaptiveCard.file) {
-        const cardPath = path.isAbsolute(ext.adaptiveCard.file)
-          ? ext.adaptiveCard.file
-          : path.join(specDir, ext.adaptiveCard.file);
-        try {
-          if (await fs.pathExists(cardPath)) {
-            const cardJson = await fs.readJSON(cardPath);
+    if (ext.adaptiveCard) {
+      if (!fn.capabilities.response_semantics) {
+        const responseSemantics: any = {};
+        if (ext.adaptiveCard.data_path) {
+          responseSemantics.data_path = ext.adaptiveCard.data_path;
+        }
+        if (ext.adaptiveCard.file) {
+          const cardJson = await resolveCardJson(ext.adaptiveCard.file);
+          if (cardJson !== undefined) {
             responseSemantics.static_template = cardJson;
           }
-        } catch {
-          // Ignore card read errors; leave static_template unset rather than
-          // producing an invalid manifest.
         }
-      }
-      if (Object.keys(responseSemantics).length > 0) {
-        fn.capabilities.response_semantics = responseSemantics;
-        modified = true;
+        if (Object.keys(responseSemantics).length > 0) {
+          fn.capabilities.response_semantics = responseSemantics;
+          modified = true;
+        }
+      } else {
+        // Kiota 1.31.1 emits a placeholder
+        // `static_template: { file: "adaptiveCards/<name>.json" }` instead of
+        // inlining the card contents. Replace it with the actual card JSON.
+        const rs = fn.capabilities.response_semantics;
+        if (isFilePlaceholder(rs.static_template)) {
+          const cardJson = await resolveCardJson(rs.static_template.file);
+          if (cardJson !== undefined) {
+            rs.static_template = cardJson;
+            modified = true;
+          }
+        }
+        // Also fill in data_path if Kiota left it empty.
+        if (!rs.data_path && ext.adaptiveCard.data_path) {
+          rs.data_path = ext.adaptiveCard.data_path;
+          modified = true;
+        }
       }
     }
 

--- a/packages/fx-core/src/common/daSpecParser.ts
+++ b/packages/fx-core/src/common/daSpecParser.ts
@@ -39,6 +39,7 @@ import * as fs from "fs-extra";
 import tmp from "tmp";
 import { createHash } from "crypto";
 import path from "path";
+import { parse as parseYaml } from "yaml";
 import { getLocalizedString } from "./localizeUtils";
 
 const daProjectConfig: ParseOptions = {
@@ -234,6 +235,145 @@ export async function generatePlugin(
     adaptiveCardUpdateStrategy
   );
   return result;
+}
+
+// Workaround for https://github.com/OfficeDev/microsoft-365-agents-toolkit/issues/15731.
+// Kiota >= 1.30.0 emits plugin manifest schema v2.4 but does NOT propagate the
+// `x-ai-adaptive-card`, `x-openai-isConsequential` and `x-ai-capabilities`
+// OpenAPI extensions into the generated `*-apiplugin.json` (only the schema
+// version was bumped by microsoft/kiota#7166; the extension propagation
+// promised by issue microsoft/kiota#7165 is not actually implemented as of
+// 1.31.1). This helper reads the source OpenAPI spec, finds those extensions
+// per operation, and patches the corresponding
+// `function.capabilities.{response_semantics,confirmation}` blocks in the
+// generated plugin manifest. Remove this workaround once Kiota propagates
+// these extensions natively.
+//
+// It is a no-op for operations whose extensions are absent or whose
+// capability blocks are already populated by Kiota.
+export async function patchOpenApiExtensionsIntoPluginManifest(
+  specPath: string,
+  pluginManifestPath: string
+): Promise<void> {
+  if (!(await fs.pathExists(specPath)) || !(await fs.pathExists(pluginManifestPath))) {
+    return;
+  }
+
+  const specRaw = await fs.readFile(specPath, "utf8");
+  let spec: any;
+  try {
+    spec = parseYaml(specRaw);
+  } catch {
+    return;
+  }
+  if (!spec || typeof spec !== "object" || !spec.paths) {
+    return;
+  }
+
+  const specDir = path.dirname(specPath);
+  type OpExt = {
+    adaptiveCard?: { data_path?: string; file?: string };
+    isConsequential?: boolean;
+    confirmation?: any;
+  };
+  const opExtensions = new Map<string, OpExt>();
+
+  const httpMethods = [
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "head",
+    "options",
+    "trace",
+    "connect",
+  ];
+  for (const pathKey of Object.keys(spec.paths)) {
+    const pathItem = spec.paths[pathKey];
+    if (!pathItem || typeof pathItem !== "object") continue;
+    for (const method of httpMethods) {
+      const op = pathItem[method];
+      if (!op || typeof op !== "object" || !op.operationId) continue;
+      const adaptiveCard = op["x-ai-adaptive-card"];
+      const isConsequential = op["x-openai-isConsequential"];
+      const aiCapabilities = op["x-ai-capabilities"];
+      if (
+        adaptiveCard === undefined &&
+        isConsequential === undefined &&
+        (!aiCapabilities || aiCapabilities.confirmation === undefined)
+      ) {
+        continue;
+      }
+      opExtensions.set(op.operationId as string, {
+        adaptiveCard: adaptiveCard && typeof adaptiveCard === "object" ? adaptiveCard : undefined,
+        isConsequential: typeof isConsequential === "boolean" ? isConsequential : undefined,
+        confirmation:
+          aiCapabilities && typeof aiCapabilities === "object"
+            ? aiCapabilities.confirmation
+            : undefined,
+      });
+    }
+  }
+
+  if (opExtensions.size === 0) {
+    return;
+  }
+
+  const manifest = (await fs.readJSON(pluginManifestPath)) as PluginManifestSchema;
+  const functions = manifest.functions ?? [];
+  let modified = false;
+
+  for (const fn of functions as any[]) {
+    const ext = opExtensions.get(fn.name);
+    if (!ext) continue;
+    fn.capabilities = fn.capabilities || {};
+
+    // 1. response_semantics from x-ai-adaptive-card.
+    if (ext.adaptiveCard && !fn.capabilities.response_semantics) {
+      const responseSemantics: any = {};
+      if (ext.adaptiveCard.data_path) {
+        responseSemantics.data_path = ext.adaptiveCard.data_path;
+      }
+      if (ext.adaptiveCard.file) {
+        const cardPath = path.isAbsolute(ext.adaptiveCard.file)
+          ? ext.adaptiveCard.file
+          : path.join(specDir, ext.adaptiveCard.file);
+        try {
+          if (await fs.pathExists(cardPath)) {
+            const cardJson = await fs.readJSON(cardPath);
+            responseSemantics.static_template = cardJson;
+          }
+        } catch {
+          // Ignore card read errors; leave static_template unset rather than
+          // producing an invalid manifest.
+        }
+      }
+      if (Object.keys(responseSemantics).length > 0) {
+        fn.capabilities.response_semantics = responseSemantics;
+        modified = true;
+      }
+    }
+
+    // 2. confirmation from x-ai-capabilities.confirmation +
+    //    x-openai-isConsequential.
+    if (ext.confirmation && !fn.capabilities.confirmation) {
+      fn.capabilities.confirmation = { ...ext.confirmation };
+      modified = true;
+    }
+    if (
+      ext.isConsequential !== undefined &&
+      fn.capabilities.confirmation &&
+      fn.capabilities.confirmation.isNonConsequential === undefined
+    ) {
+      fn.capabilities.confirmation.isNonConsequential = !ext.isConsequential;
+      modified = true;
+    }
+  }
+
+  if (modified) {
+    await fs.writeJson(pluginManifestPath, manifest, { spaces: 4 });
+  }
 }
 
 export async function parseAndUpdatePluginManifestForKiota(

--- a/packages/fx-core/src/component/driver/typeSpec/compile.ts
+++ b/packages/fx-core/src/component/driver/typeSpec/compile.ts
@@ -14,7 +14,10 @@ import {
 import fs from "fs-extra";
 import path from "path";
 import { Service } from "typedi";
-import { parseAndUpdatePluginManifestForKiota } from "../../../common/daSpecParser";
+import {
+  parseAndUpdatePluginManifestForKiota,
+  patchOpenApiExtensionsIntoPluginManifest,
+} from "../../../common/daSpecParser";
 import { kiotageneratePlugin } from "../../../common/kiotaClient";
 import { getLocalizedString } from "../../../common/localizeUtils";
 import { MetadataV4 } from "../../../common/versionMetadata";
@@ -111,6 +114,10 @@ export class TypeSpecCompileDriver implements StepDriver {
               undefined,
               true
             );
+            await patchOpenApiExtensionsIntoPluginManifest(
+              `${openApiSpecsFolderPath}/${spec}`,
+              path.join(outputFolderPath, `${pluginManifestName.toLowerCase()}-apiplugin.json`)
+            );
           } else {
             for (const spec of openapiSpecs) {
               const action = actions.find(
@@ -134,6 +141,10 @@ export class TypeSpecCompileDriver implements StepDriver {
                 undefined,
                 undefined,
                 true
+              );
+              await patchOpenApiExtensionsIntoPluginManifest(
+                `${openApiSpecsFolderPath}/${spec}`,
+                path.join(outputFolderPath, `${pluginManifestName.toLowerCase()}-apiplugin.json`)
               );
             }
           }

--- a/packages/fx-core/tests/common/daSpecParser.test.ts
+++ b/packages/fx-core/tests/common/daSpecParser.test.ts
@@ -1748,6 +1748,21 @@ describe("daSpecParser", () => {
       assert.deepEqual(await fs.readJson(manifestPath), before);
     });
 
+    it("returns silently when the parsed spec has no paths object", async () => {
+      // YAML parses to a plain string, which exercises the
+      // `!spec || typeof spec !== "object" || !spec.paths` guard.
+      const specPath = await writeSpec("just-a-string\n");
+      const before = {
+        schema_version: "v2.4",
+        functions: [{ name: "x", description: "" }],
+      };
+      const manifestPath = await writeManifest(before);
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      assert.deepEqual(await fs.readJson(manifestPath), before);
+    });
+
     it("leaves static_template unset when the referenced card file is unreadable", async () => {
       // Create a directory where a card file is expected; readJson will fail.
       const cardsDir = path.join(tmpDir, "adaptiveCards");

--- a/packages/fx-core/tests/common/daSpecParser.test.ts
+++ b/packages/fx-core/tests/common/daSpecParser.test.ts
@@ -1781,5 +1781,162 @@ describe("daSpecParser", () => {
       assert.equal(fn.capabilities.response_semantics.data_path, "$.items[0]");
       assert.notProperty(fn.capabilities.response_semantics, "static_template");
     });
+
+    it("inlines Kiota's `{ file }` placeholder for static_template", async () => {
+      // Kiota 1.31.1 emits `static_template: { file: "adaptiveCards/<name>.json" }`
+      // instead of inlining the card. The patch must replace it with the
+      // actual card JSON.
+      const cardsDir = path.join(tmpDir, "adaptiveCards");
+      await fs.ensureDir(cardsDir);
+      const cardJson = {
+        type: "AdaptiveCard",
+        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+        version: "1.5",
+        body: [{ type: "TextBlock", text: "${title}" }],
+      };
+      await fs.writeJson(path.join(cardsDir, "search.json"), cardJson);
+
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /search:",
+          "    get:",
+          "      operationId: searchIssues",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.items",
+          "        file: adaptiveCards/search.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [
+          {
+            name: "searchIssues",
+            description: "",
+            capabilities: {
+              response_semantics: {
+                data_path: "$.items",
+                static_template: { file: "adaptiveCards/search.json" },
+              },
+            },
+          },
+        ],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.deepEqual(fn.capabilities.response_semantics.static_template, cardJson);
+      assert.equal(fn.capabilities.response_semantics.data_path, "$.items");
+    });
+
+    it("does not replace a real static_template that already has card fields", async () => {
+      // If `static_template` already looks like a real Adaptive Card (has
+      // `type`/`$schema`/`body`), we must leave it alone even if a `file`
+      // property happens to be present.
+      const cardsDir = path.join(tmpDir, "adaptiveCards");
+      await fs.ensureDir(cardsDir);
+      await fs.writeJson(path.join(cardsDir, "search.json"), {
+        type: "AdaptiveCard",
+        body: [{ type: "TextBlock", text: "from disk" }],
+      });
+
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /search:",
+          "    get:",
+          "      operationId: searchIssues",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.items",
+          "        file: adaptiveCards/search.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const realCard = {
+        type: "AdaptiveCard",
+        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+        body: [{ type: "TextBlock", text: "preserved" }],
+      };
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [
+          {
+            name: "searchIssues",
+            description: "",
+            capabilities: {
+              response_semantics: {
+                data_path: "$.items",
+                static_template: realCard,
+              },
+            },
+          },
+        ],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.deepEqual(fn.capabilities.response_semantics.static_template, realCard);
+    });
+
+    it("resolves card files from the parent of the plugin manifest directory", async () => {
+      // Mirrors the real layout: spec lives in `<root>/.generated/specs/`,
+      // plugin manifest lives in `<root>/.generated/`, and the card lives in
+      // `<root>/adaptiveCards/`.
+      const generated = path.join(tmpDir, ".generated");
+      const specsDir = path.join(generated, "specs");
+      await fs.ensureDir(specsDir);
+      await fs.ensureDir(path.join(tmpDir, "adaptiveCards"));
+      const cardJson = { type: "AdaptiveCard", body: [] };
+      await fs.writeJson(path.join(tmpDir, "adaptiveCards", "card.json"), cardJson);
+
+      const specPath = path.join(specsDir, "openapi.yaml");
+      await fs.writeFile(
+        specPath,
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /x:",
+          "    get:",
+          "      operationId: getX",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.items",
+          "        file: adaptiveCards/card.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n"),
+        "utf8"
+      );
+      const manifestPath = path.join(generated, "x-apiplugin.json");
+      await fs.writeJson(manifestPath, {
+        schema_version: "v2.4",
+        functions: [
+          {
+            name: "getX",
+            description: "",
+            capabilities: {
+              response_semantics: {
+                data_path: "$.items",
+                static_template: { file: "adaptiveCards/card.json" },
+              },
+            },
+          },
+        ],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.deepEqual(fn.capabilities.response_semantics.static_template, cardJson);
+    });
   });
 });

--- a/packages/fx-core/tests/common/daSpecParser.test.ts
+++ b/packages/fx-core/tests/common/daSpecParser.test.ts
@@ -1938,5 +1938,146 @@ describe("daSpecParser", () => {
       const fn = (await fs.readJson(manifestPath)).functions[0];
       assert.deepEqual(fn.capabilities.response_semantics.static_template, cardJson);
     });
+
+    it("swallows readJSON errors when the card file exists but is invalid JSON", async () => {
+      // Exercises the `catch` branch inside resolveCardJson: pathExists
+      // succeeds but readJSON throws on a corrupt file.
+      const cardsDir = path.join(tmpDir, "adaptiveCards");
+      await fs.ensureDir(cardsDir);
+      await fs.writeFile(path.join(cardsDir, "broken.json"), "{ not valid json", "utf8");
+
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    get:",
+          "      operationId: getItems",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.items",
+          "        file: adaptiveCards/broken.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [
+          {
+            name: "getItems",
+            description: "",
+            capabilities: {
+              response_semantics: {
+                static_template: { file: "adaptiveCards/broken.json" },
+              },
+            },
+          },
+        ],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      // The placeholder should be left intact since the card could not be
+      // read; data_path should still get filled from the spec.
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.deepEqual(fn.capabilities.response_semantics.static_template, {
+        file: "adaptiveCards/broken.json",
+      });
+      assert.equal(fn.capabilities.response_semantics.data_path, "$.items");
+    });
+
+    it("fills missing data_path on an existing response_semantics with a placeholder", async () => {
+      // response_semantics exists with the Kiota `{ file }` placeholder but
+      // without a data_path; the patcher should backfill data_path from the
+      // spec while also inlining the card.
+      const cardsDir = path.join(tmpDir, "adaptiveCards");
+      await fs.ensureDir(cardsDir);
+      const card = { type: "AdaptiveCard", version: "1.5", body: [] };
+      await fs.writeJson(path.join(cardsDir, "get.json"), card);
+
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    get:",
+          "      operationId: getItems",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.value",
+          "        file: adaptiveCards/get.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [
+          {
+            name: "getItems",
+            description: "",
+            capabilities: {
+              response_semantics: {
+                // No data_path; placeholder static_template.
+                static_template: { file: "adaptiveCards/get.json" },
+              },
+            },
+          },
+        ],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.equal(fn.capabilities.response_semantics.data_path, "$.value");
+      assert.deepEqual(fn.capabilities.response_semantics.static_template, card);
+    });
+
+    it("fills missing data_path on an existing response_semantics with a real card", async () => {
+      // response_semantics exists with a real (non-placeholder) static_template
+      // but no data_path. The patcher should leave the card alone and only
+      // backfill data_path.
+      const realCard = {
+        type: "AdaptiveCard",
+        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+        body: [{ type: "TextBlock", text: "real" }],
+      };
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    get:",
+          "      operationId: getItems",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.value",
+          "        file: adaptiveCards/get.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [
+          {
+            name: "getItems",
+            description: "",
+            capabilities: {
+              response_semantics: {
+                static_template: realCard,
+              },
+            },
+          },
+        ],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.equal(fn.capabilities.response_semantics.data_path, "$.value");
+      assert.deepEqual(fn.capabilities.response_semantics.static_template, realCard);
+    });
   });
 });

--- a/packages/fx-core/tests/common/daSpecParser.test.ts
+++ b/packages/fx-core/tests/common/daSpecParser.test.ts
@@ -4,6 +4,9 @@
 import { assert } from "chai";
 import "mocha";
 import sinon from "sinon";
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
 import * as kiotaClient from "../../src/common/kiotaClient";
 import * as daSpecParser from "../../src/common/daSpecParser";
 import * as utils from "../../src/common/utils";
@@ -1532,6 +1535,251 @@ describe("daSpecParser", () => {
           sinon.match.any
         )
       );
+    });
+  });
+
+  describe("patchOpenApiExtensionsIntoPluginManifest (issue #15731)", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      // The outer describe sets up sinon stubs we don't need here; restore so
+      // real fs / yaml are exercised.
+      sinon.restore();
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kiota-15731-test-"));
+    });
+
+    afterEach(async () => {
+      try {
+        await fs.remove(tmpDir);
+      } catch {
+        // Ignore cleanup errors on Windows when files are still locked.
+      }
+    });
+
+    async function writeSpec(yaml: string): Promise<string> {
+      const specPath = path.join(tmpDir, "openapi.yaml");
+      await fs.writeFile(specPath, yaml, "utf8");
+      return specPath;
+    }
+
+    async function writeManifest(manifest: any): Promise<string> {
+      const p = path.join(tmpDir, "test-apiplugin.json");
+      await fs.writeJson(p, manifest, { spaces: 2 });
+      return p;
+    }
+
+    it("propagates x-ai-adaptive-card and inlines the static_template", async () => {
+      const cardsDir = path.join(tmpDir, "adaptiveCards");
+      await fs.ensureDir(cardsDir);
+      const card = { type: "AdaptiveCard", version: "1.5", body: [] };
+      await fs.writeJson(path.join(cardsDir, "get.json"), card);
+
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    get:",
+          "      operationId: getItems",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.value[0]",
+          "        file: adaptiveCards/get.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [{ name: "getItems", description: "" }],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const result = await fs.readJson(manifestPath);
+      const fn = result.functions[0];
+      assert.deepEqual(fn.capabilities.response_semantics.data_path, "$.value[0]");
+      assert.deepEqual(fn.capabilities.response_semantics.static_template, card);
+    });
+
+    it("propagates x-openai-isConsequential into confirmation.isNonConsequential", async () => {
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    patch:",
+          "      operationId: updateItems",
+          "      x-openai-isConsequential: true",
+          "      x-ai-capabilities:",
+          "        confirmation:",
+          "          type: AdaptiveCard",
+          "          title: Update?",
+          "          body: Confirm.",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [{ name: "updateItems", description: "" }],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.equal(fn.capabilities.confirmation.type, "AdaptiveCard");
+      assert.equal(fn.capabilities.confirmation.title, "Update?");
+      // x-openai-isConsequential: true => isNonConsequential: false
+      assert.strictEqual(fn.capabilities.confirmation.isNonConsequential, false);
+    });
+
+    it("maps x-openai-isConsequential: false to isNonConsequential: true", async () => {
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    post:",
+          "      operationId: readItems",
+          "      x-openai-isConsequential: false",
+          "      x-ai-capabilities:",
+          "        confirmation:",
+          "          type: AdaptiveCard",
+          "          title: Read",
+          "          body: ok",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [{ name: "readItems", description: "" }],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.strictEqual(fn.capabilities.confirmation.isNonConsequential, true);
+    });
+
+    it("does not overwrite capabilities Kiota already populated", async () => {
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    get:",
+          "      operationId: getItems",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.value[0]",
+          "        file: adaptiveCards/get.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const existing = {
+        schema_version: "v2.4",
+        functions: [
+          {
+            name: "getItems",
+            description: "",
+            capabilities: {
+              response_semantics: { data_path: "$.preserved" },
+            },
+          },
+        ],
+      };
+      const manifestPath = await writeManifest(existing);
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      assert.equal(fn.capabilities.response_semantics.data_path, "$.preserved");
+    });
+
+    it("is a no-op when the spec has no relevant extensions", async () => {
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    get:",
+          "      operationId: getItems",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const before = {
+        schema_version: "v2.4",
+        functions: [{ name: "getItems", description: "" }],
+      };
+      const manifestPath = await writeManifest(before);
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      assert.deepEqual(await fs.readJson(manifestPath), before);
+    });
+
+    it("returns silently when spec or manifest path does not exist", async () => {
+      // Should not throw.
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(
+        path.join(tmpDir, "missing.yaml"),
+        path.join(tmpDir, "missing.json")
+      );
+    });
+
+    it("returns silently when the spec is not valid YAML", async () => {
+      const specPath = path.join(tmpDir, "openapi.yaml");
+      // `: : :` is a YAML parse error.
+      await fs.writeFile(specPath, ":\n: :\n  : :", "utf8");
+      const before = {
+        schema_version: "v2.4",
+        functions: [{ name: "x", description: "" }],
+      };
+      const manifestPath = await writeManifest(before);
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      assert.deepEqual(await fs.readJson(manifestPath), before);
+    });
+
+    it("leaves static_template unset when the referenced card file is unreadable", async () => {
+      // Create a directory where a card file is expected; readJson will fail.
+      const cardsDir = path.join(tmpDir, "adaptiveCards");
+      await fs.ensureDir(cardsDir);
+      await fs.ensureDir(path.join(cardsDir, "broken.json"));
+
+      const specPath = await writeSpec(
+        [
+          "openapi: 3.0.0",
+          "info: { title: t, version: '1' }",
+          "paths:",
+          "  /items:",
+          "    get:",
+          "      operationId: getItems",
+          "      x-ai-adaptive-card:",
+          "        data_path: $.items[0]",
+          "        file: adaptiveCards/broken.json",
+          "      responses: { '200': { description: ok } }",
+          "",
+        ].join("\n")
+      );
+      const manifestPath = await writeManifest({
+        schema_version: "v2.4",
+        functions: [{ name: "getItems", description: "" }],
+      });
+
+      await daSpecParser.patchOpenApiExtensionsIntoPluginManifest(specPath, manifestPath);
+
+      const fn = (await fs.readJson(manifestPath)).functions[0];
+      // data_path is still propagated; static_template silently omitted.
+      assert.equal(fn.capabilities.response_semantics.data_path, "$.items[0]");
+      assert.notProperty(fn.capabilities.response_semantics, "static_template");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #15731.

When a TypeSpec project (`@microsoft/typespec-m365-copilot` emitter) compiles to OpenAPI and Kiota then generates the Copilot plugin manifest, two pieces of information were lost:

1. `x-ai-adaptive-card` (emitted from the TSP `@card` decorator) — Kiota either dropped it entirely (1.29.x, schema v2.3) or, after upgrading to 1.31.x (schema v2.4), wrote a placeholder `static_template: { "file": "adaptiveCards/X.json" }` instead of inlining the card.
2. `x-openai-isConsequential` — never propagated to `confirmation.isNonConsequential`.

The result: declarative agents built from TSP couldn't render Adaptive Cards in Microsoft 365 Copilot, and consequential‑action confirmation was unreliable.

## Changes

### `packages/fx-core/package.json`
- Bumped `@microsoft/kiota` from `1.29.0` → `1.31.1` so the generated plugin manifest uses schema **v2.4** ([microsoft/kiota#7166](https://github.com/microsoft/kiota/pull/7166)).

### `packages/fx-core/src/common/daSpecParser.ts`
- New exported async function `patchOpenApiExtensionsIntoPluginManifest(specPath, pluginManifestPath)` that runs **after** `kiotageneratePlugin` and post-processes the plugin manifest to backfill anything Kiota dropped or stubbed:
  - For each operation, looks up `x-ai-adaptive-card`, `x-ai-capabilities.confirmation`, and `x-openai-isConsequential` on the OpenAPI spec.
  - Builds `capabilities.response_semantics` if missing.
  - Detects Kiota's `static_template: { file }` placeholder (via `isFilePlaceholder`) and inlines the actual Adaptive Card JSON.
  - Resolves card paths against multiple candidate base directories (plugin manifest dir, parents, spec dir, spec parent) so it works for both flat and `appPackage/.generated/` layouts.
  - Maps `x-openai-isConsequential: false` → `confirmation.isNonConsequential: true` (and vice versa).
  - Defensive: silent no-op on missing files / unreadable cards / invalid YAML; never overwrites already-populated values.

### `packages/fx-core/src/component/driver/typeSpec/compile.ts`
- Calls `patchOpenApiExtensionsIntoPluginManifest(specPath, <name>-apiplugin.json)` after every `kiotageneratePlugin(...)` invocation (both single-spec and multi-spec branches).

### `packages/fx-core/tests/common/daSpecParser.test.ts`
- 11 new unit tests covering: extension propagation, JSONPath `data_path` preservation, `isConsequential` → `isNonConsequential` mapping (both polarities), Kiota `{ file }` placeholder inlining, real `static_template` not being overwritten, multi-base-dir card resolution, and graceful handling of missing/invalid inputs.

## Verification

End-to-end against a real TSP project (`tps0422`, GitHub API + `@card` decorator on `searchIssues`):

**Before:** plugin manifest was schema `v2.3`, `static_template` was missing or set to `{ "file": "adaptiveCards/searchIssues.json" }`.

**After (commit `f4f3ef8e`):**
- `$schema` → `https://developer.microsoft.com/json-schemas/copilot/plugin/v2.4/schema.json`
- `schema_version` → `v2.4`
- `functions[0].capabilities.response_semantics.data_path` → `$.items`
- `functions[0].capabilities.response_semantics.static_template` → fully inlined `AdaptiveCard` (type/$schema/version/body/actions all present)

Unit tests: **11 passing** (`npx mocha --require ts-node/register tests/common/daSpecParser.test.ts`). Full fx-core suite still passes coverage gate.

## Out of scope / Known limitation

`x-openai-isConsequential` propagation is implemented and unit-tested, but cannot be exercised end-to-end yet because `@microsoft/typespec-m365-copilot`'s `Confirmation` model does not expose an `isNonConsequential` field today (verified against [the official decorator reference](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/typespec-decorators) — only `body`, `title`, `type` are documented). Once that upstream library adds the field and emits the extension, no further change is needed here — the patcher will pick it up automatically. Tracking-only; orthogonal to this PR.

## Risk

- The patcher runs only when `kiotageneratePlugin` succeeds and reads the on-disk manifest; it is a pure fill-in pass and never replaces values that are already populated correctly.
- Kiota bump from `1.29.0` → `1.31.1` is required to obtain schema `v2.4`.
