### PR TITLE
fix(vscode): use MCP gateway tools directly so Fetch action works on macOS (backport to release/6.10)

### DIFF
--- a/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
+++ b/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
@@ -247,8 +247,6 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
           inputSchema: tool.inputSchema as any,
         };
       });
-    // Build a lookup key set using name+description to handle tools with duplicate names
-    const selectedToolKeys = new Set(selectedTools.map((t) => `${t.name}\n${t.description}`));
     try {
       // startMcpGateway is a proposed API (VS Code Insiders only)
       const mcpGateway = await vscode.lm.startMcpGateway();
@@ -270,15 +268,21 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
           try {
             await client.connect(transport);
             const result = await client.listTools();
-            const matched = new Set<string>();
-            tools = result.tools.filter((tool) => {
+            // The gateway queries the running MCP server directly, so its tool list is
+            // authoritative. Use it as-is instead of intersecting with vscode.lm.tools,
+            // which is not reliably populated for MCP servers on all platforms (e.g. macOS)
+            // and would otherwise collapse the result to an empty list. Deduplicate on
+            // name+description in case a proxied server reports the same tool twice.
+            const seen = new Set<string>();
+            const gatewayTools = result.tools.filter((tool) => {
               const key = `${tool.name}\n${tool.description ?? ""}`;
-              if (selectedToolKeys.has(key) && !matched.has(key)) {
-                matched.add(key);
-                return true;
+              if (seen.has(key)) {
+                return false;
               }
-              return false;
+              seen.add(key);
+              return true;
             });
+            tools = gatewayTools.length > 0 ? gatewayTools : selectedTools;
           } catch {
             tools = selectedTools;
           } finally {

--- a/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
+++ b/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
@@ -1176,7 +1176,47 @@ describe("updateActionWithMCP", () => {
       sinon.assert.calledOnce(mockGateway.dispose as sinon.SinonStub);
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
       const tools = calledInputs[QuestionNames.MCPForDAAvailableTools];
-      // tool3 should be excluded because it's not in selectedToolKeys
+      // The gateway's tool list is authoritative; all server tools are returned as-is.
+      chai.assert.equal(tools.length, 3);
+      chai.assert.equal(tools[0].name, "tool1");
+      chai.assert.equal(tools[1].name, "tool2");
+      chai.assert.equal(tools[2].name, "tool3");
+    });
+
+    it("should use gateway tools even when vscode.lm.tools is empty (macOS regression)", async () => {
+      const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
+
+      // On macOS the MCP server's tools are not surfaced in vscode.lm.tools, so the
+      // selectedTools filter is empty. The gateway result must still be used.
+      sandbox.stub(vscode.lm, "tools").value([]);
+      const mockGateway = {
+        servers: [{ label: "testServer", address: { toString: () => "http://localhost:12345" } }],
+        dispose: sandbox.stub(),
+      };
+      Object.defineProperty(vscode.lm, "startMcpGateway", {
+        value: sandbox.stub().resolves(mockGateway),
+        configurable: true,
+      });
+      const connectStub = sandbox.stub(Client.prototype, "connect").resolves();
+      const listToolsStub = sandbox.stub(Client.prototype, "listTools").resolves({
+        tools: [
+          { name: "tool1", description: "Test tool 1", inputSchema: { type: "object" as const } },
+          { name: "tool2", description: "Test tool 2", inputSchema: { type: "object" as const } },
+        ],
+      });
+      const closeStub = sandbox.stub(Client.prototype, "close").resolves();
+      sandbox.stub(axios, "get").resolves({ status: 200 });
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP(args);
+
+      chai.assert.isTrue(result.isOk());
+      sinon.assert.calledOnce(connectStub);
+      sinon.assert.calledOnce(listToolsStub);
+      sinon.assert.calledOnce(closeStub);
+      sinon.assert.calledOnce(mockGateway.dispose as sinon.SinonStub);
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      const tools = calledInputs[QuestionNames.MCPForDAAvailableTools];
       chai.assert.equal(tools.length, 2);
       chai.assert.equal(tools[0].name, "tool1");
       chai.assert.equal(tools[1].name, "tool2");
@@ -1249,7 +1289,7 @@ describe("updateActionWithMCP", () => {
       chai.assert.equal(tools.length, 1);
     });
 
-    it("should exclude gateway tools not in selectedToolKeys", async () => {
+    it("should include gateway tools even when absent from vscode.lm.tools", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
         { name: "mcp_testserver_tool1", description: "Tool A", inputSchema: {}, tags: [] },
@@ -1269,18 +1309,24 @@ describe("updateActionWithMCP", () => {
         tools: [
           {
             name: "unknownTool",
-            description: "Not matched",
+            description: "Not in vscode.lm.tools",
             inputSchema: { type: "object" as const },
           },
         ],
       });
       sandbox.stub(Client.prototype, "close").resolves();
       sandbox.stub(axios, "get").resolves({ status: 200 });
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       const result = await updateActionWithMCP(args);
 
-      // No tools match, so should return error
-      chai.assert.isTrue(result.isErr());
+      // The gateway list is authoritative, so the tool is included even though it is
+      // not present in vscode.lm.tools.
+      chai.assert.isTrue(result.isOk());
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      const tools = calledInputs[QuestionNames.MCPForDAAvailableTools];
+      chai.assert.equal(tools.length, 1);
+      chai.assert.equal(tools[0].name, "unknownTool");
     });
 
     it("should fall back to old gateway address API when servers property is absent", async () => {

--- a/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
+++ b/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
@@ -1201,7 +1201,8 @@ describe("updateActionWithMCP", () => {
       const listToolsStub = sandbox.stub(Client.prototype, "listTools").resolves({
         tools: [
           { name: "tool1", description: "Test tool 1", inputSchema: { type: "object" as const } },
-          { name: "tool2", description: "Test tool 2", inputSchema: { type: "object" as const } },
+          // tool2 has no description, exercising the `description ?? ""` dedup key path.
+          { name: "tool2", inputSchema: { type: "object" as const } },
         ],
       });
       const closeStub = sandbox.stub(Client.prototype, "close").resolves();
@@ -1287,6 +1288,42 @@ describe("updateActionWithMCP", () => {
       const tools = calledInputs[QuestionNames.MCPForDAAvailableTools];
       // Only first match should be kept due to dedup
       chai.assert.equal(tools.length, 1);
+    });
+
+    it("should fall back to selectedTools when gateway returns an empty tool list", async () => {
+      const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
+      const mockTools = [
+        { name: "mcp_testserver_tool1", description: "Fallback tool", inputSchema: {}, tags: [] },
+      ];
+
+      sandbox.stub(vscode.lm, "tools").value(mockTools);
+      const mockGateway = {
+        servers: [{ label: "testServer", address: { toString: () => "http://localhost:12345" } }],
+        dispose: sandbox.stub(),
+      };
+      Object.defineProperty(vscode.lm, "startMcpGateway", {
+        value: sandbox.stub().resolves(mockGateway),
+        configurable: true,
+      });
+      sandbox.stub(Client.prototype, "connect").resolves();
+      const listToolsStub = sandbox.stub(Client.prototype, "listTools").resolves({
+        tools: [],
+      });
+      const closeStub = sandbox.stub(Client.prototype, "close").resolves();
+      sandbox.stub(axios, "get").resolves({ status: 200 });
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP(args);
+
+      chai.assert.isTrue(result.isOk());
+      sinon.assert.calledOnce(listToolsStub);
+      sinon.assert.calledOnce(closeStub);
+      sinon.assert.calledOnce(mockGateway.dispose as sinon.SinonStub);
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      const tools = calledInputs[QuestionNames.MCPForDAAvailableTools];
+      // Empty gateway result falls back to the vscode.lm.tools-derived list.
+      chai.assert.equal(tools.length, 1);
+      chai.assert.equal(tools[0].name, "tool1");
     });
 
     it("should include gateway tools even when absent from vscode.lm.tools", async () => {

--- a/packages/vscode-extension/test/mocks/vscode-mock.ts
+++ b/packages/vscode-extension/test/mocks/vscode-mock.ts
@@ -250,6 +250,7 @@ mockedVSCode.commands = {
   selectChatModels: () => {},
   languageModels: [],
   onDidChangeLanguageModels: undefined as any,
+  tools: [],
 };
 
 (mockedVSCode as any).env = {


### PR DESCRIPTION
## Summary

Backport of #16101 to `release/6.10`.

Fixes #16090 — "ATK - fetch action from MCP not working" on macOS.

### Root cause
The "Fetch action from MCP" handler intersected the gateway's `listTools()` results with keys derived from `vscode.lm.tools`. On macOS, the VS Code LM tool registry (`vscode.lm.tools`) is not reliably populated for MCP servers, so the intersection collapsed to empty and produced "No tools found for the MCP server". On Windows the registry was populated, so it worked.

### Fix
Use the gateway's `listTools()` result as authoritative (deduplicated on `name` + `description`), and fall back to `vscode.lm.tools` only when the gateway is unavailable or returns an empty list.

### Tests
- Updated the "MCP gateway integration" suite to assert gateway tools are used directly.
- Added coverage for the empty-gateway-list fallback and the missing-description dedup path.
- 54 tests passing; handler at 100% statements/functions/lines, ~97% branch.

### Cherry-picked commits
- `a58a87e5ea` fix(vscode): use MCP gateway tools directly so Fetch action works on macOS
- `a1177cd1ad` test(vscode): cover gateway empty-list fallback and missing-description dedup path
