### PR TITLE
fix(deps): bump @typespec/compiler to 1.12.0

### DIFF
--- a/templates/vsc/common/declarative-agent-typespec/package.json.tpl
+++ b/templates/vsc/common/declarative-agent-typespec/package.json.tpl
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@microsoft/typespec-m365-copilot": "^1.0.0",
-    "@typespec/compiler": "1.5.0",
+    "@typespec/compiler": "1.12.0",
     "@typespec/http": "1.5.0",
     "@typespec/openapi": "1.5.0",
     "@typespec/openapi3": "1.5.0"


### PR DESCRIPTION
This PR was opened automatically by the vulnerability scan pipeline.

- **Ecosystem**: npm
- **Scan target**: `templates/vsc`
- **File**: `templates/vsc/common/declarative-agent-typespec/package.json.tpl`
- **Package**: `@typespec/compiler`
- **Current version**: `1.5.0`
- **Fixed version**: `1.12.0`
- **Severity**: `moderate`

An automatic fix was applied and verified locally (`npm install` + `npm audit` no longer flag this package).
Strategy used: **direct dep bump to 1.12.0**.
Please still review the diff before merging.