### PR TITLE
fix: remove invalid link https://aka.ms/teamsfx-auth-code-flow

### DIFF
--- a/packages/sdk-react/src/useGraph.ts
+++ b/packages/sdk-react/src/useGraph.ts
@@ -66,8 +66,7 @@ export function useGraphWithCredential<T>(
           err.message +=
             '\nIf you see "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" ' +
             "in the popup window, you may be using unmatched version for TeamsFx SDK (version >= 0.5.0) and Teams Toolkit (version < 3.3.0) or " +
-            "cli (version < 0.11.0). Please refer to the help link for how to fix the issue: " +
-            helpLink;
+            `cli (version < 0.11.0). Please refer to the help link for how to fix the issue: ${helpLink}`;
         }
         throw err;
       }

--- a/packages/sdk-react/src/useGraph.ts
+++ b/packages/sdk-react/src/useGraph.ts
@@ -61,10 +61,13 @@ export function useGraphWithCredential<T>(
         // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       } catch (err: unknown) {
         if (err instanceof ErrorWithCode && err.message?.includes("CancelledByUser")) {
+          const helpLink =
+            "https://learn.microsoft.com/microsoftteams/platform/toolkit/develop-single-sign-on-experience-in-teams";
           err.message +=
             '\nIf you see "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" ' +
             "in the popup window, you may be using unmatched version for TeamsFx SDK (version >= 0.5.0) and Teams Toolkit (version < 3.3.0) or " +
-            "cli (version < 0.11.0).";
+            "cli (version < 0.11.0). Please refer to the help link for how to fix the issue: " +
+            helpLink;
         }
         throw err;
       }

--- a/packages/sdk-react/src/useGraph.ts
+++ b/packages/sdk-react/src/useGraph.ts
@@ -61,11 +61,10 @@ export function useGraphWithCredential<T>(
         // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       } catch (err: unknown) {
         if (err instanceof ErrorWithCode && err.message?.includes("CancelledByUser")) {
-          const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
           err.message +=
             '\nIf you see "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" ' +
             "in the popup window, you may be using unmatched version for TeamsFx SDK (version >= 0.5.0) and Teams Toolkit (version < 3.3.0) or " +
-            `cli (version < 0.11.0). Please refer to the help link for how to fix the issue: ${helpLink}`;
+            "cli (version < 0.11.0).";
         }
         throw err;
       }

--- a/packages/sdk-react/test/useGraph.test.ts
+++ b/packages/sdk-react/test/useGraph.test.ts
@@ -224,7 +224,8 @@ describe("useGraphWithCredential() hook tests", () => {
           "CancelledByUser" +
             '\nIf you see "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" ' +
             "in the popup window, you may be using unmatched version for TeamsFx SDK (version >= 0.5.0) and Teams Toolkit (version < 3.3.0) or " +
-            "cli (version < 0.11.0).",
+            "cli (version < 0.11.0). Please refer to the help link for how to fix the issue: " +
+            "https://learn.microsoft.com/microsoftteams/platform/toolkit/develop-single-sign-on-experience-in-teams",
         );
       },
       { interval: 1 },

--- a/packages/sdk-react/test/useGraph.test.ts
+++ b/packages/sdk-react/test/useGraph.test.ts
@@ -224,7 +224,7 @@ describe("useGraphWithCredential() hook tests", () => {
           "CancelledByUser" +
             '\nIf you see "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" ' +
             "in the popup window, you may be using unmatched version for TeamsFx SDK (version >= 0.5.0) and Teams Toolkit (version < 3.3.0) or " +
-            `cli (version < 0.11.0). Please refer to the help link for how to fix the issue: https://aka.ms/teamsfx-auth-code-flow`,
+            "cli (version < 0.11.0).",
         );
       },
       { interval: 1 },

--- a/packages/sdk/src/credential/teamsUserCredential.browser.ts
+++ b/packages/sdk/src/credential/teamsUserCredential.browser.ts
@@ -133,7 +133,9 @@ export class TeamsUserCredential implements TokenCredential {
     // If code exists in result, user may using previous auth-start and auth-end page.
     if (resultJson.code) {
       const usingPreviousAuthPage =
-        "Found auth code in response. Auth code is not support for current version of SDK. ";
+        "Found auth code in response. Auth code is not support for current version of SDK. " +
+        "Please refer to the help link for how to fix the issue: " +
+        "https://learn.microsoft.com/microsoftteams/platform/toolkit/develop-single-sign-on-experience-in-teams.";
       internalLogger.error(usingPreviousAuthPage);
       throw new ErrorWithCode(usingPreviousAuthPage, ErrorCode.InvalidResponse);
     }

--- a/packages/sdk/src/credential/teamsUserCredential.browser.ts
+++ b/packages/sdk/src/credential/teamsUserCredential.browser.ts
@@ -132,10 +132,8 @@ export class TeamsUserCredential implements TokenCredential {
 
     // If code exists in result, user may using previous auth-start and auth-end page.
     if (resultJson.code) {
-      const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
       const usingPreviousAuthPage =
-        "Found auth code in response. Auth code is not support for current version of SDK. " +
-        `Please refer to the help link for how to fix the issue: ${helpLink}.`;
+        "Found auth code in response. Auth code is not support for current version of SDK. ";
       internalLogger.error(usingPreviousAuthPage);
       throw new ErrorWithCode(usingPreviousAuthPage, ErrorCode.InvalidResponse);
     }

--- a/packages/sdk/src/credential/teamsUserCredential.browser.ts
+++ b/packages/sdk/src/credential/teamsUserCredential.browser.ts
@@ -132,10 +132,10 @@ export class TeamsUserCredential implements TokenCredential {
 
     // If code exists in result, user may using previous auth-start and auth-end page.
     if (resultJson.code) {
+      const helpLink = "https://learn.microsoft.com/microsoftteams/platform/toolkit/develop-single-sign-on-experience-in-teams";
       const usingPreviousAuthPage =
         "Found auth code in response. Auth code is not support for current version of SDK. " +
-        "Please refer to the help link for how to fix the issue: " +
-        "https://learn.microsoft.com/microsoftteams/platform/toolkit/develop-single-sign-on-experience-in-teams.";
+        `Please refer to the help link for how to fix the issue: ${helpLink}.`;
       internalLogger.error(usingPreviousAuthPage);
       throw new ErrorWithCode(usingPreviousAuthPage, ErrorCode.InvalidResponse);
     }


### PR DESCRIPTION
This PR is to remove invalid link https://aka.ms/teamsfx-auth-code-flow.

The related ADO bug is https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34380244/?view=edit.