### PR TITLE
fix(fx-core): default LLMService to azure-openai when not provided

### DIFF
--- a/packages/fx-core/src/component/generator/templates/templateReplaceMap.ts
+++ b/packages/fx-core/src/component/generator/templates/templateReplaceMap.ts
@@ -14,7 +14,10 @@ export function getTemplateReplaceMap(inputs: Inputs): { [key: string]: string }
   const solutionName = inputs[QuestionNames.SolutionName] ?? appName;
   const targetFramework = inputs.targetFramework;
   const placeProjectFileInSolutionDir = inputs.placeProjectFileInSolutionDir === "true";
-  const llmService: string | undefined = inputs[QuestionNames.LLMService];
+  // Fall back to the CLI/UX default when the LLM service question was not asked
+  // or omitted in non-interactive mode, so templates that depend on
+  // {{#useAzureOpenAI}} blocks still emit a valid agent model.
+  const llmService: string = inputs[QuestionNames.LLMService] ?? "llm-service-azure-openai";
   let openAIKey: string | undefined = inputs[QuestionNames.OpenAIKey];
   let azureOpenAIKey: string | undefined = inputs[QuestionNames.AzureOpenAIKey];
   let azureAISearchApiKey: string | undefined = inputs[QuestionNames.AzureAISearchApiKey];

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -1440,4 +1440,23 @@ describe("getTemplateReplaceMap", () => {
     assert.equal(map.FoundryEndpoint, "");
     assert.equal(map.FoundryAgentId, "");
   });
+
+  it("should default useAzureOpenAI to true when LLMService is not provided", () => {
+    // Regression test for ADO 37713559: in non-interactive scaffolding the
+    // --llm-service flag default is not propagated, leaving templates such as
+    // weather-agent with an undefined `agentModel` reference.
+    const map = getTemplateReplaceMap(inputs);
+    assert.equal(map.useAzureOpenAI, "true");
+    assert.equal(map.useOpenAI, "");
+  });
+
+  it("should respect explicit LLMService = llm-service-openai", () => {
+    const openaiInputs = {
+      ...inputs,
+      [QuestionNames.LLMService]: "llm-service-openai",
+    } as Inputs;
+    const map = getTemplateReplaceMap(openaiInputs);
+    assert.equal(map.useOpenAI, "true");
+    assert.equal(map.useAzureOpenAI, "");
+  });
 });


### PR DESCRIPTION
## Problem

Scaffolding LLM-bearing templates in non-interactive mode produces a project that fails to compile.

**Repro**
```bash
atk new --interactive false \
        --app-name foo \
        --capability weather-agent \
        --programming-language typescript
cd foo && npm install && npm run build
```

```
src/agent.ts:70:8 - error TS2304: Cannot find name 'agentModel'.

70   llm: agentModel,
          ~~~~~~~~~~
```

Tracking: ADO #37713559

## Root cause

`getTemplateReplaceMap` in `packages/fx-core/src/component/generator/templates/templateReplaceMap.ts` reads `inputs[QuestionNames.LLMService]` and maps it to two Mustache flags:

```ts
useOpenAI: llmService === "llm-service-openai" ? "true" : "",
useAzureOpenAI: llmService === "llm-service-azure-openai" ? "true" : "",
```

The `--llm-service` CLI option declares a default of `"llm-service-azure-openai"` in `CreateProjectOptions.ts`, but that default is **not propagated to `inputs`** in non-interactive mode — the question system only fills it when the question is actually asked. So `inputs[LLMService]` ends up `undefined`, both flags become `""`, and every `{{#useOpenAI}}` / `{{#useAzureOpenAI}}` block in the affected templates is stripped.

For `weather-agent`, the only declarations of `agentModel` live inside those blocks (see `templates/vsc/ts/weather-agent/src/agent.ts.tpl` L66–82), so the generated `agent.ts` references `agentModel` at line 70 without ever declaring it.

Same exposure applies to `custom-copilot-*` and `basic-custom-engine-agent` templates — all LLM-bearing scaffolds.

## Fix

Apply the same default as the CLI option inside `getTemplateReplaceMap`:

```ts
const llmService: string =
  inputs[QuestionNames.LLMService] ?? "llm-service-azure-openai";
```

Explicit user input still wins (`--llm-service llm-service-openai` continues to emit `ChatOpenAI`). The flag is template-internal — only consumed by templates that gate code on `{{#useAzureOpenAI}}` / `{{#useOpenAI}}`, all of which need an LLM service by design — so non-LLM templates (basic bot, tab, message extension, etc.) are unaffected.

## Verification

- Unit tests: `getTemplateReplaceMap` suite extended with 2 new cases (defensive default + explicit-OpenAI still wins). All **99 generator tests pass**.
- End-to-end repro: rebuilt `fx-core`, re-ran the exact repro above without `--llm-service` → `npm run build` exits **0**, generated `agent.ts` declares `const agentModel = new AzureChatOpenAI({...})`.
- Negative check: with `--llm-service llm-service-openai` the generated file still emits `const agentModel = new ChatOpenAI({...})`.
- Blast-radius audit: greps for `{{#useAzureOpenAI}}` / `{{#useOpenAI}}` consumers — all are LLM-bearing templates only.

## Files changed

- `packages/fx-core/src/component/generator/templates/templateReplaceMap.ts` — 1-line defensive default (+ short comment).
- `packages/fx-core/tests/component/generator/generator.test.ts` — 2 new regression tests under `describe("getTemplateReplaceMap")`.
