### PR TITLE
fix: set current status to signed in after retrieve token

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ms-teams-vscode-extension",
   "displayName": "Microsoft 365 Agents Toolkit",
   "description": "Create, debug, and deploy agents with Microsoft 365 Agents Toolkit",
-  "version": "6.8.1-rc.0",
+  "version": "6.10.0-rc.0",
   "publisher": "TeamsDevApp",
   "author": "Microsoft Corporation",
   "private": true,

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -171,6 +171,9 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
           };
         },
       };
+      AzureAccountManager.currentStatus = loggedIn;
+      void this.notifyStatus();
+
       return credential;
     } catch (e) {
       ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Login, e, {


### PR DESCRIPTION
This pull request includes a version bump for the VS Code extension and an update to the Azure account login flow to improve status handling.

Version update:

* Updated the extension version in `package.json` from `6.8.1-rc.0` to `6.10.0-rc.0`, preparing for a new release.

Azure login improvements:

* In `azureLogin.ts`, after a successful login, the `AzureAccountManager` now updates its status to `loggedIn` and notifies listeners, ensuring the extension UI and dependent features reflect the latest authentication state.