### PR TITLE
chore: bump template and sample version for 6.10.0

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -583,6 +583,93 @@ jobs:
           echo "✅ Branch $BRANCH created successfully"
           echo "created=true" >> $GITHUB_OUTPUT
 
+      - name: Bump versions and create PR for stable release
+        id: version_bump_pr
+        if: ${{ steps.create_branch.outputs.created == 'true' && steps.config.outputs.is_stable == 'true' && env.DRY_RUN == 'false' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const branch = '${{ steps.config.outputs.branch }}';
+            const version = '${{ steps.config.outputs.version }}';
+            const majorMinor = version.replace(/\.[^.]*$/, '');
+
+            // --- 1. Bump SampleConfigTag (v3.N.0 -> v3.(N+1).0) ---
+            const samplesFile = 'packages/fx-core/src/common/samples.ts';
+            let samplesContent = fs.readFileSync(samplesFile, 'utf8');
+            const tagMatch = samplesContent.match(/SampleConfigTag = "v(\d+)\.(\d+)\.(\d+)"/);
+            if (tagMatch) {
+              const newTag = `v${tagMatch[1]}.${parseInt(tagMatch[2]) + 1}.0`;
+              samplesContent = samplesContent.replace(tagMatch[0], `SampleConfigTag = "${newTag}"`);
+              fs.writeFileSync(samplesFile, samplesContent);
+              core.info(`SampleConfigTag: v${tagMatch[1]}.${tagMatch[2]}.${tagMatch[3]} -> ${newTag}`);
+            }
+
+            // --- 2. Update templates-config.json ---
+            const configFile = 'packages/fx-core/src/common/templates-config.json';
+            const config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+            config.version = `~${majorMinor}`;
+            config.localVersion = version;
+            fs.writeFileSync(configFile, JSON.stringify(config, null, 4) + '\n');
+            core.info(`templates-config.json: version=~${majorMinor}, localVersion=${version}`);
+
+            // --- 3. Update templates/package.json ---
+            const pkgFile = 'templates/package.json';
+            const pkg = JSON.parse(fs.readFileSync(pkgFile, 'utf8'));
+            pkg.version = `${version}-alpha`;
+            fs.writeFileSync(pkgFile, JSON.stringify(pkg, null, 2) + '\n');
+            core.info(`templates/package.json: version=${version}-alpha`);
+
+            core.setOutput('version', version);
+            core.setOutput('major_minor', majorMinor);
+
+      - name: Commit and push version bump
+        id: version_bump_push
+        if: ${{ steps.version_bump_pr.outputs.version != '' }}
+        run: |
+          VERSION="${{ steps.version_bump_pr.outputs.version }}"
+          MAJOR_MINOR="${{ steps.version_bump_pr.outputs.major_minor }}"
+          BUMP_BRANCH="chore/bump-version-${MAJOR_MINOR}"
+
+          git checkout -b "$BUMP_BRANCH"
+          git add packages/fx-core/src/common/samples.ts packages/fx-core/src/common/templates-config.json templates/package.json
+          git commit -m "chore: bump template and sample version for ${VERSION}"
+          git push origin "$BUMP_BRANCH"
+
+          echo "bump_branch=$BUMP_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Create version bump PR
+        if: ${{ steps.version_bump_push.outputs.bump_branch != '' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const base = 'dev';
+            const head = '${{ steps.version_bump_push.outputs.bump_branch }}';
+            const version = '${{ steps.version_bump_pr.outputs.version }}';
+            const majorMinor = '${{ steps.version_bump_pr.outputs.major_minor }}';
+
+            const title = `chore: bump template and sample version for ${version}`;
+            const body = [
+              'This PR is created by Release Automation to bump version numbers for the stable release.',
+              '',
+              `- **Version:** ${version}`,
+              `- **SampleConfigTag:** bumped minor version`,
+              `- **templates-config.json:** version=\`~${majorMinor}\`, localVersion=\`${version}\``,
+              `- **templates/package.json:** version=\`${version}-alpha\``,
+            ].join('\n');
+
+            const pr = await github.rest.pulls.create({ owner, repo, title, head, base, body });
+            core.notice(`Created version bump PR: ${pr.data.html_url}`);
+            core.summary
+              .addHeading('📌 Version Bump PR', 2)
+              .addRaw(`\nCreated: ${pr.data.html_url}\n`)
+              .write();
+
       - name: Decide auto-CD for new release branch
         id: decide_auto_cd
         shell: bash

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -10,6 +10,7 @@ env:
   CREATE_BRANCH: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.create_branch) || 'true' }}
   RERUN_CD_ONLY: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.rerun_cd_only) || 'false' }}
   GO_PRODUCT: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.go_product) || 'false' }}
+  VERSION_BUMP_ONLY: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.version_bump_only) || 'false' }}
 
 on:
   workflow_dispatch:
@@ -32,6 +33,10 @@ on:
         default: false
       go_product:
         description: "When triggering CD, set goproduct=true (publish TTK as product)."
+        type: boolean
+        default: false
+      version_bump_only:
+        description: "Only run version bump for stable release (skip branch creation, PRs, CD triggers)."
         type: boolean
         default: false
       dry_run:
@@ -390,7 +395,7 @@ jobs:
 
       - name: Create PR to merge dev into existing release branch
         id: sync_pr
-        if: ${{ steps.check_branch.outputs.exists == 'true' && env.DRY_RUN == 'false' && env.RERUN_CD_ONLY == 'false' && steps.config.outputs.is_prerelease == 'true' }}
+        if: ${{ steps.check_branch.outputs.exists == 'true' && env.DRY_RUN == 'false' && env.RERUN_CD_ONLY == 'false' && env.VERSION_BUMP_ONLY == 'false' && steps.config.outputs.is_prerelease == 'true' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
@@ -502,7 +507,7 @@ jobs:
             core.setOutput('pr_number', String(created.data.number));
 
       - name: Create PR in samples repo (merge dev into main)
-        if: ${{ env.DRY_RUN == 'false' && env.RERUN_CD_ONLY == 'false' && steps.config.outputs.is_hotfix != 'true' }}
+        if: ${{ env.DRY_RUN == 'false' && env.RERUN_CD_ONLY == 'false' && env.VERSION_BUMP_ONLY == 'false' && steps.config.outputs.is_hotfix != 'true' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
@@ -560,7 +565,7 @@ jobs:
 
       - name: Create release branch
         id: create_branch
-        if: ${{ steps.check_branch.outputs.exists == 'false' && env.CREATE_BRANCH == 'true' && env.DRY_RUN == 'false' && env.RERUN_CD_ONLY == 'false' && steps.config.outputs.is_hotfix != 'true' }}
+        if: ${{ steps.check_branch.outputs.exists == 'false' && env.CREATE_BRANCH == 'true' && env.DRY_RUN == 'false' && env.RERUN_CD_ONLY == 'false' && env.VERSION_BUMP_ONLY == 'false' && steps.config.outputs.is_hotfix != 'true' }}
         run: |
           BRANCH="${{ steps.config.outputs.branch }}"
           IS_STABLE="${{ steps.config.outputs.is_stable }}"
@@ -585,7 +590,7 @@ jobs:
 
       - name: Bump versions and create PR for stable release
         id: version_bump_pr
-        if: ${{ steps.create_branch.outputs.created == 'true' && steps.config.outputs.is_stable == 'true' && env.DRY_RUN == 'false' }}
+        if: ${{ (steps.create_branch.outputs.created == 'true' || env.VERSION_BUMP_ONLY == 'true') && steps.config.outputs.is_stable == 'true' && env.DRY_RUN == 'false' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -672,6 +677,7 @@ jobs:
 
       - name: Decide auto-CD for new release branch
         id: decide_auto_cd
+        if: ${{ env.VERSION_BUMP_ONLY == 'false' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -708,6 +714,7 @@ jobs:
 
       - name: Compose notification (shown + email payload)
         id: notify
+        if: ${{ env.VERSION_BUMP_ONLY == 'false' }}
         run: |
           DATE=$(date -u -d '+8 hours' +%Y-%m-%d)
           PRODUCT="${{ steps.config.outputs.product }}"
@@ -826,7 +833,7 @@ jobs:
           echo "body=$BODY" >> $GITHUB_OUTPUT
 
       - name: Send email notification
-        if: ${{ env.DRY_RUN == 'false' && env.MAIL_CLIENT_ID != '' && env.MAIL_CLIENT_SECRET != '' && env.MAIL_TENANT_ID != '' }}
+        if: ${{ env.DRY_RUN == 'false' && env.VERSION_BUMP_ONLY == 'false' && env.MAIL_CLIENT_ID != '' && env.MAIL_CLIENT_SECRET != '' && env.MAIL_TENANT_ID != '' }}
         env:
           MAIL_CLIENT_ID: ${{ env.MAIL_CLIENT_ID }}
           MAIL_CLIENT_SECRET: ${{ env.MAIL_CLIENT_SECRET }}
@@ -839,7 +846,7 @@ jobs:
   trigger-cd:
     needs: prepare-release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' && needs.prepare-release.result == 'success' && ((github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' && (github.event.inputs.rerun_cd_only == 'true' || needs.prepare-release.outputs.auto_cd == 'true')) || (github.event_name == 'schedule' && needs.prepare-release.outputs.auto_cd == 'true')) }}
+    if: ${{ github.event_name != 'pull_request' && needs.prepare-release.result == 'success' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version_bump_only != 'true') && ((github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' && (github.event.inputs.rerun_cd_only == 'true' || needs.prepare-release.outputs.auto_cd == 'true')) || (github.event_name == 'schedule' && needs.prepare-release.outputs.auto_cd == 'true')) }}
     outputs:
       product: ${{ needs.prepare-release.outputs.product }}
       release_type: ${{ needs.prepare-release.outputs.release_type }}

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -187,8 +187,8 @@ jobs:
                 end
             ' releases.json)
           else
-            REASON="cut_date=$TOMORROW_UTC8 (tomorrow UTC+8)"
-            RELEASE=$(jq -c --arg d "$TOMORROW_UTC8" '[.[] | select(.cut_date == $d)] | .[0]' releases.json)
+            REASON="cut_date=$TODAY_UTC8 (UTC+8)"
+            RELEASE=$(jq -c --arg d "$TODAY_UTC8" '[.[] | select(.cut_date == $d)] | .[0]' releases.json)
           fi
 
           if [ "$RELEASE" = "null" ] || [ -z "$RELEASE" ]; then

--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -13,7 +13,7 @@ const packageJson = require("../../package.json");
 const SampleConfigOwner = "OfficeDev";
 const SampleConfigRepo = "TeamsFx-Samples";
 const SampleConfigFile = ".config/samples-config-v3.json";
-export const SampleConfigTag = "v3.2.0";
+export const SampleConfigTag = "v3.3.0";
 // prerelease tag is always using a branch.
 export const SampleConfigBranchForPrerelease = "main";
 

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -1,6 +1,6 @@
 {
-    "version": "~6.8",
-    "localVersion": "6.8.1",
+    "version": "~6.10",
+    "localVersion": "6.10.0",
     "tagPrefix": "templates@",
     "vstagPrefix": "templates-vs@",
     "vsversion": "18.6.0",

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "templates",
-  "version": "6.8.1",
+  "version": "6.10.0-alpha",
   "private": "true",
   "license": "MIT",
   "vsversion": "18.6.0",


### PR DESCRIPTION
This PR is created by Release Automation to bump version numbers for the stable release.

- **Version:** 6.10.0
- **SampleConfigTag:** bumped minor version
- **templates-config.json:** version=`~6.10`, localVersion=`6.10.0`
- **templates/package.json:** version=`6.10.0-alpha`