### PR TITLE
cherry-pick: update Azure Functions template to Node.js 22 (#15796)

### DIFF
--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/README.md
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/README.md
@@ -13,7 +13,7 @@ You can extend declarative agents using plugins to retrieve data and execute tas
 >
 > To run this app template in your local dev machine, you will need:
 >
-> - [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+> - [Node.js](https://nodejs.org/), supported versions: 22
 > - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
 > - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 > - [Microsoft 365 Copilot license](https://learn.microsoft.com/microsoft-365-copilot/extensibility/prerequisites#prerequisites)

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -43,7 +43,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~22' // Set NodeJS version to 22.x
         }
         {
           name: 'API_KEY'

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/README.md.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/README.md.tpl
@@ -13,7 +13,7 @@ You can extend declarative agents using plugins to retrieve data and execute tas
 >
 > To run this app template in your local dev machine, you will need:
 >
-> - [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+> - [Node.js](https://nodejs.org/), supported versions: 22
 > - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
 > - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 > - [Microsoft 365 Copilot license](https://learn.microsoft.com/microsoft-365-copilot/extensibility/prerequisites#prerequisites)

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -43,7 +43,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~22' // Set NodeJS version to 22.x
         }
         {
           name: 'aadAppClientId'

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/README.md
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/README.md
@@ -14,7 +14,7 @@ You can extend declarative agents using plugins to retrieve data and execute tas
 >
 > To run this app template in your local dev machine, you will need:
 >
-> - [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+> - [Node.js](https://nodejs.org/), supported versions: 22
 > - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
 > - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 > - [Microsoft 365 Copilot license](https://learn.microsoft.com/microsoft-365-copilot/extensibility/prerequisites#prerequisites)

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -42,7 +42,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~22' // Set NodeJS version to 22.x
         }
       ]
       ftpsState: 'FtpsOnly'

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/README.md
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/README.md
@@ -13,7 +13,7 @@ You can extend declarative agents using plugins to retrieve data and execute tas
 >
 > To run this app template in your local dev machine, you will need:
 >
-> - [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+> - [Node.js](https://nodejs.org/), supported versions: 22
 > - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
 > - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 > - [Microsoft 365 Copilot license](https://learn.microsoft.com/microsoft-365-copilot/extensibility/prerequisites#prerequisites)

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -42,7 +42,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~22' // Set NodeJS version to 22.x
         }
         {
           name: 'API_KEY'

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/README.md.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/README.md.tpl
@@ -13,7 +13,7 @@ You can extend declarative agents using plugins to retrieve data and execute tas
 >
 > To run this app template in your local dev machine, you will need:
 >
-> - [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+> - [Node.js](https://nodejs.org/), supported versions: 22
 > - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
 > - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 > - [Microsoft 365 Copilot license](https://learn.microsoft.com/microsoft-365-copilot/extensibility/prerequisites#prerequisites)

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -43,7 +43,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~22' // Set NodeJS version to 22.x
         }
         {
           name: 'aadAppClientId'

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/README.md
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/README.md
@@ -13,7 +13,7 @@ You can extend declarative agents using plugins to retrieve data and execute tas
 >
 > To run this app template in your local dev machine, you will need:
 >
-> - [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+> - [Node.js](https://nodejs.org/), supported versions: 22
 > - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
 > - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 > - [Microsoft 365 Copilot license](https://learn.microsoft.com/microsoft-365-copilot/extensibility/prerequisites#prerequisites)

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -41,7 +41,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~22' // Set NodeJS version to 22.x
         }
       ]
       ftpsState: 'FtpsOnly'

--- a/templates/vsc/ts/graph-connector/README.md
+++ b/templates/vsc/ts/graph-connector/README.md
@@ -40,7 +40,7 @@ Version|Date|Comments
 - [Microsoft 365 Agents Toolkit for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
 - [Azure Functions Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)
 - [Microsoft 365 Developer tenant](https://developer.microsoft.com/microsoft-365/dev-program) with [uploading custom apps enabled](https://learn.microsoft.com/microsoftteams/platform/m365-apps/prerequisites#prepare-a-developer-tenant-for-testing)
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 22
 - Have the ability to admin consent in Entra Admin Center. See [Grant tenant-wide admin consent to an application](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent?pivots=portal#prerequisites) for the required roles
 
 ## Minimal path to awesome - Debug against a real Microsoft 365 tenant

--- a/templates/vsc/ts/graph-connector/infra/azure.bicep
+++ b/templates/vsc/ts/graph-connector/infra/azure.bicep
@@ -92,7 +92,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~20' // Set NodeJS version to 20.x
+          value: '~22' // Set NodeJS version to 22.x
         }
         {
           name: 'APPINSIGHTS_INSTRUMENTATIONKEY'


### PR DESCRIPTION
## Cherry-pick PR

Cherry-picks commit ce80998bb1140ed05eef1853c606d9c96be31f62 (#15796) onto release/6.9.

## Original PR
#15796 - chore: update Azure Functions template to Node.js 22

Updates graph-connector and declarative-agent-with-action-from-scratch Azure Functions templates to Node.js 22.