### PR TITLE
fix(deps): bump undici to 4.16.0

### DIFF
--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/package.json.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/package.json.tpl
@@ -15,7 +15,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@azure/functions": "4.7.2",
+        "@azure/functions": "4.16.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0",
         "lru-memoizer": "^2.3.0"


### PR DESCRIPTION
This PR was opened automatically by the vulnerability scan pipeline.

- **Ecosystem**: npm
- **Scan target**: `templates/vsc`
- **File**: `templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/package.json.tpl`
- **Package**: `undici`
- **Current version**: `unknown`
- **Fixed version**: `4.16.0`
- **Severity**: `high`
- **Advisory**: https://github.com/advisories/GHSA-g9mf-h72j-4rw9
- **Title**: Undici has an unbounded decompression chain in HTTP responses on Node.js Fetch API via Content-Encoding leads to resource exhaustion

An automatic fix was applied and verified locally (`npm install` + `npm audit` no longer flag this package).
Strategy used: **parent @azure/functions bumped to 4.16.0**.
Please still review the diff before merging.