### PR TITLE
fix: copilot agent action support in share

### DIFF
--- a/packages/fx-core/src/component/driver/share/utils.ts
+++ b/packages/fx-core/src/component/driver/share/utils.ts
@@ -12,6 +12,7 @@ import { resolve } from "../../configManager/lifecycle";
 import { envUtil } from "../../utils/envUtil";
 import { metadataUtil } from "../../utils/metadataUtil";
 import { pathUtils } from "../../utils/pathUtils";
+import { actionName as agentPublishActionName } from "../copilotAgent/publish";
 import { actionName as extendToM365ActionName } from "../m365/acquire";
 import { Constants } from "../teamsApp/constants";
 
@@ -40,21 +41,22 @@ export async function parseShareAppActionYamlConfig(
       new UserError("FxCore", "Share", getLocalizedString("error.share.yamlConfigNotFound"))
     );
   }
-  const extendToM365Action =
+  const agentPublishAction =
+    projectModel.provision?.driverDefs.find((d) => d.uses === agentPublishActionName) ||
     projectModel.provision?.driverDefs.find((d) => d.uses === extendToM365ActionName) ||
     projectModel.deploy?.driverDefs.find((d) => d.uses === extendToM365ActionName);
-  if (!extendToM365Action) {
+  if (!agentPublishAction) {
     return err(
       new UserError(
         "FxCore",
         "Share",
-        getLocalizedString("error.share.shareActionConfigNotFound", extendToM365ActionName)
+        getLocalizedString("error.share.shareActionConfigNotFound", agentPublishActionName)
       )
     );
   }
 
   // 1. get manifest id
-  const appPackagePath = (extendToM365Action.with as any)?.appPackagePath;
+  const appPackagePath = (agentPublishAction.with as any)?.appPackagePath;
   if (!appPackagePath) {
     return err(
       new UserError(
@@ -69,7 +71,7 @@ export async function parseShareAppActionYamlConfig(
   if (readEnvRes.isErr()) {
     return err(readEnvRes.error);
   }
-  const resolvedDriver = resolve(extendToM365Action, [], []) as DriverDefinition;
+  const resolvedDriver = resolve(agentPublishAction, [], []) as DriverDefinition;
   const resolvedAppPackagePath = path.resolve(
     projectPath,
     (resolvedDriver.with as any).appPackagePath as string
@@ -107,8 +109,8 @@ export async function parseShareAppActionYamlConfig(
   }
 
   // 2. get shared title id and shared app id
-  const sharedTitleIdEnvName = (extendToM365Action.writeToEnvironmentFile as any)?.titleId;
-  const sharedAppIdEnvName = (extendToM365Action.writeToEnvironmentFile as any)?.appId;
+  const sharedTitleIdEnvName = (agentPublishAction.writeToEnvironmentFile as any)?.titleId;
+  const sharedAppIdEnvName = (agentPublishAction.writeToEnvironmentFile as any)?.appId;
   if (!sharedTitleIdEnvName || !sharedAppIdEnvName) {
     return err(
       new UserError("FxCore", "Share", getLocalizedString("error.share.sharedConfigNotFound"))

--- a/packages/fx-core/tests/component/driver/share/utils.test.ts
+++ b/packages/fx-core/tests/component/driver/share/utils.test.ts
@@ -294,7 +294,7 @@ describe("parseShareAppActionYamlConfig", () => {
     process.env["parseShareAppActionYamlConfigMockAppIdName"] = undefined;
   });
 
-  it("should return error when extendToM365Action is not found in either provision or deploy", async () => {
+  it("should return error when share action is not found in either provision or deploy", async () => {
     sandbox.stub(pathUtils, "getYmlFilePath").returns("mockTemplatePath");
     sandbox.stub(metadataUtil, "parse").resolves(
       ok({
@@ -320,8 +320,47 @@ describe("parseShareAppActionYamlConfig", () => {
     chai.assert.isTrue(result.isErr());
     if (result.isErr()) {
       chai.assert.equal(result.error.name, "Share");
-      chai.assert.include(result.error.message, 'Unable to find the "teamsApp/extendToM365"');
+      chai.assert.include(result.error.message, 'Unable to find the "copilotAgent/publish"');
     }
+  });
+
+  it("should find copilotAgent/publish action in provision", async () => {
+    const mockZipPath = createMockZipFile();
+    sandbox.stub(pathUtils, "getYmlFilePath").returns("mockTemplatePath");
+    sandbox.stub(metadataUtil, "parse").resolves(
+      ok({
+        provision: {
+          driverDefs: [
+            {
+              uses: "copilotAgent/publish",
+              with: { appPackagePath: mockZipPath } as any,
+              writeToEnvironmentFile: {
+                titleId: "parseShareAppActionYamlConfigMockTitleIdName",
+                appId: "parseShareAppActionYamlConfigMockAppIdName",
+              } as any,
+            },
+          ],
+        },
+      } as any)
+    );
+    sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+    sandbox.stub(fs, "existsSync").returns(true);
+    process.env["parseShareAppActionYamlConfigMockTitleIdName"] = "mockTitleId";
+    process.env["parseShareAppActionYamlConfigMockAppIdName"] = "mockAppId";
+
+    const result = await parseShareAppActionYamlConfig("mockProjectPath");
+
+    chai.assert.isTrue(result.isOk());
+    if (result.isOk()) {
+      chai.assert.deepEqual(result.value, {
+        teamsappId: "mockManifestId",
+        titleId: "mockTitleId",
+        appId: "mockAppId",
+      });
+    }
+
+    process.env["parseShareAppActionYamlConfigMockTitleIdName"] = undefined;
+    process.env["parseShareAppActionYamlConfigMockAppIdName"] = undefined;
   });
 
   it("should return error when extendToM365Action is missing", async () => {
@@ -427,6 +466,39 @@ describe("parseShareAppActionYamlConfig", () => {
     chai.assert.isTrue(result.isErr());
     if (result.isErr()) {
       chai.assert.equal(result.error.name, "Share to Users");
+    }
+  });
+
+  it("should return error when shared ids are missing in environment", async () => {
+    const mockZipPath = createMockZipFile();
+    sandbox.stub(pathUtils, "getYmlFilePath").returns("mockTemplatePath");
+    sandbox.stub(metadataUtil, "parse").resolves(
+      ok({
+        deploy: {
+          driverDefs: [
+            {
+              uses: "teamsApp/extendToM365",
+              with: { appPackagePath: mockZipPath } as any,
+              writeToEnvironmentFile: {
+                titleId: "parseShareAppActionYamlConfigMissingTitleIdName",
+                appId: "parseShareAppActionYamlConfigMissingAppIdName",
+              } as any,
+            },
+          ],
+        },
+      } as any)
+    );
+    sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+    sandbox.stub(fs, "existsSync").returns(true);
+    delete process.env["parseShareAppActionYamlConfigMissingTitleIdName"];
+    delete process.env["parseShareAppActionYamlConfigMissingAppIdName"];
+
+    const result = await parseShareAppActionYamlConfig("mockProjectPath");
+
+    chai.assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      chai.assert.equal(result.error.name, "Share");
+      chai.assert.include(result.error.message, "Unable to get title id or app id");
     }
   });
 


### PR DESCRIPTION
bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/38303646

This pull request updates the logic for parsing the Share App action YAML configuration to prioritize the `copilotAgent/publish` action over the previous `teamsApp/extendToM365` action and refines related error handling and tests. The main focus is on supporting new agent publishing flows and ensuring robust error reporting and test coverage.

Key changes include:

**Support for copilotAgent/publish action:**
* Updated `parseShareAppActionYamlConfig` in `utils.ts` to search for the `copilotAgent/publish` action before falling back to `teamsApp/extendToM365`, and adjusted variable names and error messages accordingly. [[1]](diffhunk://#diff-ddef62d6c8efb3a0cf5839f30fb909e7289495bcf1d7e7b4b5f0c1220fd22d8dR15) [[2]](diffhunk://#diff-ddef62d6c8efb3a0cf5839f30fb909e7289495bcf1d7e7b4b5f0c1220fd22d8dL43-R59) [[3]](diffhunk://#diff-ddef62d6c8efb3a0cf5839f30fb909e7289495bcf1d7e7b4b5f0c1220fd22d8dL72-R74) [[4]](diffhunk://#diff-ddef62d6c8efb3a0cf5839f30fb909e7289495bcf1d7e7b4b5f0c1220fd22d8dL110-R113)

**Test enhancements:**
* Added a new test to verify that the function correctly finds and processes the `copilotAgent/publish` action in the provision section.
* Added a test to ensure proper error handling when required shared IDs are missing from the environment.
* Updated existing tests to reflect the new action name and error message changes. [[1]](diffhunk://#diff-bb3129348556681a7cfd7b9f84da781acb3c002993624b316e32a14bf2d43014L297-R297) [[2]](diffhunk://#diff-bb3129348556681a7cfd7b9f84da781acb3c002993624b316e32a14bf2d43014L323-R365)