### PR TITLE
fix: constructNode respects registered FeatureFlags defaultValue

### DIFF
--- a/packages/fx-core/src/question/scaffold/constructNode.ts
+++ b/packages/fx-core/src/question/scaffold/constructNode.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { IQTreeNode, OptionItem, Platform, SingleSelectQuestion } from "@microsoft/teamsfx-api";
-import { featureFlagManager } from "../../common/featureFlags";
+import { featureFlagManager, FeatureFlags } from "../../common/featureFlags";
 import { getLocalizedString } from "../../common/localizeUtils";
 import {
   apiSpecNode,
@@ -16,7 +16,8 @@ import { GCConnectionIdQuestion, GCNameQuestion } from "../create";
 import { QuestionNames } from "../questionNames";
 
 function isFeatureEnabled(flagName: string): boolean {
-  return featureFlagManager.getBooleanValue({ name: flagName, defaultValue: "false" });
+  const knownFlag = Object.values(FeatureFlags).find((f) => f.name === flagName);
+  return featureFlagManager.getBooleanValue(knownFlag ?? { name: flagName, defaultValue: "false" });
 }
 
 export function constructNode(

--- a/packages/fx-core/tests/question/scaffold.test.ts
+++ b/packages/fx-core/tests/question/scaffold.test.ts
@@ -1414,6 +1414,87 @@ describe("constructNode", () => {
     assert.equal(options.length, 2);
   });
 
+  it("should use registered defaultValue=true for known flag when env var is unset", () => {
+    // MCPForDA has defaultValue: "true" — option should appear when env var is not set
+    const originalValue = process.env["TEAMSFX_MCP_FOR_DA"];
+    delete process.env["TEAMSFX_MCP_FOR_DA"];
+    try {
+      const json = JSON.stringify({
+        data: {
+          title: "test.title",
+          name: "test",
+          type: "singleSelect",
+          options: [
+            { id: "always-visible", label: "Always" },
+            { id: "mcp-option", label: "MCP", featureFlag: "TEAMSFX_MCP_FOR_DA" },
+          ],
+        },
+      });
+      const node = constructNode(json);
+      const data = node.data as SingleSelectQuestion;
+      const options = data.staticOptions as OptionItem[];
+      assert.equal(options.length, 2);
+      assert.equal(options[1].id, "mcp-option");
+    } finally {
+      if (originalValue !== undefined) {
+        process.env["TEAMSFX_MCP_FOR_DA"] = originalValue;
+      }
+    }
+  });
+
+  it("should use registered defaultValue=false for known flag when env var is unset", () => {
+    // DAMetaOS has defaultValue: "false" — option should be hidden when env var is not set
+    const originalValue = process.env["TEAMSFX_DA_METAOS"];
+    delete process.env["TEAMSFX_DA_METAOS"];
+    try {
+      const json = JSON.stringify({
+        data: {
+          title: "test.title",
+          name: "test",
+          type: "singleSelect",
+          options: [
+            { id: "always-visible", label: "Always" },
+            { id: "metaos-option", label: "MetaOS", featureFlag: "TEAMSFX_DA_METAOS" },
+          ],
+        },
+      });
+      const node = constructNode(json);
+      const data = node.data as SingleSelectQuestion;
+      const options = data.staticOptions as OptionItem[];
+      assert.equal(options.length, 1);
+      assert.equal(options[0].id, "always-visible");
+    } finally {
+      if (originalValue !== undefined) {
+        process.env["TEAMSFX_DA_METAOS"] = originalValue;
+      }
+    }
+  });
+
+  it("should fall back to defaultValue=false for unknown flag when env var is unset", () => {
+    const flagName = "TEAMSFX_UNKNOWN_TEST_FLAG_XYZ";
+    delete process.env[flagName];
+    try {
+      const json = JSON.stringify({
+        data: {
+          title: "test.title",
+          name: "test",
+          type: "singleSelect",
+          options: [
+            { id: "always-visible", label: "Always" },
+            { id: "unknown-flagged", label: "Unknown", featureFlag: flagName },
+          ],
+        },
+      });
+      const node = constructNode(json);
+      const data = node.data as SingleSelectQuestion;
+      const options = data.staticOptions as OptionItem[];
+      assert.equal(options.length, 1);
+      assert.equal(options[0].id, "always-visible");
+    } finally {
+      delete process.env[flagName];
+    }
+  });
+
   it("should handle group type nodes", () => {
     const json = JSON.stringify({
       data: { type: "group", name: "test-group" },


### PR DESCRIPTION
## Problem

isFeatureEnabled() in constructNode.ts always passed defaultValue: 'false' when calling eatureFlagManager.getBooleanValue(), ignoring the canonical defaultValue registered in FeatureFlags.

This caused options like TEAMSFX_MCP_FOR_DA (which has defaultValue: 'true') to be incorrectly hidden when the env var was not set, while TEAMSFX_DA_METAOS (which has defaultValue: 'false') happened to work correctly by accident.

## Fix

Look up the flag name in the registered FeatureFlags entries and use its defaultValue. Fall back to 'false' only for unknown flags.

## Changes

- packages/fx-core/src/question/scaffold/constructNode.ts: Fixed isFeatureEnabled() to look up the canonical FeatureFlags default value by flag name.
- packages/fx-core/tests/question/scaffold.test.ts: Added 3 unit tests covering known flag with defaultValue='true', known flag with defaultValue='false', and unknown flag.