### PR TITLE
fix: wrap cmd in subshell to fix ::set-teamsfx-env on Linux with semicolons (#15818)

### DIFF
--- a/packages/vscode-ui/src/ui.ts
+++ b/packages/vscode-ui/src/ui.ts
@@ -1147,7 +1147,7 @@ export class VSCodeUI implements UserInteraction {
       // Bash script for Unix-like systems
       // Use tee inside the script to display output in the terminal while capturing to file,
       // then exit with the command's actual exit code via PIPESTATUS.
-      scriptContent = `#!/bin/bash\nset +e\n${cmd} 2>&1 | tee "${tempFile}"\nexit \${PIPESTATUS[0]}\n`;
+      scriptContent = `#!/bin/bash\nset +e\n( ${cmd} ) 2>&1 | tee "${tempFile}"\nexit \${PIPESTATUS[0]}\n`;
       wrappedCmd = `bash "${scriptFile}"`;
     }
 


### PR DESCRIPTION
Cherry-pick of commit 5b7baaea54bfa302c61be6660dc1e8964099be9e to release/6.9 branch. Original PR: https://github.com/OfficeDev/microsoft-365-agents-toolkit/pull/15818