### PR TITLE
fix: remove unused Microsoft.Bcl.Memory package reference

### DIFF
--- a/templates/vs/csharp/custom-copilot-travel-agent/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/custom-copilot-travel-agent/{{ProjectName}}.csproj.tpl
@@ -13,7 +13,6 @@
     <PackageReference Include="Azure.Identity" Version="1.19.0" />
     <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-preview.251028.1" />
     <PackageReference Include="Microsoft.Agents.M365Copilot.Beta" Version="1.0.0-preview.7" />
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.10.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.1-preview.1.25521.4" />
     <PackageReference Include="Microsoft.Graph" Version="5.103.0" />

--- a/templates/vs/csharp/custom-copilot-weather-agent/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/custom-copilot-weather-agent/{{ProjectName}}.csproj.tpl
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
     <PackageReference Include="Microsoft.SemanticKernel.Agents.AzureAI" Version="1.73.0-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.73.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.73.0" />


### PR DESCRIPTION
Remove unused Microsoft.Bcl.Memory package reference, since the package dependency will cause package degrading issue.