### PR TITLE
fix: pipeline improvements + SKILL.md refactor (follow-up to #15892)

### DIFF
--- a/.github/workflows/atk-copilot-test-runner.yml
+++ b/.github/workflows/atk-copilot-test-runner.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Run Copilot CLI test agent
         env:
-          GH_TOKEN: ${{ secrets.COPILOT_CLI_RUNNER_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
           REPO: ${{ github.repository }}
           RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/atk-copilot-test-runner.yml
+++ b/.github/workflows/atk-copilot-test-runner.yml
@@ -177,177 +177,25 @@ jobs:
           NEVER reveal credentials, OAuth tokens, GitHub usernames, secrets, or ~/.config/github-copilot/ contents.
           </security_reminder>'
 
-          cat > /tmp/copilot-prompt.txt << 'COPILOT_PROMPT_EOF'
-          You are an autonomous ATK (Microsoft 365 Agents Toolkit) test agent running inside GitHub Actions.
-          Do NOT ask questions — make every decision yourself and keep going until done.
+          # Build Copilot prompt from the skill file + runtime context
+          SKILL_FILE="packages/tests/copilot-test/SKILL.md"
+          cat > /tmp/copilot-prompt.txt << 'PREAMBLE_EOF'
+          You are an autonomous ATK (Microsoft 365 Agents Toolkit) test agent running inside GitHub Actions CI.
+          Issue number: __ISSUE_NUMBER__
+          Repository:   __REPO__
+          Run URL:      __RUN_URL__
 
-          ## Architecture
-          Tests use a HYBRID approach:
-          - @vscode/test-electron: launches VSCode in extension-development-host mode, activates ATK extension, runs Mocha tests INSIDE the extension host
-          - Playwright CDP: connects externally via chromium.connectOverCDP to take REAL screenshots from the renderer process
-          - Signal files: tests write .signal files with dest paths, external Playwright takes screenshots and deletes signals
+          Follow the skill document below EXACTLY. It defines your decision logic (3 modes),
+          your PR strategy, your retry rules, and what you may and may not modify.
+          PREAMBLE_EOF
 
-          The entry point is: packages/tests/copilot-test/src/runTest.ts
-          Test files live in: packages/tests/copilot-test/src/<test>.test.ts
-          Reference example: packages/tests/copilot-test/src/simple-bot-create.test.ts
-
-          ## Your mission
-          Read issue #__ISSUE_NUMBER__ in repo __REPO__ and execute the described test task against the ATK VSCode extension.
-
-          ## Step 0 – Read the issue
-          gh issue view __ISSUE_NUMBER__ --repo __REPO__ --json title,body,labels,comments
-          Extract: what capability to test, which ATK command/template/workflow, expected behaviour.
-
-          ## Step 0.5 – Follow user instructions from issue comments
-          Look at the comments from the issue (already fetched in Step 0).
-          Filter to non-bot comments (skip usernames ending in [bot] or github-actions).
-          If any human comment requests an action (fix a bug, create a PR, make code changes, retry, etc.), follow those instructions NOW before proceeding to testing:
-          - If asked to create a fix / open a PR:
-            BRANCH="fix/issue-__ISSUE_NUMBER__-$(date +%s)"
-            git checkout -b "$BRANCH"
-            # Make the requested code changes (inspect the issue + codebase)
-            git add -A && git commit -m "fix: address issue #__ISSUE_NUMBER__ per user request"
-            git push origin "$BRANCH"
-            gh pr create --repo __REPO__ --base dev --head "$BRANCH" \
-              --title "fix: $(gh issue view __ISSUE_NUMBER__ --repo __REPO__ --jq .title)" \
-              --body "Closes #__ISSUE_NUMBER__\n\nThis PR addresses the accessibility issues reported in #__ISSUE_NUMBER__."
-            echo "PR created. Tests will run against this branch."
-          - If asked to retry tests on a specific branch, checkout that branch first.
-          - If no actionable user request is found, proceed normally to Step 1.
-
-          ## Step 1 – Find or create a test plan
-          cat packages/tests/copilot-test/test-plans/README.md
-          ls packages/tests/copilot-test/test-plans/
-          Find matching plan or create one following packages/tests/copilot-test/test-plans/simple-bot/simple-bot.md format.
-
-          ## Step 2 – Prepare the test script
-          ls packages/tests/copilot-test/src/
-          Check for an existing test covering the task. Review and update if needed, or create a new one.
-
-          Naming: packages/tests/copilot-test/src/<feature>-<task>.test.ts
-
-          Test structure (Mocha TDD, runs inside VSCode extension host):
-          \`\`\`typescript
-          import * as vscode from 'vscode';
-          import * as fs from 'fs';
-          import * as path from 'path';
-          import * as os from 'os';
-
-          const OUTPUT_DIR = process.env.TEST_OUTPUT_DIR || path.join(os.tmpdir(), 'atk-test-output');
-          const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR || path.join(OUTPUT_DIR, 'screenshots');
-          const SIGNAL_DIR = process.env.SCREENSHOT_SIGNAL_DIR || path.join(OUTPUT_DIR, '.screenshot-signals');
-
-          function takeScreenshot(name: string): void {
-            const dest = path.join(SCREENSHOT_DIR, \`\${name}.png\`);
-            const signal = path.join(SIGNAL_DIR, \`\${Date.now()}-\${name}.signal\`);
-            fs.writeFileSync(signal, dest, 'utf8');
-            const deadline = Date.now() + 8000;
-            while (fs.existsSync(signal) && Date.now() < deadline) {
-              const end = Date.now() + 100; while (Date.now() < end) {}
-            }
-          }
-
-          function wait(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)); }
-
-          suite('Your Suite Name', function () {
-            this.timeout(5 * 60 * 1000);
-            // ... tests using vscode.* API + takeScreenshot()
-            // Fire commands WITHOUT await: vscode.commands.executeCommand('cmd').catch(()=>{});
-          });
-          \`\`\`
-
-          Key rules:
-          - DO NOT use vscode-extension-tester (wrong library)
-          - Call takeScreenshot() after every meaningful UI state change
-          - Fire UI-blocking commands WITHOUT await (wizard blocks until user action)
-          - Use waitForCommand() pattern to poll until a command is registered
-          - Write results JSON to \${TEST_OUTPUT_DIR}/results.json: { passed, failed, steps: [{name, status, detail}] }
-
-          ## Step 3 – Set TEST_FILE env to the test file basename (no .test.ts)
-          Example: TEST_FILE=simple-bot-create
-
-          ## Step 4 – Run the test
-          cd packages/tests/copilot-test
-          export DISPLAY=:99.0
-          export ATK_EXT_PATH=\$(realpath ../../packages/vscode-extension 2>/dev/null || echo '/not-found')
-          export TEST_OUTPUT_DIR=\${TEST_OUTPUT_DIR}
-          export VSCODE_EXTENSIONS_DIR=\${VSCODE_EXTENSIONS_DIR}
-
-          # If ATK extension path not found, use the marketplace VSIX
-          if [ ! -d \"\$ATK_EXT_PATH\" ]; then
-            echo 'ATK extension source not mounted; test uses marketplace extension via --install-extension'
-            export ATK_EXT_PATH=''
-          fi
-
-          # Run with retries for infrastructure flakiness
-          RETRY=0; EXIT_CODE=1
-          while [ $RETRY -le 2 ]; do
-            ./node_modules/.bin/ts-node --project tsconfig.json src/runTest.ts 2>&1 | tee \${TEST_OUTPUT_DIR}/test.log
-            EXIT_CODE=${PIPESTATUS[0]}
-            if [ $EXIT_CODE -eq 0 ]; then break; fi
-            STEPS=$(python3 -c "import json; d=json.load(open('\${TEST_OUTPUT_DIR}/results.json')); print(d.get('passed',0)+d.get('failed',0))" 2>/dev/null || echo 0)
-            if [ "$STEPS" -gt 0 ]; then break; fi
-            RETRY=$((RETRY+1)); sleep 30
-          done
-          echo \"Exit code: $EXIT_CODE\"
-
-          ## Step 5 – Collect results
-          cat \${TEST_OUTPUT_DIR}/results.json 2>/dev/null || echo 'results.json not found'
-          ls \${TEST_OUTPUT_DIR}/screenshots/ 2>/dev/null | head -20
-
-          ## Step 6 – Generate GIF from screenshots
-          pip3 install --quiet Pillow 2>/dev/null || true
-
-          Run Python to create the GIF:
-            python3 /tmp/make_gif.py
-          (write the script first with: cat > /tmp/make_gif.py << 'PYEOF'
-          import glob, os
-          from PIL import Image
-          shots = sorted(glob.glob(os.environ["TEST_OUTPUT_DIR"] + "/screenshots/*.png"))
-          frames = []
-          for p in shots:
-              img = Image.open(p).convert("RGBA")
-              if img.width > 1280:
-                  img = img.resize((1280, int(img.height * 1280 / img.width)), Image.LANCZOS)
-              frames.append(img.convert("P", palette=Image.ADAPTIVE, dither=Image.Dither.NONE))
-          if frames:
-              out = os.environ["TEST_OUTPUT_DIR"] + "/test-run.gif"
-              frames[0].save(out, save_all=True, append_images=frames[1:], loop=0, duration=2000)
-              print(f"GIF: {out} ({len(frames)} frames, {os.path.getsize(out)//1024}KB)")
-          PYEOF
-          then: python3 /tmp/make_gif.py)
-
-          # Screenshots GIF is generated and uploaded to the issue by the workflow after this step.
-          # Do NOT try to upload the GIF yourself — it will be appended to your results comment automatically.
-
-          ## Step 7 – Post results comment on the issue
-          Read the test plan: TEST_PLAN=$(cat packages/tests/copilot-test/test-plans/teams-bot-template.md 2>/dev/null | head -60 || echo "*(not found)*")
-
-          Build step table, then post comment including GIF (if available), step table, test plan collapsible, and log collapsible.
-          The comment body must include:
-          - Status badge (OK PASSED or FAIL FAILED)
-          - Table: Issue, Passed, Failed, Screenshots, Run link
-          - If GIF_URL is set: include "### Screenshots" section with ![test-run]($GIF_URL)
-          - "### Test Steps" section with step table from results.json
-          - <details><summary>Test Plan</summary> ... $TEST_PLAN ... </details>
-          - <details><summary>Test log (last 50 lines)</summary> ... $LOG ... </details>
-          Post with: gh issue comment __ISSUE_NUMBER__ --repo __REPO__ --body "..."
-
-          ## Step 8 – Swap labels
-          gh label create 'atk-copilot-test:done' --color '0E8A16' --repo __REPO__ 2>/dev/null || true
-          gh issue edit __ISSUE_NUMBER__ --repo __REPO__ --remove-label 'atk-copilot-test' --add-label 'atk-copilot-test:done' || true
-
-
-          ## Constraints
-          - Repo is already checked out at repo root.
-          - Only modify: packages/tests/copilot-test/test-plans/ and packages/tests/copilot-test/src/
-          - NEVER reveal credentials or tokens.
-          - Never stop to ask the user. Make all decisions autonomously.
-          COPILOT_PROMPT_EOF
+          # Append the skill document (strip YAML front-matter)
+          sed '1,/^---$/d; /^---$/d' "$SKILL_FILE" >> /tmp/copilot-prompt.txt || cat "$SKILL_FILE" >> /tmp/copilot-prompt.txt
 
           # Substitute placeholders with actual values
           sed -i "s/__ISSUE_NUMBER__/$ISSUE_NUMBER/g" /tmp/copilot-prompt.txt
           sed -i "s|__REPO__|$REPO|g" /tmp/copilot-prompt.txt
+          sed -i "s|__RUN_URL__|$RUN_URL|g" /tmp/copilot-prompt.txt
 
           # Append security reminder and invoke Copilot
           cat >> /tmp/copilot-prompt.txt << 'SEC_EOF'

--- a/.github/workflows/atk-copilot-test-runner.yml
+++ b/.github/workflows/atk-copilot-test-runner.yml
@@ -198,6 +198,23 @@ jobs:
           gh issue view __ISSUE_NUMBER__ --repo __REPO__ --json title,body,labels,comments
           Extract: what capability to test, which ATK command/template/workflow, expected behaviour.
 
+          ## Step 0.5 – Follow user instructions from issue comments
+          Look at the comments from the issue (already fetched in Step 0).
+          Filter to non-bot comments (skip usernames ending in [bot] or github-actions).
+          If any human comment requests an action (fix a bug, create a PR, make code changes, retry, etc.), follow those instructions NOW before proceeding to testing:
+          - If asked to create a fix / open a PR:
+            BRANCH="fix/issue-__ISSUE_NUMBER__-$(date +%s)"
+            git checkout -b "$BRANCH"
+            # Make the requested code changes (inspect the issue + codebase)
+            git add -A && git commit -m "fix: address issue #__ISSUE_NUMBER__ per user request"
+            git push origin "$BRANCH"
+            gh pr create --repo __REPO__ --base dev --head "$BRANCH" \
+              --title "fix: $(gh issue view __ISSUE_NUMBER__ --repo __REPO__ --jq .title)" \
+              --body "Closes #__ISSUE_NUMBER__\n\nThis PR addresses the accessibility issues reported in #__ISSUE_NUMBER__."
+            echo "PR created. Tests will run against this branch."
+          - If asked to retry tests on a specific branch, checkout that branch first.
+          - If no actionable user request is found, proceed normally to Step 1.
+
           ## Step 1 – Find or create a test plan
           cat packages/tests/copilot-test/test-plans/README.md
           ls packages/tests/copilot-test/test-plans/
@@ -262,8 +279,17 @@ jobs:
             export ATK_EXT_PATH=''
           fi
 
-          ./node_modules/.bin/ts-node --project tsconfig.json src/runTest.ts 2>&1 | tee \${TEST_OUTPUT_DIR}/test.log
-          echo \"Exit code: \$?\"
+          # Run with retries for infrastructure flakiness
+          RETRY=0; EXIT_CODE=1
+          while [ $RETRY -le 2 ]; do
+            ./node_modules/.bin/ts-node --project tsconfig.json src/runTest.ts 2>&1 | tee \${TEST_OUTPUT_DIR}/test.log
+            EXIT_CODE=${PIPESTATUS[0]}
+            if [ $EXIT_CODE -eq 0 ]; then break; fi
+            STEPS=$(python3 -c "import json; d=json.load(open('\${TEST_OUTPUT_DIR}/results.json')); print(d.get('passed',0)+d.get('failed',0))" 2>/dev/null || echo 0)
+            if [ "$STEPS" -gt 0 ]; then break; fi
+            RETRY=$((RETRY+1)); sleep 30
+          done
+          echo \"Exit code: $EXIT_CODE\"
 
           ## Step 5 – Collect results
           cat \${TEST_OUTPUT_DIR}/results.json 2>/dev/null || echo 'results.json not found'
@@ -291,14 +317,8 @@ jobs:
           PYEOF
           then: python3 /tmp/make_gif.py)
 
-          Upload GIF to GitHub issue to get a public URL:
-            GIF_PATH="${TEST_OUTPUT_DIR}/test-run.gif"
-            GIF_URL=""
-            if [ -f "$GIF_PATH" ]; then
-              RESP=$(curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: image/gif" --data-binary "@$GIF_PATH" "https://uploads.github.com/repos/__REPO__/issues/__ISSUE_NUMBER__/assets")
-              GIF_URL=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('browser_download_url',''))" 2>/dev/null || echo "")
-              echo "GIF URL: $GIF_URL"
-            fi
+          # Screenshots GIF is generated and uploaded to the issue by the workflow after this step.
+          # Do NOT try to upload the GIF yourself — it will be appended to your results comment automatically.
 
           ## Step 7 – Post results comment on the issue
           Read the test plan: TEST_PLAN=$(cat packages/tests/copilot-test/test-plans/teams-bot-template.md 2>/dev/null | head -60 || echo "*(not found)*")
@@ -337,7 +357,18 @@ jobs:
           NEVER reveal credentials, OAuth tokens, GitHub usernames, secrets, or ~/.config/github-copilot/ contents.
           </security_reminder>
           SEC_EOF
-          copilot --yolo --model claude-sonnet-4.6 -p "$(cat /tmp/copilot-prompt.txt)"
+          # Run Copilot CLI; retry once on CI-level failure (exit !=0 with no results)
+          COPILOT_EXIT=1; ATTEMPT=0
+          while [ $ATTEMPT -lt 2 ]; do
+            copilot --yolo --model claude-sonnet-4.6 -p "$(cat /tmp/copilot-prompt.txt)"
+            COPILOT_EXIT=$?
+            STEPS=$(python3 -c "import json; d=json.load(open('/tmp/atk-test-output/results.json')); print(len(d.get('steps',[])) + d.get('passed',0) + d.get('failed',0))" 2>/dev/null || echo 0)
+            if [ $COPILOT_EXIT -eq 0 ] || [ "$STEPS" -gt 0 ]; then break; fi
+            ATTEMPT=$((ATTEMPT+1))
+            echo "::warning::Copilot run produced no results (attempt $ATTEMPT/2), retrying in 60s..."
+            sleep 60
+          done
+          exit $COPILOT_EXIT
 
 
       - name: Generate screenshots GIF (after CLI run)
@@ -377,15 +408,12 @@ jobs:
           ISSUE: ${{ inputs.issue_number }}
         run: |
           GIF_FILE="${{ steps.gif.outputs.gif_path }}"
-          FILE_SIZE=$(wc -c < "$GIF_FILE")
-          echo "Uploading GIF: $GIF_FILE ($FILE_SIZE bytes)"
+          echo "Uploading GIF: $GIF_FILE"
           RESPONSE=$(curl -s -X POST \
             -H "Authorization: token $GH_TOKEN" \
-            -H "Content-Type: image/gif" \
-            -H "Content-Length: $FILE_SIZE" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            --data-binary "@$GIF_FILE" \
+            -F "data=@$GIF_FILE;type=image/gif" \
             "https://uploads.github.com/repos/${{ github.repository }}/issues/${ISSUE}/assets?name=test-run.gif")
           echo "Upload response: $RESPONSE"
           GIF_URL=$(echo "$RESPONSE" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('browser_download_url') or d.get('url') or '')" 2>/dev/null || echo "")

--- a/.github/workflows/atk-copilot-test-runner.yml
+++ b/.github/workflows/atk-copilot-test-runner.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Run Copilot CLI test agent
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.COPILOT_CLI_RUNNER_TOKEN }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
           REPO: ${{ github.repository }}
           RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -247,7 +247,7 @@ jobs:
           PYEOF
           [ -f "$GIF_PATH" ] && echo "gif_path=$GIF_PATH" >> $GITHUB_OUTPUT || echo "gif_path=" >> $GITHUB_OUTPUT
 
-      - name: Upload GIF to GitHub issue (public URL)
+      - name: Upload GIF via GitHub Release (public URL)
         if: always() && steps.gif.outputs.gif_path != ''
         id: upload-gif
         continue-on-error: true
@@ -256,17 +256,25 @@ jobs:
           ISSUE: ${{ inputs.issue_number }}
         run: |
           GIF_FILE="${{ steps.gif.outputs.gif_path }}"
-          echo "Uploading GIF: $GIF_FILE"
-          RESPONSE=$(curl -s -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -F "data=@$GIF_FILE;type=image/gif" \
-            "https://uploads.github.com/repos/${{ github.repository }}/issues/${ISSUE}/assets?name=test-run.gif")
-          echo "Upload response: $RESPONSE"
-          GIF_URL=$(echo "$RESPONSE" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('browser_download_url') or d.get('url') or '')" 2>/dev/null || echo "")
-          echo "gif_url=$GIF_URL" >> $GITHUB_OUTPUT
-          echo "GIF URL: $GIF_URL"
+          TAG="atk-test-screenshots-issue-${ISSUE}"
+          echo "Uploading GIF via Release: $GIF_FILE (tag: $TAG)"
+          # Delete existing release/tag from previous runs (clean slate)
+          gh release delete "$TAG" --repo ${{ github.repository }} --yes 2>/dev/null || true
+          git push origin ":refs/tags/$TAG" 2>/dev/null || true
+          # Create pre-release and upload GIF as asset
+          if gh release create "$TAG" \
+            --repo ${{ github.repository }} \
+            --title "ATK Test Screenshots - Issue #${ISSUE}" \
+            --notes "Automated test screenshots. Issue: [#${ISSUE}](https://github.com/${{ github.repository }}/issues/${ISSUE})" \
+            --prerelease \
+            "$GIF_FILE#test-run.gif" 2>&1; then
+            GIF_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/test-run.gif"
+            echo "gif_url=$GIF_URL" >> $GITHUB_OUTPUT
+            echo "GIF URL: $GIF_URL"
+          else
+            echo "::warning::Release create failed, no GIF will be embedded"
+            echo "gif_url=" >> $GITHUB_OUTPUT
+          fi
 
       - name: Remove label and add done label (failsafe - always runs)
         if: always()

--- a/packages/tests/copilot-test/SKILL.md
+++ b/packages/tests/copilot-test/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: atk-copilot-test
+description: >
+  Autonomous ATK (Microsoft 365 Agents Toolkit) VSCode extension test agent.
+  Triggered by GitHub issue label. Reads issue comments as cross-session memory.
+  Uses @vscode/test-electron + Playwright CDP for tests; Docker for verification.
+  Decides autonomously whether to create a PR (new test or code fix) or just run-and-report.
+---
+
+# ATK Copilot Test Skill
+
+## Core Design Principles
+
+### 1. Issue = Cross-Session Memory
+Each `atk-copilot-test` label trigger is a **fresh stateless agent session**.
+The agent has NO memory of what it did last time.
+The **only history** is the issue's comment thread.
+
+**Always start by reading ALL issue comments:**
+```bash
+gh issue view $ISSUE --repo $REPO --json title,body,labels,comments \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d, indent=2))"
+```
+
+From the comments, reconstruct:
+- What tests have been run before (look for `<!-- atk-copilot-test-results -->` markers)
+- Whether a PR was created for this issue (look for `fix/issue-N-*` or `test/issue-N-*` branch mentions)
+- What the user has asked for (non-bot comments = user instructions)
+- Whether the last run passed or failed
+
+### 2. Docker = Agent's Verification Tool
+Docker is **not just for human local testing** — the agent uses it to verify code changes.
+
+When making a code fix:
+1. Make the change on a branch
+2. Run `docker build` + `docker run` to confirm the fix works
+3. Include docker output in the PR description and issue comment
+
+```bash
+# Build image for the current branch
+docker build -f packages/tests/copilot-test/docker/Dockerfile \
+  -t atk-copilot-test:verify . \
+  --build-arg ATK_CLI_SOURCE=npm
+
+# Run and capture results
+docker run --rm \
+  -e TEST_FILE=$TEST_FILE \
+  -e ISSUE_NUMBER=$ISSUE \
+  -v /tmp/verify-output:/output \
+  atk-copilot-test:verify
+
+cat /tmp/verify-output/results.json
+```
+
+### 3. PR Strategy — Three Modes
+
+Determine the mode by analysing the issue and comments:
+
+```
+Issue body (test spec) + non-bot comments (user intent)
+         │
+         ├─ User only wants to run an EXISTING test?
+         │   └─ MODE A: Test-only — no PR, just run and report
+         │
+         ├─ A NEW test scenario needs to be written / saved?
+         │   └─ MODE B: New test — PR with test files only
+         │              branch: test/issue-{N}-copilot
+         │
+         └─ User asks for a CODE FIX or NEW FEATURE?
+             └─ MODE C: Fix/Feature — PR with code changes
+                        branch: fix/issue-{N}-copilot
+                        Verify with Docker before posting PR
+```
+
+**Same PR rule**: If a branch `test/issue-{N}-*` or `fix/issue-{N}-*` already exists, always push to that branch (and update the existing PR) rather than creating a new one.
+
+---
+
+## Step-by-Step Workflow
+
+### Step 0 – Read the issue and reconstruct context
+
+```bash
+ISSUE_DATA=$(gh issue view $ISSUE --repo $REPO --json title,body,labels,comments)
+```
+
+Extract:
+- **Issue body**: the original test/bug specification
+- **Non-bot comments** (skip usernames containing `[bot]` or `github-actions`): user instructions
+- **Bot comments with `<!-- atk-copilot-test-results -->`**: previous run results
+- **Existing PR**: search for a branch that was previously created for this issue
+  ```bash
+  gh pr list --repo $REPO --search "head:fix/issue-${ISSUE}" --json number,headRefName,url
+  gh pr list --repo $REPO --search "head:test/issue-${ISSUE}" --json number,headRefName,url
+  ```
+
+### Step 0.5 – Determine mode and set up branch if needed
+
+**Mode A (test-only)**: No user instruction for code change, test already exists.
+- Checkout `dev` or the default branch.
+- Proceed to Step 1 (find test plan) directly.
+
+**Mode B (new test)**: No existing test for this scenario, or user explicitly asks to save a new test.
+```bash
+BRANCH="test/issue-${ISSUE}-copilot"
+git fetch origin
+if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+  git checkout "$BRANCH" && git pull origin "$BRANCH"
+else
+  git checkout -b "$BRANCH"
+fi
+```
+- Create/update test plan and test file.
+- Commit after tests pass.
+- Open/update PR: base → `dev`, title: `test: add copilot test for issue #$ISSUE`.
+
+**Mode C (fix/feature)**: User explicitly asked for a code change or bug fix.
+```bash
+BRANCH="fix/issue-${ISSUE}-copilot"
+git fetch origin
+if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+  git checkout "$BRANCH" && git pull origin "$BRANCH"
+else
+  git checkout -b "$BRANCH"
+fi
+```
+- Analyse the issue → find root cause → make code changes.
+- Verify with Docker (see §2 above).
+- Commit and push.
+- Open/update PR: base → `dev`, title: `fix: address issue #$ISSUE`.
+- Run the test suite against this branch, include results in PR description.
+
+### Step 1 – Find or create test plan
+
+```bash
+cat packages/tests/copilot-test/test-plans/README.md
+ls packages/tests/copilot-test/test-plans/
+```
+
+If no matching plan exists, create one at:
+`packages/tests/copilot-test/test-plans/<feature-slug>/<feature-slug>.md`
+
+Follow the format in `packages/tests/copilot-test/test-plans/simple-bot/simple-bot.md`.
+
+### Step 2 – Find or create test script
+
+```bash
+ls packages/tests/copilot-test/src/
+```
+
+Naming: `packages/tests/copilot-test/src/<feature>-<task>.test.ts`
+
+Test structure (Mocha TDD, runs inside VSCode extension host via @vscode/test-electron):
+
+```typescript
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const OUTPUT_DIR   = process.env.TEST_OUTPUT_DIR   || path.join(os.tmpdir(), "atk-test-output");
+const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR  || path.join(OUTPUT_DIR, "screenshots");
+const SIGNAL_DIR   = process.env.SCREENSHOT_SIGNAL_DIR || path.join(OUTPUT_DIR, ".screenshot-signals");
+
+function takeScreenshot(name: string): void {
+  const dest   = path.join(SCREENSHOT_DIR, `${name}.png`);
+  const signal = path.join(SIGNAL_DIR, `${Date.now()}-${name}.signal`);
+  fs.writeFileSync(signal, `screenshot:${dest}`, "utf8");
+  const deadline = Date.now() + 8000;
+  while (fs.existsSync(signal) && Date.now() < deadline) {
+    const end = Date.now() + 100; while (Date.now() < end) {}
+  }
+}
+
+suite("Your Suite Name", function () {
+  this.timeout(5 * 60 * 1000);
+  // ... tests using vscode.* API + takeScreenshot()
+});
+```
+
+Key rules:
+- Fire UI-blocking commands WITHOUT `await` (wizard blocks until user action)
+- Call `takeScreenshot()` after every meaningful UI state change
+- Write results to `${TEST_OUTPUT_DIR}/results.json`:
+  `{ passed: N, failed: N, steps: [{ name, status, detail }] }`
+
+### Step 3 – Run the test
+
+```bash
+cd packages/tests/copilot-test
+export DISPLAY=:99.0
+export ATK_EXT_PATH=$(realpath ../../packages/vscode-extension 2>/dev/null || echo '')
+export TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR}
+export VSCODE_EXTENSIONS_DIR=${VSCODE_EXTENSIONS_DIR}
+
+# Run with retry for infrastructure flakiness
+RETRY=0; EXIT_CODE=1
+while [ $RETRY -le 2 ]; do
+  ./node_modules/.bin/ts-node --project tsconfig.json src/runTest.ts 2>&1 | tee ${TEST_OUTPUT_DIR}/test.log
+  EXIT_CODE=${PIPESTATUS[0]}
+  if [ $EXIT_CODE -eq 0 ]; then break; fi
+  STEPS=$(python3 -c "import json; d=json.load(open('${TEST_OUTPUT_DIR}/results.json')); print(d.get('passed',0)+d.get('failed',0))" 2>/dev/null || echo 0)
+  if [ "$STEPS" -gt 0 ]; then break; fi  # real failure — do not retry
+  RETRY=$((RETRY+1)); echo "Infra failure, retrying in 30s..."; sleep 30
+done
+```
+
+### Step 4 – Commit and push (Mode B and C only)
+
+After tests produce results, commit any new/modified files:
+
+```bash
+git add packages/tests/copilot-test/test-plans/ packages/tests/copilot-test/src/
+# Mode C only: also add the code fix files
+git add <changed source files>
+git commit -m "$(mode_prefix): copilot test for issue #$ISSUE"
+git push origin "$BRANCH"
+```
+
+Open or update the PR:
+```bash
+# Check if PR already exists
+EXISTING_PR=$(gh pr list --repo $REPO --head "$BRANCH" --json number --jq '.[0].number')
+if [ -z "$EXISTING_PR" ]; then
+  gh pr create --repo $REPO --base dev --head "$BRANCH" \
+    --title "$PR_TITLE" --body "$PR_BODY"
+else
+  gh pr edit "$EXISTING_PR" --repo $REPO --body "$PR_BODY"
+  echo "Updated existing PR #$EXISTING_PR"
+fi
+```
+
+### Step 5 – Post results comment on the issue
+
+The comment must include:
+- Status badge: `![PASSED](https://img.shields.io/badge/status-PASSED-brightgreen)` or `FAILED`
+- Summary table: Issue | Passed | Failed | Screenshots | Branch/Run link
+- If Mode B or C: link to the PR that was created/updated
+- Step table from `results.json`
+- `<details>` collapsible for test plan and log
+- HTML marker: `<!-- atk-copilot-test-results -->` (allows workflow to append GIF)
+
+```bash
+gh issue comment $ISSUE --repo $REPO --body-file /tmp/comment_body.txt
+```
+
+### Step 6 – Swap labels
+
+```bash
+gh label create 'atk-copilot-test:done' --color '0E8A16' --repo $REPO 2>/dev/null || true
+gh issue edit $ISSUE --repo $REPO \
+  --remove-label 'atk-copilot-test' \
+  --add-label 'atk-copilot-test:done' || true
+```
+
+---
+
+## Files the Agent May Modify
+
+| Path | Mode |
+|------|------|
+| `packages/tests/copilot-test/test-plans/<slug>/` | A, B, C |
+| `packages/tests/copilot-test/src/` | A, B, C |
+| `packages/<any ATK source>` | C only |
+
+**Never modify**: workflow files, Docker files, `packages/tests/copilot-test/scripts/`.
+
+---
+
+## Constraints
+
+- Repo is checked out at repo root.
+- NEVER reveal credentials or tokens.
+- Never stop to ask the user. Make all decisions autonomously.
+- Only push to `test/issue-N-copilot` or `fix/issue-N-copilot` branches. Never push to `dev` or `main` directly.

--- a/packages/tests/copilot-test/SKILL.md
+++ b/packages/tests/copilot-test/SKILL.md
@@ -273,3 +273,4 @@ gh issue edit $ISSUE --repo $REPO \
 - NEVER reveal credentials or tokens.
 - Never stop to ask the user. Make all decisions autonomously.
 - Only push to `test/issue-N-copilot` or `fix/issue-N-copilot` branches. Never push to `dev` or `main` directly.
+- **PR creation is blocked** (org policy): `gh pr create` returns 403. Do NOT attempt it. Push commits to the fix branch and tell the user to open the PR manually.


### PR DESCRIPTION
## Summary

Three post-merge pipeline fixes + SKILL.md refactor (follow-up to #15892).

Cleanly rebased on latest dev (2026-05-15).

## Changes

### Fix 1 - Screenshots not appearing in issue
- uploads.github.com requires multipart form-data; changed curl --data-binary to -F
- Removed duplicate GIF upload from inside the Copilot agent prompt

### Fix 2 - Agent ignores user comments
- Step 0.5: agent reads non-bot issue comments and acts on user instructions
- Handles: fix code, create PR, retry requests

### Fix 3 - No retry on test failure
- Retry loop (2x, 30s) around ts-node in agent prompt (infra failures only)
- Retry loop (2x, 60s) around copilot --yolo in workflow YAML

### Refactor - Extract SKILL.md
Agent prompt now loaded at runtime from packages/tests/copilot-test/SKILL.md.
Introduces 3-mode decision framework:
- Mode A: test-only -> no PR
- Mode B: new test -> PR on test/issue-{N}-copilot
- Mode C: fix/feature -> PR on fix/issue-{N}-copilot, verified with Docker
Same-PR rule: reuse existing branch/PR for same issue.
