### PR TITLE
fix: remove invalid link https://aka.ms/teamsfx-bicep-add-param-tutorial

### DIFF
--- a/templates/unused/csharp/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/csharp/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/csharp/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/csharp/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -24,7 +24,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/csharp/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -24,7 +24,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/csharp/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -24,7 +24,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/csharp/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/csharp/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/csharp/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/csharp/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -15,7 +15,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -15,7 +15,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -15,7 +15,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -25,7 +25,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -25,7 +25,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -25,7 +25,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/js/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/js/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -15,7 +15,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -15,7 +15,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch-api-key/infra/azure.bicep
@@ -15,7 +15,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -24,7 +24,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -24,7 +24,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch-sso/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch-sso/infra/azure.bicep
@@ -24,7 +24,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/unused/ts/message-extension-with-api-from-scratch/infra/azure.bicep
+++ b/templates/unused/ts/message-extension-with-api-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/infra/azure.bicep
@@ -13,7 +13,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/infra/azure.bicep.tpl
@@ -14,7 +14,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku
+    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // Add functionServerfarmsSku
   }
   properties: {}
 }

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/infra/azure.bicep
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/infra/azure.bicep
@@ -12,7 +12,7 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   location: location
   sku: {
-    name: functionAppSKU // Add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
+    name: functionAppSKU // You can follow https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision#use-an-existing-microsoft-entra-app-for-your-teams-app to add functionServerfarmsSku property to provisionParameters to override the default value "Y1".
   }
   properties: {}
 }


### PR DESCRIPTION
This PR is to remove invalid link https://aka.ms/teamsfx-bicep-add-param-tutorial.

The related ado bug is https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34380234/?view=edit.