### PR TITLE
fix: update hover message for playground env

### DIFF
--- a/packages/vscode-extension/src/hoverProvider.ts
+++ b/packages/vscode-extension/src/hoverProvider.ts
@@ -69,7 +69,9 @@ export class ManifestTemplateHoverProvider implements vscode.HoverProvider {
       }
       args = [{ type: "env", env: envName }];
     } else {
-      for (const envName of envNames) {
+      for (const envName of envNames.filter(
+        (name) => name !== environmentNameManager.getPlaygroundEnvName()
+      )) {
         const envInfo = envInfos[envName];
         const value = envInfo[key];
         if (value) {
@@ -77,9 +79,6 @@ export class ManifestTemplateHoverProvider implements vscode.HoverProvider {
         } else {
           if (envName === environmentNameManager.getLocalEnvName()) {
             message += `**${envName}** Trigger debug to see placeholder value \n\n`;
-          } else if (envName === environmentNameManager.getPlaygroundEnvName()) {
-            const commandUri = vscode.Uri.parse("command:fx-extension.localdebug");
-            message += `**${envName}**: [Trigger Debug in Microsoft 365 Agents Playground to see placeholder value](${commandUri.toString()}) \n\n`;
           } else {
             const commandUri = vscode.Uri.parse("command:fx-extension.provision");
             message += `**${envName}**: [Trigger Teams: Provision in the cloud command to see placeholder value](${commandUri.toString()}) \n\n`;

--- a/packages/vscode-extension/src/hoverProvider.ts
+++ b/packages/vscode-extension/src/hoverProvider.ts
@@ -77,6 +77,9 @@ export class ManifestTemplateHoverProvider implements vscode.HoverProvider {
         } else {
           if (envName === environmentNameManager.getLocalEnvName()) {
             message += `**${envName}** Trigger debug to see placeholder value \n\n`;
+          } else if (envName === environmentNameManager.getPlaygroundEnvName()) {
+            const commandUri = vscode.Uri.parse("command:fx-extension.localdebug");
+            message += `**${envName}**: [Trigger Debug in Microsoft 365 Agents Playground to see placeholder value](${commandUri.toString()}) \n\n`;
           } else {
             const commandUri = vscode.Uri.parse("command:fx-extension.provision");
             message += `**${envName}**: [Trigger Teams: Provision in the cloud command to see placeholder value](${commandUri.toString()}) \n\n`;

--- a/packages/vscode-extension/src/hoverProvider.ts
+++ b/packages/vscode-extension/src/hoverProvider.ts
@@ -81,7 +81,7 @@ export class ManifestTemplateHoverProvider implements vscode.HoverProvider {
             message += `**${envName}** Trigger debug to see placeholder value \n\n`;
           } else {
             const commandUri = vscode.Uri.parse("command:fx-extension.provision");
-            message += `**${envName}**: [Trigger Teams: Provision in the cloud command to see placeholder value](${commandUri.toString()}) \n\n`;
+            message += `**${envName}**: [Trigger Microsoft 365 Agents: Provision in the cloud command to see placeholder value](${commandUri.toString()}) \n\n`;
           }
         }
       }

--- a/packages/vscode-extension/test/extension/hoverProvider.test.ts
+++ b/packages/vscode-extension/test/extension/hoverProvider.test.ts
@@ -128,4 +128,27 @@ describe("Manifest template hover - V3", async () => {
       chai.assert.isTrue(hover.contents.length > 0);
     }
   });
+
+  it("hover - playground env no value", async () => {
+    (envUtil.listEnv as sinon.SinonStub).restore();
+    sandbox.stub(envUtil, "listEnv").resolves(ok(["local", "playground"]));
+    sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+
+    const hoverProvider = new ManifestTemplateHoverProvider();
+    const position = new vscode.Position(5, 15);
+    const cts = new vscode.CancellationTokenSource();
+    const hover = await hoverProvider.provideHover(document, position, cts.token);
+
+    chai.assert.isTrue(hover !== undefined);
+    if (hover !== undefined) {
+      chai.assert.isTrue(hover.contents.length > 0);
+      const content = (hover.contents[0] as vscode.MarkdownString).value;
+      chai.assert.include(content, "playground");
+      chai.assert.include(content, "command:fx-extension.localdebug");
+      chai.assert.include(
+        content,
+        "Trigger Debug in Microsoft 365 Agents Playground to see placeholder value"
+      );
+    }
+  });
 });

--- a/packages/vscode-extension/test/extension/hoverProvider.test.ts
+++ b/packages/vscode-extension/test/extension/hoverProvider.test.ts
@@ -143,12 +143,9 @@ describe("Manifest template hover - V3", async () => {
     if (hover !== undefined) {
       chai.assert.isTrue(hover.contents.length > 0);
       const content = (hover.contents[0] as vscode.MarkdownString).value;
-      chai.assert.include(content, "playground");
-      chai.assert.include(content, "command:fx-extension.localdebug");
-      chai.assert.include(
-        content,
-        "Trigger Debug in Microsoft 365 Agents Playground to see placeholder value"
-      );
+      chai.assert.notInclude(content, "playground");
+      chai.assert.notInclude(content, "command:fx-extension.localdebug");
+      chai.assert.include(content, "local");
     }
   });
 });


### PR DESCRIPTION
For playground env, now it indicates to execute provision to see the placeholder which doesn't make sense since playground doesn't need provision. So I updated hover message in this PR.

The related ADO bug is https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33482927/?view=edit