### PR TITLE
fix(deps): bump serialize-javascript to 14.0.0

### DIFF
--- a/templates/vsc/common/declarative-agent-meta-os-new-project/package.json.tpl
+++ b/templates/vsc/common/declarative-agent-meta-os-new-project/package.json.tpl
@@ -44,7 +44,7 @@
     "@types/office-js": "^1.0.377",
     "@types/office-runtime": "^1.0.35",
     "babel-loader": "^9.1.3",
-    "copy-webpack-plugin": "^12.0.2",
+    "copy-webpack-plugin": "^14.0.0",
     "eslint-plugin-office-addins": "^3.0.2",
     "file-loader": "^6.2.0",
     "html-loader": "^5.0.0",


### PR DESCRIPTION
This PR was opened automatically by the CD vulnerability scan.

- **Ecosystem**: npm
- **Scan target**: `templates/vsc`
- **File**: `templates/vsc/common/declarative-agent-meta-os-new-project/package.json.tpl`
- **Package**: `serialize-javascript`
- **Current version**: `unknown`
- **Fixed version**: `14.0.0`
- **Severity**: `high`
- **Advisory**: https://github.com/advisories/GHSA-5c6j-r48x-rmvq
- **Title**: Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString()

An automatic fix was applied and verified locally (`npm install` + `npm audit` no longer flag this package).
Strategy used: **parent copy-webpack-plugin bumped to 14.0.0**.
Please still review the diff before merging.