### PR TITLE
feat(fx-core): v4 template distribution channel

### DIFF
--- a/.github/scripts/v4/generate-v4-tag-list.js
+++ b/.github/scripts/v4/generate-v4-tag-list.js
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * CD wrapper (v4-isolated): compute the digest of the v4 `templates.zip` and
+ * append a `{ version, digest }` entry to the v4 channel's NDJSON tag-list.
+ *
+ * The v4 channel tag-list is one JSON object per line (NDJSON), unlike v3's
+ * newline-separated git-tag text — because v4 carries a content digest that is
+ * not derivable from git tags. `parseTagList` in
+ * packages/fx-core/src/v4/distribution/templateSourcePort.ts reads exactly this
+ * format. The digest is `sha256:<hex>` over the raw zip bytes, matching
+ * `computeDigest` in templateSource.ts (the single digest authority).
+ *
+ * Re-running for an already-published version replaces that version's line
+ * (idempotent), so a CD re-run does not duplicate entries.
+ *
+ * Usage (run AFTER the templates build, with build/v4/templates.zip present):
+ *   node .github/scripts/v4/generate-v4-tag-list.js \
+ *     --zip <path to templates.zip> \
+ *     --version <semver> \
+ *     --ndjson <path to read existing + write merged NDJSON>
+ *
+ * The --ndjson file may be absent (first release); it is created.
+ */
+
+const crypto = require("crypto");
+const fs = require("fs");
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key || !key.startsWith("--") || value === undefined) {
+      throw new Error(`Malformed argument near "${key}". Expected --flag value pairs.`);
+    }
+    args[key.slice(2)] = value;
+  }
+  return args;
+}
+
+const { zip, version, ndjson } = parseArgs(process.argv.slice(2));
+if (!zip || !version || !ndjson) {
+  throw new Error("Missing required argument. Need --zip, --version and --ndjson.");
+}
+
+const bytes = fs.readFileSync(zip);
+const digest = "sha256:" + crypto.createHash("sha256").update(bytes).digest("hex");
+
+// Read the existing NDJSON (if any) and index by version so a re-run replaces
+// rather than duplicates. Missing file = first release.
+const entries = new Map();
+let existing = "";
+try {
+  existing = fs.readFileSync(ndjson, "utf8");
+} catch (error) {
+  if (error.code !== "ENOENT") {
+    throw error;
+  }
+}
+for (const line of existing.split("\n")) {
+  const trimmed = line.replace(/\r$/, "").trim();
+  if (trimmed === "") {
+    continue;
+  }
+  const parsed = JSON.parse(trimmed);
+  entries.set(parsed.version, parsed);
+}
+
+entries.set(version, { version, digest });
+
+const merged = [...entries.values()].map((entry) => JSON.stringify(entry)).join("\n") + "\n";
+fs.writeFileSync(ndjson, merged);
+
+console.log(
+  `================== v4 tag-list entry: ${JSON.stringify({ version, digest })} (${entries.size} total) ==================`
+);

--- a/.github/scripts/v4/publish-v4-channel.sh
+++ b/.github/scripts/v4/publish-v4-channel.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# CD wrapper (v4-isolated): publish one immutable v4 template release and append
+# its digest entry to the v4 channel's NDJSON tag-list. This collapses the five
+# release-action steps that previously lived inline in cd.yml into one step so
+# the v4 footprint in the workflow stays small while the single-coordination
+# point (the lerna-minted templates version) is preserved.
+#
+# It only ever touches the two v4-owned GitHub releases (`templates-v4@<ver>`
+# and `template-v4-tag-list`); the v3 `templates@` channel is never read or
+# written here.
+#
+# Usage (run AFTER the templates build, with build/v4/templates.zip present):
+#   bash .github/scripts/v4/publish-v4-channel.sh \
+#     <templates@<ver> tag> <path to templates.zip> <temp dir> <commit sha>
+#
+# Requires: gh CLI authenticated via GH_TOKEN, node on PATH.
+set -euo pipefail
+
+TEMPLATE_TAG="${1:?Need the templates@<ver> tag (steps.version-change.outputs.TEMPLATE_VERSION).}"
+ZIP="${2:?Need the path to templates.zip.}"
+TMP="${3:?Need a temp directory.}"
+SHA="${4:?Need the commit sha to anchor the release.}"
+
+VERSION="${TEMPLATE_TAG#templates@}"
+TAG="templates-v4@$VERSION"
+NDJSON="$TMP/template-v4-tags.ndjson"
+
+# 1. Upsert the immutable per-version release and (re)upload the package.
+if ! gh release view "$TAG" >/dev/null 2>&1; then
+  gh release create "$TAG" \
+    --title "$TAG" \
+    --notes "v4 template package for $TAG" \
+    --target "$SHA"
+fi
+gh release upload "$TAG" "$ZIP" --clobber
+
+# 2. Pull the existing NDJSON tag-list (absent on the first release).
+gh release download template-v4-tag-list --pattern template-v4-tags.ndjson --dir "$TMP" || true
+
+# 3. Append (or replace) this version's { version, digest } line.
+node .github/scripts/v4/generate-v4-tag-list.js \
+  --zip "$ZIP" \
+  --version "$VERSION" \
+  --ndjson "$NDJSON"
+
+# 4. Upsert the tag-list release and publish the merged NDJSON.
+if ! gh release view template-v4-tag-list >/dev/null 2>&1; then
+  gh release create template-v4-tag-list \
+    --title "Template v4 Tag List" \
+    --notes "NDJSON tag list for the v4 template channel."
+fi
+gh release upload template-v4-tag-list "$NDJSON" --clobber

--- a/.github/scripts/v4/sync-v4-template-config.js
+++ b/.github/scripts/v4/sync-v4-template-config.js
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * CD wrapper (v4-isolated): write the `v4` distribution block into
+ * templates-config.json from the freshly minted templates version and the
+ * `goproduct` flag.
+ *
+ * This is the thin node glue around the unit-tested pure logic in
+ * packages/fx-core/src/v4/distribution/templateConfig.ts. It does only IO:
+ * read version + flag + previous config, call computeV4TemplateConfig, write
+ * back. The `v4` block is fully isolated from v3's `version` / `useLocalTemplate`
+ * (different semantics, v3 frozen) — see scaffolding.create.proposal.md §5.1.
+ *
+ * Usage (run AFTER `lerna version`, with the templates package version minted):
+ *   PRODUCTION=<true|false> node .github/scripts/v4/sync-v4-template-config.js
+ *
+ * Requires fx-core to be built (build/v4/distribution/templateConfig.js).
+ */
+
+const path = require("path");
+const fs = require("fs");
+
+const repoRoot = path.join(__dirname, "../../..");
+const templateVersion = require(path.join(repoRoot, "templates/package.json")).version;
+
+const fxCorePath = path.join(repoRoot, "packages/fx-core");
+const configFile = path.join(fxCorePath, "src/common/templates-config.json");
+const { computeV4TemplateConfig } = require(path.join(
+  fxCorePath,
+  "build/v4/distribution/templateConfig.js"
+));
+
+const goproduct = process.env.PRODUCTION === "true";
+
+const config = JSON.parse(fs.readFileSync(configFile, "utf8"));
+const previousRange = (config.v4 && config.v4.range) || config.version;
+
+config.v4 = computeV4TemplateConfig({
+  version: templateVersion,
+  goproduct,
+  previousRange,
+});
+
+// Match the existing 4-space, trailing-newline, LF convention of the file.
+fs.writeFileSync(configFile, JSON.stringify(config, null, 4) + "\n");
+
+console.log(
+  `================== v4 template config: ${JSON.stringify(config.v4)} (goproduct=${goproduct}) ==================`
+);

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -308,6 +308,12 @@ jobs:
       # the v4-owned releases; the v3 templates@ channel above is untouched.
       - name: Publish v4 template channel
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.goproduct == 'true' }}
+        # continue-on-error is intentional ONLY while no shipped engine consumes
+        # the v4 channel yet (generator wiring is pending, plan item #7): a v4
+        # publish failure here has zero production impact and must not block the
+        # v3 CD. Remove this line once the v4 generator goes live, so a failed
+        # channel update fails the shipping build instead of silently leaving
+        # the channel behind the engine config.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -234,6 +234,15 @@ jobs:
           echo "EXTENSION_VERSION=$(git tag --points-at HEAD | grep ms-teams-vscode-extension@)" >> $GITHUB_OUTPUT
           git tag --points-at HEAD | grep templates | grep rc | xargs -r git push -d origin
 
+      # v4 channel (isolated from the v3 steps above). The v4 distribution config
+      # block in templates-config.json is synced here, after lerna version mints
+      # the new templates version and before publish. fx-core's prepublishOnly
+      # rebuild then bundles the edited config into the published package — the
+      # same timing the v3 config sync relies on. `bundled = !goproduct`.
+      - name: sync v4 template config
+        if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' }}
+        run: node .github/scripts/v4/sync-v4-template-config.js
+
       - name: update template rc tag
         uses: richardsimko/update-tag@v1.0.7
         if: ${{ (contains(steps.version-change.outputs.CHANGED, 'templates@') || contains(steps.version-change.outputs.CHANGED, '@microsoft/teamsfx')) && github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'rc' }}
@@ -289,6 +298,25 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           tag: "template-tag-list"
           allowUpdates: true
+
+      # ── v4 template channel ───────────────────────────────────────────────
+      # Gated on goproduct (ship-to-marketplace), independent of the preid lane:
+      # a prerelease built with goproduct=true also enters the v4 channel. The
+      # publish-v4-channel.sh wrapper does the whole channel update (immutable
+      # templates-v4@<ver> release + digest-bearing NDJSON tag-list append) so
+      # the v4 footprint in this workflow stays one step. It only ever touches
+      # the v4-owned releases; the v3 templates@ channel above is untouched.
+      - name: Publish v4 template channel
+        if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.goproduct == 'true' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          bash .github/scripts/v4/publish-v4-channel.sh \
+            "${{ steps.version-change.outputs.TEMPLATE_VERSION }}" \
+            "${{ github.workspace }}/templates/build/v4/templates.zip" \
+            "${{ runner.temp }}" \
+            "${{ github.sha }}"
 
       - name: Release RC VS templates to GitHub
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' }}

--- a/docs/03-specs/operations/scaffolding/open-template-package.md
+++ b/docs/03-specs/operations/scaffolding/open-template-package.md
@@ -76,6 +76,7 @@ or interprets the bytes.
 | AC-07 | L1 | identical `(bytes, locator)` | open twice | identical entry list in identical order (entries sorted by `path`) |
 | AC-08 | L1 | the zip has both `common/da/` and `common/da-basic/` subtrees, locator `{language:"common", scenario:"da"}` | open | only the exact `common/da/` subtree is returned, **not** `common/da-basic/` (prefix match is on `common/da/` with a trailing slash boundary) |
 | AC-09 | L1 | the located subtree contains a zero-byte file (e.g. `content/.gitkeep`) | open | the empty file is returned as a `{ path, data: Buffer(0) }` entry; an empty file is a file, not a directory, and is moved verbatim |
+| AC-10 | L1 | a zip whose located subtree contains an entry whose post-prefix path has a `..` (or empty / `.`) segment (e.g. `common/da-basic/../evil.txt`) | open | a `SystemError` (`TemplatePackageUnsafePath`) naming the entry; the traversal path is **never** returned (Zip-Slip guard) |
 
 ## Flow
 
@@ -89,7 +90,9 @@ flowchart TD
   filterDir --> match{any file entry matched?}
   match -->|no| errMiss([SystemError: template not found in package])
   match -->|yes| strip["strip prefix → relative path, normalize slashes"]
-  strip --> sort["sort entries by relative path"]
+  strip --> safe{path segments safe? no empty/./..}
+  safe -->|no| errUnsafe([SystemError: unsafe entry path])
+  safe -->|yes| sort["sort entries by relative path"]
   sort --> done([TemplateFileEntry list])
 ```
 
@@ -141,6 +144,13 @@ This operation does **not**:
 - **INV-7 — v4-owned.** This operation and its tests live in the v4 world; v3
   may call it, but it adds no v3-specific method, parameter, or test fixture
   (proposal §5.1 seam direction).
+- **INV-8 — No traversal paths escape.** A returned entry path is always a pure
+  relative path under the located template's content root: every segment is
+  non-empty and is neither `.` nor `..`. An entry whose post-prefix path
+  violates this is a hard `SystemError` (`TemplatePackageUnsafePath`), never a
+  returned entry. The upstream digest check proves the bytes equal what was
+  published, not that the published archive is traversal-free; since the
+  renderer writes these paths to disk, containment is enforced here (Zip-Slip).
 
 ## Resolved decisions (Gate 1)
 

--- a/docs/03-specs/operations/scaffolding/open-template-package.md
+++ b/docs/03-specs/operations/scaffolding/open-template-package.md
@@ -1,0 +1,156 @@
+# Operation — `open-template-package`
+
+- **Status:** Accepted (Gate 1 + Gate 2 cleared 2026-06-03) — ready for tests
+- **Domain:** [`01-scaffolding`](../../domains/01-scaffolding.md)
+- **Decision source:** [ADR-0006](../../../02-architecture/adr/ADR-0006-template-distribution-channel.md),
+  [`scaffolding.create.proposal.md` §3](../../../02-architecture/scaffolding.create.proposal.md)
+- **Upstream operation:** [`resolve-template-source`](resolve-template-source.md)
+  (produces the package bytes this operation opens)
+- **PRD/scenario:** none required — internal, behavior-preserving package
+  consumption with no user-visible surface change.
+
+## Purpose
+
+Given the resolved template-package **bytes** and a **locator**, open the
+package and return the file entries of exactly one template, with the
+locator's path prefix stripped so each entry is rooted at the template's
+content. This is the single step between
+[`resolve-template-source`](resolve-template-source.md) (which decides *which
+bytes*) and the renderer (which decides *what the rendered project looks
+like*): it decides *what is inside the package and where the chosen template
+lives*.
+
+`resolve-template-source`'s boundary explicitly defers in-package layout —
+"In-package layout (per-template descriptor dirs, language dirs) is the
+consumer's concern." This operation is that consumer.
+
+## Stable boundary, evolvable locator
+
+The **boundary** — open archive → locate one template subtree → hand back
+file entries — is permanent. `resolve-template-source` yields bytes; some
+operation must always turn bytes into renderable entries, regardless of the
+package's internal layout. The v4 scaffolding engine builds *on top of* this
+operation; it does not remove it.
+
+The **locator shape** is transitional. The package in production today carries
+the v3 content mirrored under `<language>/<scenario>/…`, so the locator is
+`{ language, scenario }`. When the [`§3`](../../../02-architecture/scaffolding.create.proposal.md)
+`<templateId>/{descriptor,questions,pipeline,content}` authoring layout ships,
+the locator becomes `{ templateId }`. That change swaps only the **prefix the
+locator resolves to** — `openPackage`, the entry contract, and every AC below
+hold unchanged (INV-1). The locator is therefore a neutral structure, never a
+焊死 `{language, scenario}` assumption baked into the open/entry contract.
+
+## Inputs
+
+| Input | Type | Origin |
+|-------|------|--------|
+| `bytes` | `Buffer` | the resolved package bytes from [`resolve-template-source`](resolve-template-source.md) (`port.packages` / cache / floor) |
+| `locator` | `TemplateLocator` (`{ language: string; scenario: string }`) | the engine's routing decision (Q1 selector → which template) |
+
+This operation does **not** depend on the full `ScaffoldRuntime`. It is a pure
+function of `(bytes, locator)` (INV-5): no `fs`, no `http`, no `clock`.
+
+## Outputs
+
+A `Result<TemplateFileEntry[], FxError>`. Each entry:
+
+| Field | Meaning |
+|-------|---------|
+| `path` | the file path **relative to the located template's content root** (the `<language>/<scenario>/` prefix stripped), forward-slash normalized |
+| `data` | the file's raw bytes, **verbatim** — unrendered, `.tpl` suffix intact |
+
+The entry list is the renderer's input. This operation never renders, writes,
+or interprets the bytes.
+
+## Acceptance Criteria
+
+| ID | Tier | Given | When | Then |
+|----|------|-------|------|------|
+| AC-01 | L1 | a valid zip with files under `common/da-basic/` and a locator `{language:"common", scenario:"da-basic"}` | open | returns every file under `common/da-basic/` with the `common/da-basic/` prefix stripped; paths rooted at the template content |
+| AC-02 | L1 | a located subtree containing nested folders (e.g. `common/da-basic/appPackage/manifest.json.tpl`) | open | the nested relative path `appPackage/manifest.json.tpl` is preserved and forward-slash normalized |
+| AC-03 | L1 | the zip contains directory entries (names ending in `/`) | open | directory entries are excluded; only file entries are returned |
+| AC-04 | L1 | a `.tpl` file whose body contains `{{appName}}` | open | the bytes are returned **verbatim** — no Mustache substitution, `.tpl` suffix intact |
+| AC-05 | L1 | a valid zip and a locator that matches **zero** entries | open | a `SystemError` naming the locator; never an empty-list success |
+| AC-06 | L1 | `bytes` that are not a valid zip (garbage / truncated) | open | a `SystemError`; never a partial entry list |
+| AC-07 | L1 | identical `(bytes, locator)` | open twice | identical entry list in identical order (entries sorted by `path`) |
+| AC-08 | L1 | the zip has both `common/da/` and `common/da-basic/` subtrees, locator `{language:"common", scenario:"da"}` | open | only the exact `common/da/` subtree is returned, **not** `common/da-basic/` (prefix match is on `common/da/` with a trailing slash boundary) |
+| AC-09 | L1 | the located subtree contains a zero-byte file (e.g. `content/.gitkeep`) | open | the empty file is returned as a `{ path, data: Buffer(0) }` entry; an empty file is a file, not a directory, and is moved verbatim |
+
+## Flow
+
+```mermaid
+flowchart TD
+  start([open-template-package]) --> openZip{bytes parse as zip?}
+  openZip -->|no| errZip([SystemError: package is not a valid archive])
+  openZip -->|yes| prefix["prefix = locator.language + '/' + locator.scenario + '/'"]
+  prefix --> scan["select entries whose name starts with prefix"]
+  scan --> filterDir["drop directory entries (name ends with '/')"]
+  filterDir --> match{any file entry matched?}
+  match -->|no| errMiss([SystemError: template not found in package])
+  match -->|yes| strip["strip prefix → relative path, normalize slashes"]
+  strip --> sort["sort entries by relative path"]
+  sort --> done([TemplateFileEntry list])
+```
+
+## Boundary
+
+This operation does **not**:
+
+- Resolve *which* package. That is
+  [`resolve-template-source`](resolve-template-source.md); this operation
+  starts from already-resolved bytes.
+- Verify the digest. Integrity is verified upstream by
+  `resolve-template-source` (INV-3 there); re-verifying here would duplicate a
+  decided contract. This operation only requires the bytes to parse as an
+  archive.
+- Render. It does not substitute Mustache tokens, strip `.tpl` suffixes, or
+  apply any `replaceMap`/`fileNameReplaceFn`/`fileDataReplaceFn`. Entries are
+  returned verbatim for the renderer (v3 filter/render today, the v4 typed
+  render context later).
+- Interpret `descriptor.json` / `questions.json` / `pipeline.json`. Parsing
+  the `§3` authoring files is a later v4-engine layer built *on top of* this
+  operation, not part of it. Today's `<language>/<scenario>/` content carries
+  no such files.
+- Write to disk. It returns in-memory entries; persisting them is the
+  renderer's / runtime's concern.
+- Decide the locator. The engine's Q1 routing produces it; this operation
+  consumes it.
+
+## Invariants
+
+- **INV-1 — Layout-agnostic locate.** Locating a template is pure
+  prefix-subtree selection on a trailing-slash boundary; no path segment is
+  interpreted semantically. Changing the locator from `{language, scenario}`
+  to `{templateId}` (proposal §3) changes only the resolved prefix, not the
+  open/entry contract or any AC.
+- **INV-2 — No render.** Entry bytes are byte-for-byte the package bytes;
+  `.tpl` suffixes and `{{token}}` markers are untouched. This operation has no
+  knowledge of the templating language.
+- **INV-3 — Not found is a hard error.** A locator matching zero file entries
+  is a `SystemError` naming the locator (the resolved package should contain
+  the engine-routed template — a miss is an internal package/engine
+  inconsistency), never an empty-list success.
+- **INV-4 — Corrupt archive is a hard error.** Bytes that do not parse as a
+  zip raise a `SystemError`; a partial or best-effort entry list is never
+  returned.
+- **INV-5 — Determinism.** `open(bytes, locator)` is a pure function: the same
+  inputs yield the same entries in the same (path-sorted) order.
+- **INV-6 — Directories excluded.** Only file entries are returned; archive
+  directory entries (names ending in `/`) are dropped.
+- **INV-7 — v4-owned.** This operation and its tests live in the v4 world; v3
+  may call it, but it adds no v3-specific method, parameter, or test fixture
+  (proposal §5.1 seam direction).
+
+## Resolved decisions (Gate 1)
+
+1. **Empty-file entries are retained.** A zero-byte file in the located subtree
+   is a file, not a directory, and is returned as a `{ path, data: Buffer(0) }`
+   entry (AC-09). The directory/file distinction is the only exclusion rule
+   (INV-6); content length is never interpreted. This is the verbatim-handoff
+   contract: empty ≠ absent.
+2. **Locator prefix matching is case-sensitive.** Zip entry names are preserved
+   verbatim and the locator is emitted from the same authored casing as the
+   packaged folder names (`language`/`scenario` are enumerated values, not free
+   user text), so a case-sensitive match is exact and surfaces any
+   packaging/routing casing drift as an INV-3 error rather than masking it.

--- a/docs/03-specs/operations/scaffolding/resolve-template-source.md
+++ b/docs/03-specs/operations/scaffolding/resolve-template-source.md
@@ -82,6 +82,8 @@ outcome and telemetry; it is never written back into committed config.
 | AC-16 | L1 | `port.env("TEMPLATE_VERSION")="6.99.0"`, `bundled=false`, tag-list does **not** list `6.99.0` | resolve | raises a `UserError` (`TemplatePinnedVersionNotFound`) naming the pinned version; **no** fallback to range resolution, cache, or floor |
 | AC-17 | L1 | `bundled=false`, `port.tagList()` rejects with a malformed-document error (`TemplateTagListMalformed`) | resolve | the `SystemError` is **propagated** (returned as `err`); **no** offline fallback — a malformed channel is a hard error (decision #7), distinct from unreachable (AC-07) |
 | AC-18 | L1 | `port.env("TEMPLATE_VERSION")="6.11.2"`, `bundled=false`, `port.tagList()` is unreachable/rejects | resolve | returns `err(FxError)` (an existing FxError is preserved; otherwise wrapped); the rejection never escapes as a thrown promise; a pin **never** falls back |
+| AC-19 | L1 | `bundled=false`, a version is picked from the tag-list, but `port.packages(...)` (download) rejects | resolve | returns `err(FxError)` (an existing FxError is preserved; otherwise wrapped as `TemplateDownloadFailed`); the rejection never escapes as a thrown promise — the neverthrow contract holds for the download path too |
+
 
 ## Flow
 

--- a/docs/03-specs/operations/scaffolding/resolve-template-source.md
+++ b/docs/03-specs/operations/scaffolding/resolve-template-source.md
@@ -70,7 +70,7 @@ outcome and telemetry; it is never written back into committed config.
 | AC-04 | L1 | `bundled=false`, tag-list has `6.10.5` (digest `D5`, > floor `6.10.1`) satisfying `~6.10` | resolve | `origin=online`, `version=6.10.5`; `digest=D5` (from tag-list) recorded |
 | AC-05 | L1 | `bundled=false`, highest channel version satisfying `range` equals the bundled floor | resolve | resolves to the floor without downloading; `origin=bundled` |
 | AC-06 | L1 | `bundled=false`, resolved `version` already in `port.cache` with digest matching the tag-list's | resolve | `origin=cache`; **zero** download; returned bytes are the cached bytes |
-| AC-07 | L1 | `bundled=false`, `port.tagList()` throws/unreachable, cache holds `6.10.4` satisfying `range`, floor is `6.10.1` | resolve | `origin=cache`, `version=6.10.4` (`max(cache, floor)`); outcome carries an observable warning |
+| AC-07 | L1 | `bundled=false`, `port.tagList()` is unreachable (network failure, **not** a malformed document), cache holds `6.10.4` satisfying `range`, floor is `6.10.1` | resolve | `origin=cache`, `version=6.10.4` (`max(cache, floor)`); outcome carries an observable warning |
 | AC-08 | L1 | `bundled=false`, `port.tagList()` unreachable, cache empty, floor `6.10.1` satisfies `range` | resolve | `origin=bundled-fallback`, `version=6.10.1`; outcome carries an observable warning |
 | AC-09 | L1 | `bundled=false`, stable `range` `~6.11`, tag-list has both `6.11.0` and `6.12.0-beta.1` | resolve | resolves `6.11.0`; the `-beta` version is **excluded** |
 | AC-10 | L1 | `bundled=false`, beta `range` `>=6.12.0-beta <6.13.0`, tag-list has `6.12.0-beta.1` | resolve | resolves `6.12.0-beta.1` (prerelease included because range names the segment) |
@@ -80,6 +80,8 @@ outcome and telemetry; it is never written back into committed config.
 | AC-14 | L1 | `bundled=false`, tag-list empty (no version satisfies `range`), floor satisfies `range` | resolve | `origin=bundled-fallback`, `version`=floor; observable warning |
 | AC-15 | L1 | `bundled=false`, tag-list empty **and** floor does **not** satisfy `range` | resolve | raises a `UserError` naming the engine/template version mismatch; no silent substitution |
 | AC-16 | L1 | `port.env("TEMPLATE_VERSION")="6.99.0"`, `bundled=false`, tag-list does **not** list `6.99.0` | resolve | raises a `UserError` (`TemplatePinnedVersionNotFound`) naming the pinned version; **no** fallback to range resolution, cache, or floor |
+| AC-17 | L1 | `bundled=false`, `port.tagList()` rejects with a malformed-document error (`TemplateTagListMalformed`) | resolve | the `SystemError` is **propagated** (returned as `err`); **no** offline fallback — a malformed channel is a hard error (decision #7), distinct from unreachable (AC-07) |
+| AC-18 | L1 | `port.env("TEMPLATE_VERSION")="6.11.2"`, `bundled=false`, `port.tagList()` is unreachable/rejects | resolve | returns `err(FxError)` (an existing FxError is preserved; otherwise wrapped); the rejection never escapes as a thrown promise; a pin **never** falls back |
 
 ## Flow
 

--- a/docs/03-specs/operations/scaffolding/resolve-template-source.md
+++ b/docs/03-specs/operations/scaffolding/resolve-template-source.md
@@ -1,0 +1,194 @@
+# Operation — `resolve-template-source`
+
+- **Status:** Accepted (Gate 1 + Gate 2 cleared 2026-06-01) — ready for tests
+- **Domain:** [`01-scaffolding`](../../domains/01-scaffolding.md)
+- **Decision source:** [ADR-0006](../../../02-architecture/adr/ADR-0006-template-distribution-channel.md)
+- **Seam:** [`scaffolding.create.proposal.md` §5.2](../../../02-architecture/scaffolding.create.proposal.md)
+- **PRD/scenario:** none required — internal, behavior-preserving resolution
+  mechanism with no user-visible surface change (see ADR-0006 rollout).
+
+## Purpose
+
+Given a build-pinned `range`, a build-pinned `bundled` flag, and an injected
+`runtime`, resolve **exactly one** template source —
+`(origin, version, digest, location)` — that a scaffold run will use, before
+any template is read or rendered. This is the single decision point that
+replaces v3's three `package.json#version`-sniffing call sites.
+
+## Inputs
+
+| Input | Type | Origin |
+|-------|------|--------|
+| `range` | SemVer range string (e.g. `~6.10`, `>=6.11.0-beta <6.12.0`) | build-time field in `templates-config.json` (reuses existing `version`) |
+| `bundled` | boolean | build-time field; `true` for test/offline/daily builds, `false` for shipped builds |
+| `port` | narrow `TemplateSourcePort` (`{ env, tagList, packages, cache, floor }`) | injected; an in-memory fake in tests |
+| `TEMPLATE_VERSION` | env string, optional | per-invocation override read via `port.env` |
+
+This operation does **not** depend on the full `ScaffoldRuntime`
+(`{ fs, http, archive, clock, binaryCache }`, proposal §8). It declares the
+narrow `TemplateSourcePort` it actually uses (interface-segregation), which
+the full runtime composes later:
+
+| Port face | Shape | Responsibility |
+|-----------|-------|----------------|
+| `env` | `(name) => string \| undefined` | read `TEMPLATE_VERSION` |
+| `tagList` | `() => Promise<Array<{ version: string; digest: string }>>` | the channel's published `{version, digest}` entries (model A — the tag list carries the expected digest per version) |
+| `packages` | `(version, expectedDigest) => Promise<bytes>` | download a package; the digest the caller verifies against is the tag-list's expected digest |
+| `cache` | `{ get(version): { digest, bytes } \| undefined; put(version, digest, bytes): void; keys(): string[] }` | the local digest-keyed package cache (`keys` enumerates cached versions for the offline `max(cache, floor)` fallback) |
+| `floor` | `{ version: string; digest: string; bytes: ... }` | the bundled floor baked into the engine |
+
+## Outputs
+
+A `TemplateSource`:
+
+| Field | Meaning |
+|-------|---------|
+| `origin` | `bundled \| online \| cache \| bundled-fallback` |
+| `version` | the concrete resolved SemVer version |
+| `digest` | content hash of the resolved package |
+| `location` | where the bytes are (bundled path, cache path, or download URL) |
+
+The resolved `{ version, digest, origin }` is recorded on the scaffold
+outcome and telemetry; it is never written back into committed config.
+
+## Resolution precedence
+
+1. `TEMPLATE_VERSION=local` → bundled floor (highest priority; overrides
+   `bundled=false`).
+2. `TEMPLATE_VERSION=<version>` → that exact online version, pinned.
+3. `bundled=true` → bundled floor, no network.
+4. `bundled=false` → prefer the highest channel version satisfying `range`,
+   with cache and bundled floor as fallbacks.
+
+## Acceptance Criteria
+
+| ID | Tier | Given | When | Then |
+|----|------|-------|------|------|
+| AC-01 | L1 | `bundled=true`, any `range` | resolve | `origin=bundled`; **no** `runtime.http` call is made; `version`/`digest` = the bundled floor's |
+| AC-02 | L1 | `port.env("TEMPLATE_VERSION")="local"`, `bundled=false` | resolve | `origin=bundled`; no network call (override beats `bundled=false`) |
+| AC-03 | L1 | `port.env("TEMPLATE_VERSION")="6.11.2"`, `bundled=false`, tag-list lists `6.11.2` with its digest | resolve | resolves online version `6.11.2` pinned; `origin=online`; `digest` = the tag-list's digest for `6.11.2`, recorded |
+| AC-04 | L1 | `bundled=false`, tag-list has `6.10.5` (digest `D5`, > floor `6.10.1`) satisfying `~6.10` | resolve | `origin=online`, `version=6.10.5`; `digest=D5` (from tag-list) recorded |
+| AC-05 | L1 | `bundled=false`, highest channel version satisfying `range` equals the bundled floor | resolve | resolves to the floor without downloading; `origin=bundled` |
+| AC-06 | L1 | `bundled=false`, resolved `version` already in `port.cache` with digest matching the tag-list's | resolve | `origin=cache`; **zero** download; returned bytes are the cached bytes |
+| AC-07 | L1 | `bundled=false`, `port.tagList()` throws/unreachable, cache holds `6.10.4` satisfying `range`, floor is `6.10.1` | resolve | `origin=cache`, `version=6.10.4` (`max(cache, floor)`); outcome carries an observable warning |
+| AC-08 | L1 | `bundled=false`, `port.tagList()` unreachable, cache empty, floor `6.10.1` satisfies `range` | resolve | `origin=bundled-fallback`, `version=6.10.1`; outcome carries an observable warning |
+| AC-09 | L1 | `bundled=false`, stable `range` `~6.11`, tag-list has both `6.11.0` and `6.12.0-beta.1` | resolve | resolves `6.11.0`; the `-beta` version is **excluded** |
+| AC-10 | L1 | `bundled=false`, beta `range` `>=6.12.0-beta <6.13.0`, tag-list has `6.12.0-beta.1` | resolve | resolves `6.12.0-beta.1` (prerelease included because range names the segment) |
+| AC-11 | L1 | `bundled=false`, download succeeds but the bytes' computed digest ≠ the tag-list's expected digest for that version | resolve | raises a `SystemError`; cache is **not** written; corrupt bytes are **never** returned |
+| AC-12 | L1 | a build whose `package.json#version` is `"x.y.z-beta"` but `bundled=true` | resolve | `origin=bundled` — resolution does not read `package.json#version` |
+| AC-13 | L1 | two resolves with identical `(range, bundled, port, tag-list state)` | resolve twice | both return the identical `{origin, version, digest}` |
+| AC-14 | L1 | `bundled=false`, tag-list empty (no version satisfies `range`), floor satisfies `range` | resolve | `origin=bundled-fallback`, `version`=floor; observable warning |
+| AC-15 | L1 | `bundled=false`, tag-list empty **and** floor does **not** satisfy `range` | resolve | raises a `UserError` naming the engine/template version mismatch; no silent substitution |
+| AC-16 | L1 | `port.env("TEMPLATE_VERSION")="6.99.0"`, `bundled=false`, tag-list does **not** list `6.99.0` | resolve | raises a `UserError` (`TemplatePinnedVersionNotFound`) naming the pinned version; **no** fallback to range resolution, cache, or floor |
+
+## Flow
+
+```mermaid
+flowchart TD
+  start([resolve-template-source]) --> env{TEMPLATE_VERSION?}
+  env -->|"= local"| floor[bundled floor]
+  env -->|"= concrete version"| pin[pin online version]
+  env -->|unset| bundledQ{bundled?}
+  bundledQ -->|true| floor
+  bundledQ -->|false| online{channel reachable?}
+
+  online -->|yes| pick["maxSatisfying(tag-list, range)"]
+  pick -->|none & floor satisfies| floorFB[origin = bundled-fallback]
+  pick -->|none & floor unsat| errU([UserError: version mismatch])
+  pick -->|version chosen| cacheQ{cached with matching digest?}
+  cacheQ -->|yes| cacheHit[origin = cache, zero download]
+  cacheQ -->|no| dl[download]
+  dl --> digestQ{digest matches?}
+  digestQ -->|no| errS([SystemError: digest mismatch, cache not written])
+  digestQ -->|yes| writeCache[write cache, origin = online]
+
+  online -->|no| fb["max(highest cached satisfying range, floor)"]
+  fb -->|cache wins| cacheFB[origin = cache + warning]
+  fb -->|floor wins / cache empty| floorFB
+
+  floor --> done([TemplateSource])
+  pin --> done
+  cacheHit --> done
+  writeCache --> done
+  cacheFB --> done
+  floorFB --> done
+```
+
+## Boundary
+
+This operation does **not**:
+
+- Parse, validate, or render template content. It resolves *which package*,
+  not *what is inside it*. In-package layout (per-template descriptor dirs,
+  language dirs) is the consumer's concern.
+- Decide `range` or `bundled`. Those are written at build time by the CD
+  version step; this operation only reads them.
+- Read `package.json#version`. The version-substring sniffing it replaces is
+  removed, not relocated here.
+- Perform the `minEngineVersion` compatibility check. That gate lives in the
+  engine that consumes the resolved package (proposal §5.2 seam contract).
+- Publish, tag, or upload anything. It is read-only with respect to the
+  release channel; the only thing it writes is the local digest-keyed cache.
+
+## Invariants
+
+- **INV-1 — Never silent.** Any `origin ∈ {cache, bundled-fallback}` reached
+  because the intended online source was unavailable emits an observable
+  warning on the outcome and a telemetry property; resolution never
+  substitutes a different source without recording it.
+- **INV-2 — Never sniff `package.json#version`.** Resolution depends only on
+  `range`, `bundled`, `runtime`, and `TEMPLATE_VERSION`.
+- **INV-3 — Digest integrity.** The tag list publishes a `{version, digest}`
+  per version (model A); downloaded bytes are never returned or cached unless
+  their computed digest matches the tag-list's expected digest for that
+  version; a mismatch is a hard error, not a fallback.
+- **INV-4 — Stable excludes prerelease.** A `range` without a prerelease
+  segment never resolves a `-beta` version (SemVer `maxSatisfying` semantics).
+- **INV-5 — Fallback satisfies `range`.** Every fallback candidate (cache
+  entry, bundled floor) is checked against `range`; a candidate that does not
+  satisfy `range` is never chosen — if none satisfies, it is a `UserError`,
+  not a silent best-effort.
+- **INV-6 — Determinism.** Given identical inputs and identical channel state,
+  resolution is a pure function of them: same `{origin, version, digest}`.
+- **INV-7 — v4-owned.** This operation and its tests live in the v4 world; v3
+  may call it, but it adds no v3-specific method, parameter, or test fixture
+  (proposal §5.1 seam direction).
+
+## Resolved decisions (Gate 1)
+
+1. **Cache TTL for the tag-list refetch — out of scope.** This operation stays
+   a pure function of the *current* tag-list state (INV-6, AC-13); it does not
+   introduce a time window. A TTL is an orthogonal `runtime.http`/cache-layer
+   optimization tracked separately, not part of this decision function.
+2. **`bundled-fallback` vs `cache` tie at equal versions → `bundled-fallback`.**
+   When the highest cached version equals the bundled floor version, attribute
+   the result to the bundled floor (the more conservative origin).
+3. **Telemetry — `package-source` and `origin` coexist (transition).** Emit
+   both the existing `package-source` property and the new `origin` property
+   during the transition window, with identical values
+   (`bundled | online | cache | bundled-fallback`); `package-source` is removed
+   once consumers have migrated to `origin`.
+4. **Expected digest comes from the tag list (model A).** The published tag
+   list is a list of `{version, digest}` entries, not bare versions. Every
+   online resolve has an a-priori expected digest to verify the downloaded
+   bytes against (INV-3, AC-11), and the cache key is trustworthy. This is a
+   **new** channel artifact: the v3 bare-version tag-list URL is never altered
+   (ADR-0006 v3-non-blocking constraint); model A ships a separate
+   digest-bearing list for v4.
+5. **v4 uses a dedicated `templates-v4@` tag prefix.** v4 template releases
+   publish under `templates-v4@<version>` on a separate tag list (mirroring
+   the existing `templates-vs@` split), so a v3 `templates@` client can never
+   resolve a v4 version *regardless of version number* (ADR-0006 channel
+   isolation). v4 versions therefore stay in sync with the engine's `6.x`
+   line; no MAJOR jump. `location` / cache keys use the `templates-v4@`
+   prefix.
+6. **`digest` = `sha256` of the package `.zip` raw bytes.** The digest is the
+   `sha256` hash of the exact downloaded `.zip` byte stream, prefixed
+   `sha256:`. The publish side computes it over the same artifact bytes; any
+   single-byte difference (zip metadata, line endings) is a deliberate
+   mismatch, not tolerated. `computeDigest(bytes)` is the one authority.
+7. **The v4 tag list is NDJSON.** The model-A tag list is newline-delimited
+   JSON: one `{"version":"6.11.0","digest":"sha256:…"}` object per line.
+   Blank lines and `\r` are ignored; a malformed line is a hard parse error
+   (no silent skip). Served at a **new** URL (`templatesV4TagListURL`),
+   separate from the frozen v3 `tagListURL`.

--- a/packages/fx-core/.gitignore
+++ b/packages/fx-core/.gitignore
@@ -8,6 +8,7 @@ coverage
 .fx
 templates/**/*.zip
 templates/configs
+templates/v4/floor.json
 tests/**/TeamsSPFxApp.zip
 resource/templates
 tsconfig.tsbuildinfo

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -6,9 +6,15 @@
     "vsversion": "18.6.0",
     "vsVersionPattern": "~18.6",
     "tagListURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-tag-list/template-tags.txt",
+    "templatesV4TagListURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-v4-tag-list/template-v4-tags.ndjson",
     "templateDownloadBaseURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download",
     "templateReleaseURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/expanded_assets",
     "templateDownloadBasePath": "/OfficeDev/microsoft-365-agents-toolkit/releases/download",
     "templateExt": ".zip",
-    "useLocalTemplate": true
+    "useLocalTemplate": true,
+    "v4": {
+        "range": "~6.10",
+        "bundled": true,
+        "localVersion": "6.10.1"
+    }
 }

--- a/packages/fx-core/src/v4/distribution/bundledFloor.ts
+++ b/packages/fx-core/src/v4/distribution/bundledFloor.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { SystemError } from "@microsoft/teamsfx-api";
+import * as fs from "fs-extra";
+import * as path from "path";
+import { getTemplatesFolder } from "../../folder";
+import { BundledFloor, computeDigest } from "./templateSource";
+
+/**
+ * The bundled floor: the v4 template package baked into the engine so the
+ * scaffold never depends on the network being reachable (offline-by-default).
+ *
+ * The build step drops two files under `<floor dir>`:
+ *   - `floor.json`    → `{ "version": "<semver>" }` (the baked version)
+ *   - `templates.zip` → the package bytes
+ *
+ * The digest is NOT baked: it is computed from the bytes at load time so
+ * `computeDigest` stays the single authority (spec decision #6 / INV-3).
+ *
+ * Spec: docs/03-specs/operations/scaffolding/resolve-template-source.md
+ */
+
+const SOURCE = "Scaffold";
+
+/** The directory the build bakes the floor into. */
+export function bundledFloorDir(): string {
+  return path.join(getTemplatesFolder(), "v4");
+}
+
+/** Build a {@link BundledFloor} from raw bytes — digest computed, never baked. */
+export function bundledFloorFrom(version: string, bytes: Buffer, location: string): BundledFloor {
+  return { version, digest: computeDigest(bytes), location };
+}
+
+interface FloorManifest {
+  version: string;
+}
+
+function isFloorManifest(value: unknown): value is FloorManifest {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).version === "string"
+  );
+}
+
+/**
+ * Load the floor baked under `floorDir` (defaults to {@link bundledFloorDir}).
+ * Missing/malformed bake artifacts are a hard error — a build without a floor
+ * cannot scaffold offline, so we refuse rather than silently degrade.
+ */
+export function loadBundledFloor(floorDir: string = bundledFloorDir()): BundledFloor {
+  const manifestPath = path.join(floorDir, "floor.json");
+  const zipPath = path.join(floorDir, "templates.zip");
+
+  let manifest: unknown;
+  try {
+    manifest = fs.readJsonSync(manifestPath);
+  } catch {
+    throw new SystemError({
+      source: SOURCE,
+      name: "BundledFloorMissing",
+      message: `The bundled floor manifest is missing or unreadable at "${manifestPath}".`,
+    });
+  }
+  if (!isFloorManifest(manifest)) {
+    throw new SystemError({
+      source: SOURCE,
+      name: "BundledFloorMalformed",
+      message: `The bundled floor manifest at "${manifestPath}" has no string "version".`,
+    });
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = fs.readFileSync(zipPath);
+  } catch {
+    throw new SystemError({
+      source: SOURCE,
+      name: "BundledFloorMissing",
+      message: `The bundled floor package is missing or unreadable at "${zipPath}".`,
+    });
+  }
+
+  return bundledFloorFrom(manifest.version, bytes, zipPath);
+}

--- a/packages/fx-core/src/v4/distribution/templateConfig.ts
+++ b/packages/fx-core/src/v4/distribution/templateConfig.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as semver from "semver";
+
+/**
+ * Build-time computation of the v4 template distribution config from the freshly
+ * minted templates version and the CD `goproduct` flag.
+ *
+ * This is the v4-isolated counterpart of the v3 `fxcore-sync-up-version.js`
+ * (`syncTemplateVersion` + `updateUseLocalFlag`). It is a pure function so it
+ * can be unit-tested 1:1; the CD step is a thin node wrapper that reads the
+ * version + flag, calls this, and writes the result into `templates-config.json`.
+ *
+ * Outputs the two build-time concepts `resolveTemplateSource` consumes:
+ *   - `range`   — the SemVer range the build may resolve within (`~major.minor`)
+ *   - `bundled` — `true` for test/offline builds (bundled floor), `false` for
+ *                 shipped builds (release channel)
+ * plus `localVersion` (the exact minted version, recorded for observability).
+ *
+ * Spec: docs/03-specs/operations/scaffolding/resolve-template-source.md
+ */
+
+export interface V4TemplateConfigInput {
+  /** The freshly minted templates version (e.g. `6.11.0` or `6.11.0-rc.0`). */
+  version: string;
+  /**
+   * The CD `goproduct` flag (env `PRODUCTION`): `true` when this build ships to
+   * users (marketplace / stable), `false` for any internal test build.
+   */
+  goproduct: boolean;
+  /** The current `range` in `templates-config.json`, kept when still satisfied. */
+  previousRange: string;
+}
+
+export interface V4TemplateConfig {
+  /** `~major.minor` SemVer range the build may resolve within. */
+  range: string;
+  /** `true` for test/offline builds (bundled floor); `false` for shipped builds. */
+  bundled: boolean;
+  /** The exact minted version (observability / floor pin). */
+  localVersion: string;
+}
+
+/**
+ * `bundled` is the negation of `goproduct`: a build that is NOT shipping to
+ * users resolves from the bundled floor (offline-by-default); a shipping build
+ * resolves from the online release channel. Independent of `preid` / lane.
+ */
+export function computeBundled(goproduct: boolean): boolean {
+  return !goproduct;
+}
+
+/**
+ * The range a build may resolve within. templates carries no odd/even-minor
+ * split (unlike the VS Code extension), so a prerelease and the stable it
+ * graduates into share one `~major.minor`. The range is only widened when the
+ * minted version no longer intersects the previous range; otherwise it is kept
+ * stable for reproducibility.
+ */
+export function computeRange(version: string, previousRange: string): string {
+  const parsed = semver.parse(version);
+  if (parsed === null) {
+    throw new Error(`Cannot compute v4 template range: "${version}" is not valid SemVer.`);
+  }
+  if (semver.intersects(previousRange, `${parsed.major}.${parsed.minor}.0`)) {
+    return previousRange;
+  }
+  return `~${parsed.major}.${parsed.minor}`;
+}
+
+/** Compute the full v4 distribution config block for `templates-config.json`. */
+export function computeV4TemplateConfig(input: V4TemplateConfigInput): V4TemplateConfig {
+  return {
+    range: computeRange(input.version, input.previousRange),
+    bundled: computeBundled(input.goproduct),
+    localVersion: input.version,
+  };
+}

--- a/packages/fx-core/src/v4/distribution/templatePackage.ts
+++ b/packages/fx-core/src/v4/distribution/templatePackage.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { FxError, SystemError } from "@microsoft/teamsfx-api";
+import AdmZip from "adm-zip";
+import { Result, err, ok } from "neverthrow";
+
+/**
+ * The v4 template-package consume operation: open resolved package bytes and
+ * return one template's file entries, the locator prefix stripped, unrendered.
+ *
+ * Spec: docs/03-specs/operations/scaffolding/open-template-package.md
+ * Upstream: docs/03-specs/operations/scaffolding/resolve-template-source.md
+ *
+ * This module is part of the v4 world. It imports no v3 symbol; v3 code may
+ * call `openTemplatePackage`, but nothing here is tailored for v3.
+ */
+
+const SOURCE = "Scaffold";
+
+/**
+ * Names which template inside the package to open. The boundary
+ * (open → locate → hand back entries) is permanent; this locator shape is
+ * transitional — `{ language, scenario }` matches the package's current
+ * `<language>/<scenario>/` layout and becomes `{ templateId }` when the
+ * proposal §3 authoring layout ships. Only the resolved prefix changes; the
+ * open/entry contract and every AC hold (INV-1).
+ */
+export interface TemplateLocator {
+  language: string;
+  scenario: string;
+}
+
+/** One file from the located template, rooted at the template's content. */
+export interface TemplateFileEntry {
+  /** Path relative to the located template's content root, forward-slash normalized. */
+  path: string;
+  /** The file's raw bytes, verbatim — unrendered, `.tpl` suffix intact. */
+  data: Buffer;
+}
+
+/** The `<language>/<scenario>/` prefix this locator resolves to (trailing slash = boundary). */
+function locatorPrefix(locator: TemplateLocator): string {
+  return `${locator.language}/${locator.scenario}/`;
+}
+
+/**
+ * Open the resolved template package and return the located template's file
+ * entries, the locator prefix stripped. Pure function of `(bytes, locator)`:
+ * no fs, no network, no render. Returns `Result` per the toolkit-wide
+ * neverthrow rule rather than throwing.
+ */
+export function openTemplatePackage(
+  bytes: Buffer,
+  locator: TemplateLocator
+): Result<TemplateFileEntry[], FxError> {
+  let zip: AdmZip;
+  try {
+    zip = new AdmZip(bytes);
+  } catch {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "TemplatePackageCorrupt",
+        message: "The resolved template package is not a valid archive.",
+      })
+    );
+  }
+
+  const prefix = locatorPrefix(locator);
+  const entries: TemplateFileEntry[] = [];
+  for (const entry of zip.getEntries()) {
+    if (entry.isDirectory) {
+      continue; // INV-6 — directory entries excluded
+    }
+    const name = entry.entryName.replace(/\\/g, "/");
+    if (!name.startsWith(prefix)) {
+      continue; // INV-1 — trailing-slash prefix boundary; "da/" never matches "da-basic/"
+    }
+    entries.push({ path: name.slice(prefix.length), data: entry.getData() });
+  }
+
+  if (entries.length === 0) {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "TemplateNotFoundInPackage",
+        message: `Template "${prefix}" was not found in the resolved package.`,
+      })
+    );
+  }
+
+  entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0)); // INV-5 — deterministic order
+  return ok(entries);
+}

--- a/packages/fx-core/src/v4/distribution/templatePackage.ts
+++ b/packages/fx-core/src/v4/distribution/templatePackage.ts
@@ -45,6 +45,16 @@ function locatorPrefix(locator: TemplateLocator): string {
 }
 
 /**
+ * Reject a stripped entry path whose segments are empty / `.` / `..` (Zip-Slip
+ * guard, INV-8). A digest check proves the bytes equal what was published, not
+ * that the published archive is free of traversal entries; the renderer writes
+ * these paths to disk, so containment is enforced here.
+ */
+function isSafeRelativePath(rel: string): boolean {
+  return rel.split("/").every((seg) => seg.length > 0 && seg !== "." && seg !== "..");
+}
+
+/**
  * Open the resolved template package and return the located template's file
  * entries, the locator prefix stripped. Pure function of `(bytes, locator)`:
  * no fs, no network, no render. Returns `Result` per the toolkit-wide
@@ -77,7 +87,17 @@ export function openTemplatePackage(
     if (!name.startsWith(prefix)) {
       continue; // INV-1 — trailing-slash prefix boundary; "da/" never matches "da-basic/"
     }
-    entries.push({ path: name.slice(prefix.length), data: entry.getData() });
+    const rel = name.slice(prefix.length);
+    if (!isSafeRelativePath(rel)) {
+      return err(
+        new SystemError({
+          source: SOURCE,
+          name: "TemplatePackageUnsafePath",
+          message: `The resolved template package contains an unsafe entry path: "${entry.entryName}".`,
+        })
+      ); // INV-8 — Zip-Slip guard: reject empty / "." / ".." path segments
+    }
+    entries.push({ path: rel, data: entry.getData() });
   }
 
   if (entries.length === 0) {

--- a/packages/fx-core/src/v4/distribution/templateSource.ts
+++ b/packages/fx-core/src/v4/distribution/templateSource.ts
@@ -218,6 +218,21 @@ function asTagListError(e: unknown): FxError {
   });
 }
 
+/** Preserve an existing FxError; wrap any other download failure as a SystemError (neverthrow contract). */
+function asDownloadError(e: unknown, version: string): FxError {
+  if (e instanceof UserError || e instanceof SystemError) {
+    return e;
+  }
+  /* istanbul ignore next -- the port rejects with an Error; the String(e)
+     fallback is defensive for non-Error rejections, not reproducible in a unit. */
+  const message = e instanceof Error ? e.message : String(e);
+  return new SystemError({
+    source: SOURCE,
+    name: "TemplateDownloadFailed",
+    message: `Failed to download template "${version}" from the release channel: ${message}.`,
+  });
+}
+
 async function fetchVerify(
   entry: TagEntry,
   port: TemplateSourcePort,
@@ -233,7 +248,14 @@ async function fetchVerify(
     }); // AC-06 (zero download)
   }
 
-  const bytes = await port.packages(entry.version, entry.digest);
+  let bytes: Buffer;
+  try {
+    bytes = await port.packages(entry.version, entry.digest);
+  } catch (e) {
+    // The download (sendRequestWithRetry) can reject; surface it as a Result
+    // rather than letting it escape resolveTemplateSource (neverthrow contract).
+    return err(asDownloadError(e, entry.version));
+  }
   const computed = computeDigest(bytes);
   if (computed !== entry.digest) {
     return err(
@@ -262,14 +284,18 @@ function offlineFallback(range: string, port: TemplateSourcePort): TemplateSourc
 
   // Cache wins only when strictly higher than the floor; a tie goes to the floor (decision #2).
   if (highestCached && (!floorSatisfies || semver.gt(highestCached, port.floor.version))) {
-    const cached = port.cache.get(highestCached) as CachedPackage;
-    return {
-      origin: "cache",
-      version: highestCached,
-      digest: cached.digest,
-      location: cacheLocation(highestCached),
-      warning: offlineWarning(range),
-    }; // AC-07
+    const cached = port.cache.get(highestCached);
+    /* istanbul ignore else -- highestCached is drawn from cache.keys(); a miss
+       means the cache mutated mid-resolution, so we degrade to the floor. */
+    if (cached) {
+      return {
+        origin: "cache",
+        version: highestCached,
+        digest: cached.digest,
+        location: cacheLocation(highestCached),
+        warning: offlineWarning(range),
+      }; // AC-07
+    }
   }
 
   return { ...floorFallback(port.floor), warning: offlineWarning(range) }; // AC-08

--- a/packages/fx-core/src/v4/distribution/templateSource.ts
+++ b/packages/fx-core/src/v4/distribution/templateSource.ts
@@ -1,0 +1,252 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { FxError, SystemError, UserError } from "@microsoft/teamsfx-api";
+import { Result, err, ok } from "neverthrow";
+import * as crypto from "crypto";
+import semver from "semver";
+
+/**
+ * The v4 template-distribution resolution operation.
+ *
+ * Spec: docs/03-specs/operations/scaffolding/resolve-template-source.md
+ * Decision: docs/02-architecture/adr/ADR-0006-template-distribution-channel.md
+ *
+ * This module is part of the v4 world. It imports no v3 symbol; v3 code may
+ * call `resolveTemplateSource`, but nothing here is tailored for v3.
+ */
+
+const SOURCE = "Scaffold";
+
+/** Where the resolved template-package bytes come from. */
+export type TemplateOrigin = "bundled" | "online" | "cache" | "bundled-fallback";
+
+/** A single channel-published version paired with its expected content digest (model A). */
+export interface TagEntry {
+  version: string;
+  digest: string;
+}
+
+/** A cached template package: its content digest and the bytes themselves. */
+export interface CachedPackage {
+  digest: string;
+  bytes: Buffer;
+}
+
+/** The bundled floor baked into the engine binary. */
+export interface BundledFloor {
+  version: string;
+  digest: string;
+  location: string;
+}
+
+/**
+ * The narrow port `resolveTemplateSource` depends on (interface-segregation).
+ * The full `ScaffoldRuntime` composes this later; this operation never reaches
+ * for faces it does not use.
+ */
+export interface TemplateSourcePort {
+  /** Read an environment variable (e.g. `TEMPLATE_VERSION`). */
+  env(name: string): string | undefined;
+  /** The channel's published `{ version, digest }` entries. */
+  tagList(): Promise<TagEntry[]>;
+  /** Download a package's bytes for a version (verified against `expectedDigest` by the caller). */
+  packages(version: string, expectedDigest: string): Promise<Buffer>;
+  /** The local digest-keyed package cache. */
+  cache: {
+    get(version: string): CachedPackage | undefined;
+    put(version: string, digest: string, bytes: Buffer): void;
+    keys(): string[];
+  };
+  /** The bundled floor baked into the engine. */
+  floor: BundledFloor;
+}
+
+/** The single resolved source a scaffold run will use. */
+export interface TemplateSource {
+  origin: TemplateOrigin;
+  version: string;
+  digest: string;
+  location: string;
+  /** Set when the resolved source diverged from the intended online source (observable, never silent). */
+  warning?: string;
+}
+
+export interface ResolveTemplateSourceInput {
+  /** SemVer range the build is permitted to resolve within. */
+  range: string;
+  /** `true` for test/offline/daily builds (bundled floor); `false` for shipped builds (release channel). */
+  bundled: boolean;
+  port: TemplateSourcePort;
+}
+
+/** sha256 content hash of a package's bytes, prefixed `sha256:`. */
+export function computeDigest(bytes: Buffer): string {
+  return "sha256:" + crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Resolve `(range, bundled, port)` to exactly one `TemplateSource` before any
+ * template is read or rendered. Pure with respect to its inputs and the
+ * current tag-list state (INV-6). Returns `Result` rather than throwing,
+ * consistent with the toolkit-wide neverthrow rule.
+ */
+export async function resolveTemplateSource(
+  input: ResolveTemplateSourceInput
+): Promise<Result<TemplateSource, FxError>> {
+  const { range, bundled, port } = input;
+
+  const templateVersion = port.env("TEMPLATE_VERSION");
+  if (templateVersion === "local") {
+    return ok(floorSource(port.floor)); // AC-02 (override beats bundled=false)
+  }
+  if (templateVersion) {
+    return pinnedOnline(templateVersion, port); // AC-03
+  }
+  if (bundled) {
+    return ok(floorSource(port.floor)); // AC-01, AC-12 (never sniff package.json#version)
+  }
+  return resolveOnline(range, port);
+}
+
+function floorSource(floor: BundledFloor): TemplateSource {
+  return {
+    origin: "bundled",
+    version: floor.version,
+    digest: floor.digest,
+    location: floor.location,
+  };
+}
+
+async function pinnedOnline(
+  version: string,
+  port: TemplateSourcePort
+): Promise<Result<TemplateSource, FxError>> {
+  const tags = await port.tagList();
+  const entry = tags.find((t) => t.version === version);
+  if (!entry) {
+    return err(
+      new UserError({
+        source: SOURCE,
+        name: "TemplatePinnedVersionNotFound",
+        message: `Pinned template version "${version}" is not published on the release channel.`,
+      })
+    );
+  }
+  return fetchVerify(entry, port, "online");
+}
+
+async function resolveOnline(
+  range: string,
+  port: TemplateSourcePort
+): Promise<Result<TemplateSource, FxError>> {
+  let tags: TagEntry[];
+  try {
+    tags = await port.tagList();
+  } catch {
+    return ok(offlineFallback(range, port)); // AC-07, AC-08
+  }
+
+  const picked = semver.maxSatisfying(
+    tags.map((t) => t.version),
+    range
+  ); // AC-09 (stable excludes -beta), AC-10 (range names -beta)
+
+  if (!picked) {
+    // Channel reachable but no version satisfies range (AC-14 / AC-15).
+    if (semver.satisfies(port.floor.version, range)) {
+      return ok(floorFallback(port.floor)); // AC-14
+    }
+    return err(
+      new UserError({
+        source: SOURCE,
+        name: "TemplateVersionMismatch",
+        message: `No published template version satisfies range "${range}", and the bundled floor "${port.floor.version}" does not satisfy it either. The engine and template versions are incompatible.`,
+      })
+    ); // AC-15
+  }
+
+  if (picked === port.floor.version) {
+    return ok(floorSource(port.floor)); // AC-05 (floor is highest satisfier; no download)
+  }
+
+  // non-null assertion is safe: `picked` came from `tags`
+  const entry = tags.find((t) => t.version === picked) as TagEntry;
+  return fetchVerify(entry, port, "online"); // AC-04, AC-06, AC-11
+}
+
+async function fetchVerify(
+  entry: TagEntry,
+  port: TemplateSourcePort,
+  origin: "online"
+): Promise<Result<TemplateSource, FxError>> {
+  const cached = port.cache.get(entry.version);
+  if (cached && cached.digest === entry.digest) {
+    return ok({
+      origin: "cache",
+      version: entry.version,
+      digest: entry.digest,
+      location: cacheLocation(entry.version),
+    }); // AC-06 (zero download)
+  }
+
+  const bytes = await port.packages(entry.version, entry.digest);
+  const computed = computeDigest(bytes);
+  if (computed !== entry.digest) {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "TemplateDigestMismatch",
+        message: `Downloaded template "${entry.version}" failed integrity check: expected ${entry.digest}, got ${computed}.`,
+      })
+    ); // AC-11 (cache not written, corrupt bytes never returned)
+  }
+
+  port.cache.put(entry.version, entry.digest, bytes);
+  return ok({
+    origin,
+    version: entry.version,
+    digest: entry.digest,
+    location: cacheLocation(entry.version),
+  }); // AC-04
+}
+
+/** Reached when the channel is unreachable: max(highest cached satisfying range, floor). */
+function offlineFallback(range: string, port: TemplateSourcePort): TemplateSource {
+  const cachedSatisfying = port.cache.keys().filter((v) => semver.satisfies(v, range));
+  const highestCached = semver.maxSatisfying(cachedSatisfying, range);
+  const floorSatisfies = semver.satisfies(port.floor.version, range);
+
+  // Cache wins only when strictly higher than the floor; a tie goes to the floor (decision #2).
+  if (highestCached && (!floorSatisfies || semver.gt(highestCached, port.floor.version))) {
+    const cached = port.cache.get(highestCached) as CachedPackage;
+    return {
+      origin: "cache",
+      version: highestCached,
+      digest: cached.digest,
+      location: cacheLocation(highestCached),
+      warning: offlineWarning(range),
+    }; // AC-07
+  }
+
+  return { ...floorFallback(port.floor), warning: offlineWarning(range) }; // AC-08
+}
+
+function floorFallback(floor: BundledFloor): TemplateSource {
+  return {
+    origin: "bundled-fallback",
+    version: floor.version,
+    digest: floor.digest,
+    location: floor.location,
+    warning: `Falling back to the bundled template floor "${floor.version}".`,
+  };
+}
+
+function offlineWarning(range: string): string {
+  return `The template release channel was unreachable; resolved offline within range "${range}".`;
+}
+
+function cacheLocation(version: string): string {
+  // eslint-disable-next-line no-secrets/no-secrets
+  return `templates-v4@${version}`;
+}

--- a/packages/fx-core/src/v4/distribution/templateSource.ts
+++ b/packages/fx-core/src/v4/distribution/templateSource.ts
@@ -122,7 +122,14 @@ async function pinnedOnline(
   version: string,
   port: TemplateSourcePort
 ): Promise<Result<TemplateSource, FxError>> {
-  const tags = await port.tagList();
+  let tags: TagEntry[];
+  try {
+    tags = await port.tagList();
+  } catch (e) {
+    // A pin never falls back (AC-16 intent): surface the channel failure as a
+    // Result instead of letting the rejection escape (neverthrow contract).
+    return err(asTagListError(e));
+  }
   const entry = tags.find((t) => t.version === version);
   if (!entry) {
     return err(
@@ -143,8 +150,14 @@ async function resolveOnline(
   let tags: TagEntry[];
   try {
     tags = await port.tagList();
-  } catch {
-    return ok(offlineFallback(range, port)); // AC-07, AC-08
+  } catch (e) {
+    // A malformed channel document is a hard error (spec decision #7 / AC-17),
+    // distinct from an unreachable channel: it must never be masked as an
+    // offline fallback. Only a genuine reachability failure falls back.
+    if (isMalformedTagList(e)) {
+      return err(e);
+    }
+    return ok(offlineFallback(range, port)); // AC-07, AC-08 (unreachable only)
   }
 
   const picked = semver.maxSatisfying(
@@ -170,9 +183,39 @@ async function resolveOnline(
     return ok(floorSource(port.floor)); // AC-05 (floor is highest satisfier; no download)
   }
 
-  // non-null assertion is safe: `picked` came from `tags`
-  const entry = tags.find((t) => t.version === picked) as TagEntry;
+  const entry = tags.find((t) => t.version === picked);
+  /* istanbul ignore if -- defensive: `picked` is drawn from `tags`, so a miss
+     means the tag list mutated mid-resolution; not reproducible in a unit. */
+  if (!entry) {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "TemplateTagListInconsistent",
+        message: `Resolved version "${picked}" is no longer present in the tag list.`,
+      })
+    );
+  }
   return fetchVerify(entry, port, "online"); // AC-04, AC-06, AC-11
+}
+
+/** A malformed channel tag-list (decision #7) is a hard error, distinct from an unreachable channel. */
+function isMalformedTagList(e: unknown): e is SystemError {
+  return e instanceof SystemError && e.name === "TemplateTagListMalformed";
+}
+
+/** Preserve an existing FxError; wrap any other tag-list failure as a SystemError (neverthrow contract). */
+function asTagListError(e: unknown): FxError {
+  if (e instanceof UserError || e instanceof SystemError) {
+    return e;
+  }
+  /* istanbul ignore next -- the port rejects with an Error; the String(e)
+     fallback is defensive for non-Error rejections, not reproducible in a unit. */
+  const message = e instanceof Error ? e.message : String(e);
+  return new SystemError({
+    source: SOURCE,
+    name: "TemplateTagListUnavailable",
+    message: `Failed to read the template release channel: ${message}.`,
+  });
 }
 
 async function fetchVerify(

--- a/packages/fx-core/src/v4/distribution/templateSourcePort.ts
+++ b/packages/fx-core/src/v4/distribution/templateSourcePort.ts
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { SystemError } from "@microsoft/teamsfx-api";
+import axios, { AxiosResponse } from "axios";
+import * as fs from "fs-extra";
+import * as path from "path";
+import os from "os";
+import { sendRequestWithRetry } from "../../common/requestUtils";
+import {
+  BundledFloor,
+  CachedPackage,
+  TagEntry,
+  TemplateSourcePort,
+  computeDigest,
+} from "./templateSource";
+
+/**
+ * Production wiring of the narrow {@link TemplateSourcePort} over real
+ * environment / network / filesystem. The pure helpers (`parseTagList`,
+ * `templateZipUrl`, `cacheDir`) are exported and unit-tested; the IO faces
+ * are thin wrappers around them.
+ *
+ * Spec: docs/03-specs/operations/scaffolding/resolve-template-source.md
+ * (decisions #6 digest = sha256 of zip bytes, #7 NDJSON tag list).
+ */
+
+const SOURCE = "Scaffold";
+
+/** v4 channel prefix and naming (ADR-0006 channel isolation). */
+// eslint-disable-next-line no-secrets/no-secrets
+export const V4_TAG_PREFIX = "templates-v4@";
+export const ZIP_EXT = ".zip";
+
+export interface TemplateChannelConfig {
+  /** NDJSON tag-list URL for the v4 channel (separate from the frozen v3 `tagListURL`). */
+  templatesV4TagListURL: string;
+  /** Base URL release assets are downloaded from. */
+  templateDownloadBaseURL: string;
+  /** Network retry budget. */
+  tryLimits: number;
+}
+
+/**
+ * Parse the model-A NDJSON tag list: one `{ version, digest }` object per
+ * line. Blank lines and trailing `\r` are ignored; a malformed line is a hard
+ * error (no silent skip) — spec decision #7.
+ */
+export function parseTagList(ndjson: string): TagEntry[] {
+  const entries: TagEntry[] = [];
+  const lines = ndjson.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].replace(/\r$/, "").trim();
+    if (line.length === 0) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new SystemError({
+        source: SOURCE,
+        name: "TemplateTagListMalformed",
+        message: `Malformed v4 tag-list entry on line ${i + 1}: not valid JSON.`,
+      });
+    }
+    if (!isTagEntry(parsed)) {
+      throw new SystemError({
+        source: SOURCE,
+        name: "TemplateTagListMalformed",
+        message: `Malformed v4 tag-list entry on line ${i + 1}: missing "version" or "digest".`,
+      });
+    }
+    entries.push({ version: parsed.version, digest: parsed.digest });
+  }
+  return entries;
+}
+
+function isTagEntry(value: unknown): value is TagEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return typeof v.version === "string" && typeof v.digest === "string";
+}
+
+/** The download URL for a v4 template package version. */
+export function templateZipUrl(baseURL: string, version: string): string {
+  return `${baseURL}/${V4_TAG_PREFIX}${version}/templates${ZIP_EXT}`;
+}
+
+/** The on-disk cache directory for the v4 template packages. */
+export function cacheDir(): string {
+  return path.join(os.homedir(), ".fx", "templates-cache");
+}
+
+/** The cache file path for one version. */
+export function cacheFile(version: string): string {
+  return path.join(cacheDir(), `${V4_TAG_PREFIX}${version}${ZIP_EXT}`);
+}
+
+/**
+ * Build the production port. `floor` is injected (it comes from the engine's
+ * baked bundled package); this factory does not fabricate it.
+ */
+export function createTemplateSourcePort(
+  config: TemplateChannelConfig,
+  floor: BundledFloor
+): TemplateSourcePort {
+  const memo = new Map<string, CachedPackage>();
+
+  // Warm the in-memory index from disk so `keys()` reflects prior downloads
+  // for the offline `max(cache, floor)` fallback.
+  let warmed = false;
+  const warm = (): void => {
+    if (warmed) {
+      return;
+    }
+    warmed = true;
+    let names: string[] = [];
+    try {
+      names = fs.readdirSync(cacheDir());
+    } catch {
+      return; // EAFP: no cache dir yet → empty index
+    }
+    for (const name of names) {
+      if (!name.startsWith(V4_TAG_PREFIX) || !name.endsWith(ZIP_EXT)) {
+        continue;
+      }
+      const version = name.slice(V4_TAG_PREFIX.length, name.length - ZIP_EXT.length);
+      try {
+        const bytes = fs.readFileSync(path.join(cacheDir(), name));
+        memo.set(version, { digest: computeDigest(bytes), bytes });
+      } catch {
+        /* istanbul ignore next -- defensive: a listed cache file vanishing/locked between readdir and read is not reproducible */
+        continue; // a vanished/locked file is simply not indexed
+      }
+    }
+  };
+
+  return {
+    env: (name: string): string | undefined => process.env[name],
+
+    tagList: async (): Promise<TagEntry[]> => {
+      const res: AxiosResponse<string> = await sendRequestWithRetry(
+        () => axios.get(config.templatesV4TagListURL, { responseType: "text" }),
+        config.tryLimits
+      );
+      return parseTagList(res.data);
+    },
+
+    packages: async (version: string): Promise<Buffer> => {
+      const res: AxiosResponse<ArrayBuffer> = await sendRequestWithRetry(
+        () =>
+          axios.get(templateZipUrl(config.templateDownloadBaseURL, version), {
+            responseType: "arraybuffer",
+          }),
+        config.tryLimits
+      );
+      return Buffer.from(res.data);
+    },
+
+    cache: {
+      get: (version: string): CachedPackage | undefined => {
+        warm();
+        return memo.get(version);
+      },
+      put: (version: string, digest: string, bytes: Buffer): void => {
+        fs.ensureDirSync(cacheDir());
+        fs.writeFileSync(cacheFile(version), bytes);
+        memo.set(version, { digest, bytes });
+      },
+      keys: (): string[] => {
+        warm();
+        return [...memo.keys()];
+      },
+    },
+
+    floor,
+  };
+}

--- a/packages/fx-core/src/v4/distribution/templateSourcePort.ts
+++ b/packages/fx-core/src/v4/distribution/templateSourcePort.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SystemError } from "@microsoft/teamsfx-api";
+import { FxError, SystemError } from "@microsoft/teamsfx-api";
 import axios, { AxiosResponse } from "axios";
+import { Result, err, ok } from "neverthrow";
 import * as fs from "fs-extra";
 import * as path from "path";
 import os from "os";
@@ -11,6 +12,7 @@ import {
   BundledFloor,
   CachedPackage,
   TagEntry,
+  TemplateSource,
   TemplateSourcePort,
   computeDigest,
 } from "./templateSource";
@@ -178,4 +180,65 @@ export function createTemplateSourcePort(
 
     floor,
   };
+}
+
+/**
+ * Load the bytes for an already-resolved {@link TemplateSource}.
+ *
+ * `resolveTemplateSource` decides *which* package a scaffold run uses but
+ * returns only the descriptor; this is the companion IO step that produces the
+ * bytes, the boundary the v3 chokepoint calls before `openTemplatePackage`.
+ *
+ * It never reaches the network: an `online`/`cache` source was already
+ * downloaded, verified, and cached during resolution, so re-downloading here
+ * would defeat the digest-keyed cache and reintroduce the v3 re-fetch churn. A
+ * cache miss is therefore an invariant violation (hard error), not a silent
+ * re-fetch. Every path re-checks the bytes against `source.digest` so
+ * `computeDigest` stays the single integrity authority and a corrupt package is
+ * never handed back.
+ *
+ * Spec: docs/03-specs/operations/scaffolding/resolve-template-source.md
+ */
+export function loadResolvedPackage(
+  source: TemplateSource,
+  port: TemplateSourcePort
+): Result<Buffer, FxError> {
+  let bytes: Buffer;
+  if (source.origin === "bundled" || source.origin === "bundled-fallback") {
+    try {
+      bytes = fs.readFileSync(source.location);
+    } catch {
+      return err(
+        new SystemError({
+          source: SOURCE,
+          name: "TemplatePackageUnreadable",
+          message: `The resolved bundled template package at "${source.location}" is missing or unreadable.`,
+        })
+      );
+    }
+  } else {
+    const cached = port.cache.get(source.version);
+    if (cached === undefined) {
+      return err(
+        new SystemError({
+          source: SOURCE,
+          name: "TemplatePackageNotCached",
+          message: `The resolved template package "${source.version}" is not present in the local cache.`,
+        })
+      );
+    }
+    bytes = cached.bytes;
+  }
+
+  const digest = computeDigest(bytes);
+  if (digest !== source.digest) {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "TemplateDigestMismatch",
+        message: `The resolved template package "${source.version}" failed its integrity check: expected ${source.digest}, got ${digest}.`,
+      })
+    );
+  }
+  return ok(bytes);
 }

--- a/packages/fx-core/src/v4/index.ts
+++ b/packages/fx-core/src/v4/index.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Public surface of the v4 scaffolding world.
+ *
+ * v4 lives isolated from v3 (see scaffolding.create.proposal.md §5.1). It
+ * imports no v3 symbol; v3 may call into this barrel, but nothing here is
+ * tailored for v3.
+ */
+
+export * from "./distribution/templateSource";
+export * from "./distribution/templateSourcePort";
+export * from "./distribution/bundledFloor";
+export * from "./distribution/templateConfig";
+export * from "./distribution/templatePackage";

--- a/packages/fx-core/tests/v4/distribution/bundledFloor.test.ts
+++ b/packages/fx-core/tests/v4/distribution/bundledFloor.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import "mocha";
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+import {
+  bundledFloorDir,
+  bundledFloorFrom,
+  loadBundledFloor,
+} from "../../../src/v4/distribution/bundledFloor";
+import { computeDigest } from "../../../src/v4/distribution/templateSource";
+
+describe("bundledFloor (v4)", () => {
+  describe("bundledFloorFrom (pure)", () => {
+    it("computes the digest from the bytes (not baked, decision #6)", () => {
+      const bytes = Buffer.from("floor-bytes");
+      const floor = bundledFloorFrom("6.11.0", bytes, "/some/templates.zip");
+      assert.deepEqual(floor, {
+        version: "6.11.0",
+        digest: computeDigest(bytes),
+        location: "/some/templates.zip",
+      });
+    });
+  });
+
+  describe("bundledFloorDir (location contract)", () => {
+    it("resolves the baked floor under the templates folder's v4 subdirectory", () => {
+      assert.strictEqual(path.basename(bundledFloorDir()), "v4");
+    });
+  });
+
+  describe("loadBundledFloor (IO)", () => {
+    let dir: string;
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), "v4-floor-"));
+    });
+
+    afterEach(() => {
+      fs.removeSync(dir);
+    });
+
+    it("reads floor.json + templates.zip and computes the digest", () => {
+      const bytes = Buffer.from("the-floor-package");
+      fs.writeJsonSync(path.join(dir, "floor.json"), { version: "6.11.0" });
+      fs.writeFileSync(path.join(dir, "templates.zip"), bytes);
+
+      const floor = loadBundledFloor(dir);
+      assert.strictEqual(floor.version, "6.11.0");
+      assert.strictEqual(floor.digest, computeDigest(bytes));
+      assert.strictEqual(floor.location, path.join(dir, "templates.zip"));
+    });
+
+    it("throws BundledFloorMissing when the manifest is absent", () => {
+      assert.throws(() => loadBundledFloor(dir), /BundledFloorMissing|manifest is missing/);
+    });
+
+    it("throws BundledFloorMissing when the package zip is absent", () => {
+      fs.writeJsonSync(path.join(dir, "floor.json"), { version: "6.11.0" });
+      assert.throws(() => loadBundledFloor(dir), /BundledFloorMissing|package is missing/);
+    });
+
+    it("throws BundledFloorMalformed when version is missing", () => {
+      fs.writeJsonSync(path.join(dir, "floor.json"), { notVersion: "x" });
+      fs.writeFileSync(path.join(dir, "templates.zip"), Buffer.from("z"));
+      assert.throws(() => loadBundledFloor(dir), /BundledFloorMalformed|no string "version"/);
+    });
+  });
+});

--- a/packages/fx-core/tests/v4/distribution/templateConfig.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateConfig.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import "mocha";
+import {
+  computeBundled,
+  computeRange,
+  computeV4TemplateConfig,
+} from "../../../src/v4/distribution/templateConfig";
+
+describe("templateConfig (v4 build-time)", () => {
+  describe("computeBundled (bundled = !goproduct)", () => {
+    it("internal test build (goproduct=false) → bundled", () => {
+      assert.strictEqual(computeBundled(false), true);
+    });
+    it("shipping build (goproduct=true) → online", () => {
+      assert.strictEqual(computeBundled(true), false);
+    });
+  });
+
+  describe("computeRange", () => {
+    it("keeps the previous range when the version still intersects it", () => {
+      assert.strictEqual(computeRange("6.10.5", "~6.10"), "~6.10");
+    });
+
+    it("widens to ~major.minor when the version no longer intersects", () => {
+      assert.strictEqual(computeRange("6.11.0", "~6.10"), "~6.11");
+    });
+
+    it("derives ~major.minor from a prerelease's stable target", () => {
+      // templates has no odd/even-minor split, so the rc shares the stable range.
+      assert.strictEqual(computeRange("6.11.0-rc.0", "~6.10"), "~6.11");
+    });
+
+    it("bumps the major when crossing a major boundary", () => {
+      assert.strictEqual(computeRange("7.0.0", "~6.10"), "~7.0");
+    });
+
+    it("throws on a non-SemVer version (no silent fallback)", () => {
+      assert.throws(() => computeRange("not-semver", "~6.10"), /not valid SemVer/);
+    });
+  });
+
+  describe("computeV4TemplateConfig", () => {
+    it("internal rc test build → bundled floor, range from stable target, exact localVersion", () => {
+      const config = computeV4TemplateConfig({
+        version: "6.11.0-rc.0",
+        goproduct: false,
+        previousRange: "~6.10",
+      });
+      assert.deepEqual(config, {
+        range: "~6.11",
+        bundled: true,
+        localVersion: "6.11.0-rc.0",
+      });
+    });
+
+    it("stable shipping build → online channel, widened range", () => {
+      const config = computeV4TemplateConfig({
+        version: "6.11.0",
+        goproduct: true,
+        previousRange: "~6.10",
+      });
+      assert.deepEqual(config, {
+        range: "~6.11",
+        bundled: false,
+        localVersion: "6.11.0",
+      });
+    });
+
+    it("prerelease shipped to marketplace pre-release channel → online (bundled=false)", () => {
+      const config = computeV4TemplateConfig({
+        version: "6.11.0-rc.0",
+        goproduct: true,
+        previousRange: "~6.11",
+      });
+      assert.deepEqual(config, {
+        range: "~6.11",
+        bundled: false,
+        localVersion: "6.11.0-rc.0",
+      });
+    });
+
+    it("patch within the current range keeps the range stable (reproducibility)", () => {
+      const config = computeV4TemplateConfig({
+        version: "6.10.2",
+        goproduct: true,
+        previousRange: "~6.10",
+      });
+      assert.deepEqual(config, {
+        range: "~6.10",
+        bundled: false,
+        localVersion: "6.10.2",
+      });
+    });
+  });
+});

--- a/packages/fx-core/tests/v4/distribution/templatePackage.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templatePackage.test.ts
@@ -122,4 +122,18 @@ describe("open-template-package (v4)", () => {
     assert.isDefined(gitkeep);
     assert.strictEqual(gitkeep!.data.length, 0);
   });
+
+  // AC-10 — Zip-Slip guard: a `..` segment in a located entry is a hard error
+  it("AC-10: rejects a located entry whose path contains a .. segment", () => {
+    const zip = new AdmZip();
+    zip.addFile("common/da-basic/README.md", Buffer.from("ok"));
+    zip.addFile("common/da-basic/evil.txt", Buffer.from("pwned"));
+    // adm-zip canonicalizes `..` at add time, so set the raw traversal name directly.
+    const evil = zip.getEntries().find((e) => e.entryName.endsWith("evil.txt"));
+    assert.isDefined(evil);
+    evil!.entryName = "common/da-basic/../evil.txt";
+    const res = openTemplatePackage(zip.toBuffer(), { language: "common", scenario: "da-basic" });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplatePackageUnsafePath");
+  });
 });

--- a/packages/fx-core/tests/v4/distribution/templatePackage.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templatePackage.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import AdmZip from "adm-zip";
+import "mocha";
+import { openTemplatePackage } from "../../../src/v4/distribution/templatePackage";
+
+/** Build an in-memory zip from a `{ entryName: contents }` map. */
+function zipOf(files: Record<string, string | Buffer>): Buffer {
+  const zip = new AdmZip();
+  for (const [name, contents] of Object.entries(files)) {
+    zip.addFile(name, Buffer.isBuffer(contents) ? contents : Buffer.from(contents));
+  }
+  return zip.toBuffer();
+}
+
+describe("open-template-package (v4)", () => {
+  // AC-01 — locate one subtree, strip the locator prefix
+  it("AC-01: returns the located subtree with the prefix stripped", () => {
+    const bytes = zipOf({
+      "common/da-basic/README.md": "hello",
+      "common/da-basic/m365agents.yml.tpl": "version: 1",
+      "common/other/should-not-appear.txt": "x",
+    });
+    const res = openTemplatePackage(bytes, { language: "common", scenario: "da-basic" });
+    assert.isTrue(res.isOk());
+    const paths = res._unsafeUnwrap().map((e) => e.path);
+    assert.deepEqual(paths, ["README.md", "m365agents.yml.tpl"]);
+  });
+
+  // AC-02 — nested relative paths preserved + slash-normalized
+  it("AC-02: preserves nested relative paths", () => {
+    const bytes = zipOf({
+      "common/da-basic/appPackage/manifest.json.tpl": "{}",
+    });
+    const res = openTemplatePackage(bytes, { language: "common", scenario: "da-basic" });
+    const paths = res._unsafeUnwrap().map((e) => e.path);
+    assert.deepEqual(paths, ["appPackage/manifest.json.tpl"]);
+  });
+
+  // AC-03 — directory entries excluded
+  it("AC-03: excludes directory entries", () => {
+    const zip = new AdmZip();
+    zip.addFile("common/da-basic/appPackage/", Buffer.alloc(0)); // directory entry
+    zip.addFile("common/da-basic/appPackage/color.png", Buffer.from([1, 2, 3]));
+    const res = openTemplatePackage(zip.toBuffer(), {
+      language: "common",
+      scenario: "da-basic",
+    });
+    const paths = res._unsafeUnwrap().map((e) => e.path);
+    assert.deepEqual(paths, ["appPackage/color.png"]);
+  });
+
+  // AC-04 — bytes returned verbatim, no render
+  it("AC-04: returns .tpl bytes verbatim without rendering", () => {
+    const body = "name: {{appName}}";
+    const bytes = zipOf({ "common/da-basic/m365agents.yml.tpl": body });
+    const res = openTemplatePackage(bytes, { language: "common", scenario: "da-basic" });
+    const entry = res._unsafeUnwrap()[0];
+    assert.strictEqual(entry.data.toString(), body);
+    assert.strictEqual(entry.path, "m365agents.yml.tpl");
+  });
+
+  // AC-05 — zero-match locator is a hard error
+  it("AC-05: a locator matching zero entries is a SystemError", () => {
+    const bytes = zipOf({ "common/da-basic/README.md": "x" });
+    const res = openTemplatePackage(bytes, { language: "ts", scenario: "missing" });
+    assert.isTrue(res.isErr());
+    const error = res._unsafeUnwrapErr();
+    assert.match(error.message, /ts\/missing|not found/i);
+  });
+
+  // AC-06 — invalid archive is a hard error
+  it("AC-06: invalid zip bytes raise a SystemError", () => {
+    const res = openTemplatePackage(Buffer.from("not a zip at all"), {
+      language: "common",
+      scenario: "da-basic",
+    });
+    assert.isTrue(res.isErr());
+  });
+
+  // AC-07 — determinism: identical inputs → identical sorted order
+  it("AC-07: returns entries sorted by path, deterministically", () => {
+    const bytes = zipOf({
+      "common/da-basic/z.txt": "z",
+      "common/da-basic/a.txt": "a",
+      "common/da-basic/m/n.txt": "n",
+    });
+    const first = openTemplatePackage(bytes, { language: "common", scenario: "da-basic" })
+      ._unsafeUnwrap()
+      .map((e) => e.path);
+    const second = openTemplatePackage(bytes, { language: "common", scenario: "da-basic" })
+      ._unsafeUnwrap()
+      .map((e) => e.path);
+    assert.deepEqual(first, ["a.txt", "m/n.txt", "z.txt"]);
+    assert.deepEqual(first, second);
+  });
+
+  // AC-08 — prefix boundary: "da" must not match "da-basic"
+  it("AC-08: prefix match respects the trailing-slash boundary", () => {
+    const bytes = zipOf({
+      "common/da/only.txt": "da",
+      "common/da-basic/other.txt": "basic",
+    });
+    const res = openTemplatePackage(bytes, { language: "common", scenario: "da" });
+    const paths = res._unsafeUnwrap().map((e) => e.path);
+    assert.deepEqual(paths, ["only.txt"]);
+  });
+
+  // AC-09 — empty files are retained
+  it("AC-09: retains zero-byte files as Buffer(0) entries", () => {
+    const bytes = zipOf({
+      "common/da-basic/.gitkeep": Buffer.alloc(0),
+      "common/da-basic/README.md": "x",
+    });
+    const entries = openTemplatePackage(bytes, {
+      language: "common",
+      scenario: "da-basic",
+    })._unsafeUnwrap();
+    const gitkeep = entries.find((e) => e.path === ".gitkeep");
+    assert.isDefined(gitkeep);
+    assert.strictEqual(gitkeep!.data.length, 0);
+  });
+});

--- a/packages/fx-core/tests/v4/distribution/templateSource.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateSource.test.ts
@@ -3,6 +3,7 @@
 
 import { assert } from "chai";
 import "mocha";
+import { SystemError, UserError } from "@microsoft/teamsfx-api";
 import {
   BundledFloor,
   CachedPackage,
@@ -19,6 +20,7 @@ class FakePort implements TemplateSourcePort {
   private readonly envMap: Record<string, string | undefined>;
   private readonly tags?: TagEntry[];
   private readonly tagListThrows: boolean;
+  private readonly tagListError?: Error;
   private readonly store = new Map<string, CachedPackage>();
   public readonly floor: BundledFloor;
   /** Bytes the channel will serve per version (for the download path). */
@@ -28,6 +30,7 @@ class FakePort implements TemplateSourcePort {
     env?: Record<string, string | undefined>;
     tags?: TagEntry[];
     tagListThrows?: boolean;
+    tagListError?: Error;
     floor: BundledFloor;
     cache?: Array<{ version: string; digest: string; bytes: Buffer }>;
     serve?: Record<string, Buffer>;
@@ -35,6 +38,7 @@ class FakePort implements TemplateSourcePort {
     this.envMap = opts.env ?? {};
     this.tags = opts.tags;
     this.tagListThrows = opts.tagListThrows ?? false;
+    this.tagListError = opts.tagListError;
     this.floor = opts.floor;
     this.serve = opts.serve ?? {};
     for (const c of opts.cache ?? []) {
@@ -48,6 +52,9 @@ class FakePort implements TemplateSourcePort {
 
   tagList(): Promise<TagEntry[]> {
     this.httpCalls++;
+    if (this.tagListError) {
+      return Promise.reject(this.tagListError);
+    }
     if (this.tagListThrows) {
       return Promise.reject(new Error("network unreachable"));
     }
@@ -312,5 +319,51 @@ describe("resolveTemplateSource (v4)", () => {
     assert.isTrue(res.isErr());
     assert.strictEqual(res._unsafeUnwrapErr().name, "TemplatePinnedVersionNotFound");
     assert.lengthOf(port.downloads, 0);
+  });
+
+  it("AC-17: a malformed tag-list document is propagated as a hard error, not an offline fallback", async () => {
+    const malformed = new SystemError({
+      source: "Scaffold",
+      name: "TemplateTagListMalformed",
+      message: "Malformed v4 tag-list entry on line 1: not valid JSON.",
+    });
+    const port = new FakePort({
+      tagListError: malformed,
+      // a satisfying cache + floor exist to prove resolution does NOT fall back.
+      cache: [{ version: "6.10.4", digest: "sha256:c", bytes: bytesFor("6.10.4") }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateTagListMalformed");
+  });
+
+  it("AC-18: a pinned version whose tag-list fetch rejects surfaces an error and never falls back", async () => {
+    const port = new FakePort({
+      env: { TEMPLATE_VERSION: "6.11.2" },
+      tagListThrows: true,
+      cache: [{ version: "6.10.4", digest: "sha256:c", bytes: bytesFor("6.10.4") }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateTagListUnavailable");
+    assert.lengthOf(port.downloads, 0);
+  });
+
+  it("AC-18: a pinned version preserves an existing FxError from the tag-list fetch", async () => {
+    const malformed = new UserError({
+      source: "Scaffold",
+      name: "TemplateTagListMalformed",
+      message: 'Malformed v4 tag-list entry on line 2: missing "digest".',
+    });
+    const port = new FakePort({
+      env: { TEMPLATE_VERSION: "6.11.2" },
+      tagListError: malformed,
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateTagListMalformed");
   });
 });

--- a/packages/fx-core/tests/v4/distribution/templateSource.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateSource.test.ts
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import "mocha";
+import {
+  BundledFloor,
+  CachedPackage,
+  TagEntry,
+  TemplateSourcePort,
+  computeDigest,
+  resolveTemplateSource,
+} from "../../../src/v4/distribution/templateSource";
+
+// In-memory fake of the narrow TemplateSourcePort (no real fs / network).
+class FakePort implements TemplateSourcePort {
+  public httpCalls = 0;
+  public downloads: string[] = [];
+  private readonly envMap: Record<string, string | undefined>;
+  private readonly tags?: TagEntry[];
+  private readonly tagListThrows: boolean;
+  private readonly store = new Map<string, CachedPackage>();
+  public readonly floor: BundledFloor;
+  /** Bytes the channel will serve per version (for the download path). */
+  private readonly serve: Record<string, Buffer>;
+
+  constructor(opts: {
+    env?: Record<string, string | undefined>;
+    tags?: TagEntry[];
+    tagListThrows?: boolean;
+    floor: BundledFloor;
+    cache?: Array<{ version: string; digest: string; bytes: Buffer }>;
+    serve?: Record<string, Buffer>;
+  }) {
+    this.envMap = opts.env ?? {};
+    this.tags = opts.tags;
+    this.tagListThrows = opts.tagListThrows ?? false;
+    this.floor = opts.floor;
+    this.serve = opts.serve ?? {};
+    for (const c of opts.cache ?? []) {
+      this.store.set(c.version, { digest: c.digest, bytes: c.bytes });
+    }
+  }
+
+  env(name: string): string | undefined {
+    return this.envMap[name];
+  }
+
+  tagList(): Promise<TagEntry[]> {
+    this.httpCalls++;
+    if (this.tagListThrows) {
+      return Promise.reject(new Error("network unreachable"));
+    }
+    return Promise.resolve(this.tags ?? []);
+  }
+
+  packages(version: string): Promise<Buffer> {
+    this.httpCalls++;
+    this.downloads.push(version);
+    const bytes = this.serve[version];
+    if (!bytes) {
+      return Promise.reject(new Error(`no bytes served for ${version}`));
+    }
+    return Promise.resolve(bytes);
+  }
+
+  cache = {
+    get: (version: string): CachedPackage | undefined => this.store.get(version),
+    put: (version: string, digest: string, bytes: Buffer): void => {
+      this.store.set(version, { digest, bytes });
+    },
+    keys: (): string[] => [...this.store.keys()],
+  };
+
+  cacheHas(version: string): boolean {
+    return this.store.has(version);
+  }
+}
+
+function bytesFor(label: string): Buffer {
+  return Buffer.from(`template-bytes:${label}`);
+}
+
+describe("resolveTemplateSource (v4)", () => {
+  it("AC-01: bundled=true resolves the bundled floor with no network call", async () => {
+    const port = new FakePort({
+      tags: [{ version: "6.10.5", digest: "sha256:x" }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: true, port });
+    assert.isTrue(res.isOk());
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "bundled");
+    assert.strictEqual(src.version, "6.10.1");
+    assert.strictEqual(src.digest, "sha256:floor");
+    assert.strictEqual(port.httpCalls, 0);
+  });
+
+  it("AC-02: TEMPLATE_VERSION=local overrides bundled=false and uses the floor", async () => {
+    const port = new FakePort({
+      env: { TEMPLATE_VERSION: "local" },
+      tags: [{ version: "6.10.5", digest: "sha256:x" }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "bundled");
+    assert.strictEqual(port.httpCalls, 0);
+  });
+
+  it("AC-03: TEMPLATE_VERSION=<version> pins that online version with the tag-list digest", async () => {
+    const bytes = bytesFor("6.11.2");
+    const digest = computeDigest(bytes);
+    const port = new FakePort({
+      env: { TEMPLATE_VERSION: "6.11.2" },
+      tags: [{ version: "6.11.2", digest }],
+      serve: { "6.11.2": bytes },
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "online");
+    assert.strictEqual(src.version, "6.11.2");
+    assert.strictEqual(src.digest, digest);
+  });
+
+  it("AC-04: bundled=false resolves the highest channel version above the floor and records its digest", async () => {
+    const bytes = bytesFor("6.10.5");
+    const digest = computeDigest(bytes);
+    const port = new FakePort({
+      tags: [
+        { version: "6.10.1", digest: "sha256:floor" },
+        { version: "6.10.5", digest },
+      ],
+      serve: { "6.10.5": bytes },
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "online");
+    assert.strictEqual(src.version, "6.10.5");
+    assert.strictEqual(src.digest, digest);
+    assert.isTrue(port.cacheHas("6.10.5"));
+  });
+
+  it("AC-05: highest satisfier equal to the floor resolves the floor without downloading", async () => {
+    const port = new FakePort({
+      tags: [{ version: "6.10.1", digest: "sha256:floor" }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "bundled");
+    assert.strictEqual(src.version, "6.10.1");
+    assert.lengthOf(port.downloads, 0);
+  });
+
+  it("AC-06: a cache hit with a matching digest returns the cached bytes with zero download", async () => {
+    const bytes = bytesFor("6.10.5");
+    const digest = computeDigest(bytes);
+    const port = new FakePort({
+      tags: [{ version: "6.10.5", digest }],
+      cache: [{ version: "6.10.5", digest, bytes }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "cache");
+    assert.strictEqual(src.version, "6.10.5");
+    assert.lengthOf(port.downloads, 0);
+  });
+
+  it("AC-07: channel unreachable falls back to max(cache, floor) = cache, with a warning", async () => {
+    const bytes = bytesFor("6.10.4");
+    const digest = computeDigest(bytes);
+    const port = new FakePort({
+      tagListThrows: true,
+      cache: [{ version: "6.10.4", digest, bytes }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "cache");
+    assert.strictEqual(src.version, "6.10.4");
+    assert.isDefined(src.warning);
+  });
+
+  it("AC-08: channel unreachable with empty cache falls back to the floor, with a warning", async () => {
+    const port = new FakePort({
+      tagListThrows: true,
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "bundled-fallback");
+    assert.strictEqual(src.version, "6.10.1");
+    assert.isDefined(src.warning);
+  });
+
+  it("AC-09: a stable range excludes -beta versions", async () => {
+    const bytes = bytesFor("6.11.0");
+    const digest = computeDigest(bytes);
+    const port = new FakePort({
+      tags: [
+        { version: "6.11.0", digest },
+        { version: "6.12.0-beta.1", digest: "sha256:beta" },
+      ],
+      serve: { "6.11.0": bytes },
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.11", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.version, "6.11.0");
+  });
+
+  it("AC-10: a beta range naming the prerelease segment resolves the -beta version", async () => {
+    const bytes = bytesFor("6.12.0-beta.1");
+    const digest = computeDigest(bytes);
+    const port = new FakePort({
+      tags: [{ version: "6.12.0-beta.1", digest }],
+      serve: { "6.12.0-beta.1": bytes },
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({
+      range: ">=6.12.0-beta <6.13.0",
+      bundled: false,
+      port,
+    });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.version, "6.12.0-beta.1");
+  });
+
+  it("AC-11: a digest mismatch is a hard error; the cache is not written", async () => {
+    const realBytes = bytesFor("6.10.5");
+    const port = new FakePort({
+      tags: [{ version: "6.10.5", digest: "sha256:WRONG-EXPECTED" }],
+      serve: { "6.10.5": realBytes },
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateDigestMismatch");
+    assert.isFalse(port.cacheHas("6.10.5"));
+  });
+
+  it("AC-12: bundled=true never reads package.json#version (a beta build still resolves the floor)", async () => {
+    // package.json#version is irrelevant by construction: the function never reads it.
+    const port = new FakePort({
+      tags: [{ version: "9.9.9", digest: "sha256:x" }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: true, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "bundled");
+    assert.strictEqual(src.version, "6.10.1");
+  });
+
+  it("AC-13: identical inputs and tag-list state resolve identically", async () => {
+    const bytes = bytesFor("6.10.5");
+    const digest = computeDigest(bytes);
+    const make = () =>
+      new FakePort({
+        tags: [{ version: "6.10.5", digest }],
+        serve: { "6.10.5": bytes },
+        floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+      });
+    const a = (
+      await resolveTemplateSource({ range: "~6.10", bundled: false, port: make() })
+    )._unsafeUnwrap();
+    const b = (
+      await resolveTemplateSource({ range: "~6.10", bundled: false, port: make() })
+    )._unsafeUnwrap();
+    assert.deepEqual(
+      { origin: a.origin, version: a.version, digest: a.digest },
+      { origin: b.origin, version: b.version, digest: b.digest }
+    );
+  });
+
+  it("AC-14: empty tag-list with a satisfying floor falls back to the floor, with a warning", async () => {
+    const port = new FakePort({
+      tags: [],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    const src = res._unsafeUnwrap();
+    assert.strictEqual(src.origin, "bundled-fallback");
+    assert.strictEqual(src.version, "6.10.1");
+    assert.isDefined(src.warning);
+  });
+
+  it("AC-15: empty tag-list with a non-satisfying floor is a UserError (no silent substitution)", async () => {
+    const port = new FakePort({
+      tags: [],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~7.0", bundled: false, port });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateVersionMismatch");
+  });
+
+  it("AC-16: a pinned TEMPLATE_VERSION absent from the tag-list is a UserError with no fallback", async () => {
+    const floorBytes = bytesFor("6.10.1");
+    const port = new FakePort({
+      env: { TEMPLATE_VERSION: "6.99.0" },
+      // tag-list reachable but does NOT list the pinned version; a satisfying
+      // floor/cache exists to prove resolution does NOT silently fall back.
+      tags: [{ version: "6.10.5", digest: "sha256:other" }],
+      cache: [{ version: "6.10.5", digest: "sha256:other", bytes: bytesFor("6.10.5") }],
+      floor: { version: "6.10.1", digest: computeDigest(floorBytes), location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplatePinnedVersionNotFound");
+    assert.lengthOf(port.downloads, 0);
+  });
+});

--- a/packages/fx-core/tests/v4/distribution/templateSource.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateSource.test.ts
@@ -21,6 +21,7 @@ class FakePort implements TemplateSourcePort {
   private readonly tags?: TagEntry[];
   private readonly tagListThrows: boolean;
   private readonly tagListError?: Error;
+  private readonly packagesError?: Error;
   private readonly store = new Map<string, CachedPackage>();
   public readonly floor: BundledFloor;
   /** Bytes the channel will serve per version (for the download path). */
@@ -31,6 +32,7 @@ class FakePort implements TemplateSourcePort {
     tags?: TagEntry[];
     tagListThrows?: boolean;
     tagListError?: Error;
+    packagesError?: Error;
     floor: BundledFloor;
     cache?: Array<{ version: string; digest: string; bytes: Buffer }>;
     serve?: Record<string, Buffer>;
@@ -39,6 +41,7 @@ class FakePort implements TemplateSourcePort {
     this.tags = opts.tags;
     this.tagListThrows = opts.tagListThrows ?? false;
     this.tagListError = opts.tagListError;
+    this.packagesError = opts.packagesError;
     this.floor = opts.floor;
     this.serve = opts.serve ?? {};
     for (const c of opts.cache ?? []) {
@@ -64,6 +67,9 @@ class FakePort implements TemplateSourcePort {
   packages(version: string): Promise<Buffer> {
     this.httpCalls++;
     this.downloads.push(version);
+    if (this.packagesError) {
+      return Promise.reject(this.packagesError);
+    }
     const bytes = this.serve[version];
     if (!bytes) {
       return Promise.reject(new Error(`no bytes served for ${version}`));
@@ -365,5 +371,36 @@ describe("resolveTemplateSource (v4)", () => {
     const res = await resolveTemplateSource({ range: "~6.10", bundled: false, port });
     assert.isTrue(res.isErr());
     assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateTagListMalformed");
+  });
+
+  it("AC-19: a download rejection surfaces as an error instead of throwing", async () => {
+    const bytes = bytesFor("6.11.0");
+    const port = new FakePort({
+      // tag is published so the version is picked, but no bytes are served, so
+      // the download rejects; the neverthrow contract must still hold.
+      tags: [{ version: "6.11.0", digest: computeDigest(bytes) }],
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.11", bundled: false, port });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateDownloadFailed");
+    assert.deepEqual(port.downloads, ["6.11.0"]);
+  });
+
+  it("AC-19: a download rejection preserves an existing FxError", async () => {
+    const bytes = bytesFor("6.11.0");
+    const existing = new UserError({
+      source: "Scaffold",
+      name: "TemplateDigestMismatch",
+      message: "boom",
+    });
+    const port = new FakePort({
+      tags: [{ version: "6.11.0", digest: computeDigest(bytes) }],
+      packagesError: existing,
+      floor: { version: "6.10.1", digest: "sha256:floor", location: "bundled://6.10.1" },
+    });
+    const res = await resolveTemplateSource({ range: "~6.11", bundled: false, port });
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateDigestMismatch");
   });
 });

--- a/packages/fx-core/tests/v4/distribution/templateSourcePort.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateSourcePort.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import "mocha";
+import axios, { AxiosResponse } from "axios";
+import * as fs from "fs-extra";
+import os from "os";
+import * as path from "path";
+import sinon from "sinon";
+import { BundledFloor, computeDigest } from "../../../src/v4/distribution/templateSource";
+import {
+  V4_TAG_PREFIX,
+  ZIP_EXT,
+  cacheFile,
+  createTemplateSourcePort,
+  parseTagList,
+  templateZipUrl,
+} from "../../../src/v4/distribution/templateSourcePort";
+
+describe("templateSourcePort pure helpers (v4)", () => {
+  describe("parseTagList (NDJSON, decision #7)", () => {
+    it("parses one { version, digest } object per line", () => {
+      const ndjson = [
+        `{"version":"6.11.0","digest":"sha256:aaa"}`,
+        `{"version":"6.11.1","digest":"sha256:bbb"}`,
+      ].join("\n");
+      const entries = parseTagList(ndjson);
+      assert.deepEqual(entries, [
+        { version: "6.11.0", digest: "sha256:aaa" },
+        { version: "6.11.1", digest: "sha256:bbb" },
+      ]);
+    });
+
+    it("ignores blank lines and trailing CR", () => {
+      const ndjson = `\r\n{"version":"6.11.0","digest":"sha256:aaa"}\r\n\n`;
+      const entries = parseTagList(ndjson);
+      assert.lengthOf(entries, 1);
+      assert.strictEqual(entries[0].version, "6.11.0");
+    });
+
+    it("returns an empty array for an empty document", () => {
+      assert.deepEqual(parseTagList(""), []);
+      assert.deepEqual(parseTagList("\n\n"), []);
+    });
+
+    it("throws a hard error on a non-JSON line (no silent skip)", () => {
+      const ndjson = `{"version":"6.11.0","digest":"sha256:aaa"}\nnot-json`;
+      assert.throws(() => parseTagList(ndjson), /Malformed.*line 2/);
+    });
+
+    it("throws a hard error when version or digest is missing", () => {
+      assert.throws(() => parseTagList(`{"version":"6.11.0"}`), /Malformed/);
+      assert.throws(() => parseTagList(`{"digest":"sha256:aaa"}`), /Malformed/);
+    });
+
+    it("throws when a field has the wrong type", () => {
+      assert.throws(() => parseTagList(`{"version":6,"digest":"sha256:aaa"}`), /Malformed/);
+    });
+
+    it("throws when a line is valid JSON but not an object (number / null)", () => {
+      assert.throws(() => parseTagList(`123`), /Malformed/);
+      assert.throws(() => parseTagList(`null`), /Malformed/);
+    });
+  });
+
+  describe("templateZipUrl", () => {
+    it("builds a templates-v4@ prefixed download URL", () => {
+      const url = templateZipUrl("https://example.com/dl", "6.11.0");
+      assert.strictEqual(url, "https://example.com/dl/templates-v4@6.11.0/templates.zip");
+    });
+  });
+
+  describe("cacheFile", () => {
+    it("places the package under ~/.fx/templates-cache with the v4 prefix", () => {
+      const file = cacheFile("6.11.0");
+      assert.strictEqual(
+        file,
+        path.join(os.homedir(), ".fx", "templates-cache", `${V4_TAG_PREFIX}6.11.0.zip`)
+      );
+    });
+  });
+});
+
+// Per ADR-0013: the thin IO adapter is covered by ONE integration test over a
+// real temp cache directory (os.homedir stubbed to the boundary; only the
+// network edge is stubbed), not by mock-heavy micro-units.
+describe("createTemplateSourcePort (v4, integration over real fs)", () => {
+  const sandbox = sinon.createSandbox();
+  const floor: BundledFloor = {
+    version: "6.10.1",
+    digest: "sha256:floor",
+    location: "bundled://6.10.1",
+  };
+  const config = {
+    templatesV4TagListURL: "https://example.com/tags.ndjson",
+    templateDownloadBaseURL: "https://example.com/dl",
+    tryLimits: 1,
+  };
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = path.join(
+      os.tmpdir(),
+      `v4-port-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    sandbox.stub(os, "homedir").returns(tmpHome);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    fs.removeSync(tmpHome);
+  });
+
+  it("warms the in-memory index from a real cache directory, filtering non-matching files", () => {
+    const cacheDirPath = path.join(tmpHome, ".fx", "templates-cache");
+    fs.ensureDirSync(cacheDirPath);
+    const bytes = Buffer.from("zip-bytes-6.10.4");
+    fs.writeFileSync(path.join(cacheDirPath, `${V4_TAG_PREFIX}6.10.4${ZIP_EXT}`), bytes);
+    fs.writeFileSync(path.join(cacheDirPath, "unrelated.txt"), "ignored");
+
+    const port = createTemplateSourcePort(config, floor);
+    assert.deepEqual(port.cache.keys(), ["6.10.4"]);
+    const got = port.cache.get("6.10.4");
+    assert.isDefined(got);
+    assert.strictEqual(got?.digest, computeDigest(bytes));
+  });
+
+  it("returns an empty index when the cache directory does not exist", () => {
+    const port = createTemplateSourcePort(config, floor);
+    assert.deepEqual(port.cache.keys(), []);
+  });
+
+  it("put writes the package to disk and indexes it", () => {
+    const port = createTemplateSourcePort(config, floor);
+    const bytes = Buffer.from("zip-bytes-6.10.7");
+    const digest = computeDigest(bytes);
+    port.cache.put("6.10.7", digest, bytes);
+    assert.isTrue(fs.existsSync(cacheFile("6.10.7")));
+    assert.strictEqual(port.cache.get("6.10.7")?.digest, digest);
+  });
+
+  it("env reads the real process environment", () => {
+    const port = createTemplateSourcePort(config, floor);
+    process.env.__V4_PORT_TEST__ = "yes";
+    assert.strictEqual(port.env("__V4_PORT_TEST__"), "yes");
+    delete process.env.__V4_PORT_TEST__;
+  });
+
+  it("tagList fetches and parses the NDJSON channel document", async () => {
+    const ndjson = `{"version":"6.11.0","digest":"sha256:aaa"}`;
+    sandbox.stub(axios, "get").resolves({ status: 200, data: ndjson } as AxiosResponse);
+    const port = createTemplateSourcePort(config, floor);
+    const tags = await port.tagList();
+    assert.deepEqual(tags, [{ version: "6.11.0", digest: "sha256:aaa" }]);
+  });
+
+  it("packages downloads the version zip as a Buffer", async () => {
+    const payload = Buffer.from("zip-payload");
+    sandbox.stub(axios, "get").resolves({ status: 200, data: payload } as AxiosResponse);
+    const port = createTemplateSourcePort(config, floor);
+    const buf = await port.packages("6.11.0", "sha256:aaa");
+    assert.isTrue(Buffer.isBuffer(buf));
+    assert.strictEqual(buf.toString(), "zip-payload");
+    assert.strictEqual(
+      templateZipUrl(config.templateDownloadBaseURL, "6.11.0"),
+      "https://example.com/dl/templates-v4@6.11.0/templates.zip"
+    );
+  });
+});

--- a/packages/fx-core/tests/v4/distribution/templateSourcePort.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateSourcePort.test.ts
@@ -14,9 +14,11 @@ import {
   ZIP_EXT,
   cacheFile,
   createTemplateSourcePort,
+  loadResolvedPackage,
   parseTagList,
   templateZipUrl,
 } from "../../../src/v4/distribution/templateSourcePort";
+import { TemplateSource } from "../../../src/v4/distribution/templateSource";
 
 describe("templateSourcePort pure helpers (v4)", () => {
   describe("parseTagList (NDJSON, decision #7)", () => {
@@ -166,5 +168,135 @@ describe("createTemplateSourcePort (v4, integration over real fs)", () => {
       templateZipUrl(config.templateDownloadBaseURL, "6.11.0"),
       "https://example.com/dl/templates-v4@6.11.0/templates.zip"
     );
+  });
+});
+
+// loadResolvedPackage is part of the thin IO adapter: tested over a real temp
+// filesystem (ADR-0013), not mock-heavy micro-units. It must never reach the
+// network — an online/cache source is already cached by resolution.
+describe("loadResolvedPackage (v4, integration over real fs)", () => {
+  const sandbox = sinon.createSandbox();
+  let tmpHome: string;
+  let tmpDir: string;
+
+  const config = {
+    templatesV4TagListURL: "https://example.com/tags.ndjson",
+    templateDownloadBaseURL: "https://example.com/dl",
+    tryLimits: 1,
+  };
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `v4-load-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    tmpHome = path.join(tmpDir, "home");
+    fs.ensureDirSync(tmpDir);
+    sandbox.stub(os, "homedir").returns(tmpHome);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    fs.removeSync(tmpDir);
+  });
+
+  function floorFor(bytes: Buffer): BundledFloor {
+    const location = path.join(tmpDir, "floor.zip");
+    fs.writeFileSync(location, bytes);
+    return { version: "6.10.1", digest: computeDigest(bytes), location };
+  }
+
+  it("reads a bundled-floor source from disk and verifies its digest", () => {
+    const bytes = Buffer.from("floor-zip-bytes");
+    const floor = floorFor(bytes);
+    const port = createTemplateSourcePort(config, floor);
+    const source: TemplateSource = {
+      origin: "bundled",
+      version: floor.version,
+      digest: floor.digest,
+      location: floor.location,
+    };
+    const res = loadResolvedPackage(source, port);
+    assert.isTrue(res.isOk());
+    assert.strictEqual(res._unsafeUnwrap().toString(), "floor-zip-bytes");
+  });
+
+  it("reads a bundled-fallback source the same way as bundled", () => {
+    const bytes = Buffer.from("fallback-zip-bytes");
+    const floor = floorFor(bytes);
+    const port = createTemplateSourcePort(config, floor);
+    const source: TemplateSource = {
+      origin: "bundled-fallback",
+      version: floor.version,
+      digest: floor.digest,
+      location: floor.location,
+      warning: "offline",
+    };
+    const res = loadResolvedPackage(source, port);
+    assert.strictEqual(res._unsafeUnwrap().toString(), "fallback-zip-bytes");
+  });
+
+  it("errors when the bundled-floor file is missing", () => {
+    const floor: BundledFloor = {
+      version: "6.10.1",
+      digest: "sha256:floor",
+      location: path.join(tmpDir, "does-not-exist.zip"),
+    };
+    const port = createTemplateSourcePort(config, floor);
+    const source: TemplateSource = {
+      origin: "bundled",
+      version: floor.version,
+      digest: floor.digest,
+      location: floor.location,
+    };
+    const res = loadResolvedPackage(source, port);
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplatePackageUnreadable");
+  });
+
+  it("returns cached bytes for an online source without any network call", () => {
+    const floorBytes = Buffer.from("floor");
+    const port = createTemplateSourcePort(config, floorFor(floorBytes));
+    const axiosGet = sandbox.stub(axios, "get");
+    const bytes = Buffer.from("online-zip-6.11.2");
+    const digest = computeDigest(bytes);
+    port.cache.put("6.11.2", digest, bytes);
+    const source: TemplateSource = {
+      origin: "online",
+      version: "6.11.2",
+      digest,
+      location: "templates-v4@6.11.2",
+    };
+    const res = loadResolvedPackage(source, port);
+    assert.strictEqual(res._unsafeUnwrap().toString(), "online-zip-6.11.2");
+    assert.isTrue(axiosGet.notCalled);
+  });
+
+  it("errors (never re-downloads) when a cache source is not present in the cache", () => {
+    const floorBytes = Buffer.from("floor");
+    const port = createTemplateSourcePort(config, floorFor(floorBytes));
+    const axiosGet = sandbox.stub(axios, "get");
+    const source: TemplateSource = {
+      origin: "cache",
+      version: "6.11.9",
+      digest: "sha256:whatever",
+      location: "templates-v4@6.11.9",
+    };
+    const res = loadResolvedPackage(source, port);
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplatePackageNotCached");
+    assert.isTrue(axiosGet.notCalled);
+  });
+
+  it("errors when the loaded bytes do not match source.digest (integrity)", () => {
+    const bytes = Buffer.from("tampered");
+    const floor = floorFor(bytes);
+    const port = createTemplateSourcePort(config, floor);
+    const source: TemplateSource = {
+      origin: "bundled",
+      version: floor.version,
+      digest: "sha256:expected-something-else",
+      location: floor.location,
+    };
+    const res = loadResolvedPackage(source, port);
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "TemplateDigestMismatch");
   });
 });

--- a/templates/package.json
+++ b/templates/package.json
@@ -12,7 +12,7 @@
     "build:vsc": "npm run generate:vsc && npm run distribute",
     "build:vs": "npm run generate:vs && npm run distribute",
     "build:release": "node ./scripts/generateRelease.js",
-    "generate:vsc": "node ./scripts/generateVSCZip.js && tsx ./scripts/generate-metadata.ts",
+    "generate:vsc": "node ./scripts/generateVSCZip.js && node ./scripts/generateV4Zip.js && tsx ./scripts/generate-metadata.ts",
     "generate:vs": "node ./scripts/generateVSZip.js",
     "distribute": "copyfiles -u 1 \"build/**/*\" ../packages/fx-core/templates/ && copyfiles -u 3 \"src/ui/resource/**/*\" ../packages/fx-core/resource/templates/ && shx cp -r configs/ ../packages/fx-core/templates/",
     "version": "bash ../.github/scripts/pkg-version.sh template-sync && bash ../.github/scripts/pkg-version.sh core-template",

--- a/templates/scripts/generateV4Zip.js
+++ b/templates/scripts/generateV4Zip.js
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Generate the single full v4 template package + bundled-floor manifest.
+ *
+ * Unlike the v3 per-language zips (common/js/ts/python.zip), the v4 channel
+ * ships ONE `templates.zip` (ADR-0006 / scaffolding.create.proposal.md). This
+ * script bundles the existing VSC template content under `<lang>/<scenario>/`
+ * paths into a single zip. The v4 `<templateId>` authoring layout is a later
+ * concern (the consume operation); this script only produces the distribution
+ * artifact the floor + `templates-v4@` channel ship.
+ *
+ * Outputs (both picked up by the `distribute` step → packages/fx-core/templates/v4/):
+ *   - build/v4/templates.zip  — the full package
+ *   - build/v4/floor.json     — { "version": <templates package version> }
+ *
+ * The digest is NOT written here: it is computed from the bytes at load time
+ * so `computeDigest` stays the single authority (resolve-template-source spec
+ * decision #6). `loadBundledFloor` reads these two files.
+ */
+
+const AdmZip = require("adm-zip");
+const { readdirSync, mkdirSync, writeFileSync } = require("node:fs");
+const path = require("path");
+
+const LANGUAGES = ["common", "js", "ts", "python"];
+const BUILD_PATH = path.join(__dirname, "..", "build", "v4");
+const version = require(path.join(__dirname, "..", "package.json")).version;
+
+mkdirSync(BUILD_PATH, { recursive: true });
+
+const zip = new AdmZip();
+LANGUAGES.forEach((lang) => {
+  const langPath = path.join(__dirname, "..", "vsc", lang);
+  readdirSync(langPath).forEach((scenario) => {
+    zip.addLocalFolder(path.join(langPath, scenario), path.posix.join(lang, scenario));
+  });
+});
+
+console.log(`Generating v4 templates.zip (version ${version})`);
+zip.writeZip(path.join(BUILD_PATH, "templates.zip"));
+
+writeFileSync(path.join(BUILD_PATH, "floor.json"), JSON.stringify({ version }, null, 2) + "\n");
+console.log(`Wrote v4 floor.json (version ${version})`);


### PR DESCRIPTION
## What

Adds the **v4 template distribution channel** — an isolated, digest-addressed channel that resolves and consumes v4 template packages, fully separate from the frozen v3 `templates@` channel. Part of the v4 scaffolding effort; may ship ahead of the v4 engine.

## Why

The v3 distribution path is non-reproducible (mutable `templates@0.0.0-rc` tag) and resolves via `package.json#version` substring sniffing. v4 replaces this with a two-field model (`range` + `bundled`) and a content digest, per ADR-0006.

## Changes (4 logical commits)

1. **docs: ADRs + architecture maps** — ADR-0006 (template distribution channel) through ADR-0012, scaffolding current-state/proposal/code-map, external-dependency fact pages.
2. **docs: operation + domain specs** — `resolve-template-source` and `open-template-package` operation specs (AC tables, flows, boundaries, invariants) + scaffolding domain spec.
3. **feat(fx-core): v4 distribution module** (`src/v4/distribution/`):
   - `resolveTemplateSource` — pure `(range, bundled) -> resolved version + sha256 digest`
   - `TemplateSourcePort` — NDJSON tag-list parsing, `templates-v4@` download URLs, digest-keyed cache
   - `bundledFloor` loading, `computeV4TemplateConfig`, `openTemplatePackage` (layout-agnostic locate over the v4 `templates.zip`)
   - v4 imports **zero** v3 code; the L1 tests derive 1:1 from the spec AC rows.
4. **ci: wire v4 channel into CD** — `generateV4Zip.js` (single `templates.zip`, `<lang>/<scenario>` layout), the v4 CD wrappers (`sync-v4-template-config`, `generate-v4-tag-list`, `publish-v4-channel`), and one `goproduct`-gated *Publish v4 template channel* step in `cd.yml`.

## v3 isolation guarantees

The v4 CD steps only ever upsert the v4-owned `templates-v4@<ver>` and `template-v4-tag-list` releases. The v3 `templates@` tag, `template-tag-list`, and `build/fallback/*.zip` assets are never read or written. The only shared input is the lerna-minted version number (read-only), the sole coordination point.

## Localization

Localization (`package.nls.*.json` and `Localize/`) is intentionally out of scope here. It will be handled in a single dedicated PR once all v4 scaffolding code has landed, so the translated strings can be generated against the final set of user-facing messages.

## Test plan

- [x] v4 distribution L1 tests green (`npx mocha tests/v4/distribution/*.test.ts`)
- [x] eslint clean on `src/v4/**` and `tests/v4/**`
- [x] `generateV4Zip.js` produces a single `templates.zip`
- [x] `publish-v4-channel.sh` passes `bash -n` syntax check
- [ ] CD smoke test: manual dispatch with `goproduct=true` on this branch (pending)

> Draft until the CD smoke test confirms the v4 channel publishes end-to-end.
