### PR TITLE
fix: update hovering message for the copliot access

### DIFF
--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -7,7 +7,7 @@
   "teamstoolkit.accountTree.copilotStatusUnknown": "Copilot Access Check Failed",
   "teamstoolkit.accountTree.copilotStatusUnknownTooltip": "We're unable to confirm copilot access status. Please try again after some time.",
   "teamstoolkit.accountTree.copilotWarning": "Copilot Access Disabled",
-  "teamstoolkit.accountTree.copilotWarningTooltip": "Microsoft 365 account administrator hasn't enabled Copilot access for this account. Contact your Teams administrator to resolve this issue by enrolling in Microsoft 365 Copilot Early Access program. Visit: https://aka.ms/PluginsEarlyAccess",
+  "teamstoolkit.accountTree.copilotWarningTooltip": "Your Microsoft 365 account doesn't have Copilot developer access, to set up development environment to extend Copilot, visit [Set up development environment to extend Copilot](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/prerequisites)",
   "teamstoolkit.accountTree.m365AccountTooltip": "Microsoft 365 ACCOUNT  \nThe Microsoft 365 Agents Toolkit requires a Microsoft 365 organizational account with Teams running and registered.",
   "teamstoolkit.accountTree.sideloadingEnable": "Enable Custom App Upload",
   "teamstoolkit.accountTree.sideloadingUseTestTenant": "Use Test Tenant",

--- a/packages/vscode-extension/src/treeview/account/copilotNode.ts
+++ b/packages/vscode-extension/src/treeview/account/copilotNode.ts
@@ -70,7 +70,9 @@ export class CopilotNode extends DynamicNode {
     } else {
       this.label = localize("teamstoolkit.accountTree.copilotWarning");
       this.iconPath = warningIcon;
-      this.tooltip = localize("teamstoolkit.accountTree.copilotWarningTooltip");
+      this.tooltip = new vscode.MarkdownString(
+        localize("teamstoolkit.accountTree.copilotWarningTooltip")
+      );
       this.contextValue = ContextValues.ShowInfo;
       this.command = {
         title: this.label,


### PR DESCRIPTION
This PR is to replace old link https://aka.ms/PluginsEarlyAccess with https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/prerequisites in the hovering message for the copilot access. And the hover messages is updated as well.

The related ADO bug is https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35799759