### PR TITLE
fix: surface descriptive error when declarativeAgent.json has invalid array shape (#15837)

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -316,7 +316,7 @@ export class CreateAppPackageDriver implements StepDriver {
       );
       if (getCopilotGptRes.isOk()) {
         // Add action files
-        if (getCopilotGptRes.value.actions) {
+        if (Array.isArray(getCopilotGptRes.value.actions)) {
           const pluginFiles = getCopilotGptRes.value.actions.map((action) => action.file);
 
           for (const pluginFile of pluginFiles) {
@@ -346,7 +346,7 @@ export class CreateAppPackageDriver implements StepDriver {
           }
         }
         // Add embedded knowledge files
-        if (getCopilotGptRes.value.capabilities) {
+        if (Array.isArray(getCopilotGptRes.value.capabilities)) {
           const embeddedKnowledgeCapabilities = getCopilotGptRes.value.capabilities.filter(
             (capability) => capability.name === DeclarativeCopilotCapabilityName.EmbeddedKnowledge
           );

--- a/packages/fx-core/src/component/driver/teamsApp/utils/CopilotGptManifestUtils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/CopilotGptManifestUtils.ts
@@ -57,7 +57,12 @@ export class CopilotGptManifestUtils {
     content = stripBom(content);
 
     try {
-      const manifest = JSON.parse(content) as DeclarativeCopilotManifestSchema;
+      // Route through the typed converter so structural mismatches (e.g. an object
+      // where an array is required) throw a descriptive error here rather than later
+      // at consumer call sites such as `capabilities.filter(...)`.
+      const manifest = DeclarativeAgentManifestConverter.jsonToManifest(
+        content
+      ) as unknown as DeclarativeCopilotManifestSchema;
       return ok(manifest);
     } catch (e) {
       return err(new JSONSyntaxError(path, e, "CopilotGptManifestUtils"));
@@ -94,10 +99,12 @@ export class CopilotGptManifestUtils {
     let content = fs.readFileSync(path, { encoding: "utf-8" });
     content = stripBom(content);
     try {
-      const manifest = JSON.parse(content) as DeclarativeCopilotManifestSchema;
+      const manifest = DeclarativeAgentManifestConverter.jsonToManifest(
+        content
+      ) as unknown as DeclarativeCopilotManifestSchema;
       return ok(manifest);
     } catch (e) {
-      return err(new FileNotFoundError("CopilotGptManifestUtils", path));
+      return err(new JSONSyntaxError(path, e, "CopilotGptManifestUtils"));
     }
   }
 

--- a/packages/fx-core/tests/component/driver/teamsApp/copilotGptManifest.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/copilotGptManifest.test.ts
@@ -37,6 +37,7 @@ import { pluginManifestUtils } from "../../../../src/component/driver/teamsApp/u
 import { WrapDriverContext } from "../../../../src/component/driver/util/wrapUtil";
 import {
   FileNotFoundError,
+  JSONSyntaxError,
   MissingEnvironmentVariablesError,
   WriteFileError,
 } from "../../../../src/error";
@@ -1357,7 +1358,7 @@ describe("copilotGptManifestUtils", () => {
       }
     });
 
-    it("should return FileNotFoundError if JSON parse fails", () => {
+    it("should return JSONSyntaxError if JSON parse fails", () => {
       sandbox.stub(fs, "pathExistsSync").returns(true);
       sandbox.stub(fs, "readFileSync").returns("invalid json");
 
@@ -1365,7 +1366,28 @@ describe("copilotGptManifestUtils", () => {
 
       chai.assert.isTrue(res.isErr());
       if (res.isErr()) {
-        chai.assert.isTrue(res.error instanceof FileNotFoundError);
+        chai.assert.isTrue(res.error instanceof JSONSyntaxError);
+      }
+    });
+
+    it("should return JSONSyntaxError if manifest has invalid shape (#15837)", () => {
+      // Reproduces issue #15837: capabilities provided as object instead of array.
+      // The typed converter throws a descriptive error instead of letting the bad value
+      // propagate to a downstream `.filter is not a function` TypeError.
+      const badManifest = {
+        version: "v1.6",
+        name: "test",
+        description: "test",
+        capabilities: { name: "CodeInterpreter" },
+      };
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(badManifest));
+
+      const res = copilotGptManifestUtils.readCopilotGptManifestFileSync("testPath");
+
+      chai.assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        chai.assert.isTrue(res.error instanceof JSONSyntaxError);
       }
     });
   });

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -2274,5 +2274,114 @@ describe("teamsApp/createAppPackage", async () => {
         chai.assert.isTrue(result.error instanceof FileNotFoundError);
       }
     });
+
+    // Regression test for issue #15837. The original failure mode was a TypeError
+    // ("ce.value.capabilities.filter is not a function") thrown deep inside the build
+    // because a malformed declarativeAgent.json produced an untyped object where an
+    // array was expected. With Phase 1 (typed reader) the read step rejects the
+    // manifest with a descriptive JSONSyntaxError, and Phase 3 (Array.isArray guards)
+    // prevents the crash class even if a future code path bypasses the typed reader.
+    it("propagates JSONSyntaxError when declarativeAgent.json has invalid shape (#15837)", async () => {
+      const args: CreateAppPackageArgs = {
+        manifestPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+        outputZipPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.bad-shape.zip",
+        outputJsonPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.bad-shape.json",
+      };
+
+      const manifest = {
+        manifestVersion: "1.19",
+      } as TeamsManifestV1D19.TeamsManifestV1D19;
+      manifest.copilotAgents = {
+        declarativeAgents: [{ file: "resources/declarativeAgent.json", id: "1" }],
+      };
+      manifest.icons = {
+        color: "resources/color.png",
+        outline: "resources/outline.png",
+      };
+
+      sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+      sinon.stub(fs, "chmod").callsFake(async () => {});
+      sinon.stub(fs, "writeFile").callsFake(async () => {});
+      sinon.stub(fs, "pathExists").resolves(true);
+      // Simulate the typed converter rejecting a non-array `capabilities` field —
+      // this is exactly what `readCopilotGptManifestFile` now produces for the
+      // user's manifest in #15837.
+      sinon
+        .stub(copilotGptManifestUtils, "getManifest")
+        .resolves(
+          err(
+            new JSONSyntaxError(
+              "declarativeAgent.json",
+              new Error(
+                'Invalid value for key "capabilities". Expected array but got {"name":"CodeInterpreter"}'
+              ),
+              "CopilotGptManifestUtils"
+            )
+          )
+        );
+
+      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+
+      chai.assert.isTrue(result.isErr(), "createAppPackage should return err, not throw");
+      if (result.isErr()) {
+        chai.assert.isTrue(
+          result.error instanceof JSONSyntaxError,
+          `expected JSONSyntaxError, got ${result.error.constructor.name}`
+        );
+        chai.assert.include(result.error.message, "capabilities");
+      }
+    });
+
+    // Defense-in-depth: even if `getManifest` returns a manifest with a non-array
+    // `capabilities` (e.g. a future code path that bypasses the typed reader),
+    // createAppPackage must not crash with `TypeError: capabilities.filter is not a function`.
+    it("does not crash when capabilities is not an array (defensive guard)", async () => {
+      const args: CreateAppPackageArgs = {
+        manifestPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+        outputZipPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.guard.zip",
+        outputJsonPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.guard.json",
+      };
+
+      const manifest = {
+        manifestVersion: "1.19",
+      } as TeamsManifestV1D19.TeamsManifestV1D19;
+      manifest.copilotAgents = {
+        declarativeAgents: [{ file: "resources/declarativeAgent.json", id: "1" }],
+      };
+      manifest.icons = {
+        color: "resources/color.png",
+        outline: "resources/outline.png",
+      };
+
+      // Bypass the typed reader by stubbing getManifest to return a manifest where
+      // `capabilities` is an object instead of an array.
+      const malformedManifest = {
+        name: "TestDeclarativeCopilot",
+        description: "shape-bypass test",
+        actions: [],
+        capabilities: { name: "CodeInterpreter" } as any,
+      } as DeclarativeCopilotManifestSchema;
+
+      sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+      sinon.stub(fs, "chmod").callsFake(async () => {});
+      sinon.stub(fs, "writeFile").callsFake(async () => {});
+      sinon.stub(fs, "pathExists").resolves(true);
+      sinon.stub(copilotGptManifestUtils, "getManifest").resolves(ok(malformedManifest));
+
+      // Must not throw a TypeError. The guard treats non-array as "no embedded
+      // knowledge capabilities" and the build proceeds normally.
+      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+      chai.assert.isTrue(result.isOk(), "build should not crash on non-array capabilities");
+
+      if (await fs.pathExists(args.outputZipPath)) {
+        await fs.remove(args.outputZipPath);
+      }
+    });
   });
 });

--- a/packages/manifest/src/generated-types/index.ts
+++ b/packages/manifest/src/generated-types/index.ts
@@ -265,6 +265,14 @@ const daConverterMap: Converters = {
     DeclarativeAgentManifestV1D4.Convert.toDeclarativeAgentManifestV1D4,
     DeclarativeAgentManifestV1D4.Convert.declarativeAgentManifestV1D4ToJson,
   ],
+  "v1.5": [
+    DeclarativeAgentManifestV1D5.Convert.toDeclarativeAgentManifestV1D5,
+    DeclarativeAgentManifestV1D5.Convert.declarativeAgentManifestV1D5ToJson,
+  ],
+  "v1.6": [
+    DeclarativeAgentManifestV1D6.Convert.toDeclarativeAgentManifestV1D6,
+    DeclarativeAgentManifestV1D6.Convert.declarativeAgentManifestV1D6ToJson,
+  ],
 };
 const ApiPluginConverterMap: Converters = {
   "v2.1": [

--- a/packages/manifest/test/converterMapParity.test.ts
+++ b/packages/manifest/test/converterMapParity.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+import fs from "fs-extra";
+import "mocha";
+import * as path from "path";
+import {
+  ApiPluginManifestConverter,
+  DeclarativeAgentManifestConverter,
+  TeamsManifestConverter,
+} from "../src";
+
+// These tests guard against drift between the JSON schema folders under
+// src/json-schemas and the converter dispatch maps in src/generated-types/index.ts.
+// When a new schema version is added (and `npm run convert` regenerates the per-version
+// type files), the corresponding entry in the converter map must also be added.
+// Without these tests, a missing map entry silently degrades `jsonToManifest` to an
+// unchecked cast (the source of issue #15837 for declarative-agent v1.5/v1.6).
+
+const schemasRoot = path.join(__dirname, "..", "src", "json-schemas");
+
+function listVersions(folder: string): string[] {
+  if (!fs.existsSync(folder)) return [];
+  return fs
+    .readdirSync(folder, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+}
+
+function probeConverter(
+  converter: { jsonToManifest(json: string): unknown },
+  versionField: string,
+  versionValue: string
+): boolean {
+  // A registered version throws on invalid shape (quicktype `cast()`).
+  // An unregistered version returns the unchecked cast without throwing.
+  const badJson = JSON.stringify({ [versionField]: versionValue });
+  try {
+    converter.jsonToManifest(badJson);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe("Converter map parity with json-schemas folders", () => {
+  it("declarative-agent: every schema folder has a registered converter", () => {
+    const folder = path.join(schemasRoot, "copilot", "declarative-agent");
+    const versions = listVersions(folder);
+    chai.expect(versions.length, "no declarative-agent schemas found").to.be.greaterThan(0);
+
+    const missing = versions.filter(
+      (v) => !probeConverter(DeclarativeAgentManifestConverter, "version", v)
+    );
+    chai
+      .expect(missing, `daConverterMap missing entries for: ${missing.join(", ")}`)
+      .to.deep.equal([]);
+  });
+
+  it("api-plugin: every schema folder has a registered converter", () => {
+    const folder = path.join(schemasRoot, "copilot", "plugin");
+    const versions = listVersions(folder);
+    chai.expect(versions.length, "no plugin schemas found").to.be.greaterThan(0);
+
+    const missing = versions.filter(
+      (v) => !probeConverter(ApiPluginManifestConverter, "schema_version", v)
+    );
+    chai
+      .expect(missing, `ApiPluginConverterMap missing entries for: ${missing.join(", ")}`)
+      .to.deep.equal([]);
+  });
+
+  it("teams: every schema folder has a registered converter (with documented exemptions)", () => {
+    const folder = path.join(schemasRoot, "teams");
+    const versions = listVersions(folder);
+    chai.expect(versions.length, "no teams schemas found").to.be.greaterThan(0);
+
+    // Folder names use "v1.5"; map keys use "1.5". devPreview maps as-is.
+    const toMapKey = (folderName: string) =>
+      folderName === "vDevPreview" ? "devPreview" : folderName.replace(/^v/, "");
+
+    // v1.0 has historically been intentionally absent from TeamsManifestConverterMap.
+    // Add to this list if a future version is deliberately skipped, with a short reason.
+    const knownExemptions = new Set<string>(["1.0"]);
+
+    const missing = versions
+      .map(toMapKey)
+      .filter(
+        (v) =>
+          !knownExemptions.has(v) && !probeConverter(TeamsManifestConverter, "manifestVersion", v)
+      );
+    chai
+      .expect(missing, `TeamsManifestConverterMap missing entries for: ${missing.join(", ")}`)
+      .to.deep.equal([]);
+  });
+});

--- a/packages/tests/src/e2e/declarativeAgent/DeclarativeAgentInvalidManifestShape.tests.ts
+++ b/packages/tests/src/e2e/declarativeAgent/DeclarativeAgentInvalidManifestShape.tests.ts
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @author Zhiyu You <zhiyou@microsoft.com>
+ *
+ * Regression tests for issue #15837 (https://github.com/OfficeDev/microsoft-365-agents-toolkit/issues/15837).
+ *
+ * Original failure: a `declarativeAgent.json` with `capabilities` (or `actions`)
+ * provided as an object instead of an array crashed the build with a raw
+ * `TypeError: ...filter is not a function`, surfaced as opaque "unknown.wYe".
+ *
+ * The fix routes manifest reads through the typed converter
+ * (`DeclarativeAgentManifestConverter.jsonToManifest`) and adds defensive
+ * `Array.isArray` guards in `createAppPackage`. These tests assert the user-
+ * visible behavior: a descriptive `UserError` (not a `TypeError`) that names
+ * the offending field and the file.
+ *
+ * Implementation note: each test exercises `teamsapp package`, which invokes
+ * the same `teamsApp/zipAppPackage` driver that runs during `teamsapp provision`
+ * — i.e. the exact crash site the bug fix targets. Using `package` rather than
+ * `provision` keeps the test fast and Azure-credential-free while covering the
+ * identical code path.
+ *
+ * Linked manual test cases (Microsoft Teams Extensibility ADO project,
+ * plan #24569079, suite #27971458 "Project - Declarative Agent"):
+ *   - 37862958: [VSC][CLI] Provision fails gracefully ... invalid capabilities shape (#15837)
+ *   - 37862961: [VSC][CLI] Provision fails gracefully ... invalid actions shape
+ *   - 37862962: [VSC][CLI] Zip Teams App Package surfaces schema errors from sub-manifests
+ */
+
+import { ProgrammingLanguage } from "@microsoft/teamsfx-core";
+import { it } from "@microsoft/extra-shot-mocha";
+import { expect } from "chai";
+import * as fs from "fs-extra";
+import { describe } from "mocha";
+import * as path from "path";
+
+import {
+  cleanUpLocalProject,
+  getTestFolder,
+  getUniqueAppName,
+} from "../commonUtils";
+import { Executor } from "../../utils/executor";
+import { Capability } from "../../utils/constants";
+
+const AUTHOR = "zhiyou@microsoft.com";
+
+interface InvalidShapeAssertionOptions {
+  // Substring that MUST appear in the error output (typically the field name).
+  mustInclude: string[];
+  // Substrings that MUST NOT appear (the regression markers).
+  mustNotInclude?: string[];
+}
+
+const DEFAULT_FORBIDDEN = ["TypeError", "is not a function", "unknown.wYe"];
+
+function assertInvalidShapeError(
+  result: { success: boolean; stdout: string; stderr: string },
+  opts: InvalidShapeAssertionOptions,
+): void {
+  expect(
+    result.success,
+    `command unexpectedly succeeded. stdout=${result.stdout}`,
+  ).to.be.false;
+
+  const combined = `${result.stdout}\n${result.stderr}`;
+  for (const needle of opts.mustInclude) {
+    expect(combined.toLowerCase()).to.include(
+      needle.toLowerCase(),
+      `expected error output to mention "${needle}"`,
+    );
+  }
+  for (const needle of opts.mustNotInclude ?? DEFAULT_FORBIDDEN) {
+    expect(combined).to.not.include(
+      needle,
+      `error output should not contain regression marker "${needle}"`,
+    );
+  }
+}
+
+async function createBasicDeclarativeAgentProject(
+  appName: string,
+  testFolder: string,
+): Promise<string> {
+  const customized: Record<string, string> = { "with-plugin": "no" };
+  const { success } = await Executor.createProject(
+    testFolder,
+    appName,
+    Capability.DeclarativeAgent,
+    ProgrammingLanguage.None,
+    customized,
+  );
+  expect(success, "scaffold should succeed").to.be.true;
+  return path.resolve(testFolder, appName);
+}
+
+async function mutateDeclarativeAgent(
+  projectPath: string,
+  mutator: (json: Record<string, unknown>) => void,
+): Promise<void> {
+  const manifestPath = path.join(
+    projectPath,
+    "appPackage",
+    "declarativeAgent.json",
+  );
+  const json = (await fs.readJSON(manifestPath)) as Record<string, unknown>;
+  mutator(json);
+  await fs.writeJSON(manifestPath, json, { spaces: 2 });
+}
+
+describe("Declarative agent - invalid manifest shape (#15837 regression)", function () {
+  this.timeout(5 * 60 * 1000);
+
+  it(
+    "package fails with descriptive error when capabilities is not an array (#15837)",
+    { testPlanCaseId: 37862958, author: AUTHOR },
+    async function () {
+      const testFolder = getTestFolder();
+      const appName = getUniqueAppName();
+      const projectPath = await createBasicDeclarativeAgentProject(
+        appName,
+        testFolder,
+      );
+
+      try {
+        // Repro #15837: capabilities supplied as an object rather than an array.
+        await mutateDeclarativeAgent(projectPath, (json) => {
+          json.capabilities = { name: "CodeInterpreter" };
+        });
+
+        const failed = await Executor.package(projectPath);
+        assertInvalidShapeError(failed, { mustInclude: ["capabilities"] });
+
+        // Recovery: restoring a valid array shape lets the same command succeed.
+        await mutateDeclarativeAgent(projectPath, (json) => {
+          json.capabilities = [{ name: "CodeInterpreter" }];
+        });
+        const recovered = await Executor.package(projectPath);
+        expect(
+          recovered.success,
+          `package should succeed after restoring valid capabilities. stderr=${recovered.stderr}`,
+        ).to.be.true;
+      } finally {
+        await cleanUpLocalProject(projectPath);
+      }
+    },
+  );
+
+  it(
+    "package fails with descriptive error when actions is not an array",
+    { testPlanCaseId: 37862961, author: AUTHOR },
+    async function () {
+      const testFolder = getTestFolder();
+      const appName = getUniqueAppName();
+      const projectPath = await createBasicDeclarativeAgentProject(
+        appName,
+        testFolder,
+      );
+
+      try {
+        // Even on a no-plugin template, an `actions` field of the wrong shape
+        // must be rejected before the build attempts `actions.map(...)`.
+        await mutateDeclarativeAgent(projectPath, (json) => {
+          json.actions = { id: "fake-action", file: "ai-plugin.json" };
+        });
+
+        const failed = await Executor.package(projectPath);
+        assertInvalidShapeError(failed, { mustInclude: ["actions"] });
+
+        // Recovery: removing the invalid field lets the same command succeed.
+        await mutateDeclarativeAgent(projectPath, (json) => {
+          delete json.actions;
+        });
+        const recovered = await Executor.package(projectPath);
+        expect(
+          recovered.success,
+          `package should succeed after removing invalid actions. stderr=${recovered.stderr}`,
+        ).to.be.true;
+      } finally {
+        await cleanUpLocalProject(projectPath);
+      }
+    },
+  );
+
+  it(
+    "package surfaces sub-manifest schema errors instead of crashing",
+    { testPlanCaseId: 37862962, author: AUTHOR },
+    async function () {
+      const testFolder = getTestFolder();
+      const appName = getUniqueAppName();
+      const projectPath = await createBasicDeclarativeAgentProject(
+        appName,
+        testFolder,
+      );
+
+      try {
+        // A different shape error (string instead of array) must be reported
+        // via the same UserError path, not a raw TypeError.
+        await mutateDeclarativeAgent(projectPath, (json) => {
+          json.capabilities = "CodeInterpreter";
+        });
+
+        const failed = await Executor.package(projectPath);
+        assertInvalidShapeError(failed, {
+          mustInclude: ["capabilities", "declarativeAgent.json"],
+        });
+      } finally {
+        await cleanUpLocalProject(projectPath);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #15837.

A `declarativeAgent.json` whose `capabilities` (or `actions`) field is an object instead of an array crashed Provision/Build with `TypeError: ...filter is not a function`, surfaced to users as the opaque `unknown.wYe` telemetry name.

**Root cause:** the manifest was read via raw `JSON.parse(...) as T` cast and consumed via `.filter(...)` / `.map(...)` without any shape validation. The typed converter that *would* have caught this was silently disabled for the v1.5/v1.6 schema versions used by all current templates.

## What changed

### `packages/manifest`
- Register **v1.5** and **v1.6** in `daConverterMap` (`generated-types/index.ts`). The converter dispatch now actually type-checks current templates instead of falling through to an unchecked cast.
- Add **`converterMapParity.test.ts`** so any future schema folder added under `src/json-schemas/...` without a matching map entry fails CI. Documents the v1.0 Teams exemption explicitly.

### `packages/fx-core`
- Route `CopilotGptManifestUtils.readCopilotGptManifestFile{,Sync}` through `DeclarativeAgentManifestConverter.jsonToManifest`. Invalid shapes now throw a descriptive error wrapped in `JSONSyntaxError` naming the offending field and file. Also fixes a pre-existing bug where the sync method returned `FileNotFoundError` for parse failures.
- Replace `if (x)` with `Array.isArray(x)` guards in `createAppPackage.execute` (defense in depth: future code paths that bypass the typed reader still cannot crash with `TypeError`).
- Added unit tests in `copilotGptManifest.test.ts` and `createAppPackage.test.ts` covering the #15837 repro plus the defensive guard.

### `packages/tests`
- New e2e `DeclarativeAgentInvalidManifestShape.tests.ts` linked to ADO test cases **37862958 / 37862961 / 37862962**. Each exercises `teamsapp package` (same driver as Provision) and asserts the failure is a `UserError` naming the offending field, not a raw `TypeError` or `unknown.wYe`.

## Behaviour change

| Before | After |
|---|---|
| `TypeError: ce.value.capabilities.filter is not a function` … `unknown.wYe` | `JSONSyntaxError: Failed to parse declarativeAgent.json: Invalid value for key "capabilities". Expected array but got {...}` |

Valid manifests (every template ships a valid one) take the same code path as before — no functional change for the happy path.

## Test results

| Suite | Tests | Result |
|---|---|---|
| `packages/manifest` (full) | 140 | ✅ all pass (incl. 3 new parity tests) |
| `packages/fx-core` `teamsApp` driver suite | 347 | ✅ all pass (incl. 4 new tests) |
| TypeScript | — | clean (`tsc --noEmit`) |
| ESLint | — | 0 errors across all changed files |

### Coverage on changed lines
| File | Coverage on changed lines |
|---|---|
| `packages/manifest/.../generated-types/index.ts` (new map entries) | 100% |
| `packages/fx-core/.../createAppPackage.ts` (Array.isArray guards) | 100% (file overall: 98.25%) |
| `packages/fx-core/.../CopilotGptManifestUtils.ts` (typed reader swap) | 100% on changed lines |

## Risk

Low. The user-visible behavior change only triggers when a manifest is structurally invalid. A pre-existing bug in `readCopilotGptManifestFileSync` (returning `FileNotFoundError` for parse failures) is incidentally corrected; one existing test was updated to reflect the corrected error type.

## Manual test mapping

| ADO Test Case | Description |
|---|---|
| [37862958](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37862958) | [VSC][CLI] Provision fails gracefully when `declarativeAgent.json` has invalid `capabilities` shape (#15837) |
| [37862961](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37862961) | [VSC][CLI] Provision fails gracefully when `declarativeAgent.json` has invalid `actions` shape |
| [37862962](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37862962) | [VSC][CLI] Zip Teams App Package surfaces schema errors from sub-manifests |

(Suite #27971458 — Project - Declarative Agent, in plan #24569079 TeamsFx Test Plan TTK&CLI)
