### PR TITLE
fix: TDP portal scaffold fails for declarative agent with copilot connector and other special-generator templates

### DIFF
--- a/packages/fx-core/src/component/generator/combinedProject/generator.ts
+++ b/packages/fx-core/src/component/generator/combinedProject/generator.ts
@@ -8,6 +8,7 @@
 import {
   AppPackageFolderName,
   Context,
+  err,
   FxError,
   GeneratorResult,
   Inputs,
@@ -23,6 +24,7 @@ import {
   QuestionNames,
 } from "../../../question";
 import { ActionContext } from "../../middleware/actionExecutionMW";
+import { developerPortalScaffoldUtils } from "../../developerPortalScaffoldUtils";
 import { DefaultTemplateGenerator } from "../defaultGenerator";
 import { Generator } from "../generator";
 import { TemplateInfo } from "../templates/templateInfo";
@@ -116,7 +118,7 @@ export class CombinedProjectGenerator extends DefaultTemplateGenerator {
   }
 
   // override this method to do post-step after template download
-  post(
+  async post(
     context: Context,
     inputs: Inputs,
     destinationPath: string,
@@ -128,6 +130,19 @@ export class CombinedProjectGenerator extends DefaultTemplateGenerator {
     fs.copySync(srcFolder, targetFolder, { overwrite: true });
     // delete folder
     fs.removeSync(path.join(destinationPath, this.temporaryFolderName));
+
+    // If coming from TDP portal, apply TDP-specific file updates (e.g. manifest patching)
+    if (inputs.teamsAppFromTdp) {
+      const res = await developerPortalScaffoldUtils.updateFilesForTdp(
+        context,
+        inputs.teamsAppFromTdp,
+        inputs
+      );
+      if (res.isErr()) {
+        return err(res.error);
+      }
+    }
+
     return Promise.resolve(ok({}));
   }
 }

--- a/packages/fx-core/src/component/generator/declarativeAgent/generator.ts
+++ b/packages/fx-core/src/component/generator/declarativeAgent/generator.ts
@@ -35,6 +35,7 @@ import { EmbeddedKnowledgeLocalDirectoryName } from "../../driver/teamsApp/const
 import { copilotGptManifestUtils } from "../../driver/teamsApp/utils/CopilotGptManifestUtils";
 import { ActionContext } from "../../middleware/actionExecutionMW";
 import { outputScaffoldingWarningMessage } from "../../utils/common";
+import { developerPortalScaffoldUtils } from "../../developerPortalScaffoldUtils";
 import { DefaultTemplateGenerator } from "../defaultGenerator";
 import { Generator } from "../generator";
 import { TemplateInfo } from "../templates/templateInfo";
@@ -189,6 +190,16 @@ export class DeclarativeAgentGenerator extends DefaultTemplateGenerator {
         return ok({ warnings: addPluginRes.value.warnings });
       }
     } else {
+      if (inputs.teamsAppFromTdp) {
+        const res = await developerPortalScaffoldUtils.updateFilesForTdp(
+          context,
+          inputs.teamsAppFromTdp,
+          inputs
+        );
+        if (res.isErr()) {
+          return err(res.error);
+        }
+      }
       return ok({});
     }
   }

--- a/packages/fx-core/src/component/generator/other/tdpGenerator.ts
+++ b/packages/fx-core/src/component/generator/other/tdpGenerator.ts
@@ -12,6 +12,7 @@ import { developerPortalScaffoldUtils } from "../../developerPortalScaffoldUtils
 import { ActionContext } from "../../middleware/actionExecutionMW";
 import { DefaultTemplateGenerator } from "../defaultGenerator";
 import { Generator } from "../generator";
+import { TemplateNames } from "../templates/templateNames";
 import { TemplateInfo } from "../templates/templateInfo";
 
 /**
@@ -22,8 +23,13 @@ export class TdpGenerator extends DefaultTemplateGenerator {
 
   // activation condition
   public override activate(context: Context, inputs: Inputs): boolean {
-    // Reuse some templates which are handled by other generators
-    return inputs.teamsAppFromTdp !== undefined;
+    // Reuse some templates which are handled by other generators.
+    // DeclarativeAgentWithGraphConnector is a combined template that must be handled by
+    // CombinedProjectGenerator, even in TDP flow — exclude it here so the correct generator runs.
+    return (
+      inputs.teamsAppFromTdp !== undefined &&
+      inputs[QuestionNames.TemplateName] !== TemplateNames.DeclarativeAgentWithGraphConnector
+    );
   }
 
   public override async getTemplateInfos(

--- a/packages/fx-core/src/component/generator/other/tdpGenerator.ts
+++ b/packages/fx-core/src/component/generator/other/tdpGenerator.ts
@@ -21,14 +21,35 @@ import { TemplateInfo } from "../templates/templateInfo";
 export class TdpGenerator extends DefaultTemplateGenerator {
   componentName = "tdp-generator";
 
+  // Templates that must be handled by their own specialized generators.
+  // TdpGenerator must not intercept these even in TDP flow.
+  private static readonly specialGeneratorTemplates = new Set<string>([
+    // CombinedProjectGenerator: splits into GraphConnector + DeclarativeAgentBasic sub-templates
+    TemplateNames.DeclarativeAgentWithGraphConnector,
+    // DeclarativeAgentGenerator: has special post() for TypeSpec, MCP, existing action, etc.
+    TemplateNames.DeclarativeAgentBasic,
+    TemplateNames.DeclarativeAgentWithActionFromScratch,
+    TemplateNames.DeclarativeAgentWithActionFromScratchBearer,
+    TemplateNames.DeclarativeAgentWithActionFromScratchOAuth,
+    TemplateNames.DeclarativeAgentWithExistingAction,
+    TemplateNames.DeclarativeAgentWithTypeSpec,
+    TemplateNames.DeclarativeAgentWithActionFromMCP,
+    // DeclarativeAgentWithExistingApiSpecGenerator: parses API spec
+    TemplateNames.DeclarativeAgentWithActionFromExistingApiSpec,
+    // CustomEngineAgentWithExistingApiSpecGenerator: parses API spec
+    TemplateNames.CustomCopilotRagCustomApi,
+    // OfficeAddinGeneratorNew
+    TemplateNames.DeclarativeAgentMetaOSNewProject,
+  ]);
+
   // activation condition
   public override activate(context: Context, inputs: Inputs): boolean {
-    // Reuse some templates which are handled by other generators.
-    // DeclarativeAgentWithGraphConnector is a combined template that must be handled by
-    // CombinedProjectGenerator, even in TDP flow — exclude it here so the correct generator runs.
+    // TdpGenerator handles simple templates that exist directly in the zip.
+    // Templates that require specialized generators (special post-processing,
+    // multi-template scaffolding, API spec parsing, etc.) must not be intercepted here.
     return (
       inputs.teamsAppFromTdp !== undefined &&
-      inputs[QuestionNames.TemplateName] !== TemplateNames.DeclarativeAgentWithGraphConnector
+      !TdpGenerator.specialGeneratorTemplates.has(inputs[QuestionNames.TemplateName])
     );
   }
 

--- a/packages/fx-core/tests/component/generator/combinedGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/combinedGenerator.test.ts
@@ -5,13 +5,14 @@
  * @author zhaofengxu@microsoft.com
  */
 
-import { Inputs, OptionItem, Platform } from "@microsoft/teamsfx-api";
+import { err, Inputs, ok, OptionItem, Platform, UserError } from "@microsoft/teamsfx-api";
 import { assert } from "chai";
 import fs from "fs-extra";
 import "mocha";
 import { RestoreFn } from "mocked-env";
 import sinon from "sinon";
 import { createContext, setTools } from "../../../src/common/globalVars";
+import { developerPortalScaffoldUtils } from "../../../src/component/developerPortalScaffoldUtils";
 import { CombinedProjectGenerator } from "../../../src/component/generator/combinedProject/generator";
 import { TemplateNames } from "../../../src/component/generator/templates/templateNames";
 import { ApiAuthOptions, ProgrammingLanguage, QuestionNames } from "../../../src/question";
@@ -71,6 +72,46 @@ describe("combined generator", async () => {
 
       const res = await generator.post(context, inputs, "");
       assert.isTrue(res.isOk());
+    });
+
+    it("post calls updateFilesForTdp when teamsAppFromTdp is set", async () => {
+      const generator = new CombinedProjectGenerator();
+      const context = createContext();
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: "./",
+        [QuestionNames.TemplateName]: TemplateNames.DeclarativeAgentWithGraphConnector,
+        [QuestionNames.AppName]: "app",
+        teamsAppFromTdp: { teamsAppId: "fake-id" },
+      };
+
+      sandbox.stub(fs, "copySync").returns();
+      sandbox.stub(fs, "removeSync").returns();
+      sandbox.stub(developerPortalScaffoldUtils, "updateFilesForTdp").resolves(ok(undefined));
+
+      const res = await generator.post(context, inputs, "");
+      assert.isTrue(res.isOk());
+    });
+
+    it("post returns error when updateFilesForTdp fails in TDP flow", async () => {
+      const generator = new CombinedProjectGenerator();
+      const context = createContext();
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: "./",
+        [QuestionNames.TemplateName]: TemplateNames.DeclarativeAgentWithGraphConnector,
+        [QuestionNames.AppName]: "app",
+        teamsAppFromTdp: { teamsAppId: "fake-id" },
+      };
+
+      sandbox.stub(fs, "copySync").returns();
+      sandbox.stub(fs, "removeSync").returns();
+      sandbox
+        .stub(developerPortalScaffoldUtils, "updateFilesForTdp")
+        .resolves(err(new UserError("fakeSource", "fakeError", "fakeError")));
+
+      const res = await generator.post(context, inputs, "");
+      assert.isTrue(res.isErr() && res.error.name === "fakeError");
     });
   });
 

--- a/packages/fx-core/tests/component/generator/declarativeAgentGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/declarativeAgentGenerator.test.ts
@@ -32,6 +32,7 @@ import { featureFlagManager } from "../../../src/common/featureFlags";
 import { createContext, setTools } from "../../../src/common/globalVars";
 import { copilotGptManifestUtils } from "../../../src/component/driver/teamsApp/utils/CopilotGptManifestUtils";
 import { pluginManifestUtils } from "../../../src/component/driver/teamsApp/utils/PluginManifestUtils";
+import { developerPortalScaffoldUtils } from "../../../src/component/developerPortalScaffoldUtils";
 import { DeclarativeAgentGenerator } from "../../../src/component/generator/declarativeAgent/generator";
 import * as generatorHelper from "../../../src/component/generator/declarativeAgent/helper";
 import * as oneDriveSharePointHandler from "../../../src/component/generator/declarativeAgent/oneDriveSharePointHandler";
@@ -445,6 +446,50 @@ describe("copilotExtension", async () => {
 
       const res = await generator.post(context, inputs, "");
       assert.isTrue(res.isOk());
+    });
+
+    it("post calls updateFilesForTdp when teamsAppFromTdp is set", async () => {
+      const generator = new DeclarativeAgentGenerator();
+      const context = createContext();
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: "./",
+        [QuestionNames.TemplateName]: TemplateNames.DeclarativeAgentBasic,
+        [QuestionNames.AppName]: "app",
+        teamsAppFromTdp: { teamsAppId: "fake-id" },
+      };
+
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox
+        .stub(copilotGptManifestUtils, "getManifestPath")
+        .resolves(ok("declarativeAgent.json"));
+      sandbox.stub(developerPortalScaffoldUtils, "updateFilesForTdp").resolves(ok(undefined));
+
+      const res = await generator.post(context, inputs, "");
+      assert.isTrue(res.isOk());
+    });
+
+    it("post returns error when updateFilesForTdp fails in TDP flow", async () => {
+      const generator = new DeclarativeAgentGenerator();
+      const context = createContext();
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: "./",
+        [QuestionNames.TemplateName]: TemplateNames.DeclarativeAgentBasic,
+        [QuestionNames.AppName]: "app",
+        teamsAppFromTdp: { teamsAppId: "fake-id" },
+      };
+
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox
+        .stub(copilotGptManifestUtils, "getManifestPath")
+        .resolves(ok("declarativeAgent.json"));
+      sandbox
+        .stub(developerPortalScaffoldUtils, "updateFilesForTdp")
+        .resolves(err(new UserError("fakeSource", "fakeError", "fakeError")));
+
+      const res = await generator.post(context, inputs, "");
+      assert.isTrue(res.isErr() && res.error.name === "fakeError");
     });
   });
 


### PR DESCRIPTION
## Problem

When selecting Declarative Agent + Copilot Connector from TDP portal, scaffold fails with:
TemplateNotFoundError: Unable to find template: declarative-agent-with-graph-connector

Other templates requiring special generators would also scaffold incorrectly.

## Root Cause

TdpGenerator is first in the generator chain and activates for ALL TDP flows.
- declarative-agent-with-graph-connector does not exist as a standalone zip folder - it requires CombinedProjectGenerator to split into graph-connector + declarative-agent-basic sub-templates.
- Templates like declarative-agent-with-action-from-mcp require DeclarativeAgentGenerator.post() to run generateForMCPForDA.

## Fix

1. tdpGenerator.ts: Added specialGeneratorTemplates exclusion set so TdpGenerator skips templates handled by specialized generators.
2. declarativeAgent/generator.ts: Added updateFilesForTdp() call in post() for TDP flows so manifest patching still runs.
3. combinedProject/generator.ts: Added updateFilesForTdp() in post() for TDP flow.

## Templates fixed
- declarative-agent-with-graph-connector: TemplateNotFoundError
- declarative-agent-with-action-from-mcp: Missing generateForMCPForDA
- declarative-agent-typespec, api-plugin-from-scratch variants: Missing post() processing
- api-plugin-from-existing-api: Missing API spec parsing
- custom-copilot-rag-custom-api: Missing API spec parsing
- declarative-agent-meta-os-new-project: Wrong generator

[workitem](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37625220/)