### PR TITLE
fix(vscode): "Build a Declarative Agent" walkthrough opens default Welcome page

### DIFF
--- a/packages/vscode-extension/src/handlers/walkthrough.ts
+++ b/packages/vscode-extension/src/handlers/walkthrough.ts
@@ -8,7 +8,6 @@ import { TelemetryEvent } from "../telemetry/extTelemetryEvents";
 import { CreateProjectResult, FxError, Result, Stage, ok } from "@microsoft/teamsfx-api";
 import { getSystemInputs } from "../utils/systemEnvUtils";
 import { getTriggerFromProperty } from "../utils/telemetryUtils";
-import { featureFlagManager, FeatureFlags } from "@microsoft/teamsfx-core";
 
 export async function createProjectFromWalkthroughHandler(
   args?: any[]
@@ -28,9 +27,7 @@ export async function createProjectFromWalkthroughHandler(
 }
 
 export function getBuildIntelligentAppsWalkthroughID() {
-  return featureFlagManager.getBooleanValue(FeatureFlags.ChatParticipantUIEntries)
-    ? "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentAppsWithChat"
-    : "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps";
+  return "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps";
 }
 
 export async function openBuildIntelligentAppsWalkthroughHandler(

--- a/packages/vscode-extension/test/handlers/controlHandlers.test.ts
+++ b/packages/vscode-extension/test/handlers/controlHandlers.test.ts
@@ -64,7 +64,7 @@ describe("Control Handlers", () => {
       sandbox.assert.calledOnceWithExactly(
         executeCommands,
         "workbench.action.openWalkthrough",
-        "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentAppsWithChat"
+        "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps"
       );
     });
 


### PR DESCRIPTION
## Summary

Fixes the regression tracked in [ADO #37894976](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37894976): in a fresh VS Code environment, clicking **Build a Declarative Agent** in the welcome view (or running the matching command from the walkthrough picker) opens VS Code's generic Welcome page instead of the Build a Declarative Agent walkthrough.

## Root cause

PR #15845 made two coupled changes that drifted apart:

1. It hardcoded `shouldEnableChatParticipantUIEntries = true` in `extension.ts`, so `FeatureFlags.ChatParticipantUIEntries` is always on.
2. It deleted the `buildIntelligentAppsWithChat` walkthrough (and its sibling `teamsToolkitGetStartedWithChat` / `teamsAgentGetStarted`) from `packages/vscode-extension/package.json`, leaving only `buildIntelligentApps`.

But `getBuildIntelligentAppsWalkthroughID()` in `packages/vscode-extension/src/handlers/walkthrough.ts` was left untouched:

```ts
export function getBuildIntelligentAppsWalkthroughID() {
  return featureFlagManager.getBooleanValue(FeatureFlags.ChatParticipantUIEntries)
    ? "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentAppsWithChat" // ← no longer exists
    : "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps";
}
```

Because the flag is now always `true`, every caller (`openWelcomeHandler`, `openBuildIntelligentAppsWalkthroughHandler`, `selectWalkthrough`) invokes `workbench.action.openWalkthrough` with the deleted ID `…#buildIntelligentAppsWithChat`. VS Code can't find that walkthrough and silently falls back to the default Welcome page — exactly what the bug screenshot shows.

## Fix

Collapse the helper to always return the surviving walkthrough ID, and drop the now-unused feature-flag imports:

```ts
export function getBuildIntelligentAppsWalkthroughID() {
  return "TeamsDevApp.ms-teams-vscode-extension#buildIntelligentApps";
}
```

## Tests

- Updated the matching expectation in `test/handlers/controlHandlers.test.ts` (the "with chat" branch now also expects `#buildIntelligentApps`, since the helper no longer differentiates).
- `npx mocha --no-timeouts --require ts-node/register test/handlers/walkthrough.test.ts test/handlers/controlHandlers.test.ts` → **16 passing**.
- `npm run build` → succeeds.

## Risk

Low. The change is one line of behavior + a stale-import cleanup. It restores the only walkthrough ID still defined in `package.json`, which is what the `false` branch already returned and what the existing `selectWalkthrough` test already asserted.

## Linked work item

ADO #37894976 — `[VSC][Daily] In a new VS Code environment, entering "Build a Declarative Agent" in the welcome walkthrough opens an incorrect page`
