### PR TITLE
feat(fx-core): pull metadata from v4 release when TEAMSFX_V4_ENABLED

### DIFF
--- a/.github/scripts/v4/publish-v4-channel.sh
+++ b/.github/scripts/v4/publish-v4-channel.sh
@@ -14,7 +14,13 @@
 #
 # Usage (run AFTER the templates build, with build/v4/templates.zip present):
 #   bash .github/scripts/v4/publish-v4-channel.sh \
-#     <templates@<ver> tag> <path to templates.zip> <temp dir> <commit sha>
+#     <templates@<ver> tag> <path to templates.zip> <temp dir> <commit sha> \
+#     [path to metadata.zip]
+#
+# The optional 5th argument is transitional: it mirrors the v3 `metadata.zip`
+# onto the v4 release so `fetchOnlineTemplateMetadata` can pull metadata from
+# the v4 tag when TEAMSFX_V4_ENABLED is on. Remove once selector.json drives
+# metadata distribution.
 #
 # Requires: gh CLI authenticated via GH_TOKEN, node on PATH.
 set -euo pipefail
@@ -23,6 +29,7 @@ TEMPLATE_TAG="${1:?Need the templates@<ver> tag (steps.version-change.outputs.TE
 ZIP="${2:?Need the path to templates.zip.}"
 TMP="${3:?Need a temp directory.}"
 SHA="${4:?Need the commit sha to anchor the release.}"
+METADATA_ZIP="${5:-}"
 
 VERSION="${TEMPLATE_TAG#templates@}"
 TAG="templates-v4@$VERSION"
@@ -36,6 +43,12 @@ if ! gh release view "$TAG" >/dev/null 2>&1; then
     --target "$SHA"
 fi
 gh release upload "$TAG" "$ZIP" --clobber
+
+# 1b. Transitional: mirror the v3 metadata.zip onto the v4 release so the
+#     engine can fetch metadata from the v4 tag when TEAMSFX_V4_ENABLED is on.
+if [ -n "$METADATA_ZIP" ]; then
+  gh release upload "$TAG" "$METADATA_ZIP" --clobber
+fi
 
 # 2. Pull the existing NDJSON tag-list (absent on the first release).
 gh release download template-v4-tag-list --pattern template-v4-tags.ndjson --dir "$TMP" || true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -322,7 +322,8 @@ jobs:
             "${{ steps.version-change.outputs.TEMPLATE_VERSION }}" \
             "${{ github.workspace }}/templates/build/v4/templates.zip" \
             "${{ runner.temp }}" \
-            "${{ github.sha }}"
+            "${{ github.sha }}" \
+            "${{ github.workspace }}/templates/build/metadata.zip"
 
       - name: Release RC VS templates to GitHub
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' }}

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -2,6 +2,7 @@
     "version": "~6.10",
     "localVersion": "6.10.1",
     "tagPrefix": "templates@",
+    "v4tagPrefix": "templates-v4@",
     "vstagPrefix": "templates-vs@",
     "vsversion": "18.6.0",
     "vsVersionPattern": "~18.6",

--- a/packages/fx-core/src/component/generator/templateHelper.ts
+++ b/packages/fx-core/src/component/generator/templateHelper.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { ConfigFolderName } from "@microsoft/teamsfx-api";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
 import { featureFlagManager, FeatureFlags } from "../../common/featureFlags";
 
 const packageJson = require("../../../package.json");
@@ -26,12 +30,16 @@ export function useLocalTemplate(): boolean {
 }
 
 /**
- * Transitional: the v4 channel only publishes online metadata for stable
- * (goproduct) releases under `templates-v4@<ver>`. Prerelease/test builds have
- * no v4 release, so when the v4 flag is on for a prerelease build the metadata
- * and UI readers must read the bundled copy and ignore any (possibly stale v3)
- * `~/.fx` cache left by a previous v3 run. Stable v4 builds download v4 metadata
- * into `~/.fx` and read it from there as usual.
+ * Transitional: in the v4 channel the metadata/UI readers must read the bundled
+ * copy and ignore any (possibly stale v3) `~/.fx` cache UNLESS the v4 online
+ * fetch populated its cache. `fetchOnlineTemplateMetadata` writes
+ * `~/.fx/template-version-v4.txt` only after a successful v4 download, so its
+ * presence is the single signal that downloaded v4 metadata is available:
+ *   - present → read the downloaded v4 cache;
+ *   - absent  → bundled build / channel unreachable / not yet published, so
+ *               read the bundled copy (never a stale v3 cache).
+ * This mirrors the `resolveTemplateSource` decision in
+ * `fetchOnlineTemplateMetadata`.
  *
  * Remove once selector.json drives metadata distribution.
  */
@@ -39,6 +47,10 @@ export function useBundledMetadataForV4(): boolean {
   if (!featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled)) {
     return false;
   }
-  const version: string = packageJson.version;
-  return version.includes("alpha") || version.includes("beta") || version.includes("rc");
+  const v4VersionFile = path.join(
+    os.homedir(),
+    `.${String(ConfigFolderName)}`,
+    "template-version-v4.txt"
+  );
+  return !fs.pathExistsSync(v4VersionFile);
 }

--- a/packages/fx-core/src/component/generator/templateHelper.ts
+++ b/packages/fx-core/src/component/generator/templateHelper.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { featureFlagManager, FeatureFlags } from "../../common/featureFlags";
+
 const packageJson = require("../../../package.json");
 
 /**
@@ -21,4 +23,22 @@ export function useLocalTemplate(): boolean {
   }
 
   return false;
+}
+
+/**
+ * Transitional: the v4 channel only publishes online metadata for stable
+ * (goproduct) releases under `templates-v4@<ver>`. Prerelease/test builds have
+ * no v4 release, so when the v4 flag is on for a prerelease build the metadata
+ * and UI readers must read the bundled copy and ignore any (possibly stale v3)
+ * `~/.fx` cache left by a previous v3 run. Stable v4 builds download v4 metadata
+ * into `~/.fx` and read it from there as usual.
+ *
+ * Remove once selector.json drives metadata distribution.
+ */
+export function useBundledMetadataForV4(): boolean {
+  if (!featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled)) {
+    return false;
+  }
+  const version: string = packageJson.version;
+  return version.includes("alpha") || version.includes("beta") || version.includes("rc");
 }

--- a/packages/fx-core/src/component/generator/templates/metadata/index.ts
+++ b/packages/fx-core/src/component/generator/templates/metadata/index.ts
@@ -20,10 +20,14 @@ function getTemplateMetadataConfig(configName: string, platform?: Platform): Tem
     configName
   );
 
-  // Check if cached JSON exists, otherwise fallback to bundled templates folder
+  // Check if cached JSON exists, otherwise fallback to bundled templates folder.
+  // The v4 channel migration covers only the VSC/CLI metadata (`templates-v4@`);
+  // VS keeps its v3 `templates-vs@` cache untouched, so the v4 bundled decision
+  // is not applied for Platform.VS.
+  const forceBundledForV4 = platform !== Platform.VS && useBundledMetadataForV4();
   if (
     !useLocalTemplate() &&
-    !useBundledMetadataForV4() &&
+    !forceBundledForV4 &&
     cachedJsonPath &&
     fs.pathExistsSync(cachedJsonPath)
   ) {

--- a/packages/fx-core/src/component/generator/templates/metadata/index.ts
+++ b/packages/fx-core/src/component/generator/templates/metadata/index.ts
@@ -6,7 +6,7 @@ import fs from "fs-extra";
 import os from "os";
 import path from "path";
 import { getTemplatesFolder } from "../../../../folder";
-import { useLocalTemplate } from "../../templateHelper";
+import { useBundledMetadataForV4, useLocalTemplate } from "../../templateHelper";
 import { Template } from "./interface";
 
 function getTemplateMetadataConfig(configName: string, platform?: Platform): Template[] {
@@ -21,7 +21,12 @@ function getTemplateMetadataConfig(configName: string, platform?: Platform): Tem
   );
 
   // Check if cached JSON exists, otherwise fallback to bundled templates folder
-  if (!useLocalTemplate() && cachedJsonPath && fs.pathExistsSync(cachedJsonPath)) {
+  if (
+    !useLocalTemplate() &&
+    !useBundledMetadataForV4() &&
+    cachedJsonPath &&
+    fs.pathExistsSync(cachedJsonPath)
+  ) {
     jsonPath = cachedJsonPath;
   } else {
     jsonPath = path.join(getTemplatesFolder(), "metadata", configName);

--- a/packages/fx-core/src/component/generator/v4MetadataSource.ts
+++ b/packages/fx-core/src/component/generator/v4MetadataSource.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { FxError } from "@microsoft/teamsfx-api";
+import { Result } from "neverthrow";
+import templateConfig from "../../common/templates-config.json";
+import { loadBundledFloor } from "../../v4/distribution/bundledFloor";
+import { TemplateSource, resolveTemplateSource } from "../../v4/distribution/templateSource";
+import { createTemplateSourcePort } from "../../v4/distribution/templateSourcePort";
+import { defaultTryLimits } from "./constant";
+
+/**
+ * Resolve which v4 template release the metadata should come from, using the
+ * SAME single decision point as the template package:
+ * `resolveTemplateSource((v4.range, v4.bundled, port))`.
+ *
+ * `bundled` is CD-baked (= !goproduct), so goproduct builds (stable AND
+ * prerelease) resolve to an `online`/`cache` source while non-goproduct/daily
+ * builds resolve to the bundled floor. The metadata.zip asset lives in the same
+ * `templates-v4@<version>` release as the resolved package, so the resolved
+ * version names the release that `fetchOnlineTemplateMetadata` pulls metadata
+ * from. Resolving here also downloads, verifies, and caches the template
+ * package, so a later content scaffold reuses it with no re-download.
+ *
+ * An unreachable channel resolves to a bundled-fallback origin (not an error);
+ * only a malformed tag list or a digest mismatch surfaces as `Result.err`.
+ *
+ * Transitional: remove once selector.json drives metadata distribution.
+ */
+export function resolveV4MetadataSource(): Promise<Result<TemplateSource, FxError>> {
+  const port = createTemplateSourcePort(
+    {
+      templatesV4TagListURL: templateConfig.templatesV4TagListURL,
+      templateDownloadBaseURL: templateConfig.templateDownloadBaseURL,
+      tryLimits: defaultTryLimits,
+    },
+    loadBundledFloor()
+  );
+  return resolveTemplateSource({
+    range: templateConfig.v4.range,
+    bundled: templateConfig.v4.bundled,
+    port,
+  });
+}

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -66,6 +66,7 @@ import {
   setErrorContext,
   setTools,
 } from "../common/globalVars";
+import { featureFlagManager, FeatureFlags } from "../common/featureFlags";
 import { clearLocaleCache, getLocalizedString } from "../common/localizeUtils";
 import { ListCollaboratorResult, PermissionsResult } from "../common/permissionInterface";
 import { getProjectMetadata, isValidProjectV3 } from "../common/projectSettingsHelper";
@@ -2675,8 +2676,16 @@ export class FxCore extends FxCoreOpenPluginPart {
         return ok(undefined); // Already up-to-date
       }
 
-      // Construct metadata.zip download URL based on tag prefix and version
-      const tag = `${templateConfig.tagPrefix}${latestVersion}`;
+      // Construct metadata.zip download URL based on tag prefix and version.
+      // Transitional: when the v4 channel is enabled, pull metadata from the
+      // v4 release tag (`templates-v4@<ver>`). The v4 release shares the exact
+      // same version string as the v3 `templates@<ver>` release (both minted
+      // from the same templates version), so only the tag prefix differs.
+      // Remove this branch once selector.json drives metadata distribution.
+      const tagPrefix = featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled)
+        ? templateConfig.v4tagPrefix
+        : templateConfig.tagPrefix;
+      const tag = `${tagPrefix}${latestVersion}`;
       const metadataZipUrl = `${templateConfig.templateDownloadBaseURL}/${tag}/metadata.zip`;
 
       const zip = await fetchZipFromUrl(metadataZipUrl);

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -2667,6 +2667,17 @@ export class FxCore extends FxCoreOpenPluginPart {
       // cache hit, while still caching within a channel (no re-download every
       // activation). Remove once selector.json drives metadata distribution.
       const useV4Channel = featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled);
+
+      // Transitional: the v4 channel publishes no mutable `0.0.0-rc` release
+      // (only immutable `templates-v4@<ver>` tags minted on stable CD) and is
+      // bundled during the prerelease/test phase. So in v4 mode on a daily/
+      // beta/rc build, skip the online fetch (the v4 RC URL would 404 on every
+      // activation) and let the readers fall back to bundled metadata. Remove
+      // once selector.json drives metadata distribution.
+      if (useV4Channel && latestVersion === "0.0.0-rc") {
+        return ok(undefined);
+      }
+
       const versionFile = path.join(
         metadataDir,
         useV4Channel ? "template-version-v4.txt" : "template-version.txt"

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -141,6 +141,7 @@ import {
 } from "../component/generator/openApiSpec/helper";
 import { useLocalTemplate } from "../component/generator/templateHelper";
 import { TemplateNames } from "../component/generator/templates/templateNames";
+import { resolveV4MetadataSource } from "../component/generator/v4MetadataSource";
 import {
   fetchZipFromUrl,
   getTemplateLatestVersion,
@@ -2638,46 +2639,56 @@ export class FxCore extends FxCoreOpenPluginPart {
     // Downloads the latest online template metadata (metadata.zip) into user's home .fx folder.
     // Caches the template version so subsequent calls avoid redundant downloads if unchanged.
     try {
-      // Determine latest template version (respect prerelease env variable similar to getTemplateVSCUrl)
-      const coreVersion = require("../../package.json").version as string;
-
-      let latestVersion = "0.0.0-rc";
-      if (
-        coreVersion.includes("alpha") ||
-        coreVersion.includes("beta") ||
-        coreVersion.includes("rc")
-      ) {
-        // daily build, prerelease or rc
-        latestVersion = "0.0.0-rc";
-      } else {
-        // stable version
-        latestVersion = await getTemplateLatestVersion();
-      }
+      const useV4Channel = featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled);
 
       const homedir = os.homedir();
       const metadataDir = path.join(homedir, `.${String(ConfigFolderName)}`);
       await fs.ensureDir(metadataDir);
 
-      // Transitional: when the v4 channel is enabled, pull metadata from the
-      // v4 release tag (`templates-v4@<ver>`). The v4 release shares the exact
-      // same version string as the v3 `templates@<ver>` release (both minted
-      // from the same templates version), so the cached version string alone
-      // cannot tell the two channels apart. Use a channel-specific cache file
-      // so flipping the flag triggers a fresh download instead of a stale v3
-      // cache hit, while still caching within a channel (no re-download every
-      // activation). Remove once selector.json drives metadata distribution.
-      const useV4Channel = featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled);
-
-      // Transitional: the v4 channel publishes no mutable `0.0.0-rc` release
-      // (only immutable `templates-v4@<ver>` tags minted on stable CD) and is
-      // bundled during the prerelease/test phase. So in v4 mode on a daily/
-      // beta/rc build, skip the online fetch (the v4 RC URL would 404 on every
-      // activation) and let the readers fall back to bundled metadata. Remove
-      // once selector.json drives metadata distribution.
-      if (useV4Channel && latestVersion === "0.0.0-rc") {
-        return ok(undefined);
+      let latestVersion: string;
+      if (useV4Channel) {
+        // Transitional: in the v4 channel the metadata rides the SAME single
+        // decision point as the template package —
+        // `resolveTemplateSource((v4.range, v4.bundled, port))`. The `bundled`
+        // field is CD-baked (= !goproduct), so goproduct builds (stable AND
+        // prerelease) resolve to an online/cache source while non-goproduct or
+        // daily builds resolve to the bundled floor. metadata.zip lives in the
+        // same `templates-v4@<ver>` release as the resolved package, so the
+        // resolved version names the release to pull metadata from. Remove once
+        // selector.json drives metadata distribution.
+        const resolved = await resolveV4MetadataSource();
+        if (resolved.isErr()) {
+          // Malformed tag list / digest mismatch are hard errors (no silent
+          // fallback). An unreachable channel does not reach here — it already
+          // resolved to a bundled-fallback origin handled below.
+          return err(resolved.error);
+        }
+        const source = resolved.value;
+        if (source.origin === "bundled" || source.origin === "bundled-fallback") {
+          // Bundled build or unreachable channel: read the bundled metadata
+          // (the readers fall back via `useBundledMetadataForV4`). No download.
+          return ok(undefined);
+        }
+        latestVersion = source.version;
+      } else {
+        // v3: prerelease builds use the mutable rolling `0.0.0-rc` tag; stable
+        // builds resolve the latest published templates version.
+        const coreVersion = require("../../package.json").version as string;
+        if (
+          coreVersion.includes("alpha") ||
+          coreVersion.includes("beta") ||
+          coreVersion.includes("rc")
+        ) {
+          latestVersion = "0.0.0-rc";
+        } else {
+          latestVersion = await getTemplateLatestVersion();
+        }
       }
 
+      // Use a channel-specific cache file so flipping the flag triggers a fresh
+      // download instead of a stale v3 cache hit; the v4 file's presence is also
+      // the readers' signal (`useBundledMetadataForV4`) that downloaded v4
+      // metadata is available.
       const versionFile = path.join(
         metadataDir,
         useV4Channel ? "template-version-v4.txt" : "template-version.txt"

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -2658,7 +2658,19 @@ export class FxCore extends FxCoreOpenPluginPart {
       const metadataDir = path.join(homedir, `.${String(ConfigFolderName)}`);
       await fs.ensureDir(metadataDir);
 
-      const versionFile = path.join(metadataDir, "template-version.txt");
+      // Transitional: when the v4 channel is enabled, pull metadata from the
+      // v4 release tag (`templates-v4@<ver>`). The v4 release shares the exact
+      // same version string as the v3 `templates@<ver>` release (both minted
+      // from the same templates version), so the cached version string alone
+      // cannot tell the two channels apart. Use a channel-specific cache file
+      // so flipping the flag triggers a fresh download instead of a stale v3
+      // cache hit, while still caching within a channel (no re-download every
+      // activation). Remove once selector.json drives metadata distribution.
+      const useV4Channel = featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled);
+      const versionFile = path.join(
+        metadataDir,
+        useV4Channel ? "template-version-v4.txt" : "template-version.txt"
+      );
       const needDownload = async (): Promise<boolean> => {
         // Always re-download for mutable pre-release tags (content changes but tag stays the same)
         if (latestVersion === "0.0.0-rc") return true;
@@ -2677,14 +2689,7 @@ export class FxCore extends FxCoreOpenPluginPart {
       }
 
       // Construct metadata.zip download URL based on tag prefix and version.
-      // Transitional: when the v4 channel is enabled, pull metadata from the
-      // v4 release tag (`templates-v4@<ver>`). The v4 release shares the exact
-      // same version string as the v3 `templates@<ver>` release (both minted
-      // from the same templates version), so only the tag prefix differs.
-      // Remove this branch once selector.json drives metadata distribution.
-      const tagPrefix = featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled)
-        ? templateConfig.v4tagPrefix
-        : templateConfig.tagPrefix;
+      const tagPrefix = useV4Channel ? templateConfig.v4tagPrefix : templateConfig.tagPrefix;
       const tag = `${tagPrefix}${latestVersion}`;
       const metadataZipUrl = `${templateConfig.templateDownloadBaseURL}/${tag}/metadata.zip`;
 

--- a/packages/fx-core/src/question/scaffold/vsc/rootNode.ts
+++ b/packages/fx-core/src/question/scaffold/vsc/rootNode.ts
@@ -6,7 +6,10 @@ import fs from "fs-extra";
 import os from "os";
 import path from "path";
 import { TOOLS } from "../../../common/globalVars";
-import { useLocalTemplate } from "../../../component/generator/templateHelper";
+import {
+  useBundledMetadataForV4,
+  useLocalTemplate,
+} from "../../../component/generator/templateHelper";
 import { getTemplatesFolder } from "../../../folder";
 import { constructNode } from "../constructNode";
 
@@ -31,7 +34,7 @@ function loadUiNode(fileName: string, platform: Platform): IQTreeNode {
 
   let jsonPath: string;
   let source: string;
-  if (!useLocalTemplate() && fs.pathExistsSync(cachedJsonPath)) {
+  if (!useLocalTemplate() && !useBundledMetadataForV4() && fs.pathExistsSync(cachedJsonPath)) {
     jsonPath = cachedJsonPath;
     source = "cache";
   } else {

--- a/packages/fx-core/tests/component/generator/templates/metadata.test.ts
+++ b/packages/fx-core/tests/component/generator/templates/metadata.test.ts
@@ -14,6 +14,8 @@ import {
 import * as templateHelper from "../../../../src/component/generator/templateHelper";
 import * as folder from "../../../../src/folder";
 import { Template } from "../../../../src/component/generator/templates/metadata/interface";
+import { featureFlagManager } from "../../../../src/common/featureFlags";
+import packageJson from "../../../../package.json";
 
 const mockTemplates: Template[] = [
   { id: "t1", name: "TypeScript Bot", language: "typescript", description: "A TS bot" },
@@ -97,6 +99,23 @@ describe("metadata platform routing", () => {
 
       const readPath = readFileSyncStub.firstCall.args[0] as string;
       assert.include(readPath, bundledPath);
+    });
+
+    it("falls back to bundled path when v4 channel forces bundled metadata even if cache exists", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(templateHelper, "useBundledMetadataForV4").returns(true);
+      const bundledPath = path.resolve("/bundled");
+      sandbox.stub(folder, "getTemplatesFolder").returns(bundledPath);
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      const readFileSyncStub = sandbox
+        .stub(fs, "readFileSync")
+        .returns(JSON.stringify(mockTemplates));
+
+      getAllTemplatesOnPlatform(Platform.VSCode);
+
+      const readPath = readFileSyncStub.firstCall.args[0] as string;
+      assert.include(readPath, bundledPath);
+      assert.notInclude(readPath, ".fx");
     });
 
     it("returns only csharp templates for Platform.VS", () => {
@@ -215,4 +234,35 @@ describe("metadata platform routing", () => {
       assert.deepEqual(result, []);
     });
   });
+});
+
+describe("useBundledMetadataForV4", () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("returns false when the v4 flag is off", () => {
+    sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+    sandbox.stub(packageJson, "version").value("1.0.0-rc.0");
+
+    assert.isFalse(templateHelper.useBundledMetadataForV4());
+  });
+
+  it("returns false for a stable build even when the v4 flag is on", () => {
+    sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+    sandbox.stub(packageJson, "version").value("1.0.0");
+
+    assert.isFalse(templateHelper.useBundledMetadataForV4());
+  });
+
+  for (const version of ["1.0.0-alpha.0", "1.0.0-beta.1", "1.0.0-rc.2"]) {
+    it(`returns true for prerelease build ${version} when the v4 flag is on`, () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+      sandbox.stub(packageJson, "version").value(version);
+
+      assert.isTrue(templateHelper.useBundledMetadataForV4());
+    });
+  }
 });

--- a/packages/fx-core/tests/component/generator/templates/metadata.test.ts
+++ b/packages/fx-core/tests/component/generator/templates/metadata.test.ts
@@ -15,7 +15,6 @@ import * as templateHelper from "../../../../src/component/generator/templateHel
 import * as folder from "../../../../src/folder";
 import { Template } from "../../../../src/component/generator/templates/metadata/interface";
 import { featureFlagManager } from "../../../../src/common/featureFlags";
-import packageJson from "../../../../package.json";
 
 const mockTemplates: Template[] = [
   { id: "t1", name: "TypeScript Bot", language: "typescript", description: "A TS bot" },
@@ -116,6 +115,20 @@ describe("metadata platform routing", () => {
       const readPath = readFileSyncStub.firstCall.args[0] as string;
       assert.include(readPath, bundledPath);
       assert.notInclude(readPath, ".fx");
+    });
+
+    it("keeps reading the VS cache even when v4 channel forces bundled metadata", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(templateHelper, "useBundledMetadataForV4").returns(true);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      const pathExistsStub = sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      getAllTemplatesOnPlatform(Platform.VS);
+
+      // The v4 migration covers only VSC/CLI; VS keeps its v3 vs-metadata cache.
+      const checkedPath = pathExistsStub.firstCall.args[0] as string;
+      assert.include(checkedPath, "vs-metadata");
     });
 
     it("returns only csharp templates for Platform.VS", () => {
@@ -245,24 +258,26 @@ describe("useBundledMetadataForV4", () => {
 
   it("returns false when the v4 flag is off", () => {
     sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
-    sandbox.stub(packageJson, "version").value("1.0.0-rc.0");
+    const pathExistsStub = sandbox.stub(fs, "pathExistsSync").returns(false);
 
     assert.isFalse(templateHelper.useBundledMetadataForV4());
+    // Short-circuits before touching the filesystem.
+    assert.isFalse(pathExistsStub.called);
   });
 
-  it("returns false for a stable build even when the v4 flag is on", () => {
+  it("returns false (read the downloaded v4 cache) when the v4 version file exists", () => {
     sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
-    sandbox.stub(packageJson, "version").value("1.0.0");
+    const pathExistsStub = sandbox.stub(fs, "pathExistsSync").returns(true);
 
     assert.isFalse(templateHelper.useBundledMetadataForV4());
+    const checkedPath = pathExistsStub.firstCall.args[0] as string;
+    assert.include(checkedPath, "template-version-v4.txt");
   });
 
-  for (const version of ["1.0.0-alpha.0", "1.0.0-beta.1", "1.0.0-rc.2"]) {
-    it(`returns true for prerelease build ${version} when the v4 flag is on`, () => {
-      sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
-      sandbox.stub(packageJson, "version").value(version);
+  it("returns true (read bundled) when the v4 version file is absent", () => {
+    sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+    sandbox.stub(fs, "pathExistsSync").returns(false);
 
-      assert.isTrue(templateHelper.useBundledMetadataForV4());
-    });
-  }
+    assert.isTrue(templateHelper.useBundledMetadataForV4());
+  });
 });

--- a/packages/fx-core/tests/component/generator/v4MetadataSource.test.ts
+++ b/packages/fx-core/tests/component/generator/v4MetadataSource.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import "mocha";
+import { ok, Result } from "neverthrow";
+import * as sinon from "sinon";
+import { FxError } from "@microsoft/teamsfx-api";
+import templateConfig from "../../../src/common/templates-config.json";
+import { resolveV4MetadataSource } from "../../../src/component/generator/v4MetadataSource";
+import * as bundledFloor from "../../../src/v4/distribution/bundledFloor";
+import * as templateSource from "../../../src/v4/distribution/templateSource";
+import * as templateSourcePort from "../../../src/v4/distribution/templateSourcePort";
+
+describe("resolveV4MetadataSource", () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("resolves through the same single decision point as the template package", async () => {
+    const fakeFloor = { version: "6.10.1" } as any;
+    const fakePort = { tagList: () => Promise.resolve([]) } as any;
+    const loadFloorStub = sandbox.stub(bundledFloor, "loadBundledFloor").returns(fakeFloor);
+    const createPortStub = sandbox
+      .stub(templateSourcePort, "createTemplateSourcePort")
+      .returns(fakePort);
+    const expected: Result<templateSource.TemplateSource, FxError> = ok({
+      origin: "online" as const,
+      version: "2.0.0",
+      digest: "sha256:x",
+      location: "",
+    });
+    const resolveStub = sandbox.stub(templateSource, "resolveTemplateSource").resolves(expected);
+
+    const result = await resolveV4MetadataSource();
+
+    assert.strictEqual(result, expected);
+    assert.isTrue(loadFloorStub.calledOnce);
+    // The port is built from the v4 channel config in templates-config.json.
+    assert.isTrue(
+      createPortStub.calledOnceWith(
+        sinon.match({
+          templatesV4TagListURL: templateConfig.templatesV4TagListURL,
+          templateDownloadBaseURL: templateConfig.templateDownloadBaseURL,
+        }),
+        fakeFloor
+      )
+    );
+    // The resolver reads v4.range / v4.bundled (never the top-level version).
+    assert.isTrue(
+      resolveStub.calledOnceWith(
+        sinon.match({
+          range: templateConfig.v4.range,
+          bundled: templateConfig.v4.bundled,
+          port: fakePort,
+        })
+      )
+    );
+  });
+});

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -7961,6 +7961,29 @@ describe("fetchOnlineTemplateMetadata", () => {
     assert.isTrue(unzipStub.calledOnce);
   });
 
+  it("should skip online fetch in v4 channel for a prerelease (0.0.0-rc) build", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(packageJson, "version").value("1.0.0-rc.0");
+    sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+
+    const getLatestStub = sandbox.stub(generatorUtils, "getTemplateLatestVersion");
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl");
+    const unzipStub = sandbox.stub(generatorUtils, "unzip");
+
+    sandbox.stub(fs, "ensureDir").resolves();
+    const writeFileStub = sandbox.stub(fs, "writeFile").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadata();
+
+    assert.isTrue(result.isOk());
+    // The v4 channel has no `templates-v4@0.0.0-rc` release: do not hit the
+    // network and let the readers fall back to bundled metadata.
+    assert.equal(getLatestStub.called, false);
+    assert.equal(fetchZipStub.called, false);
+    assert.equal(unzipStub.called, false);
+    assert.equal(writeFileStub.called, false);
+  });
+
   it("should skip download when cached version matches latest version", async () => {
     sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(packageJson, "version").value("1.0.0");

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -7894,6 +7894,36 @@ describe("fetchOnlineTemplateMetadata", () => {
     assert.isTrue(writeFileStub.calledWith(sinon.match.string, "2.0.0", { encoding: "utf-8" }));
   });
 
+  it("should download metadata from the v4 release tag when V4 channel is enabled", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(templateConfigModule, "v4tagPrefix").value("templates-v4@");
+    sandbox
+      .stub(templateConfigModule, "templateDownloadBaseURL")
+      .value("https://example.com/releases/download");
+    sandbox.stub(packageJson, "version").value("1.0.0");
+    sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+
+    sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("2.0.0");
+    const mockZip = new AdmZip();
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
+    const unzipStub = sandbox.stub(generatorUtils, "unzip").resolves();
+
+    sandbox.stub(fs, "pathExists").resolves(false);
+    sandbox.stub(fs, "ensureDir").resolves();
+    sandbox.stub(fs, "writeFile").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadata();
+
+    assert.isTrue(result.isOk());
+    assert.isTrue(fetchZipStub.calledOnce);
+    assert.isTrue(
+      fetchZipStub.calledWith(
+        "https://example.com/releases/download/templates-v4@2.0.0/metadata.zip"
+      )
+    );
+    assert.isTrue(unzipStub.calledOnce);
+  });
+
   it("should skip download when cached version matches latest version", async () => {
     sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(packageJson, "version").value("1.0.0");

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -7997,6 +7997,32 @@ describe("fetchOnlineTemplateMetadata", () => {
     assert.equal(writeFileStub.called, false);
   });
 
+  it("should return error when v4 source resolution fails", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(packageJson, "version").value("1.0.0");
+    sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+
+    // A malformed tag list / digest mismatch is a hard error (no silent fallback).
+    const resolveError = new UserError("test", "ResolveError", "resolve failed");
+    const resolveStub = sandbox
+      .stub(v4MetadataSource, "resolveV4MetadataSource")
+      .resolves(err(resolveError));
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl");
+    const unzipStub = sandbox.stub(generatorUtils, "unzip");
+
+    sandbox.stub(fs, "ensureDir").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadata();
+
+    assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      assert.strictEqual(result.error, resolveError);
+    }
+    assert.equal(resolveStub.called, true);
+    assert.equal(fetchZipStub.called, false);
+    assert.equal(unzipStub.called, false);
+  });
+
   it("should skip download when cached version matches latest version", async () => {
     sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(packageJson, "version").value("1.0.0");

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -91,6 +91,7 @@ import * as oneDriveSharePointHandler from "../../src/component/generator/declar
 import * as openApiSpecHelper from "../../src/component/generator/openApiSpec/helper";
 import * as templateHelper from "../../src/component/generator/templateHelper";
 import { TemplateNames } from "../../src/component/generator/templates/templateNames";
+import * as v4MetadataSource from "../../src/component/generator/v4MetadataSource";
 import * as generatorUtils from "../../src/component/generator/utils";
 import { LaunchHelper } from "../../src/component/m365/launchHelper";
 import { envUtil } from "../../src/component/utils/envUtil";
@@ -7903,11 +7904,14 @@ describe("fetchOnlineTemplateMetadata", () => {
     sandbox.stub(packageJson, "version").value("1.0.0");
     sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
 
-    sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("2.0.0");
+    // The v4 metadata rides the same decision point as the template package; an
+    // online source names the `templates-v4@<version>` release to pull from.
+    sandbox
+      .stub(v4MetadataSource, "resolveV4MetadataSource")
+      .resolves(ok({ origin: "online", version: "2.0.0", digest: "sha256:x", location: "" }));
     const mockZip = new AdmZip();
     const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
     const unzipStub = sandbox.stub(generatorUtils, "unzip").resolves();
-
     sandbox.stub(fs, "pathExists").resolves(false);
     sandbox.stub(fs, "ensureDir").resolves();
     const writeFileStub = sandbox.stub(fs, "writeFile").resolves();
@@ -7940,7 +7944,9 @@ describe("fetchOnlineTemplateMetadata", () => {
     sandbox.stub(packageJson, "version").value("1.0.0");
     sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
 
-    sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("2.0.0");
+    sandbox
+      .stub(v4MetadataSource, "resolveV4MetadataSource")
+      .resolves(ok({ origin: "online", version: "2.0.0", digest: "sha256:x", location: "" }));
     const mockZip = new AdmZip();
     const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
     const unzipStub = sandbox.stub(generatorUtils, "unzip").resolves();
@@ -7961,12 +7967,19 @@ describe("fetchOnlineTemplateMetadata", () => {
     assert.isTrue(unzipStub.calledOnce);
   });
 
-  it("should skip online fetch in v4 channel for a prerelease (0.0.0-rc) build", async () => {
+  it("should skip online fetch in v4 channel when the resolved source is bundled", async () => {
     sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(packageJson, "version").value("1.0.0-rc.0");
     sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
 
-    const getLatestStub = sandbox.stub(generatorUtils, "getTemplateLatestVersion");
+    // A bundled (non-goproduct) or unreachable channel resolves to a bundled /
+    // bundled-fallback origin: the readers fall back to bundled metadata and no
+    // download happens.
+    const resolveStub = sandbox
+      .stub(v4MetadataSource, "resolveV4MetadataSource")
+      .resolves(
+        ok({ origin: "bundled-fallback", version: "6.10.1", digest: "sha256:x", location: "" })
+      );
     const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl");
     const unzipStub = sandbox.stub(generatorUtils, "unzip");
 
@@ -7976,9 +7989,9 @@ describe("fetchOnlineTemplateMetadata", () => {
     const result = await core.fetchOnlineTemplateMetadata();
 
     assert.isTrue(result.isOk());
-    // The v4 channel has no `templates-v4@0.0.0-rc` release: do not hit the
-    // network and let the readers fall back to bundled metadata.
-    assert.equal(getLatestStub.called, false);
+    // The resolved source is bundled: do not hit the network and let the readers
+    // fall back to bundled metadata.
+    assert.equal(resolveStub.called, true);
     assert.equal(fetchZipStub.called, false);
     assert.equal(unzipStub.called, false);
     assert.equal(writeFileStub.called, false);

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -7910,7 +7910,7 @@ describe("fetchOnlineTemplateMetadata", () => {
 
     sandbox.stub(fs, "pathExists").resolves(false);
     sandbox.stub(fs, "ensureDir").resolves();
-    sandbox.stub(fs, "writeFile").resolves();
+    const writeFileStub = sandbox.stub(fs, "writeFile").resolves();
 
     const result = await core.fetchOnlineTemplateMetadata();
 
@@ -7921,6 +7921,43 @@ describe("fetchOnlineTemplateMetadata", () => {
         "https://example.com/releases/download/templates-v4@2.0.0/metadata.zip"
       )
     );
+    assert.isTrue(unzipStub.calledOnce);
+    // The v4 channel uses its own version cache file so switching the flag does
+    // not get a stale hit on the shared v3 cache.
+    assert.isTrue(
+      writeFileStub.calledWith(sinon.match(/template-version-v4\.txt$/), "2.0.0", {
+        encoding: "utf-8",
+      })
+    );
+  });
+
+  it("should still download v4 metadata when only the shared v3 cache is current", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(templateConfigModule, "v4tagPrefix").value("templates-v4@");
+    sandbox
+      .stub(templateConfigModule, "templateDownloadBaseURL")
+      .value("https://example.com/releases/download");
+    sandbox.stub(packageJson, "version").value("1.0.0");
+    sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+
+    sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("2.0.0");
+    const mockZip = new AdmZip();
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
+    const unzipStub = sandbox.stub(generatorUtils, "unzip").resolves();
+
+    sandbox.stub(fs, "ensureDir").resolves();
+    sandbox.stub(fs, "writeFile").resolves();
+    // The v4 version file is absent even though the (shared-name) v3 cache would
+    // otherwise look current; the v4 channel must not be fooled into skipping.
+    sandbox
+      .stub(fs, "pathExists")
+      .callsFake((p: string) => Promise.resolve(p.endsWith("template-version.txt")));
+    sandbox.stub(fs, "readFile").resolves("2.0.0" as any);
+
+    const result = await core.fetchOnlineTemplateMetadata();
+
+    assert.isTrue(result.isOk());
+    assert.isTrue(fetchZipStub.calledOnce);
     assert.isTrue(unzipStub.calledOnce);
   });
 

--- a/packages/fx-core/tests/question/scaffold.test.ts
+++ b/packages/fx-core/tests/question/scaffold.test.ts
@@ -48,6 +48,7 @@ import { daProjectTypeNode } from "../../src/question/scaffold/vsc/daProjectType
 
 import * as mcpToolFetcher from "../../src/component/utils/mcpToolFetcher";
 import fs from "fs-extra";
+import * as templateHelper from "../../src/component/generator/templateHelper";
 import {
   BotCapabilityOptions,
   CustomCopilotRagOptions,
@@ -1223,6 +1224,20 @@ describe("rootNode", () => {
     const nodeCLI = getRootProjectTypeNode(Platform.CLI);
     assert.isDefined(nodeCLI);
     assert.isDefined(nodeCLI.data);
+  });
+
+  it("should load bundled UI node when v4 channel forces bundled metadata even if cache exists", () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(templateHelper, "useBundledMetadataForV4").returns(true);
+    sandbox.stub(fs, "pathExistsSync").returns(true);
+    const readFileSyncStub = sandbox
+      .stub(fs, "readFileSync")
+      .returns(JSON.stringify({ data: { type: "group", name: "root" } }));
+
+    getRootProjectTypeNode(Platform.VSCode);
+
+    const readPath = readFileSyncStub.firstCall.args[0] as string;
+    assert.notInclude(readPath, `.fx`);
   });
 });
 


### PR DESCRIPTION
## What

Transitional follow-up to #16086. When the v4 channel flag (`TEAMSFX_V4_ENABLED`) is on, `fetchOnlineTemplateMetadata` downloads `metadata.zip` from the `templates-v4@<ver>` release instead of `templates@<ver>`. The v4 release shares the exact same version string as the v3 release, so only the tag prefix differs; version resolution, cache, unzip target (`~/.fx`) and the metadata/ui readers are untouched.

The v4 publish script (`publish-v4-channel.sh`) now mirrors `metadata.zip` onto the v4 release, and `cd.yml` passes its path.

## Why

Keeps v4-channel metadata version-consistent with v4 template content while the v3 channel stays the default. Explicitly transitional — remove once `selector.json` drives metadata distribution.

## Tests

Added `should download metadata from the v4 release tag when V4 channel is enabled`; all 23 `fetchOnlineTemplateMetadata*` tests pass.