### PR TITLE
fix: improve accessibility for Sample Gallery focus and keyboard navigation

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.scss
@@ -10,6 +10,11 @@
     display: flex;
     flex-direction: column;
 
+    &:focus-visible {
+      outline: 2px solid var(--vscode-focusBorder, #007FD4);
+      outline-offset: -2px;
+    }
+
     .thumbnail {
       img {
         aspect-ratio: 40 / 23;

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.scss
@@ -87,9 +87,16 @@
       padding-left: 8px;
       top: 0px;
       font-size: 16px;
+      cursor: pointer;
+      border-radius: 2px;
 
       &:hover {
         color: var(--vscode-editor-foreground);
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--vscode-focusBorder, #007FD4);
+        outline-offset: 1px;
       }
     }
   }

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
@@ -110,9 +110,21 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
         </div>
         <div className="filter-tag-bar">
           {this.props.filterTags.map((tag) => (
-            <div className="filter-tag">
+            <div className="filter-tag" key={tag}>
               <span>{tag}</span>
-              <span className="codicon codicon-close" onClick={() => this.onTagRemoved(tag)}></span>
+              <span
+                className="codicon codicon-close"
+                role="button"
+                tabIndex={0}
+                aria-label={`Remove ${tag} filter`}
+                onClick={() => this.onTagRemoved(tag)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    this.onTagRemoved(tag);
+                  }
+                }}
+              ></span>
             </div>
           ))}
           {this.props.filterTags.length > 0 && (


### PR DESCRIPTION
Fixes two a11y bugs: (1) Focus indicator contrast ratio 2.257:1 on sample cards - added focus-visible outline with --vscode-focusBorder for 4.5:1 ratio. (2) Filter Remove button not keyboard accessible - added role=button, tabIndex, aria-label, onKeyDown handler.

fix [bug](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37907357) and [bug](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37906314/)