### PR TITLE
docs: add v4 architecture/specs scaffold and vibe-coding skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,22 +6,52 @@ PNPM monorepo (Lerna) building the Microsoft 365 Agents Toolkit: a VS Code exten
 CLI tools, and core engine for scaffolding, provisioning, deploying, and publishing
 Microsoft 365 / Teams agents.
 
-Core packages: `fx-core`, `cli`, `vscode-extension`, `server`, `api`, `manifest` — shipping, code-first.
+Core packages: `fx-core`, `cli`, `vscode-extension`, `server`, `api`, `manifest`. An in-place refactor toward a v4 architecture is in progress; v4 design decisions are being collected as ADRs under [`docs/02-architecture/`](../docs/02-architecture/README.md). Until those ADRs land, treat the existing code shape as authoritative for maintenance and treat [`docs/02-architecture/`](../docs/02-architecture/README.md) as the source for any new structural decision. Maintenance and refactor work coexist in the same packages.
+
+## Global behavioral principles
+
+These apply to every contribution — human or AI agent — across all packages and
+skills. Adapted from [Karpathy's
+guidelines](https://github.com/multica-ai/andrej-karpathy-skills/blob/main/skills/karpathy-guidelines/SKILL.md).
+They bias toward caution over speed; use judgment for trivial changes (typos,
+dependency bumps, lint cleanup).
+
+1. **Think before coding.** State assumptions explicitly. If multiple readings of
+   the request exist, surface them instead of silently picking one. If something
+   is unclear, stop and ask — do not paper over confusion with code. If a
+   simpler approach exists, say so and push back when warranted.
+2. **Simplicity first.** Write the minimum code that solves the problem. No
+   speculative features, no abstractions for single-use code, no "flexibility"
+   that was not requested, no error handling for impossible scenarios. If 200
+   lines could be 50, rewrite.
+3. **Surgical changes.** Touch only what the request requires. Do not refactor
+   or reformat adjacent code, do not delete pre-existing dead code unasked.
+   Match existing style even if you would do it differently. Remove only the
+   imports/variables/functions that your own changes orphaned. Every changed
+   line should trace directly to the request.
+4. **Goal-driven execution.** Restate the task as a verifiable outcome before
+   writing code (e.g. "fix bug" → "write a failing test that reproduces it,
+   then make it pass"). For multi-step work, write a brief plan with a
+   verification step per item, then loop until each is green. Strong success
+   criteria let you finish without constant clarification.
+
+The per-PR gates in [`.github/skills/vibe-coding/SKILL.md`](skills/vibe-coding/SKILL.md)
+operationalize these principles for behavior-changing or structural-shape work;
+the principles still apply to maintenance and to PRD / scenario work.
 
 ## Where to start (router)
 
 | User intent | Entry skill / doc |
 |---|---|
 | Add or update engine-neutral PRD / scenario design before specs or code | **`prd-ux-design`** skill |
-| Code change in `fx-core`, `cli`, `vscode-extension`, `server`, `api`, `manifest` | **`dev-workflow`** skill |
-| Multi-step task / plan to disk | **`plan-tracker`** skill |
-| CI E2E lifecycle test failed | **`e2e-troubleshooting`** skill |
-| ESLint / Prettier pipeline issue | **`lint-format`** skill |
-| Per-package coding conventions | `.github/instructions/*.instructions.md` (auto-loaded by `applyTo`) |
+| Add or change behavior, or refactor toward a structural shape governed by ADRs in [`docs/02-architecture/`](../docs/02-architecture/README.md) | **`vibe-coding`** skill |
+| Per-package coding conventions and cross-cutting security rules | `.github/instructions/*.instructions.md` (auto-loaded by `applyTo`) |
 
-Generic expert knowledge (TypeScript, code review, debugging, security, test design) is
-**not** packaged as skills — the AI applies general expertise constrained by the
-instructions and specs in this repo.
+Pure maintenance (a bug fix, dependency bump, lint cleanup, or internal refactor that does not change behavior or structural shape) has no dedicated workflow skill — follow the coding-style, architecture, and package-specific rules below.
+
+Generic expert knowledge (TypeScript, debugging, security, test design) is **not**
+packaged as skills — the AI applies general expertise constrained by the instructions
+and specs in this repo.
 
 ## Last todo of every code-modifying turn
 
@@ -39,7 +69,7 @@ When generating or editing code in this repository:
 
 Full conventions live in `.github/instructions/` — auto-loaded for matching file patterns. Key rules:
 
-- **Copyright header** on every `.ts` file — see [`codebase.instructions.md`](instructions/codebase.instructions.md).
+- **Copyright header** on every `.ts` file.
 - **`Result<T, FxError>`** from `neverthrow` — never `throw` for expected failures.
 - **`UserError`** for user-fixable issues; **`SystemError`** for infra failures.
 - **Strict TypeScript** — no `as` casts; prefer type predicates and discriminated unions.
@@ -51,36 +81,64 @@ Full conventions live in `.github/instructions/` — auto-loaded for matching fi
 
 ---
 
-# Architecture Overview
-The toolkit follows a **layered architecture** with clear separation of concerns:
+# Architecture overview
 
-┌──────────────────┐ ┌──────────────────────┐ ┌────────────────────┐
-│  VS Code Ext.    │ │  CLI                 │ │  Server            │
-│  (vscode-ext.)   │ │  (packages/cli)      │ │  (packages/server) │
-│  - UI Commands,  │ │  - Command Line      │ │  - JSON-RPC based  │
-│    TreeView,     │ │    Interface         │ │  - Used by VS ext. │
-│    CodeLens      │ │                      │ │                    │
-└────────┬─────────┘ └──────────┬───────────┘ └──────────┬─────────┘
-         └─────────────────┬────┘                        │
-                           └────────────────┬────────────┘
-┌──────────────────────────▼──────────────────────────────────────────┐
-│                         FX-Core Layer                               │
-│   (packages/fx-core)                                                │
-│   - Project Generation, Lifecycle, Drivers, Manifest Utilities      │
-└──────────────────────────────┬──────────────────────────────────────┘
-                               │
-┌──────────────────────────────▼──────────────────────────────────────┐
-│                          API Layer                                  │
-│   (packages/api)                                                    │
-│   - Type Definitions, Interfaces, Question Models                   │
-└──────────────────────────────┬──────────────────────────────────────┘
-                               │
-┌──────────────────────────────▼──────────────────────────────────────┐
-│                        Manifest Layer                               │
-│   (packages/manifest)                                               │
-│   - App Manifest Types, Converters, OOP Wrappers                    │
-│   - Three manifest types: Teams, Declarative Agent, API Plugin      │
-└─────────────────────────────────────────────────────────────────────┘
+The monorepo holds two independent groups of packages. Do not mix them.
+
+## Group 1 — Toolkit engine (what users install)
+
+Three user-facing surfaces sit on a single engine. The engine is consumed via `fx-core` + the shared types in `api`; surfaces should not implement domain logic.
+
+| Package | Role | Depends on (intra-repo) |
+|---|---|---|
+| `packages/vscode-extension` | VS Code surface (commands, tree view, webviews) | `api`, `fx-core`, `vscode-ui` |
+| `packages/cli` | Command-line surface | `api`, `fx-core` |
+| `packages/server` | JSON-RPC server consumed by the Visual Studio client | `api`, `fx-core` |
+| `packages/fx-core` | Engine — scaffold / provision / deploy / publish, drivers, lifecycle | `api`, `spec-parser` |
+| `packages/api` | Public TS types and interfaces shared by surfaces and engine | `manifest` |
+| `packages/manifest` | Generated types + converters for Teams / Declarative Agent / API Plugin manifests | — |
+| `packages/spec-parser` | OpenAPI → API Plugin spec parsing | `manifest` |
+| `packages/vscode-ui` | Reusable prompt / quick-pick helpers for VS Code surfaces | `api` |
+| `packages/mcp-server` | The toolkit's own MCP server for AI clients | — |
+
+Dependency direction (arrow = "depends on"; downstream → upstream). Upstream packages must build first.
+
+```mermaid
+graph TD
+  vsx[vscode-extension] --> fxcore[fx-core]
+  cli --> fxcore
+  server --> fxcore
+  vsx --> api
+  cli --> api
+  server --> api
+  vsx --> vsui[vscode-ui]
+  vsui --> api
+  fxcore --> api
+  fxcore --> sp[spec-parser]
+  api --> mf[manifest]
+  sp --> mf
+```
+
+Practical consequences (see also Common pitfalls below):
+- `manifest` and `api` are upstream of `fx-core`; rebuild them before testing anything that imports them.
+- All three surfaces talk to the engine via `fx-core` + `api` only.
+
+## Group 2 — App-runtime SDKs (deprecating, do not extend)
+
+These were shipped into apps the toolkit scaffolds. **All four are deprecated** with sunset dates already announced in their READMEs. Do not add new features here. Bug fixes only, and only when there is no reasonable alternative; prefer redirecting users to the migration target.
+
+| Package | npm / NuGet name | Sunset | Migration target |
+|---|---|---|---|
+| `packages/sdk` | `@microsoft/teamsfx` | 2026-07 | `@microsoft/agents-hosting` |
+| `packages/sdk-react` | `@microsoft/teamsfx-react` | 2026-07 | Copy hooks into the app's own source |
+| `packages/adaptivecards-tools-sdk` | `@microsoft/adaptivecards-tools` | 2026-09 | `adaptivecards-templating` |
+| `packages/dotnet-sdk` | `Microsoft.TeamsFx` | 2026-09 | (Blazor / TeamsFx .NET path being retired) |
+
+None of these are imported by the engine (`fx-core` / `api` / `manifest`), so changes here cannot affect the toolkit itself — they only affect already-scaffolded apps pinning the old version.
+
+## Tooling-only packages
+
+Build / lint / test infrastructure and legacy companions, not part of the shipped engine and not part of the runtime SDKs: `eslint-plugin-teamsfx`, `prettier-config`, `extra-shot-mocha`, `metrics-ts`, `tests`, `function-extension`, `simpleauth`.
 
 ## Key file locations
 
@@ -99,9 +157,10 @@ The toolkit follows a **layered architecture** with clear separation of concerns
 
 Detailed instructions for individual packages are available in `.github/instructions/`:
 
-| Package | Instructions File | Key Exports |
-|---------|-------------------|-------------|
+| Scope | Instructions File | Covers |
+|-------|-------------------|--------|
 | `@microsoft/app-manifest` (packages/manifest) | `.github/instructions/manifest.instructions.md` | `TeamsManifest`, `DeclarativeAgentManifest`, `APIPluginManifest`, `AppManifestUtils`, Wrappers |
+| All `packages/**/*.{ts,tsx}` | `.github/instructions/security.instructions.md` | Webview XSS, command injection, path traversal, untrusted JSON, cryptography |
 
 > **Note**: When working with a specific package, read the corresponding instructions file for detailed documentation about the package's architecture, APIs, and patterns
 

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -1,0 +1,143 @@
+---
+description: Security rules for toolkit TypeScript code — webview XSS, shell/path injection, untrusted JSON parsing, cryptography. Complements the cross-cutting rules in copilot-instructions.md (maskSecret, EAFP, no `as` casts).
+applyTo: 'packages/**/*.ts,packages/**/*.tsx'
+---
+
+# Security Rules
+
+Scope: the toolkit's TypeScript engine, CLI, and VS Code extension. The toolkit
+does not host a public HTTP API, does not issue JWTs, does not talk to SQL
+databases, and delegates user authentication and authorization to Microsoft
+Identity (MSAL / `@azure/identity`). Categories below are limited to threats
+that actually apply to that surface.
+
+Cross-cutting basics (`maskSecret()` before logging, EAFP for filesystem, no
+`as` casts, `getLocalizedString` for user-facing strings) live in
+[copilot-instructions.md](../copilot-instructions.md) — those still apply; this
+file adds the concrete patterns reviewers and the AI need to see.
+
+## Webview XSS — `packages/vscode-extension/src/controls/**`
+
+React escapes children by default. The only XSS vectors are `innerHTML` and
+`dangerouslySetInnerHTML`. Anything user- or project-supplied that reaches
+those must be sanitized or rejected.
+
+```tsx
+// Bad
+element.innerHTML = userInput;
+return <div dangerouslySetInnerHTML={{ __html: userInput }} />;
+
+// Good
+element.textContent = userInput;
+return <div>{userInput}</div>;
+```
+
+Verify the webview is created with a Content Security Policy that disables
+inline scripts and external sources.
+
+## Command injection — `child_process` callers
+
+The CLI and extension shell out to `func`, `azd`, `npm`, etc. Never build a
+shell string with template literals.
+
+```typescript
+// Bad
+import { exec } from "child_process";
+exec(`func start --port ${port}`);
+
+// Good
+import { spawn } from "child_process";
+spawn("func", ["start", "--port", String(port)], { shell: false });
+```
+
+If a shell is unavoidable (piping, env expansion), quote arguments explicitly
+and never pass user-controlled values raw.
+
+## Path traversal — template / project file I/O
+
+Resolve user-supplied paths against a fixed root and verify containment before
+read or write.
+
+```typescript
+// Bad
+const filePath = `./templates/${userInput}`;
+
+// Good
+import * as path from "path";
+const root = path.resolve("./templates");
+const filePath = path.resolve(root, path.normalize(userInput));
+if (!filePath.startsWith(root + path.sep)) {
+  return err(new UserError({
+    source: "fx-core",
+    name: "PathEscapesRoot",
+    message: getLocalizedString("error.path.escapes-root"),
+  }));
+}
+```
+
+## Untrusted JSON — manifests, plugin specs
+
+Teams / Declarative Agent / API Plugin manifests come from the user's project.
+Parse via the validating converters in `packages/manifest`; do not `as`-cast
+`JSON.parse` results.
+
+```typescript
+// Bad
+const manifest = JSON.parse(text) as TeamsManifest;
+
+// Good
+import { AppManifestUtils } from "@microsoft/app-manifest";
+const result = AppManifestUtils.parse(text);
+if (result.isErr()) return err(result.error);
+const manifest = result.value;
+```
+
+## Cryptography
+
+The engine and CLI should derive as little as possible — push secret material
+into Key Vault / VS Code SecretStorage and reference it. When derivation is
+unavoidable:
+
+```typescript
+// Bad
+const token = Math.random().toString(36);
+import { createHash } from "crypto";
+const hash = createHash("md5").update(secret).digest("hex");
+
+// Good
+import { randomBytes, scrypt } from "crypto";
+const token = randomBytes(32).toString("hex");
+// For password-derived material, use scrypt / a vetted KDF.
+```
+
+Never use `Math.random` for tokens, IDs that need unpredictability, or
+anything security-sensitive. Never use MD5 or SHA1 for credentials.
+
+## Error messages to the user
+
+Do not leak internal paths, stack frames, or remote URLs into the user-facing
+string. Keep full context in telemetry; surface a localized friendly message.
+
+```typescript
+// Bad
+return err(new SystemError({
+  source: "fx-core",
+  name: "ProvisionFailed",
+  message: `${error.stack} for ${innerUrl}`,
+}));
+
+// Good
+logger.error("Provision failed", { error, correlationId });
+return err(new SystemError({
+  source: "fx-core",
+  name: "ProvisionFailed",
+  message: getLocalizedString("error.provision.generic"),
+}));
+```
+
+## Dependencies
+
+- Use the official npm registry only.
+- `pnpm audit` clean at merge time (no high / critical).
+- `pnpm-lock.yaml` is committed; never hand-edit it — run `pnpm install`.
+- Prefer Node stdlib or an existing helper over pulling a new dependency.

--- a/.github/skills/prd-ux-design/SKILL.md
+++ b/.github/skills/prd-ux-design/SKILL.md
@@ -21,7 +21,7 @@ Do not use this skill for specs, tests, code, or implementation. Handoff to engi
 
 | Artifact | Location | Role |
 |---|---|---|
-| PRD pages and requirement deltas | [`docs/01-product/prd/`](../../../docs/01-product/prd/README.md) | Markdown-only product intent: problem, users, scope, success criteria, constraints |
+| PRD pages and requirement deltas | `docs/01-product/prd/` | Markdown-only product intent: problem, users, scope, success criteria, constraints |
 | Scenario directory guide | [`docs/01-product/scenarios/README.md`](../../../docs/01-product/scenarios/README.md) | Format rules for AI-readable scenario Markdown and human-readable scenario HTML |
 | Scenario HTML components | [`docs/01-product/_assets/scenario-components/`](../../../docs/01-product/_assets/scenario-components/README.md) | Reusable VS Code-style static flow components and icon assets for scenario HTML |
 | Scenario Markdown | `docs/01-product/scenarios/<group>/<scenario-slug>.md` | Concrete user flow: steps, states, edge cases, per-surface notes, inline Mermaid flow, and CLI E2E / VS Code UI test intent |
@@ -33,7 +33,7 @@ Do not use this skill for specs, tests, code, or implementation. Handoff to engi
 | Product review stylesheet | [`docs/01-product/_assets/product-review/product-review.css`](../../../docs/01-product/_assets/product-review/product-review.css) | Shared page-level styles for product index and scenario HTML; not a behavior source |
 | Product review index | [`docs/01-product/scenarios/index.html`](../../../docs/01-product/scenarios/index.html) | Human-facing locator for scenario HTML pages under `docs/01-product/scenarios/`; do not list README or Markdown source files |
 | Product artifact renderer | [`docs/01-product/_assets/product-artifact-viewer/index.html`](../../../docs/01-product/_assets/product-artifact-viewer/index.html) | Tooling-only renderer for Markdown artifacts; not a product artifact |
-| Backups | [`docs/01-product/_backups_/`](../../../docs/01-product/_backups_/README.md) | Pre-reorganization source material; not active PRD/scenario contract |
+| Backups | `docs/01-product/_backups_/` | Pre-reorganization source material; not active PRD/scenario contract |
 
 PRDs are high-level product documents. Scenarios split PRD intent into concrete flows such as creating, testing, or provisioning a DA. Scenario Markdown, including inline Mermaid, is the AI-primary source for experience behavior and later CLI E2E / VS Code UI test intent. HTML helps humans, AI agents, and engineering review layout, navigation, and visual states, but they must not derive specs, AC rows, tests, or behavior contracts from HTML alone.
 
@@ -59,7 +59,7 @@ Start from the concrete request: PM chat, GitHub Issue, ADO Work Item, or existi
 
 ### Phase 2 — Ask before guessing
 
-If the requirement, owner, success criteria, or user flow is unclear, stop and ask specific questions.
+This mirrors **Global behavioral principle #1** in [`.github/copilot-instructions.md`](../../copilot-instructions.md): if the requirement, owner, success criteria, or user flow is unclear, stop and ask specific questions.
 
 - GitHub Issue / ADO: comment with concrete questions and `@owner`.
 - Chat: ask the user directly.

--- a/.github/skills/vibe-coding/SKILL.md
+++ b/.github/skills/vibe-coding/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: vibe-coding
+description: "End-to-end workflow for agent-driven changes that add or modify behavior in the toolkit packages. Use when: adding or changing a behavior (anything that warrants an Acceptance Criteria row); refactoring toward a structural shape governed by ADRs in `docs/02-architecture/`; adding a behavior-changing CLI or VS Code action. Codifies the design-first → tests-from-AC → implement → verify → self-review → docs-when-needed cycle that keeps contributions safe to merge."
+argument-hint: "Describe the behavior change or structural-shape work"
+---
+
+# Vibe Coding
+
+## When to use this skill
+
+Use this skill when the change is **non-trivial AND meets at least one of these conditions** — the workflow is the same whether a human or an AI agent (Copilot, Claude Code, Cursor, etc.) is doing the work:
+
+- It adds, changes, or removes user-observable behavior — anything that warrants an Acceptance Criteria row.
+- It touches structural shape governed by ADRs in [`docs/02-architecture/`](../../../docs/02-architecture/README.md) (composition pattern, error model, input validation, registries, context propagation, etc.).
+
+"Vibe coding" in this codebase means **agent-driven implementation with hard safety gates**, never throwaway sandbox work.
+
+Don't use this skill for:
+
+- **Pure maintenance** — a bug fix that keeps the existing shape (changes a value, not a contract), an internal refactor with no behavior or shape change, or a localization tweak. Follow `.github/copilot-instructions.md` and the per-package conventions under `.github/instructions/`.
+- **Trivial changes** — typo fixes, dependency bumps, lint cleanup, or doc-only edits. Go straight to PR.
+
+This skill inherits the **Global behavioral principles** in [`.github/copilot-instructions.md`](../../copilot-instructions.md) (think before coding, simplicity first, surgical changes, goal-driven execution). The gates below operationalize them for behavior-changing work; do not repeat the principles, follow them.
+
+## What this skill enforces
+
+Structural rules live in [`docs/02-architecture/`](../../../docs/02-architecture/README.md) (and any ADRs there). Behavioral contracts live in [`docs/04-specs/`](../../../docs/04-specs/README.md). The workflow below ties them to per-PR discipline.
+
+The non-negotiable gates per PR:
+
+1. **Requirements first** — start from a GitHub Issue, ADO Work Item, chat request, or [`prd-ux-design`](../prd-ux-design/SKILL.md) handoff; confirm approved PRD + scenario artifacts exist before specs. If PRD or scenario work is needed, complete `prd-ux-design` first.
+2. **Spec first after requirements are clear** — Operation Spec / Domain Spec / ADR / data-model entity in [`docs/04-specs/`](../../../docs/04-specs/README.md) written or located **before** any code is touched.
+3. **Tests next** — every required test is derived 1:1 from the spec's `## Acceptance Criteria` table and includes the AC ID in its name (`it("AC-01: ...")`). Each AC row is tagged with its tier (L1 / L2 / L3); L2 CLI E2E and L3 VS Code UI tests are documented but not hard PR gates yet.
+4. **Architectural and per-package rules followed** — implementation respects the ADRs in [`docs/02-architecture/`](../../../docs/02-architecture/README.md) and the matching files under [`.github/instructions/`](../../instructions/) for every path touched. Specifics (composition pattern, error model, input validation, registries, context propagation) live in those documents, not in this skill.
+5. **New Template added to the template registry has a scaffold integration test**; CLI E2E coverage is documented as L2 but not a hard PR gate yet.
+6. **Lint clean, format clean, 80% coverage gate green.**
+7. **Conventional Commits** (`feat(<scope>):`, `fix(<scope>):` where `<scope>` is the package or domain touched, e.g. `feat(fx-core):`, `fix(cli):`).
+8. **Downstream docs that describe shape** (template registry, driver catalogue, CLI surface) updated **in the same PR** when shape changes.
+
+A PR that bypasses any of these is rejected — by CI or by review.
+
+## Workflow
+
+### Phase -1 — Intake and requirement confirmation
+
+Start from a GitHub Issue, ADO Work Item, or chat request.
+
+1. **Classify**: `feature` / `bug` / `chore`.
+2. **Identify owner and domain**: find the human owner and which capability domain this touches (see [`docs/04-specs/`](../../../docs/04-specs/README.md) for the domain layer).
+3. **Read product context**: PRD pages in `docs/01-product/prd/`, scenario flows in [`docs/01-product/scenarios/`](../../../docs/01-product/scenarios/README.md), and architecture / infrastructure constraints under [`docs/02-architecture/`](../../../docs/02-architecture/README.md) and [`docs/03-infrastructure/`](../../../docs/03-infrastructure/README.md).
+4. **Check approval state**: if PRD or scenario artifacts are missing, ambiguous, or materially changing, stop and use [`prd-ux-design`](../prd-ux-design/SKILL.md). Continue here only with approved PRD + scenario artifacts or an explicit note that no PRD/scenario change is needed.
+5. **Summarize requirement input**: cite the approved PRD + scenario artifacts or the no-change decision before moving to specs.
+
+### Phase 0 — PRD + scenario handoff validation
+
+For product or interaction changes, validate the approved PRD under `docs/01-product/prd/` and the scenario under `docs/01-product/scenarios/<group>/<scenario>.md` before writing specs. Do not perform full PRD/scenario design in this skill; use [`prd-ux-design`](../prd-ux-design/SKILL.md) for that work.
+
+| Surface | Scenario artifact format | Current test gate |
+|---|---|---|
+| VS Code UX | Markdown scenario + inline Mermaid flow as the AI-primary behavior source; companion HTML mock/state artifact as visual/state reference for humans, AI agents, and engineering | L3 UI tests are documented but not required yet |
+| CLI | Markdown scenario + inline Mermaid flow | CLI E2E tests are documented as L2 but not required yet |
+
+For AI agents and engineering implementation, Markdown and Mermaid are the authoritative behavior inputs. Companion scenario HTML should also be reviewed for visual structure and UI states, but do not derive specs, AC rows, or tests from HTML alone.
+
+If the PRD or scenario change is material and not already approved, stop and hand off to `prd-ux-design`. The output of this phase is either:
+
+- Approved PRD + scenario artifacts under `docs/01-product/prd/` and `docs/01-product/scenarios/`.
+- A short note that existing PRD + scenario design already covers the request.
+
+### Phase 1 — Design first (spec)
+
+For any non-trivial change, locate or write the spec **after requirements are clear and before writing tests or code**. Specs are the authoritative behavioral contracts that tests are derived from.
+
+**Start here:** [`docs/04-specs/README.md`](../../../docs/04-specs/README.md) — defines the layer hierarchy (PRD → Scenario → Domain Spec → Operation Spec → Tests → Code) and spec formats.
+
+#### Spec location
+
+| Change kind | Where the spec lives |
+|-------------|---------------------|
+| New / changed Operation, driver, or lifecycle stage | `docs/04-specs/operations/<domain>/<operation>.md` (see [`docs/04-specs/`](../../../docs/04-specs/README.md)) |
+| New Domain or domain boundary change | `docs/04-specs/domains/<nn>-<domain>.md` (see [`docs/04-specs/`](../../../docs/04-specs/README.md)) |
+| Architectural decision | New ADR under [`docs/02-architecture/`](../../../docs/02-architecture/README.md) (see that folder for the ADR convention) |
+| New / changed data contract or entity | `docs/04-specs/data-model/entities/` (see [`docs/04-specs/`](../../../docs/04-specs/README.md)) |
+| New CLI surface, command group, flow | Scenario under [`docs/01-product/scenarios/`](../../../docs/01-product/scenarios/README.md); confirm via [`prd-ux-design`](../prd-ux-design/SKILL.md) |
+| New Template (any kind) | `.dev/templates.json` (machine registry, when present) |
+
+> Terminology: **Capability** (PM word) and **Domain** (engineering word) refer to the same concept; **Operation** is an atomic engine action belonging to a Domain; **Template** composes Operations into a shippable starting point. See [`docs/04-specs/README.md`](../../../docs/04-specs/README.md) for the full glossary.
+
+#### What a spec must contain before any test or code is written
+
+For an operation spec, all of these sections must be complete:
+- `## Acceptance Criteria` — ID-based table, each row maps to one test case (no rows = blocked).
+- `## Flow` — Mermaid flow or sequence diagram for stateful, cross-step, or user-visible behavior changes.
+- `## Boundary` — explicit list of what this operation does NOT do.
+- `## Invariants` — constraints that must never be violated.
+
+**AI gap discovery:** Attempt to complete the spec. Where sections cannot be filled,
+output specific questions rather than guessing:
+> "Cannot complete AC table because:
+>  1. Should an unreachable MCP server fail immediately or retry? How many times?
+>  2. Is adding the same action URL twice an error or idempotent?"
+
+Blocked spec = upstream ambiguity. Do not proceed to tests or code. Surface to PM → update PRD first.
+
+**Two human gates before any test or code is written:**
+1. **Gate 1 — Answer AI questions**: resolve all ambiguities surfaced during spec drafting.
+2. **Gate 2 — Approve AC table**: review each row; scenario clear? expected result correct?
+
+Only after Gate 2 approval does AI generate tests and implement.
+
+For an agent: treat `## Acceptance Criteria` rows as the test plan, `## Boundary` + `## Invariants` as hard constraints on implementation scope.
+
+### Phase 2 — Confirm design inputs
+
+Design from approved PRD + scenarios + existing ADRs. Do **not** copy structural
+shape from existing implementation code as the basis for new design — re-derive
+shape from requirements and ADRs. Reading existing code in `packages/fx-core/`,
+`packages/cli/`, etc. for context is fine; mirroring its structure into a new
+module is a code-review red flag. Ask: *"What product requirement justifies
+this shape, independent of how the current code happens to do it?"*
+
+If no ADR yet exists for the structural question at hand, stop and open one
+under [`docs/02-architecture/`](../../../docs/02-architecture/README.md) rather
+than inventing a per-feature answer. ADRs are the place to commit a structural
+decision; this skill only enforces that decisions get made there.
+
+### Phase 3 — Tests from AC and Flow (before any implementation)
+
+Tests are derived **directly** from the approved AC table and any approved `## Flow` diagram. They are written **before** implementation and fail first. Test names must include the AC ID so reviewers can trace test ↔ spec:
+
+```typescript
+// AC-01: valid inputs → success
+it("AC-01: returns clientId and objectId on success", ...)
+
+// AC-03: name > 120 chars → UserError
+it("AC-03: returns UserError(AadAppNameTooLong) when name exceeds limit", ...)
+```
+
+**Each AC row in the spec carries a Tier**:
+
+- **L1 — Engine** (unit + integration; per-PR, fast). Within L1, integration is weighted over unit for lifecycle code.
+- **L2 — E2E** (real CLI against real M365 + Azure). **Documented but not a hard PR gate yet.**
+- **L3 — UI** (VS Code wizard / command palette / webview flows). **Documented but not a hard PR gate yet.**
+
+The ADRs that formalize the tiering and the inverted lifecycle test pyramid live under [`docs/02-architecture/`](../../../docs/02-architecture/README.md) as they land.
+
+Map from what you'll implement to what test it needs:
+
+| What you'll implement | Required test(s) | Tier |
+|---|---|---|
+| Pure function (no I/O) | Unit test (`tests/unit/<area>/`) | L1 (unit) |
+| Engine action with side effects (operation, driver, lifecycle stage) | Integration test exercising full pipeline (`tests/integration/`) — mock only outermost HTTP | L1 (integration) |
+| New Template added to the template registry | Scaffold integration test; document L2 E2E scenario if applicable | L1 (integration); L2 documented |
+| New CLI action | CLI integration test; document L2 E2E scenario if it writes resources | L1 (integration); L2 documented |
+| New VS Code command / wizard | Handler unit test; document L3 UI scenario if user-visible | L1 (unit); L3 documented |
+
+A unit test that only re-mocks what an integration test already covers is a delete signal.
+
+**At end of this phase**, every L1 AC row maps to a unit or integration test, every required test is failing for the expected reason, and no implementation file has been touched yet. L2 CLI E2E and L3 VS Code UI cases may be documented without being implemented in this PR.
+
+### Phase 4 — Implement to pass tests
+
+Write the minimal code that turns the failing tests green. Follow:
+
+- The ADRs in [`docs/02-architecture/`](../../../docs/02-architecture/README.md)
+  for structural rules (composition pattern, error model, input validation,
+  registries, context propagation, file size, etc.).
+- The matching file under [`.github/instructions/`](../../instructions/) when one
+  applies to a path you touch (the toolkit auto-loads these by `applyTo`
+  pattern).
+- The cross-cutting rules in
+  [`.github/copilot-instructions.md`](../../copilot-instructions.md).
+
+When a design contradicts an accepted ADR, the design changes, not the ADR. If
+an ADR is wrong, supersede it first via a new ADR; don't quietly diverge in
+code. If no ADR exists for the question at hand, escalate per Phase 2 rather
+than inventing a per-feature answer.
+
+### Phase 5 — Verify gates (mechanical)
+
+Before claiming done, run the full local gate:
+
+```bash
+# In the package you touched, e.g. packages/fx-core or packages/cli:
+npm run build              # tsc + postbuild (eslint --fix + prettier --write)
+npm run test:unit          # unit tests with NYC coverage
+npm run test:integration   # integration tests
+npm run lint               # 0 errors required
+npm run format:check       # CI gate
+```
+
+For a change that registers a new template, run the relevant CLI E2E when the environment and credentials are available:
+
+```bash
+cd packages/cli
+npm run test:e2e -- --grep "<your-template-id>"
+```
+
+Unit and integration gates must be green; do not proceed to Phase 6 with a red L1 gate. L2 CLI E2E and L3 VS Code UI failures are tracked but do not block the PR while those gates are still deferred.
+
+For local E2E runs, M365 + Azure credentials must be configured in the developer's environment; see the test setup notes in the touched package's README.
+
+### Phase 6 — Self-review (judgement)
+
+Mechanical gates do not catch quality. Before claiming done, audit the diff against:
+
+1. **ADRs in [`docs/02-architecture/`](../../../docs/02-architecture/README.md)** — every new file/function must respect them. Common slips show up in file size, in module-scoped runtime state, and in error-handling shape.
+2. **Matching `.github/instructions/*`** — for each touched file path, the instruction file whose `applyTo` matches should be re-checked. Common slips: copyright header missing, `as` cast snuck in, raw user-facing string instead of `getLocalizedString`, secret not masked.
+3. **The Anti-patterns list at the bottom of this skill** — flag any match and fix before PR.
+
+Output of this phase is either "all checks pass" or a list of concrete fixes → loop back to Phase 3.
+
+### Phase 7 — Downstream docs (conditional)
+
+If the change altered something a downstream doc describes — template registry, driver catalogue, CLI surface, package layout, error catalogue, feature flag, conventions — update those docs in the same PR. The Phase 0 spec is upstream; it precedes code and was already correct.
+
+If the spec from Phase 0 turned out to need clarification mid-implementation, fix it now and explain why in the PR description. The PR must contain both the code change and the doc change. PRs that ship code without doc updates are rejected at review.
+
+### Phase 8 — PR
+
+Conventional Commits format (commitlint enforces):
+
+```
+feat(fx-core): add <thing> operation
+fix(cli): handle <case> in provision action
+docs(architecture): add ADR-NNNN for <decision>
+```
+
+PR description must reference the design page or ADR.
+
+CODEOWNERS will auto-assign reviewers. Reviewers will check:
+
+- ✅ Spec exists in `docs/04-specs/` and is referenced in the PR.
+- ✅ Tests carry AC IDs and trace 1:1 to AC rows.
+- ✅ Integration test exists for any new engine action with side effects (operation, driver, lifecycle stage).
+- ✅ Scaffold integration test for any new template registered in the template registry; L2 E2E scenario documented when applicable.
+- ✅ ADRs in [`docs/02-architecture/`](../../../docs/02-architecture/README.md) and matching `.github/instructions/*` followed for every path touched.
+- ✅ Lint / format / coverage gates green.
+- ✅ Downstream docs updated where the drift checklist required.
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "I copied this shape from `fx-core/...`" | Used existing code as design input | Stop. Re-derive shape from PRD + spec + ADRs. |
+| Wrote implementation in Phase 4 before any test was failing | Skipped Phase 3 ordering | Revert; write the failing AC tests first, then re-implement. |
+| Test passes locally, fails in CI | Probably a `process.env` race or async cleanup gap | Run `tests/integration/` locally; check for missing `await`. |
+| Reviewer says "no docs change" | Skipped Phase 7 | Add the doc update to this PR; don't open a follow-up. |
+| File is much larger than peers in the same folder | Per-file readability rule (in `docs/02-architecture/`) violated | Refactor — split per-feature concerns. Reviewer will request this. |
+
+## Anti-patterns to flag in self-review
+
+- A new engine action with side effects but no integration test — required.
+- A new template in the template registry without a scaffold integration test.
+- A test name without an AC ID prefix — required if the test maps to a spec.
+- A "TODO: add tests later" comment — not allowed; tests are written in Phase 3.
+- A "TODO: add docs later" comment — not allowed; this is the doc-PR.
+- Use of `console.log` — use the package's logger.
+- Throwing for an expected failure — return a `Result`-typed error per the package convention.
+- Catching `unknown` and silently swallowing — preserve via `innerError` or equivalent.
+- A vague error name like `Error` or `Failed` — name it for the failure mode (telemetry partition key).
+- Anything that contradicts an accepted ADR under [`docs/02-architecture/`](../../../docs/02-architecture/README.md) without first superseding that ADR.
+
+## See also
+
+- [`prd-ux-design` skill](../prd-ux-design/SKILL.md) — PRD and scenario design that precedes this workflow
+- [`docs/02-architecture/`](../../../docs/02-architecture/README.md) — architecture scope and ADRs
+- [`docs/03-infrastructure/`](../../../docs/03-infrastructure/README.md) — provisioning / deployment patterns
+- [`docs/04-specs/`](../../../docs/04-specs/README.md) — spec layer hierarchy, glossary, required sections

--- a/docs/01-product/_assets/product-artifact-viewer/index.html
+++ b/docs/01-product/_assets/product-artifact-viewer/index.html
@@ -552,7 +552,7 @@
     async function runMermaid() {
       try {
         if (!mermaidApi) {
-          mermaidApi = await import("https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs");
+          mermaidApi = await import("https://cdn.jsdelivr.net/npm/mermaid@10.9.6/dist/mermaid.esm.min.mjs");
           mermaidApi.default.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
         }
         await mermaidApi.default.run({ querySelector: ".mermaid" });

--- a/docs/01-product/_assets/scenario-components/scenario-components.js
+++ b/docs/01-product/_assets/scenario-components/scenario-components.js
@@ -351,7 +351,7 @@ async function renderMarkdownMermaidFlow(root, source, flowIndex = 0) {
     if (!mermaid) throw new Error("No Mermaid code block found in Markdown source.");
 
     body.innerHTML = `<div class="mermaid">${escapeHtml(mermaid)}</div>`;
-    const mermaidApi = await import("https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs");
+    const mermaidApi = await import("https://cdn.jsdelivr.net/npm/mermaid@10.9.6/dist/mermaid.esm.min.mjs");
     mermaidApi.default.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
     await mermaidApi.default.run({ nodes: [body.querySelector(".mermaid")] });
   } catch (error) {
@@ -377,7 +377,7 @@ async function renderMarkdownSection(root, source, heading, level) {
 
     const mermaidNodes = Array.from(body.querySelectorAll(".mermaid"));
     if (mermaidNodes.length > 0) {
-      const mermaidApi = await import("https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs");
+      const mermaidApi = await import("https://cdn.jsdelivr.net/npm/mermaid@10.9.6/dist/mermaid.esm.min.mjs");
       mermaidApi.default.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
       await mermaidApi.default.run({ nodes: mermaidNodes });
     }

--- a/docs/02-architecture/README.md
+++ b/docs/02-architecture/README.md
@@ -1,0 +1,54 @@
+# Architecture
+
+Engine-neutral architecture documents for the Microsoft 365 Agents Toolkit. This
+folder answers a single question:
+
+> *"How is the engine itself built — what shape must any new piece of code fit
+> into, and what cross-cutting contracts does it have to honor?"*
+
+Architecture is engine-internal: it describes the toolkit's own codebase. The
+runtime substrate the toolkit deploys *to* lives in
+[`docs/03-infrastructure/`](../03-infrastructure/README.md). Business behavior —
+what a feature does from the user's point of view — lives in
+[`docs/01-product/`](../01-product/README.md) and is contracted in
+[`docs/04-specs/`](../04-specs/README.md).
+
+## What lives here
+
+Three kinds of content, in this order:
+
+1. **Chosen structure** — package boundaries, layering, dependency direction,
+   composition rules, lifecycle composition. The deliberate shape of the engine.
+2. **Cross-cutting contracts** — error model, logging / telemetry boundary,
+   configuration model, context propagation, public vs internal API surface, i18n.
+   Things every package must agree on for the engine to work as one system.
+3. **Resulting constraints** — rules new code must follow because of (1) and (2)
+   (e.g. "no cross-package internal imports", "no new module-scoped runtime
+   state"). Constraints are the *output* of architectural decisions, not the
+   definition of architecture.
+
+Binding decisions are recorded as **ADRs** (numbered, dated, immutable). Every
+constraint in this folder should be traceable to an ADR that explains *why*.
+
+## What does NOT live here
+
+- Per-feature behavior, AC tables, operation specs, data-model entities → [`docs/04-specs/`](../04-specs/README.md).
+- Provisioning / deployment / runtime topology → [`docs/03-infrastructure/`](../03-infrastructure/README.md).
+- Product intent, scenarios, surface UX → [`docs/01-product/`](../01-product/README.md).
+- Per-package coding conventions (file headers, lint rules, naming) → [`.github/instructions/`](../../.github/instructions/).
+
+## Conventions
+
+- ADRs are Markdown, English, numbered sequentially, and never edited after they
+  are accepted. To change an accepted decision, add a new ADR whose status is
+  `Accepted` and update the old one's status to `Superseded by ADR-NNNN`.
+- Architecture pages reference ADRs by number rather than restating them.
+- Specific architectural choices (e.g. composition pattern, error type, registry
+  vs class hierarchy) belong in ADRs, not in this README — this page is a
+  contents page, not a decision log.
+
+## Status
+
+This folder is being populated. Until subpages exist, individual ADRs are the
+authoritative source as they land; where no ADR exists yet, the corresponding
+decision is treated as open.

--- a/docs/03-infrastructure/README.md
+++ b/docs/03-infrastructure/README.md
@@ -1,0 +1,45 @@
+# Infrastructure
+
+Engine-neutral infrastructure documents for the Microsoft 365 Agents Toolkit.
+This folder answers a single question:
+
+> *"What runtime substrate does the toolkit (or what it scaffolds) live on, and
+> what cross-cutting contracts govern provisioning, identity, deployment, and
+> operations?"*
+
+Infrastructure is engine-external: it describes the cloud / identity / pipeline
+substrate the toolkit produces, consumes, or runs against. The internal shape of
+the engine itself lives in [`docs/02-architecture/`](../02-architecture/README.md).
+
+## What lives here
+
+Three kinds of content, in this order:
+
+1. **Chosen substrate and topology** — target clouds and runtimes, resource-group
+   layout, region and environment model (`dev`, `staging`, `prod`), tagging,
+   naming.
+2. **Provisioning / runtime contracts** — Bicep / Terraform module shape,
+   parameter and output contracts, identity baselines (managed identity,
+   federated credentials, RBAC), secret handling, network assumptions, telemetry
+   backend, CI/CD and release-channel conventions.
+3. **Resulting constraints** — rules every starter template, driver, or
+   deployment plan must follow because of (1) and (2). Constraints are the
+   *output* of these decisions, not the definition of infrastructure.
+
+Binding infrastructure decisions that are hard to reverse or cross-cutting are
+recorded as ADRs under [`docs/02-architecture/`](../02-architecture/README.md);
+pattern pages in this folder link back to those ADRs rather than restating them.
+
+## What does NOT live here
+
+- Engine-internal driver implementations or operation specs → [`docs/04-specs/`](../04-specs/README.md).
+- How the engine is internally composed → [`docs/02-architecture/`](../02-architecture/README.md).
+- Concrete starter infrastructure that ships *to users* under `templates/` —
+  those are shipping artifacts, not the doc-level contract. This folder may
+  reference them as examples but does not own them.
+- Product intent or scenario flows → [`docs/01-product/`](../01-product/README.md).
+
+## Status
+
+This folder is being populated. Add infrastructure pages here as patterns
+stabilize across templates and supported clouds.

--- a/docs/04-specs/README.md
+++ b/docs/04-specs/README.md
@@ -1,0 +1,61 @@
+# Specs
+
+Authoritative behavioral contract layer for the Microsoft 365 Agents Toolkit.
+Tests are derived 1:1 from spec acceptance-criteria rows; implementation is
+written to make those tests green.
+
+## Layer hierarchy
+
+```
+PRD (docs/01-product/prd/)
+  └─ Scenario (docs/01-product/scenarios/)
+      └─ Domain Spec (docs/04-specs/domains/<nn>-<domain>.md)
+          └─ Operation Spec (docs/04-specs/operations/<domain>/<operation>.md)
+              └─ Acceptance Criteria table   ← tests are derived from this table
+                  └─ Tests (1:1 with AC rows, name carries AC-ID)
+                      └─ Code (implementation makes failing tests green)
+```
+
+Architectural decisions that span multiple specs live as ADRs under
+[`docs/02-architecture/`](../02-architecture/README.md). Data contracts and
+entities live under `data-model/`.
+
+## Spec kinds
+
+| Kind | Path pattern | Purpose |
+|------|--------------|---------|
+| Domain Spec | `domains/<nn>-<domain>.md` | Boundary, vocabulary, and rules for one of the capability domains. |
+| Operation Spec | `operations/<domain>/<operation>.md` | One atomic engine action: inputs, outputs, AC table, flow, boundary, invariants. |
+| Data-model Entity | `data-model/entities/<entity>.md` | Stable contract for a domain entity (shape, identifiers, lifecycle). |
+
+## Required sections in an Operation Spec
+
+An operation spec is **complete** (eligible for tests/code) only when all of these
+sections are filled:
+
+- `## Acceptance Criteria` — ID-based table; one row per testable behavior.
+- `## Flow` — Mermaid diagram for stateful or cross-step behavior.
+- `## Boundary` — what the operation does NOT do.
+- `## Invariants` — constraints that must never be violated.
+
+If a section cannot be completed because of upstream ambiguity, stop and surface
+the gap as a question to PM rather than guessing. See the
+[`vibe-coding`](../../.github/skills/vibe-coding/SKILL.md) skill for the full
+spec → tests → code gate.
+
+## Glossary (authoritative for this repo)
+
+- **Capability** — PM word for a feature area users perceive.
+- **Domain** — engineering word for the same area; one domain spec per domain.
+- **Operation** — one atomic engine action belonging to a domain.
+- **Template** — composes Operations into a shippable starting point.
+- **Driver** — implementation primitive used by Operations to interact with
+  external systems (clouds, services, files). Its shape is governed by
+  [`docs/02-architecture/`](../02-architecture/README.md).
+
+## Status
+
+This folder is being populated. Until per-domain and per-operation specs land, the
+spec format above is the contract; treat the
+[`vibe-coding`](../../.github/skills/vibe-coding/SKILL.md) skill as the operating
+workflow.


### PR DESCRIPTION
## Summary

Sets up the documentation skeleton and AI-agent workflow that the v4 refactor will hang off of. No package code or runtime behavior is touched in this PR.

## What changed

### Docs scaffold (new)

- `docs/02-architecture/README.md` — engine-internal scope: package boundaries, cross-cutting contracts, ADR home.
- `docs/03-infrastructure/README.md` — engine-external scope: runtime substrate, provisioning, identity, deployment.
- `docs/04-specs/README.md` — behavioral contract layer (PRD → Scenario → Domain → Operation → AC → Tests → Code), plus required spec sections and glossary.

These three READMEs are intentionally contents-pages, not decision logs — concrete decisions land later as ADRs / specs.

### AI-agent workflow (`.github/`)

- **New skill** `.github/skills/vibe-coding/SKILL.md` — end-to-end design-first → tests-from-AC → implement → verify → self-review cycle for behavior-changing or structural-shape work. Inherits the global principles in `copilot-instructions.md` instead of restating them.
- **New instructions file** `.github/instructions/security.instructions.md` (auto-loaded for `packages/**/*.{ts,tsx}`) — webview XSS, shell/path-injection, untrusted JSON parsing, crypto. Complements the cross-cutting rules already in `copilot-instructions.md` (`maskSecret`, EAFP, no `as` casts).
- **Refresh** `.github/skills/prd-ux-design/SKILL.md` — small cross-reference cleanups; dropped hyperlinks to `prd/README.md` and `_backups_/README.md` since those folders aren't tracked yet (the paths are still mentioned as inline code).
- **Update** `.github/copilot-instructions.md` — router table now points to the two surviving skills (`prd-ux-design`, `vibe-coding`) and the per-package instruction files; package overview and key file locations refreshed.

### Doc viewers (small fix)

- Pinned Mermaid to `10.9.6` in `docs/01-product/_assets/product-artifact-viewer/index.html` and `docs/01-product/_assets/scenario-components/scenario-components.js` to stop drifting against the CDN's `@latest` tag.

## Scope and non-goals

- No `packages/**` changes; no runtime, build, or test surface touched.
- ADRs themselves are deliberately not included — `docs/02-architecture/` is intentionally being populated incrementally.
- `docs/01-product/prd/` and `docs/01-product/_backups_/` are intentionally **not** staged here. `prd/` isn't yet aligned with the new framework, and `_backups_/` is pre-reorganization source material.

## Risk

Docs-only. Lowest-risk change class.

Opened as **draft** so reviewers can sanity-check the router and the three new scope anchors before they become the basis for ADRs.