### PR TITLE
fix: clean up stale ceaNode.json and teamsNode.json from build/ui

### DIFF
--- a/templates/scripts/generate-metadata.ts
+++ b/templates/scripts/generate-metadata.ts
@@ -39,19 +39,15 @@ function main() {
   assertNoHardcodedStrings(tdpWizardNode, "tdpWizardNode");
 
   fs.mkdirSync(path.resolve(__dirname, "../build/metadata"), { recursive: true });
-  fs.mkdirSync(path.resolve(__dirname, "../build/ui"), { recursive: true });
 
-  // Remove stale files from before PR #15560 that replaced ceaNode.json / teamsNode.json
-  // with the combined wizardNode.json + tdpNode.json. Without this cleanup the old files
-  // would persist in build/ui/ and be re-distributed by the `distribute` npm script,
-  // causing packages/fx-core/templates/ui/ to contain obsolete JSON files.
-  for (const stale of ["ceaNode.json", "teamsNode.json"]) {
-    const stalePath = path.resolve(__dirname, "../build/ui", stale);
-    if (fs.existsSync(stalePath)) {
-      fs.unlinkSync(stalePath);
-      console.log(`[cleanup] Removed stale file: ${stale}`);
-    }
+  // Always wipe and recreate build/ui/ so no stale JSON files from previous builds
+  // (e.g. ceaNode.json / teamsNode.json from before PR #15560) are redistributed by the
+  // `distribute` script into packages/fx-core/templates/ui/.
+  const buildUiDir = path.resolve(__dirname, "../build/ui");
+  if (fs.existsSync(buildUiDir)) {
+    fs.rmSync(buildUiDir, { recursive: true, force: true });
   }
+  fs.mkdirSync(buildUiDir, { recursive: true });
 
   fs.writeFileSync(
     path.resolve(__dirname, "../build/ui/wizardNode.json"),

--- a/templates/scripts/generate-metadata.ts
+++ b/templates/scripts/generate-metadata.ts
@@ -41,6 +41,18 @@ function main() {
   fs.mkdirSync(path.resolve(__dirname, "../build/metadata"), { recursive: true });
   fs.mkdirSync(path.resolve(__dirname, "../build/ui"), { recursive: true });
 
+  // Remove stale files from before PR #15560 that replaced ceaNode.json / teamsNode.json
+  // with the combined wizardNode.json + tdpNode.json. Without this cleanup the old files
+  // would persist in build/ui/ and be re-distributed by the `distribute` npm script,
+  // causing packages/fx-core/templates/ui/ to contain obsolete JSON files.
+  for (const stale of ["ceaNode.json", "teamsNode.json"]) {
+    const stalePath = path.resolve(__dirname, "../build/ui", stale);
+    if (fs.existsSync(stalePath)) {
+      fs.unlinkSync(stalePath);
+      console.log(`[cleanup] Removed stale file: ${stale}`);
+    }
+  }
+
   fs.writeFileSync(
     path.resolve(__dirname, "../build/ui/wizardNode.json"),
     JSON.stringify(wizardNode, null, 2),


### PR DESCRIPTION
## Root Cause

PR #15560 changed `generate-metadata.ts` to write `wizardNode.json` + `tdpNode.json` instead of the old `ceaNode.json` + `teamsNode.json`. However, the `templates/build/ui/` directory is **never cleaned between runs**.

Developers who built the project before PR #15560 was merged will have stale `ceaNode.json` / `teamsNode.json` in `templates/build/ui/`. When they pull the new `dev` branch and re-run `npm run setup`:

1. `generate:vsc` runs the new `generate-metadata.ts` → writes `wizardNode.json` + `tdpNode.json` to `build/ui/`
2. But the stale `ceaNode.json` and `teamsNode.json` are still there in `build/ui/`
3. `distribute` runs `copyfiles -u 1 "build/**/*" ../packages/fx-core/templates/` → copies **all** files in `build/ui/`, including stale ones
4. Result: `packages/fx-core/templates/ui/` gets `ceaNode.json` and `teamsNode.json` back

**Symptom**: Before `npm run setup`, those files don't exist (PR #15560 deleted them from git). After `npm run setup`, they reappear.

## Fix

In `generate-metadata.ts`, wipe the entire `build/ui/` directory before writing new files. This ensures only the currently-generated files (`wizardNode.json`, `tdpNode.json`) are ever present in `build/ui/`, so `distribute` only copies the correct files.

This is more future-proof than hardcoding specific filenames — any future renames or removals of generated JSON files are handled automatically.
