### PR TITLE
refactor: remove TEAMSFX_MCP_FOR_DA umbrella feature flag

### DIFF
--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -26,7 +26,6 @@ export class FeatureFlagName {
   static readonly SensitivityLabelEnabled = "TEAMSFX_SENSITIVITY_LABEL";
   static readonly DAMetaOS = "TEAMSFX_DA_METAOS";
   static readonly CFShortcutMetaOS = "TEAMSFX_CF_SHORTCUT_METAOS";
-  static readonly MCPForDA = "TEAMSFX_MCP_FOR_DA";
   static readonly BrokerAuth = "TEAMSFX_BROKER_AUTH";
   // Add config files to existing project to make it toolkit compatible
   static readonly GenerateConfigFiles = "TEAMSFX_GENERATE_CONFIG_FILES";
@@ -93,10 +92,6 @@ export class FeatureFlags {
   static readonly CFShortcutMetaOS = {
     name: FeatureFlagName.CFShortcutMetaOS,
     defaultValue: "false",
-  };
-  static readonly MCPForDA = {
-    name: FeatureFlagName.MCPForDA,
-    defaultValue: "true",
   };
   static readonly BrokerAuth = {
     name: FeatureFlagName.BrokerAuth,

--- a/packages/fx-core/src/component/generator/declarativeAgent/generator.ts
+++ b/packages/fx-core/src/component/generator/declarativeAgent/generator.ts
@@ -160,10 +160,7 @@ export class DeclarativeAgentGenerator extends DefaultTemplateGenerator {
       await setGeneralSensitivityLabel(context, declarativeCopilotManifestPathRes.value);
     }
 
-    if (
-      featureFlagManager.getBooleanValue(FeatureFlags.MCPForDA) &&
-      TemplateNames.DeclarativeAgentWithActionFromMCP === inputs[QuestionNames.TemplateName]
-    ) {
+    if (TemplateNames.DeclarativeAgentWithActionFromMCP === inputs[QuestionNames.TemplateName]) {
       const result = await generateForMCPForDA(destinationPath, inputs);
       return result;
     }

--- a/packages/fx-core/src/question/constants.ts
+++ b/packages/fx-core/src/question/constants.ts
@@ -504,11 +504,7 @@ export class ActionStartOptions {
 
   static all(inputs: Inputs, doesProjectExists?: boolean): OptionItem[] {
     if (doesProjectExists) {
-      const options: OptionItem[] = [ActionStartOptions.apiSpec()];
-      if (featureFlagManager.getBooleanValue(FeatureFlags.MCPForDA)) {
-        options.push(ActionStartOptions.mcp());
-      }
-      return options;
+      return [ActionStartOptions.apiSpec(), ActionStartOptions.mcp()];
     } else {
       // use constant string to avoid cycle dependency
       return [ActionStartOptions.newApi(), ActionStartOptions.apiSpec()];

--- a/packages/fx-core/src/question/scaffold/vsc/daProjectTypeNode.ts
+++ b/packages/fx-core/src/question/scaffold/vsc/daProjectTypeNode.ts
@@ -68,9 +68,7 @@ export function daProjectTypeNode(
                 ...(featureFlagManager.getBooleanValue(FeatureFlags.DAMetaOS)
                   ? [ActionStartOptions.DAMetaOS()]
                   : []),
-                ...(featureFlagManager.getBooleanValue(FeatureFlags.MCPForDA)
-                  ? [ActionStartOptions.mcp()]
-                  : []),
+                ActionStartOptions.mcp(),
               ],
               default: ActionStartOptions.newApi().id,
               onDidSelection: setTemplateName,

--- a/packages/fx-core/templates/ui/tdpNode.json
+++ b/packages/fx-core/templates/ui/tdpNode.json
@@ -112,8 +112,7 @@
                     "id": "mcp",
                     "label": "template.createProjectQuestion.mcpForDa.label",
                     "detail": "template.createProjectQuestion.mcpForDa.detail",
-                    "data": "declarative-agent-with-action-from-mcp",
-                    "featureFlag": "TEAMSFX_MCP_FOR_DA"
+                    "data": "declarative-agent-with-action-from-mcp"
                   }
                 ]
               },

--- a/packages/fx-core/templates/ui/wizardNode.json
+++ b/packages/fx-core/templates/ui/wizardNode.json
@@ -134,8 +134,7 @@
                     "id": "mcp",
                     "label": "template.createProjectQuestion.mcpForDa.label",
                     "detail": "template.createProjectQuestion.mcpForDa.detail",
-                    "data": "declarative-agent-with-action-from-mcp",
-                    "featureFlag": "TEAMSFX_MCP_FOR_DA"
+                    "data": "declarative-agent-with-action-from-mcp"
                   }
                 ]
               },

--- a/packages/fx-core/tests/component/generator/declarativeAgentGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/declarativeAgentGenerator.test.ts
@@ -1875,8 +1875,7 @@ describe("helper", async () => {
   });
 
   describe("generator.post MCPForDA branch", () => {
-    it("post() calls generateForMCPForDA when flag and template match", async () => {
-      const { FeatureFlags } = await import("../../../src/common/featureFlags");
+    it("post() calls generateForMCPForDA when template matches", async () => {
       const generator = new DeclarativeAgentGenerator();
       const context = createContext();
       const destinationPath = "/test/destination";
@@ -1884,10 +1883,6 @@ describe("helper", async () => {
       sandbox
         .stub(copilotGptManifestUtils, "getManifestPath")
         .resolves(ok("/test/destination/appPackage/da.json"));
-      sandbox.stub(featureFlagManager, "getBooleanValue").callsFake((flag: any) => {
-        if (flag === FeatureFlags.MCPForDA) return true;
-        return false;
-      });
       const generateStub = sandbox
         .stub(generatorHelper, "generateForMCPForDA")
         .resolves(ok({ warnings: [] }));

--- a/packages/fx-core/tests/question/question.test.ts
+++ b/packages/fx-core/tests/question/question.test.ts
@@ -1825,33 +1825,18 @@ describe("ActionStartOptions", () => {
   });
 
   describe("all()", () => {
-    it("should include MCP option on VSCode platform when MCPForDA is enabled", () => {
-      sandbox.stub(featureFlagManager, "getBooleanValue").callsFake((flag) => {
-        if (flag === FeatureFlags.MCPForDA) return true;
-        return false;
-      });
+    it("should include MCP option on VSCode platform", () => {
       const inputs: Inputs = { platform: Platform.VSCode };
       const options = ActionStartOptions.all(inputs, true);
       assert.isTrue(options.some((o) => o.id === ActionStartOptions.mcp().id));
       assert.isTrue(options.some((o) => o.id === ActionStartOptions.apiSpec().id));
     });
 
-    it("should include MCP option on CLI platform when MCPForDA is enabled", () => {
-      sandbox.stub(featureFlagManager, "getBooleanValue").callsFake((flag) => {
-        if (flag === FeatureFlags.MCPForDA) return true;
-        return false;
-      });
+    it("should include MCP option on CLI platform", () => {
       const inputs: Inputs = { platform: Platform.CLI };
       const options = ActionStartOptions.all(inputs, true);
       assert.isTrue(options.some((o) => o.id === ActionStartOptions.mcp().id));
       assert.isTrue(options.some((o) => o.id === ActionStartOptions.apiSpec().id));
-    });
-
-    it("should not include MCP option on CLI platform when MCPForDA is disabled", () => {
-      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
-      const inputs: Inputs = { platform: Platform.CLI };
-      const options = ActionStartOptions.all(inputs, true);
-      assert.isFalse(options.some((o) => o.id === ActionStartOptions.mcp().id));
     });
 
     it("should return newApi and apiSpec when doesProjectExists is false", () => {

--- a/packages/fx-core/tests/question/scaffold.test.ts
+++ b/packages/fx-core/tests/question/scaffold.test.ts
@@ -286,14 +286,7 @@ describe("daProjectTypeNode", () => {
     assert.isTrue(conditionFunc(testInputs));
   });
 
-  it("should include MCP option when MCPForDA feature flag is enabled", () => {
-    sandbox.stub(featureFlagManager, "getBooleanValue").callsFake((flag) => {
-      if (flag === FeatureFlags.MCPForDA) {
-        return true;
-      }
-      return false;
-    });
-
+  it("should include MCP option", () => {
     const node = daProjectTypeNode();
     const withPluginNode = node.children?.[0];
     assert.isDefined(withPluginNode);
@@ -324,44 +317,6 @@ describe("daProjectTypeNode", () => {
     assert.isDefined(mcpOption);
     const mcpOptionId = typeof mcpOption === "string" ? mcpOption : mcpOption?.id;
     assert.equal(mcpOptionId, "mcp");
-  });
-
-  it("should not include MCP option when MCPForDA feature flag is disabled", () => {
-    sandbox.stub(featureFlagManager, "getBooleanValue").callsFake((flag) => {
-      if (flag === FeatureFlags.MCPForDA) {
-        return false;
-      }
-      return false;
-    });
-
-    const node = daProjectTypeNode();
-    const withPluginNode = node.children?.[0];
-    assert.isDefined(withPluginNode);
-
-    const actionTypeNode = withPluginNode?.children?.[0];
-    assert.isDefined(actionTypeNode);
-
-    const actionTypeData = actionTypeNode?.data as SingleSelectQuestion;
-    assert.isDefined(actionTypeData);
-    assert.isDefined(actionTypeData.staticOptions);
-
-    // Check that MCP option is not included in staticOptions
-    const staticOptions = actionTypeData.staticOptions;
-    let mcpOption: string | OptionItem | undefined;
-
-    if (Array.isArray(staticOptions) && staticOptions.length > 0) {
-      if (typeof staticOptions[0] === "string") {
-        mcpOption = (staticOptions as string[]).find(
-          (option) => option === ActionStartOptions.mcp().id
-        );
-      } else {
-        mcpOption = (staticOptions as OptionItem[]).find(
-          (option) => option.id === ActionStartOptions.mcp().id
-        );
-      }
-    }
-
-    assert.isUndefined(mcpOption);
   });
 });
 

--- a/packages/vscode-extension/.vscode/launch.json
+++ b/packages/vscode-extension/.vscode/launch.json
@@ -13,8 +13,7 @@
       "env": {
         "NODE_ENV": "development",
         "TEAMSFX_SAMPLE_CONFIG_BRANCH": "dev",
-        "TEMPLATE_VERSION": "local",
-        "TEAMSFX_MCP_FOR_DA": "true"
+        "TEMPLATE_VERSION": "local"
       },
       "preLaunchTask": "watch"
     },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1585,11 +1585,6 @@
           "default": "Info",
           "markdownDescription": "Set the log level of Microsoft 365 Agents Toolkit. The default value is `Info`. The available values are `Debug`, `Verbose`, `Info`. The definitions of the log levels are:\n\n`Debug`:\n\n- HTTP request and response details from Microsoft 365 Agents Toolkit to external services such as Azure, Microsoft 365, and Developer Portal.\n- Information related to Microsoft 365 and Azure accounts and access permissions.\n- Debugging information for each Microsoft 365 Agents Toolkit command execution, such as stack trace, ARM deployment information, etc.\n\n`Verbose`:\n\n- Progress information when executing lifecycle commands defined in the YAML file.\n- Execution details of each action that defined in the YAML file, including outcomes, result summaries, diagnostic information, etc.\n\n`Info`: Microsoft 365 Agents Toolkit command execution summaries.\n"
         },
-        "M365AgentsToolkit.enableDeclarativeAgentMCPSupport": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable MCP server support for Declarative Agent."
-        },
         "M365AgentsToolkit.enableLaunchAgentForTeamsInCopilot": {
           "type": "boolean",
           "default": false,

--- a/packages/vscode-extension/src/config.ts
+++ b/packages/vscode-extension/src/config.ts
@@ -29,10 +29,6 @@ export class ConfigManager {
       ConfigurationKey.BicepEnvCheckerEnable,
       false
     ).toString();
-    process.env[FeatureFlags.MCPForDA.name] = this.getConfiguration(
-      ConfigurationKey.EnableMCPforDA,
-      true
-    ).toString();
     process.env[FeatureFlags.CEAEnabled.name] = this.getConfiguration(
       ConfigurationKey.EnableCEA,
       false

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -4,7 +4,6 @@ export const CONFIGURATION_PREFIX = "M365AgentsToolkit";
 export enum ConfigurationKey {
   BicepEnvCheckerEnable = "prerequisiteCheck.bicep",
   LogLevel = "logLevel",
-  EnableMCPforDA = "enableDeclarativeAgentMCPSupport",
   EnableCEA = "enableLaunchAgentForTeamsInCopilot",
   EnableDAMetaOS = "enableDeclarativeAgentInOfficeAddIn",
   EnableCFShortcutMetaOS = "enableCustomFunctionShortcutInOfficeAddIn",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1332,7 +1332,7 @@ function registerLanguageFeatures(context: vscode.ExtensionContext) {
     );
   }
 
-  if (featureFlagManager.getBooleanValue(FeatureFlags.MCPForDA)) {
+  {
     const workspaceMCPConfigSelector: vscode.DocumentSelector = {
       pattern: `**/mcp.json`,
     };

--- a/templates/src/ui/da.ts
+++ b/templates/src/ui/da.ts
@@ -88,7 +88,6 @@ export const daNode = {
                 label: "template.createProjectQuestion.mcpForDa.label",
                 detail: "template.createProjectQuestion.mcpForDa.detail",
                 data: "declarative-agent-with-action-from-mcp",
-                featureFlag: "TEAMSFX_MCP_FOR_DA",
               },
             ],
           },


### PR DESCRIPTION
## Summary

The `TEAMSFX_MCP_FOR_DA` umbrella flag has been at default-true for some time and the MCP-backed Declarative Agent creation flow is now fully GA. This PR removes the flag and all of its gating across `fx-core`, `vscode-extension`, templates, and launch configs so the MCP-backed DA path is unconditionally available.

## Changes

**fx-core**
- Drop `MCPForDA` from `FeatureFlagName` / `FeatureFlags` (`src/common/featureFlags.ts`).
- Unconditionally expose `ActionStartOptions.mcp()` in the scaffold wizard (`src/question/scaffold/vsc/daProjectTypeNode.ts`) and `ActionStartOptions.all()` (`src/question/constants.ts`).
- Remove the flag check in the declarative agent generator (`src/component/generator/declarativeAgent/generator.ts`).

**vscode-extension**
- Unwrap `WorkspaceMCPConfigCodeLensProvider` registration in `src/extension.ts`.
- Drop the `loadFeatureFlags()` bridge for the flag in `src/config.ts`.
- Remove `ConfigurationKey.EnableMCPforDA` from `src/constants.ts`.
- Remove the `M365AgentsToolkit.enableDeclarativeAgentMCPSupport` configuration contribution from `package.json`.

**templates / launch**
- Strip `"featureFlag": "TEAMSFX_MCP_FOR_DA"` entries from `tdpNode.json`, `wizardNode.json`, and `templates/src/ui/da.ts`.
- Remove `"TEAMSFX_MCP_FOR_DA": "true"` env entries from `.vscode/launch.json` (both root and `packages/vscode-extension/`).

**tests**
- Collapse positive/negative flag-stubbed test pairs into single unconditional cases in `scaffold.test.ts`, `question.test.ts`, and `declarativeAgentGenerator.test.ts`.

## Validation

- `pnpm setup:vsc` — full build chain green.
- `npm run lint` (fx-core) — 0 errors.
- `npm run lint` (vscode-extension) — 0 errors.
- `npm run test:unit` (fx-core) — **3897 passing, 18 pending, 0 failing**.
- `npm run test:unit` (vscode-extension) — **1024 passing, 0 failing**.

## Risk

Low. The flag has been default-true for some time; this only removes dead branches and the now-unreachable disabled path. No user-facing setting is added; the removed VS Code setting `M365AgentsToolkit.enableDeclarativeAgentMCPSupport` will simply be ignored if it was ever set.
