### PR TITLE
refactor: split ATK Copilot test pipeline into 3-layer architecture

### DIFF
--- a/.github/workflows/atk-copilot-test-coverage.yml
+++ b/.github/workflows/atk-copilot-test-coverage.yml
@@ -1,0 +1,262 @@
+name: ATK Copilot Test Coverage
+# Orchestrates Copilot-driven ATK UI test coverage for a GitHub issue.
+#
+# Architecture (3-layer pipeline):
+#   [Label] atk-copilot-test-label.yml
+#       -> [Coverage] THIS FILE  (Copilot CLI brain)
+#           -> [Runner] atk-copilot-test-runner.yml  (pure executor)
+#
+# Flow:
+#   1. Copilot CLI reads the issue, finds/creates test plan + test script.
+#   2. Triggers atk-copilot-test-runner.yml with the script name + branch ref.
+#   3. Downloads results.json; if the test script has bugs, fixes and re-runs (max 3x).
+#   4. If product bug: files bugs/<feature>-bug.md.
+#   5. Posts structured results comment; swaps label to atk-copilot-test:done.
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number whose body describes the test task'
+        required: true
+        type: string
+      author_login:
+        description: 'GitHub login of the user who triggered the run'
+        required: false
+        default: ''
+        type: string
+  workflow_call:
+    inputs:
+      issue_number:
+        description: 'Issue number whose body describes the test task'
+        required: true
+        type: string
+      author_login:
+        required: false
+        default: ''
+        type: string
+    secrets:
+      COPILOT_CLI_RUNNER_TOKEN:
+        required: true
+
+concurrency:
+  group: atk-copilot-test-${{ inputs.issue_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  run-coverage:
+    name: ATK Copilot Test Coverage (issue #${{ inputs.issue_number }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      actions: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Copilot CLI
+        run: |
+          npm install -g @github/copilot@1.0.9
+          copilot --version
+
+      - name: Set up Copilot credentials
+        env:
+          GH_USER:         ${{ vars.COPILOT_CLI_RUNNER_USER }}
+          TEST_USER_TOKEN: ${{ secrets.COPILOT_CLI_RUNNER_TOKEN }}
+          GH_APP_ID:       ${{ vars.COPILOT_CLI_RUNNER_APP_ID }}
+        run: |
+          mkdir -p ~/.config/github-copilot
+          echo '{
+            "'"github.com:${GH_APP_ID}"'":{
+              "user": "'"$GH_USER"'",
+              "oauth_token":"'"$TEST_USER_TOKEN"'",
+              "githubAppId":"'"$GH_APP_ID"'"
+            }
+          }' > ~/.config/github-copilot/apps.json
+          chmod 600 ~/.config/github-copilot/apps.json
+
+      - name: Verify Copilot auth
+        run: |
+          if [ ! -s ~/.config/github-copilot/apps.json ]; then
+            echo "::error::apps.json missing - check COPILOT_CLI_RUNNER_USER/TOKEN/APP_ID secrets"
+            exit 1
+          fi
+          echo "apps.json present ($(wc -c < ~/.config/github-copilot/apps.json) bytes)"
+
+      - name: Post in-progress comment
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE="${{ inputs.issue_number }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${ISSUE}/comments" \
+            --paginate \
+            --jq '.[] | select(.body | contains("<!-- atk-copilot-test -->")) | .id' | tail -1)
+          BODY="<!-- atk-copilot-test -->
+          ### ATK Copilot Test - started
+
+          Analysing issue and preparing test environment...
+
+          [View workflow run]($RUN_URL)"
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY"
+          else
+            gh issue comment "$ISSUE" --body "$BODY"
+          fi
+
+      - name: Run coverage agent
+        env:
+          GH_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO:        ${{ github.repository }}
+          RUN_URL:     "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_RUNNER_TOKEN }}
+          INPUT_PROMPT: |
+            You are running fully autonomously inside GitHub Actions CI. There is no human watching.
+            Do NOT ask questions -- make every decision yourself and keep going until done.
+
+            Your ONLY job: ensure the change described in issue #${ISSUE_NUMBER} is covered by an
+            ATK UI test, run that test, and report results back to the issue.
+
+            Only modify files under packages/tests/copilot-test/test-plans/ and
+            packages/tests/copilot-test/src/ (and bugs/ for bug reports). Do NOT touch any other files.
+
+            ## Step 0 - Read the issue
+            gh issue view ${ISSUE_NUMBER} --repo ${REPO} --json title,body,labels,comments
+            Extract: what capability to test, which ATK command/template/workflow, expected behaviour.
+
+            ## Step 1 - Find or create a test plan
+            ls packages/tests/copilot-test/test-plans/
+            cat packages/tests/copilot-test/test-plans/README.md
+            Find a matching plan or create one following the template at
+            packages/tests/copilot-test/test-plans/template.md.
+            Naming: packages/tests/copilot-test/test-plans/<feature-slug>/<feature-slug>.md
+
+            ## Step 2 - Find or create a test script
+            ls packages/tests/copilot-test/src/
+            Check for an existing test file covering the task. Review and update if needed, or create a new one.
+
+            Naming: packages/tests/copilot-test/src/<feature>-<task>.test.ts
+            Reference: packages/tests/copilot-test/src/simple-bot-create.test.ts
+
+            CRITICAL test structure rules (these are not negotiable):
+            - Use @vscode/test-electron + Mocha TDD (NOT vscode-extension-tester)
+            - Call takeScreenshot() after every meaningful UI state change
+            - Fire UI-blocking VSCode commands WITHOUT await (wizard blocks until user action)
+            - Write results JSON to ${TEST_OUTPUT_DIR}/results.json:
+              { passed, failed, steps: [{name, status, detail}] }
+            - Read packages/tests/copilot-test/README.md for the full test structure reference
+
+            ## Step 3 - Commit and push
+            After writing/updating test plan and test script:
+              git add packages/tests/copilot-test/
+              git commit -m "Add/update test: <feature> (issue #${ISSUE_NUMBER})"
+              git push origin $(git branch --show-current)
+
+            ## Step 4 - Run the test via the CI runner
+            Note the current branch name: BRANCH=$(git branch --show-current)
+            Trigger atk-copilot-test-runner.yml with the script name and explicit branch ref:
+              gh workflow run atk-copilot-test-runner.yml \
+                --repo ${REPO} \
+                --ref $BRANCH \
+                --field script=<test-file-basename-without-.test.ts>
+
+            Wait 15 seconds for the run to be registered, then find the run ID:
+              sleep 15
+              RUN_ID=$(gh run list --workflow=atk-copilot-test-runner.yml \
+                --repo ${REPO} --branch $BRANCH --limit=1 \
+                --json databaseId --jq '.[0].databaseId')
+              gh run watch $RUN_ID --repo ${REPO}
+
+            ## Step 5 - Analyze results
+            Download the results artifact:
+              gh run download $RUN_ID --repo ${REPO} \
+                --pattern "atk-test-results-*" --dir /tmp/test-results
+              cat /tmp/test-results/results.json
+
+            Decision tree:
+            - All steps pass -> proceed to Step 6 with success status.
+            - Any step fails -> diagnose the failure:
+              a) TEST SCRIPT ISSUE (wrong vscode API usage, wrong selector, timing issue):
+                 Fix the test script in packages/tests/copilot-test/src/.
+                 Commit "Fix test: <feature> - <reason>", push.
+                 Re-trigger runner with same script name + branch (max 3 total iterations).
+                 If still failing after 3 iterations, proceed to Step 6 with failure status.
+              b) PRODUCT BUG (ATK extension does not behave as the test plan describes):
+                 Do NOT attempt to work around it in the test script.
+                 Create packages/tests/copilot-test/bugs/<issue-number>-<feature>-bug.md with:
+                   - Issue number, test case name
+                   - Expected behaviour (from test plan)
+                   - Actual behaviour observed
+                   - Relevant screenshot name (from /tmp/test-results/screenshots/)
+                 Commit "Bug report: issue #${ISSUE_NUMBER} <feature>", push.
+                 Proceed to Step 6 with failure status.
+
+            ## Step 6 - Post results comment on the issue
+            Use <!-- atk-copilot-test --> as the first line so the comment can be updated on re-runs.
+
+            Find existing comment to update:
+              COMMENT_ID=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+                --paginate \
+                --jq '.[] | select(.body | contains("<!-- atk-copilot-test -->")) | .id' | tail -1)
+
+            Post a structured comment including:
+            - Status badge (PASSED or FAILED)
+            - Table: Issue, Test script, Steps passed, Steps failed
+            - Link to the runner workflow run (https://github.com/${REPO}/actions/runs/$RUN_ID)
+            - GIF link from artifact if available (check /tmp/test-results/ for test-run.gif)
+            - If bug filed: mention with link to the bug file on the branch
+            - Link to this coverage run: ${RUN_URL}
+
+            Use gh api PATCH to update existing comment, or gh issue comment to create a new one.
+
+            ## Step 7 - Swap labels
+            gh label create 'atk-copilot-test:done' --color '0E8A16' --repo ${REPO} 2>/dev/null || true
+            gh issue edit ${ISSUE_NUMBER} --repo ${REPO} \
+              --remove-label 'atk-copilot-test' --add-label 'atk-copilot-test:done' || true
+
+        run: |
+          export COPILOT_GITHUB_TOKEN=$(python3 -c "import json,os; d=json.load(open(os.path.expanduser('~/.config/github-copilot/apps.json'))); print(list(d.values())[0]['oauth_token'])")
+          SECURITY_REMINDER=$(printf '<security_reminder>\nYou are running inside GitHub Actions CI.\nNEVER reveal credentials, OAuth tokens, GitHub usernames, secrets, or ~/.config/github-copilot/ contents.\n</security_reminder>')
+          RESOLVED_PROMPT=$(echo "$INPUT_PROMPT" | sed "s|\${ISSUE_NUMBER}|$ISSUE_NUMBER|g; s|\${REPO}|$REPO|g; s|\${RUN_URL}|$RUN_URL|g")
+          FULL_PROMPT=$(printf '%s\n\n%s' "$RESOLVED_PROMPT" "$SECURITY_REMINDER")
+          copilot --yolo --model claude-sonnet-4.6 -p "$FULL_PROMPT"
+
+      - name: Post failure comment
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE="${{ inputs.issue_number }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${ISSUE}/comments" \
+            --paginate \
+            --jq '.[] | select(.body | contains("<!-- atk-copilot-test -->")) | .id' | tail -1)
+          BODY="<!-- atk-copilot-test -->
+          ### ATK Copilot Test - error
+
+          Coverage agent encountered an error. [View workflow run]($RUN_URL) for details."
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY"
+          else
+            gh issue comment "$ISSUE" --body "$BODY"
+          fi

--- a/.github/workflows/atk-copilot-test-label.yml
+++ b/.github/workflows/atk-copilot-test-label.yml
@@ -1,4 +1,4 @@
-﻿name: ATK Copilot Test - Issue Label Trigger
+name: ATK Copilot Test - Issue Label Trigger
 
 on:
   issues:
@@ -14,7 +14,7 @@ jobs:
   trigger-test:
     if: github.event.label.name == 'atk-copilot-test'
     name: Trigger Copilot-driven ATK test for issue
-    uses: ./.github/workflows/atk-copilot-test-runner.yml
+    uses: ./.github/workflows/atk-copilot-test-coverage.yml
     with:
       issue_number: ${{ github.event.issue.number }}
       author_login: ${{ github.event.sender.login }}

--- a/.github/workflows/atk-copilot-test-runner.yml
+++ b/.github/workflows/atk-copilot-test-runner.yml
@@ -1,67 +1,57 @@
 name: ATK Copilot Test Runner
-
-# Triggered by atk-copilot-test-label.yml (via workflow_call) or manually.
+# Pure test executor -- Layer 3 of the ATK Copilot test pipeline.
 #
-# Architecture: @vscode/test-electron (activates ATK extension + Mocha) 
-#               + Playwright CDP (takes real screenshots from outside extension host)
+# Architecture (3-layer pipeline):
+#   [Label] atk-copilot-test-label.yml
+#       -> [Coverage] atk-copilot-test-coverage.yml  (Copilot CLI brain)
+#           -> [Runner] THIS FILE  (pure executor)
 #
-# Flow:
-#  1. Read the GitHub issue to understand the test task.
-#  2. Copilot CLI analyses the issue and packages/tests/copilot-test/test-plans/ to choose/create a test script.
-#  3. The test runs headlessly (Xvfb + VSCode/test-electron + Playwright CDP).
-#  4. Screenshots and a summary are posted back to the issue as a comment.
-#  5. Label is swapped: atk-copilot-test -> atk-copilot-test:done.
+# This workflow takes a test script name, runs it headlessly against the ATK
+# VSCode extension, and uploads results + screenshots as an artifact.
+# It has no knowledge of GitHub issues, labels, or Copilot CLI.
 
 on:
   workflow_dispatch:
     inputs:
-      issue_number:
-        description: 'Issue number whose body describes the test task'
+      script:
+        description: 'Test file basename (e.g. simple-bot-create for simple-bot-create.test.ts)'
         required: true
         type: string
-      author_login:
-        description: 'GitHub login of the user who triggered the run'
-        required: false
-        default: ''
-        type: string
-
   workflow_call:
     inputs:
-      issue_number:
-        description: 'Issue number whose body describes the test task'
+      script:
+        description: 'Test file basename (e.g. simple-bot-create for simple-bot-create.test.ts)'
         required: true
         type: string
-      author_login:
-        required: false
-        default: ''
-        type: string
-    secrets:
-      COPILOT_CLI_RUNNER_TOKEN:
-        required: true
-
-concurrency:
-  group: atk-copilot-test-${{ inputs.issue_number || github.run_id }}
-  cancel-in-progress: true
+    outputs:
+      passed:
+        description: 'Number of passed test steps'
+        value: ${{ jobs.run-test.outputs.passed }}
+      failed:
+        description: 'Number of failed test steps'
+        value: ${{ jobs.run-test.outputs.failed }}
+      artifact_url:
+        description: 'URL of the uploaded test results artifact'
+        value: ${{ jobs.run-test.outputs.artifact_url }}
 
 env:
   TEST_OUTPUT_DIR: /tmp/atk-test-output
 
 jobs:
-  run-atk-copilot-test:
-    name: ATK Copilot Test (issue #${{ inputs.issue_number }})
+  run-test:
+    name: ATK Test (${{ inputs.script }})
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 45
     permissions:
-      contents: write
-      actions: write
-      issues: write
-      pull-requests: write
+      contents: read
+      actions: read
+    outputs:
+      passed:      ${{ steps.parse-results.outputs.passed }}
+      failed:      ${{ steps.parse-results.outputs.failed }}
+      artifact_url: ${{ steps.upload-results.outputs.artifact-url }}
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: true
-          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -95,7 +85,6 @@ jobs:
       - name: Install redhat.vscode-yaml (satisfies ATK extensionDependencies)
         run: |
           mkdir -p $HOME/vscode-extensions
-          # Download yaml extension from VS Code marketplace
           curl -L -o /tmp/vscode-yaml.vsix \
             "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/vscode-yaml/latest/vspackage" \
             --header "Accept: application/octet-stream" 2>/dev/null || true
@@ -104,7 +93,6 @@ jobs:
             echo "VSCODE_EXTENSIONS_DIR=$HOME/vscode-extensions" >> $GITHUB_ENV
             echo "redhat.vscode-yaml installed to $HOME/vscode-extensions"
           else
-            # Fallback: use --install-extension at runtime via launchArgs
             echo "::warning::yaml vsix download failed; ATK will use --install-extension fallback"
           fi
 
@@ -115,238 +103,61 @@ jobs:
           echo "DISPLAY=:99.0" >> $GITHUB_ENV
 
       - name: Prepare output directory
-        run: mkdir -p "$TEST_OUTPUT_DIR/screenshots" "$TEST_OUTPUT_DIR/projects"
-
-      - name: Install Copilot CLI
         run: |
-          npm install -g @github/copilot@1.0.9
-          copilot --version
+          mkdir -p "$TEST_OUTPUT_DIR/screenshots" \
+                   "$TEST_OUTPUT_DIR/projects" \
+                   "$TEST_OUTPUT_DIR/.screenshot-signals"
 
-      - name: Set up Copilot credentials
+      - name: Run test
         env:
-          GH_USER:         ${{ vars.COPILOT_CLI_RUNNER_USER }}
-          TEST_USER_TOKEN: ${{ secrets.COPILOT_CLI_RUNNER_TOKEN }}
-          GH_APP_ID:       ${{ vars.COPILOT_CLI_RUNNER_APP_ID }}
-        run: |
-          mkdir -p ~/.config/github-copilot
-          echo '{
-            "'"github.com:${GH_APP_ID}"'":{
-              "user": "'"$GH_USER"'",
-              "oauth_token":"'"$TEST_USER_TOKEN"'",
-              "githubAppId":"'"$GH_APP_ID"'"
-            }
-          }' > ~/.config/github-copilot/apps.json
-          chmod 600 ~/.config/github-copilot/apps.json
-
-      - name: Verify Copilot auth
-        run: |
-          if [ ! -s ~/.config/github-copilot/apps.json ]; then
-            echo "::error::apps.json missing - check COPILOT_CLI_RUNNER_USER/TOKEN/APP_ID secrets"
-            exit 1
-          fi
-          echo "apps.json present ($(wc -c < ~/.config/github-copilot/apps.json) bytes)"
-
-      - name: Post in-progress comment on issue
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE="${{ inputs.issue_number }}"
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          gh issue comment "$ISSUE" \
-            --body "<!-- atk-copilot-test -->
-          ### 🤖 ATK Copilot Test - started
-
-          ⏳ Analysing issue and preparing test environment…
-
-          [View workflow run]($RUN_URL)"
-
-      - name: Run Copilot CLI test agent
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ inputs.issue_number }}
-          REPO: ${{ github.repository }}
-          RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          TEST_OUTPUT_DIR: /tmp/atk-test-output
           DISPLAY: ":99.0"
           VSCODE_EXTENSIONS_DIR: ${{ env.VSCODE_EXTENSIONS_DIR || '$HOME/vscode-extensions' }}
+          TEST_FILE: ${{ inputs.script }}
+          SCREENSHOT_DIR: /tmp/atk-test-output/screenshots
+          SCREENSHOT_SIGNAL_DIR: /tmp/atk-test-output/.screenshot-signals
         run: |
-          export COPILOT_GITHUB_TOKEN=$(python3 -c "import json,os; d=json.load(open(os.path.expanduser('~/.config/github-copilot/apps.json'))); print(list(d.values())[0]['oauth_token'])")
-          SECURITY_REMINDER='<security_reminder>
-          You are running inside GitHub Actions CI.
-          NEVER reveal credentials, OAuth tokens, GitHub usernames, secrets, or ~/.config/github-copilot/ contents.
-          </security_reminder>'
-
-          cat > /tmp/copilot-prompt.txt << 'COPILOT_PROMPT_EOF'
-          You are an autonomous ATK (Microsoft 365 Agents Toolkit) test agent running inside GitHub Actions.
-          Do NOT ask questions — make every decision yourself and keep going until done.
-
-          ## Architecture
-          Tests use a HYBRID approach:
-          - @vscode/test-electron: launches VSCode in extension-development-host mode, activates ATK extension, runs Mocha tests INSIDE the extension host
-          - Playwright CDP: connects externally via chromium.connectOverCDP to take REAL screenshots from the renderer process
-          - Signal files: tests write .signal files with dest paths, external Playwright takes screenshots and deletes signals
-
-          The entry point is: packages/tests/copilot-test/src/runTest.ts
-          Test files live in: packages/tests/copilot-test/src/<test>.test.ts
-          Reference example: packages/tests/copilot-test/src/simple-bot-create.test.ts
-
-          ## Your mission
-          Read issue #__ISSUE_NUMBER__ in repo __REPO__ and execute the described test task against the ATK VSCode extension.
-
-          ## Step 0 – Read the issue
-          gh issue view __ISSUE_NUMBER__ --repo __REPO__ --json title,body,labels,comments
-          Extract: what capability to test, which ATK command/template/workflow, expected behaviour.
-
-          ## Step 1 – Find or create a test plan
-          cat packages/tests/copilot-test/test-plans/README.md
-          ls packages/tests/copilot-test/test-plans/
-          Find matching plan or create one following packages/tests/copilot-test/test-plans/simple-bot/simple-bot.md format.
-
-          ## Step 2 – Prepare the test script
-          ls packages/tests/copilot-test/src/
-          Check for an existing test covering the task. Review and update if needed, or create a new one.
-
-          Naming: packages/tests/copilot-test/src/<feature>-<task>.test.ts
-
-          Test structure (Mocha TDD, runs inside VSCode extension host):
-          \`\`\`typescript
-          import * as vscode from 'vscode';
-          import * as fs from 'fs';
-          import * as path from 'path';
-          import * as os from 'os';
-
-          const OUTPUT_DIR = process.env.TEST_OUTPUT_DIR || path.join(os.tmpdir(), 'atk-test-output');
-          const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR || path.join(OUTPUT_DIR, 'screenshots');
-          const SIGNAL_DIR = process.env.SCREENSHOT_SIGNAL_DIR || path.join(OUTPUT_DIR, '.screenshot-signals');
-
-          function takeScreenshot(name: string): void {
-            const dest = path.join(SCREENSHOT_DIR, \`\${name}.png\`);
-            const signal = path.join(SIGNAL_DIR, \`\${Date.now()}-\${name}.signal\`);
-            fs.writeFileSync(signal, dest, 'utf8');
-            const deadline = Date.now() + 8000;
-            while (fs.existsSync(signal) && Date.now() < deadline) {
-              const end = Date.now() + 100; while (Date.now() < end) {}
-            }
-          }
-
-          function wait(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)); }
-
-          suite('Your Suite Name', function () {
-            this.timeout(5 * 60 * 1000);
-            // ... tests using vscode.* API + takeScreenshot()
-            // Fire commands WITHOUT await: vscode.commands.executeCommand('cmd').catch(()=>{});
-          });
-          \`\`\`
-
-          Key rules:
-          - DO NOT use vscode-extension-tester (wrong library)
-          - Call takeScreenshot() after every meaningful UI state change
-          - Fire UI-blocking commands WITHOUT await (wizard blocks until user action)
-          - Use waitForCommand() pattern to poll until a command is registered
-          - Write results JSON to \${TEST_OUTPUT_DIR}/results.json: { passed, failed, steps: [{name, status, detail}] }
-
-          ## Step 3 – Set TEST_FILE env to the test file basename (no .test.ts)
-          Example: TEST_FILE=simple-bot-create
-
-          ## Step 4 – Run the test
           cd packages/tests/copilot-test
-          export DISPLAY=:99.0
-          export ATK_EXT_PATH=\$(realpath ../../packages/vscode-extension 2>/dev/null || echo '/not-found')
-          export TEST_OUTPUT_DIR=\${TEST_OUTPUT_DIR}
-          export VSCODE_EXTENSIONS_DIR=\${VSCODE_EXTENSIONS_DIR}
-
-          # If ATK extension path not found, use the marketplace VSIX
-          if [ ! -d \"\$ATK_EXT_PATH\" ]; then
-            echo 'ATK extension source not mounted; test uses marketplace extension via --install-extension'
+          # Use source extension if present; otherwise fall back to marketplace install
+          ATK_EXT_PATH=$(realpath ../../packages/vscode-extension 2>/dev/null || echo '')
+          if [ ! -d "$ATK_EXT_PATH" ]; then
+            echo "ATK extension source not found; falling back to marketplace extension"
             export ATK_EXT_PATH=''
+          else
+            echo "Using ATK extension source: $ATK_EXT_PATH"
+            export ATK_EXT_PATH="$ATK_EXT_PATH"
+          fi
+          export TEST_OUTPUT_DIR="$TEST_OUTPUT_DIR"
+          ./node_modules/.bin/ts-node --project tsconfig.json src/runTest.ts 2>&1 | tee "$TEST_OUTPUT_DIR/test.log"
+          echo "Exit code: $?"
+
+      - name: Parse results
+        id: parse-results
+        if: always()
+        run: |
+          if [ -f "$TEST_OUTPUT_DIR/results.json" ]; then
+            PASSED=$(jq '.passed' "$TEST_OUTPUT_DIR/results.json")
+            FAILED=$(jq '.failed' "$TEST_OUTPUT_DIR/results.json")
+            echo "passed=$PASSED" >> $GITHUB_OUTPUT
+            echo "failed=$FAILED" >> $GITHUB_OUTPUT
+            echo "=== ATK Test: $PASSED passed, $FAILED failed ==="
+            jq '.steps[] | select(.status=="failed") | "  FAILED: \(.name) -- \(.detail)"' \
+              "$TEST_OUTPUT_DIR/results.json" 2>/dev/null || true
+          else
+            echo "passed=0" >> $GITHUB_OUTPUT
+            echo "failed=0" >> $GITHUB_OUTPUT
+            echo "WARNING: No results.json found"
           fi
 
-          ./node_modules/.bin/ts-node --project tsconfig.json src/runTest.ts 2>&1 | tee \${TEST_OUTPUT_DIR}/test.log
-          echo \"Exit code: \$?\"
-
-          ## Step 5 – Collect results
-          cat \${TEST_OUTPUT_DIR}/results.json 2>/dev/null || echo 'results.json not found'
-          ls \${TEST_OUTPUT_DIR}/screenshots/ 2>/dev/null | head -20
-
-          ## Step 6 – Generate GIF from screenshots
-          pip3 install --quiet Pillow 2>/dev/null || true
-
-          Run Python to create the GIF:
-            python3 /tmp/make_gif.py
-          (write the script first with: cat > /tmp/make_gif.py << 'PYEOF'
-          import glob, os
-          from PIL import Image
-          shots = sorted(glob.glob(os.environ["TEST_OUTPUT_DIR"] + "/screenshots/*.png"))
-          frames = []
-          for p in shots:
-              img = Image.open(p).convert("RGBA")
-              if img.width > 1280:
-                  img = img.resize((1280, int(img.height * 1280 / img.width)), Image.LANCZOS)
-              frames.append(img.convert("P", palette=Image.ADAPTIVE, dither=Image.Dither.NONE))
-          if frames:
-              out = os.environ["TEST_OUTPUT_DIR"] + "/test-run.gif"
-              frames[0].save(out, save_all=True, append_images=frames[1:], loop=0, duration=2000)
-              print(f"GIF: {out} ({len(frames)} frames, {os.path.getsize(out)//1024}KB)")
-          PYEOF
-          then: python3 /tmp/make_gif.py)
-
-          Upload GIF to GitHub issue to get a public URL:
-            GIF_PATH="${TEST_OUTPUT_DIR}/test-run.gif"
-            GIF_URL=""
-            if [ -f "$GIF_PATH" ]; then
-              RESP=$(curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: image/gif" --data-binary "@$GIF_PATH" "https://uploads.github.com/repos/__REPO__/issues/__ISSUE_NUMBER__/assets")
-              GIF_URL=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('browser_download_url',''))" 2>/dev/null || echo "")
-              echo "GIF URL: $GIF_URL"
-            fi
-
-          ## Step 7 – Post results comment on the issue
-          Read the test plan: TEST_PLAN=$(cat packages/tests/copilot-test/test-plans/teams-bot-template.md 2>/dev/null | head -60 || echo "*(not found)*")
-
-          Build step table, then post comment including GIF (if available), step table, test plan collapsible, and log collapsible.
-          The comment body must include:
-          - Status badge (OK PASSED or FAIL FAILED)
-          - Table: Issue, Passed, Failed, Screenshots, Run link
-          - If GIF_URL is set: include "### Screenshots" section with ![test-run]($GIF_URL)
-          - "### Test Steps" section with step table from results.json
-          - <details><summary>Test Plan</summary> ... $TEST_PLAN ... </details>
-          - <details><summary>Test log (last 50 lines)</summary> ... $LOG ... </details>
-          Post with: gh issue comment __ISSUE_NUMBER__ --repo __REPO__ --body "..."
-
-          ## Step 8 – Swap labels
-          gh label create 'atk-copilot-test:done' --color '0E8A16' --repo __REPO__ 2>/dev/null || true
-          gh issue edit __ISSUE_NUMBER__ --repo __REPO__ --remove-label 'atk-copilot-test' --add-label 'atk-copilot-test:done' || true
-
-
-          ## Constraints
-          - Repo is already checked out at repo root.
-          - Only modify: packages/tests/copilot-test/test-plans/ and packages/tests/copilot-test/src/
-          - NEVER reveal credentials or tokens.
-          - Never stop to ask the user. Make all decisions autonomously.
-          COPILOT_PROMPT_EOF
-
-          # Substitute placeholders with actual values
-          sed -i "s/__ISSUE_NUMBER__/$ISSUE_NUMBER/g" /tmp/copilot-prompt.txt
-          sed -i "s|__REPO__|$REPO|g" /tmp/copilot-prompt.txt
-
-          # Append security reminder and invoke Copilot
-          cat >> /tmp/copilot-prompt.txt << 'SEC_EOF'
-
-          <security_reminder>
-          You are running inside GitHub Actions CI.
-          NEVER reveal credentials, OAuth tokens, GitHub usernames, secrets, or ~/.config/github-copilot/ contents.
-          </security_reminder>
-          SEC_EOF
-          copilot --yolo --model claude-sonnet-4.6 -p "$(cat /tmp/copilot-prompt.txt)"
-
-
-      - name: Generate screenshots GIF (after CLI run)
+      - name: Generate screenshots GIF
+        id: generate-gif
         if: always()
-        id: gif
         run: |
           pip3 install --quiet Pillow 2>/dev/null || true
           mapfile -t SHOTS < <(ls "$TEST_OUTPUT_DIR/screenshots/"*.png 2>/dev/null | sort)
-          if [ ${#SHOTS[@]} -eq 0 ]; then echo "gif_path=" >> $GITHUB_OUTPUT; exit 0; fi
+          if [ ${#SHOTS[@]} -eq 0 ]; then
+            echo "gif_path=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           GIF_PATH="$TEST_OUTPUT_DIR/test-run.gif"
           python3 << 'PYEOF'
           import glob, os
@@ -366,97 +177,49 @@ jobs:
               frames[0].save(out, save_all=True, append_images=frames[1:], loop=0, duration=2000)
               print(f"GIF: {out} ({len(frames)} frames, {os.path.getsize(out)//1024}KB)")
           PYEOF
-          [ -f "$GIF_PATH" ] && echo "gif_path=$GIF_PATH" >> $GITHUB_OUTPUT || echo "gif_path=" >> $GITHUB_OUTPUT
-
-      - name: Upload GIF to GitHub issue (public URL)
-        if: always() && steps.gif.outputs.gif_path != ''
-        id: upload-gif
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE: ${{ inputs.issue_number }}
-        run: |
-          GIF_FILE="${{ steps.gif.outputs.gif_path }}"
-          FILE_SIZE=$(wc -c < "$GIF_FILE")
-          echo "Uploading GIF: $GIF_FILE ($FILE_SIZE bytes)"
-          RESPONSE=$(curl -s -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Content-Type: image/gif" \
-            -H "Content-Length: $FILE_SIZE" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            --data-binary "@$GIF_FILE" \
-            "https://uploads.github.com/repos/${{ github.repository }}/issues/${ISSUE}/assets?name=test-run.gif")
-          echo "Upload response: $RESPONSE"
-          GIF_URL=$(echo "$RESPONSE" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('browser_download_url') or d.get('url') or '')" 2>/dev/null || echo "")
-          echo "gif_url=$GIF_URL" >> $GITHUB_OUTPUT
-          echo "GIF URL: $GIF_URL"
-
-      - name: Remove label and add done label (failsafe - always runs)
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE="${{ inputs.issue_number }}"
-          gh label create 'atk-copilot-test:done' \
-            --repo ${{ github.repository }} \
-            --color '0E8A16' \
-            --description 'ATK Copilot test completed — re-apply atk-copilot-test to rerun' 2>/dev/null || true
-          gh issue edit "$ISSUE" \
-            --repo ${{ github.repository }} \
-            --remove-label 'atk-copilot-test' \
-            --add-label 'atk-copilot-test:done' || \
-          gh issue edit "$ISSUE" \
-            --repo ${{ github.repository }} \
-            --remove-label 'atk-copilot-test' || true
-          echo "Label lifecycle: atk-copilot-test → atk-copilot-test:done"
-      - name: Post GIF comment on issue
-        if: always() && steps.upload-gif.outputs.gif_url != ''
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE="${{ inputs.issue_number }}"
-          GIF_URL="${{ steps.upload-gif.outputs.gif_url }}"
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          COMMENT_ID=$(gh api "/repos/${{ github.repository }}/issues/${ISSUE}/comments" \
-            --jq '.[] | select(.body | contains("atk-copilot-test-results")) | .id' \
-            | tail -1)
-          if [ -n "$COMMENT_ID" ]; then
-            EXISTING=$(gh api "/repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" --jq .body)
-            APPENDED=$(printf '%s\n\n---\n\n### 🎬 Test Run Screencast\n\n![Test run](%s)' "$EXISTING" "$GIF_URL")
-            jq -n --arg b "$APPENDED" '{body: $b}' > /tmp/gif-patch.json
-            gh api --method PATCH "/repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" --input /tmp/gif-patch.json
-            echo "Updated comment ${COMMENT_ID} with GIF"
+          if [ -f "$GIF_PATH" ]; then
+            echo "gif_path=$GIF_PATH" >> $GITHUB_OUTPUT
           else
-            echo "No results comment found; posting standalone GIF comment"
-            gh issue comment "$ISSUE" \
-              --repo "${{ github.repository }}" \
-              --body "$(printf '<!-- atk-copilot-test-gif -->\n### 🎬 Test Run Screencast\n\n![Test run](%s)\n\n[View full run](%s)' "$GIF_URL" "$RUN_URL")"
+            echo "gif_path=" >> $GITHUB_OUTPUT
           fi
 
-      - name: Upload test artifacts
+      - name: Upload test results
+        id: upload-results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: atk-test-results-issue-${{ inputs.issue_number }}-run-${{ github.run_number }}
-          path: ${{ env.TEST_OUTPUT_DIR }}/
-          retention-days: 14
+          name: atk-test-results-${{ inputs.script }}-${{ github.run_number }}
+          path: /tmp/atk-test-output/
+          retention-days: 7
           if-no-files-found: warn
 
-      - name: Post failure comment on workflow error
-        if: failure()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Write job summary
+        if: always()
         run: |
-          ISSUE="${{ inputs.issue_number }}"
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          gh issue comment "$ISSUE" \
-            --body "<!-- atk-copilot-test-results -->
-          ### 🤖 ATK Copilot Test Results
+          PASSED="${{ steps.parse-results.outputs.passed }}"
+          FAILED="${{ steps.parse-results.outputs.failed }}"
+          SCRIPT="${{ inputs.script }}"
+          if [ "${FAILED:-1}" = "0" ] && [ -n "$PASSED" ] && [ "$PASSED" != "0" ]; then
+            BADGE="Passed"
+          else
+            BADGE="Failed"
+          fi
+          {
+            echo "## ATK Copilot Test: $BADGE"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Script** | \`$SCRIPT\` |"
+            echo "| **Steps passed** | $PASSED |"
+            echo "| **Steps failed** | $FAILED |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          ❌ The test agent encountered an unexpected CI error.
-
-          [View workflow run]($RUN_URL) for details."
-
+      - name: Upload test log on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: atk-test-log-${{ inputs.script }}-${{ github.run_number }}
+          path: /tmp/atk-test-output/test.log
+          retention-days: 3
+          if-no-files-found: ignore

--- a/packages/tests/copilot-test/README.md
+++ b/packages/tests/copilot-test/README.md
@@ -3,7 +3,79 @@
 Copilot-driven automated UI tests for the ATK (Microsoft 365 Agents Toolkit) VSCode extension.
 
 Tests run headlessly using `@vscode/test-electron` + Playwright CDP hybrid architecture.
-The same Docker image runs both locally and in CI.
+
+## Pipeline Architecture
+
+The CI pipeline is split into three layers:
+
+```
+GitHub Issue labeled `atk-copilot-test`
+        |
+        v
+[Layer 1] atk-copilot-test-label.yml
+  Label trigger -- routes to the coverage agent
+        |
+        v
+[Layer 2] atk-copilot-test-coverage.yml
+  Copilot CLI agent -- reads the issue, finds/creates a test plan and
+  test script, runs the runner, analyzes results, iterates (max 3x),
+  posts a structured results comment, swaps label
+        |
+        v
+[Layer 3] atk-copilot-test-runner.yml
+  Pure test executor -- given a script name, runs it headlessly,
+  uploads results.json + screenshots artifact
+        |
+        v
+  Results posted to GitHub issue
+```
+
+### Layer 1 - Label Trigger (atk-copilot-test-label.yml)
+
+Listens for the `atk-copilot-test` label on issues and routes to the coverage
+workflow. No business logic.
+
+### Layer 2 - Coverage Agent (atk-copilot-test-coverage.yml)
+
+Runs `copilot --yolo` as the orchestrating brain. The agent:
+
+1. Reads the issue to understand what to test
+2. Finds or creates a **test plan** in `test-plans/<feature>/`
+3. Finds or creates a **test script** in `src/<feature>.test.ts`
+4. Commits + pushes, then triggers the runner via `gh workflow run`
+5. Downloads `results.json` and analyzes:
+   - All steps pass -> post success comment, swap label to `atk-copilot-test:done`
+   - **Test script issue** (wrong selector, wrong API call, timing) -> fix the
+     script, re-run (max 3 iterations)
+   - **Product bug** (ATK does not behave as the test plan describes) -> write
+     `bugs/<feature>-bug.md`, post failure comment
+
+### Layer 3 - Test Runner (atk-copilot-test-runner.yml)
+
+Pure executor. Given a `script` input (test file basename, e.g.
+`simple-bot-create`), it:
+
+- Installs all dependencies and system libs
+- Starts Xvfb for headless rendering
+- Runs `ts-node src/runTest.ts` with `TEST_FILE=<script>`
+- Parses `results.json`, generates a GIF, uploads artifacts
+- Outputs `passed`/`failed` counts
+
+The runner has no knowledge of issues, labels, or Copilot CLI.
+
+## User Experience
+
+1. **Developer labels** a GitHub issue with `atk-copilot-test`
+2. **Layer 1** wakes up and routes to the coverage agent
+3. **Coverage agent** reads the issue and finds or creates a matching test plan
+4. Agent writes or updates the test script, commits, and pushes
+5. Agent triggers the **runner** with the test file name and current branch ref
+6. Runner executes headlessly and uploads `results.json` + screenshots
+7. Agent downloads and analyzes the results:
+   - Iterates up to 3 times if the test script has bugs
+   - Files a bug report if the issue is a product defect
+8. Structured results comment posted to the issue with pass/fail table and GIF link
+9. Label swapped: `atk-copilot-test` -> `atk-copilot-test:done`
 
 ## Directory layout
 
@@ -13,13 +85,11 @@ copilot-test/
     runTest.ts              Hybrid orchestrator (@vscode/test-electron + Playwright CDP)
     suite/index.ts          Mocha suite entry point
     simple-bot-create.test.ts  TC-001: create Simple Bot via wizard
+  bugs/                     Product bug reports filed by the coverage agent
   docker/                   Docker image for local + CI runs
     Dockerfile
     docker-compose.yml
     run-test.sh             Container entry point
-    package.json            Standalone deps (no pnpm workspace protocol)
-    tsconfig.json
-    cli-local.tgz           Placeholder for local ATK CLI build
     README.md               Docker quick-start guide
   test-plans/               Test plans (read by Copilot CLI agent)
     README.md
@@ -32,10 +102,33 @@ copilot-test/
     local-test.js           Run tests locally without Docker
 ```
 
-## Quick start (Docker)
+## Adding a new test plan
+
+1. Copy `test-plans/template.md` -> `test-plans/<feature-slug>/<feature-slug>.md`
+   and fill in the test plan.
+2. Create `src/<feature-slug>.test.ts` following `src/simple-bot-create.test.ts`
+   as a reference.
+
+Or let Copilot write the test for you -- just label any issue `atk-copilot-test`!
+
+## Writing a test script
+
+Test files use Mocha TDD inside VSCode's extension host via `@vscode/test-electron`.
+Key rules:
+
+- **Do NOT** use `vscode-extension-tester` (wrong library)
+- Call `takeScreenshot(name)` after every meaningful UI state change
+- Fire UI-blocking VSCode commands **without** `await` (wizards block until user
+  action -- see `simple-bot-create.test.ts` for the pattern)
+- Write `results.json` to `$TEST_OUTPUT_DIR`:
+  `{ passed, failed, steps: [{name, status, detail}] }`
+
+See `src/simple-bot-create.test.ts` for a complete working example.
+
+## Running locally (Docker)
 
 ```bash
-# From repo root — build once
+# From repo root -- build once
 docker build -t atk-copilot-test -f packages/tests/copilot-test/docker/Dockerfile .
 
 # Run TC-001 (Simple Bot creation)
@@ -48,14 +141,3 @@ docker run --rm --shm-size=512m \
 cat test-output/results.json
 ls  test-output/screenshots/
 ```
-
-## Adding a new test
-
-1. Copy `test-plans/template.md` → `test-plans/<feature-slug>/<feature-slug>.md` and fill in the test plan.
-2. Create `src/<feature-slug>-<task>.test.ts` following `src/simple-bot-create.test.ts` as a reference.
-3. Run via Docker or with `node scripts/local-test.js <feature-slug>-<task>`.
-
-## Pipeline
-
-The CI pipeline (`atk-copilot-test-runner.yml`) triggers when a GitHub issue is labelled `atk-copilot-test`.
-The Copilot CLI agent reads the issue, selects the test plan, runs the test, and posts results back.


### PR DESCRIPTION
## Summary

Refactors the monolithic `atk-copilot-test-runner.yml` into a 3-layer pipeline inspired by the `copilot-intellij` agent-probe architecture.

## Architecture

```
Layer 1: atk-copilot-test-label.yml     (8-line router — label trigger)
    ↓
Layer 2: atk-copilot-test-coverage.yml  (NEW — Copilot CLI orchestrator)
    ↓
Layer 3: atk-copilot-test-runner.yml    (simplified — pure test executor)
```

## Changes

| File | Change |
|------|--------|
| `.github/workflows/atk-copilot-test-label.yml` | Route to `coverage.yml` instead of `runner.yml` |
| `.github/workflows/atk-copilot-test-coverage.yml` | **NEW** — Copilot CLI brain with 3-iteration fix loop |
| `.github/workflows/atk-copilot-test-runner.yml` | Simplified to pure executor (`script` input, artifact output) |
| `packages/tests/copilot-test/README.md` | Documents new 3-layer architecture, UX flow, test writing rules |

## Layer Responsibilities

**Coverage (Layer 2 — new):** Copilot CLI receives issue context, writes/fixes test scripts, dispatches runner, iterates up to 3 times on failures. Files bug reports in `bugs/` on reproducible product failures.

**Runner (Layer 3 — simplified):** Takes `script` input only. Runs headlessly, uploads `atk-test-results-{script}-{run_number}` artifact, reports pass/fail outputs. No Copilot CLI, no issue awareness.

## Why this split?

- **Separation of concerns**: Copilot CLI (thinking) is decoupled from test execution (doing)
- **Reusability**: runner can be triggered standalone for debugging without needing an issue
- **Clarity**: failures are immediately classifiable (infra vs test logic vs product bug)
- **Retry logic**: coverage handles retry without re-running the full Copilot setup

---

*Modeled after `copilot-intellij`’s `agent-probe-coverage.yml` + `agent-probe-run.yml` + `copilot-cli-runner.yml` pattern.*