### PR TITLE
ci(vscuse): add /atk-vsuse-test comment trigger and make gate optional

### DIFF
--- a/.github/workflows/pr-vscuse-test-comment-trigger.yml
+++ b/.github/workflows/pr-vscuse-test-comment-trigger.yml
@@ -1,0 +1,124 @@
+name: PR VscUse Test Plan Comment Trigger
+
+# Triggered when a PR comment starts with `/atk-vsuse-test`.
+#
+# This workflow:
+#   1. Verifies the commenter has write/maintain/admin permission (anti-abuse).
+#   2. Extracts the hint text after `/atk-vsuse-test`.
+#   3. Posts a hidden marker comment (<!-- atk-vsuse-test-hint -->) carrying the hint
+#      so the existing pr-vscuse-test.yml workflow can feed it to the AI plan selector.
+#   4. Removes and re-adds the `atk-vsuse-test` label on the PR — the `pull_request: labeled`
+#      event then re-runs pr-vscuse-test.yml, which will now pick up the hint.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+concurrency:
+  group: pr-vscuse-test-comment-trigger-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  trigger-vscuse-test:
+    # Only run when the comment is on a PR and starts with the trigger keyword.
+    if: >-
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/atk-vsuse-test')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Authorize commenter and extract hint
+        id: authorize
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const assoc   = context.payload.comment.author_association;
+            if (!allowed.includes(assoc)) {
+              core.setFailed(`Commenter (${context.payload.comment.user.login}, association=${assoc}) is not authorized to trigger atk-vsuse-test.`);
+              return;
+            }
+
+            // Strip the trigger keyword and any leading whitespace/colon.
+            const raw = context.payload.comment.body || '';
+            const hint = raw
+              .replace(/^\/atk-vsuse-test\b[:\s]*/, '')
+              .trim();
+
+            core.setOutput('hint', hint);
+            core.setOutput('pr_number', String(context.payload.issue.number));
+            console.log(`PR #${context.payload.issue.number} hint (${hint.length} chars): ${hint.slice(0, 200)}`);
+
+      - name: React to triggering comment
+        if: success()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner:      context.repo.owner,
+              repo:       context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content:    'eyes',
+            });
+
+      - name: Post hidden hint marker comment
+        if: steps.authorize.outputs.hint != ''
+        uses: actions/github-script@v6
+        env:
+          HINT:      ${{ steps.authorize.outputs.hint }}
+          PR_NUMBER: ${{ steps.authorize.outputs.pr_number }}
+          ACTOR:     ${{ github.event.comment.user.login }}
+        with:
+          script: |
+            const hint     = process.env.HINT;
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const actor    = process.env.ACTOR;
+            // The marker is what pr-vscuse-test.yml searches for. Keep it stable.
+            const body = [
+              '<!-- atk-vsuse-test-hint -->',
+              `**🎯 VscUse test plan hint from @${actor}:**`,
+              '',
+              '```',
+              hint,
+              '```',
+              '',
+              '_The next `atk-vsuse-test` run will pass this hint to the AI plan selector._',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner:        context.repo.owner,
+              repo:         context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+      - name: (Re)apply atk-vsuse-test label to fire pr-vscuse-test.yml
+        uses: actions/github-script@v6
+        env:
+          PR_NUMBER: ${{ steps.authorize.outputs.pr_number }}
+        with:
+          script: |
+            const owner    = context.repo.owner;
+            const repo     = context.repo.repo;
+            const issueNum = parseInt(process.env.PR_NUMBER);
+            const label    = 'atk-vsuse-test';
+
+            // Remove first (ignore 404 if not present) so re-adding always fires `labeled`.
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: issueNum, name: label,
+              });
+              console.log(`Removed existing '${label}' label.`);
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              console.log(`Label '${label}' was not present — adding fresh.`);
+            }
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: issueNum, labels: [label],
+            });
+            console.log(`Applied '${label}' label to PR #${issueNum}.`);

--- a/.github/workflows/pr-vscuse-test.yml
+++ b/.github/workflows/pr-vscuse-test.yml
@@ -1,10 +1,17 @@
 ﻿name: PR VscUse Test Plan Selector
 
-# Triggered when the 'atk-vsuse-test' label is added to a PR,
+# Triggered automatically on every PR open/sync/reopen/ready_for_review,
+# when the 'atk-vsuse-test' label is added to a PR,
 # OR manually via workflow_dispatch with a pr_number input.
 #
+# IMPORTANT: this workflow is INFORMATIONAL ONLY — it must NEVER block merge.
+#   * The job always exits with success, regardless of UI test outcome.
+#   * Do NOT add this workflow to required status checks in branch protection.
+#   * Authors can merge while it is still running, or after it reports failure.
+#   * Results are surfaced via PR comments; use them as guidance, not a gate.
+#
 # This workflow:
-#   1. Resolves PR context (works for both label and manual triggers)
+#   1. Resolves PR context (works for label, auto, and manual triggers)
 #   2. Gets the diff between the PR branch and the target branch
 #   3. Calls GitHub Models (GPT-4.1) to select relevant VscUse test plans
 #   4. Posts a PR comment listing the selected plans
@@ -13,7 +20,7 @@
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -34,7 +41,13 @@ permissions:
 
 jobs:
   select-plans-and-run:
-    if: github.event.label.name == 'atk-vsuse-test' || github.event_name == 'workflow_dispatch'
+    # Run for: label add (atk-vsuse-test), automatic PR events (skip drafts), or manual dispatch.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && (
+        (github.event.action == 'labeled' && github.event.label.name == 'atk-vsuse-test') ||
+        (github.event.action != 'labeled' && github.event.pull_request.draft == false)
+      ))
     runs-on: ubuntu-latest
 
     steps:
@@ -70,6 +83,40 @@ jobs:
             core.setOutput('pr_title',  prTitle);
             core.setOutput('pr_body',   prBody.slice(0, 2000));
             console.log(`PR #${prNumber}: ${headRef} -> ${baseRef}  "${prTitle}"`);
+
+      # ── 0b. Fetch most recent user-supplied AI hint (posted by pr-vscuse-test-comment-trigger.yml) ──
+      - name: Fetch latest user hint from PR comments
+        id: user-hint
+        uses: actions/github-script@v6
+        env:
+          PR_NUMBER: ${{ steps.pr-context.outputs.pr_number }}
+        with:
+          script: |
+            const MARKER = '<!-- atk-vsuse-test-hint -->';
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner:        context.repo.owner,
+              repo:         context.repo.repo,
+              issue_number: prNumber,
+              per_page:     100,
+            });
+            // Most recent hint comment wins.
+            const hintComment = comments
+              .filter(c => (c.body || '').includes(MARKER))
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+
+            let hint = '';
+            if (hintComment) {
+              // Extract text inside the first fenced code block of the marker comment.
+              const m = hintComment.body.match(/```[^\n]*\n([\s\S]*?)\n```/);
+              hint = (m ? m[1] : hintComment.body.replace(MARKER, '')).trim();
+            }
+            // Cap to keep prompt size bounded.
+            if (hint.length > 1500) hint = hint.slice(0, 1500) + '…';
+            core.setOutput('hint', hint);
+            console.log(hint
+              ? `Found user hint (${hint.length} chars): ${hint.slice(0, 200)}`
+              : 'No user hint comment found.');
 
       # ── 1. Checkout plans dir + full git history for diff ─────────────
       - name: Checkout repo
@@ -213,6 +260,7 @@ jobs:
           DIFF_STAT:            ${{ steps.diff-summary.outputs.diff_stat }}
           BASE_BRANCH:          ${{ steps.pr-context.outputs.base_ref }}
           HEAD_BRANCH:          ${{ steps.pr-context.outputs.head_ref }}
+          USER_HINT:            ${{ steps.user-hint.outputs.hint }}
         run: |
           set -euo pipefail
 
@@ -220,10 +268,17 @@ jobs:
           PLANS_TEXT=$(find packages/tests/vscuse/vscode-test-cases/plans \
             -maxdepth 1 -name "*.json" -exec basename {} .json \; | sort)
 
-          SYSTEM_PROMPT='You are a test plan selector for the Microsoft 365 Agents Toolkit (ATK) VS Code extension. Select the most relevant VscUse UI test plans for a given PR based on the changed files and PR description. IMPORTANT CONTEXT: VscUse tests only test the VS Code extension. The plan files are all for VS Code templates. There are NO C# plan files. FILE PATH MAPPING (apply in order, stop at first match): 1) templates/vs/** (Visual Studio C# templates, NOT VS Code) -> These have no VscUse test plans; return only 1-2 smoke plans (Basic_Custom_Engine_Azure_OpenAI_ts_Copilot_Remote_Debug or General_Teams_Agent_OpenAI_py_Remote_Debug) as a basic sanity check. 2) templates/vscode/ts/custom-copilot-** -> Basic_Custom_Engine_*_ts_* Remote_Debug plans only. 3) templates/vscode/js/** -> *_js_* Remote_Debug plans only. 4) templates/vscode/py/** -> *_py_* Remote_Debug plans only. 5) templates/vscode/**declarative** or **da-** -> DA_*. 6) templates/vscode/**message-extension** -> Message_Extension_*. 7) templates/vscode/**tab** -> Basic_Tab_*. 8) templates/vscode/**bot** -> Simple_Bot_*. 9) packages/vscode-extension/src/treeview/** -> Feature_TreeView_*. 10) packages/vscode-extension/** -> Feature_*. 11) trivial/infra changes (remove pkg, typo, readme, CI yml) -> 1-2 smoke plans only. LANGUAGE RULES (for vscode templates only): _ts_=TypeScript plans; _js_=JavaScript plans; _py_=Python plans. ALL plans have a language suffix (_ts_, _js_, or _py_) - never invent a plan name without one. PLAN PREFIXES: DA_*=Declarative Agent; Basic_Custom_Engine_*=Custom Engine AI bot; General_Teams_Agent_*=Teams agent; Teams_Agent_With_Data_*=AI Search/RAG; Weather_Agent_*=Weather bot; Simple_Bot_*=Simple bot; Message_Extension_*=Message extension; Basic_Tab_*=Tab app; Feature_*=VS Code UI features. Keep total 1-5 plans. Output ONLY a JSON object: {"plans": ["PlanName1"], "reason": "one sentence"}'
+          SYSTEM_PROMPT='You are a test plan selector for the Microsoft 365 Agents Toolkit (ATK) VS Code extension. Select the most relevant VscUse UI test plans for a given PR based on the changed files and PR description. IMPORTANT: If a USER HINT is provided below, treat it as AUTHORITATIVE guidance from a human reviewer — it overrides your own heuristics. The hint may name specific plans to include or exclude, or describe which feature area to focus on; honour it as long as the requested plans actually exist in the available list. IMPORTANT CONTEXT: VscUse tests only test the VS Code extension. The plan files are all for VS Code templates. There are NO C# plan files. FILE PATH MAPPING (apply in order, stop at first match): 1) templates/vs/** (Visual Studio C# templates, NOT VS Code) -> These have no VscUse test plans; return only 1-2 smoke plans (Basic_Custom_Engine_Azure_OpenAI_ts_Copilot_Remote_Debug or General_Teams_Agent_OpenAI_py_Remote_Debug) as a basic sanity check. 2) templates/vscode/ts/custom-copilot-** -> Basic_Custom_Engine_*_ts_* Remote_Debug plans only. 3) templates/vscode/js/** -> *_js_* Remote_Debug plans only. 4) templates/vscode/py/** -> *_py_* Remote_Debug plans only. 5) templates/vscode/**declarative** or **da-** -> DA_*. 6) templates/vscode/**message-extension** -> Message_Extension_*. 7) templates/vscode/**tab** -> Basic_Tab_*. 8) templates/vscode/**bot** -> Simple_Bot_*. 9) packages/vscode-extension/src/treeview/** -> Feature_TreeView_*. 10) packages/vscode-extension/** -> Feature_*. 11) trivial/infra changes (remove pkg, typo, readme, CI yml) -> 1-2 smoke plans only. LANGUAGE RULES (for vscode templates only): _ts_=TypeScript plans; _js_=JavaScript plans; _py_=Python plans. ALL plans have a language suffix (_ts_, _js_, or _py_) - never invent a plan name without one. PLAN PREFIXES: DA_*=Declarative Agent; Basic_Custom_Engine_*=Custom Engine AI bot; General_Teams_Agent_*=Teams agent; Teams_Agent_With_Data_*=AI Search/RAG; Weather_Agent_*=Weather bot; Simple_Bot_*=Simple bot; Message_Extension_*=Message extension; Basic_Tab_*=Tab app; Feature_*=VS Code UI features. Keep total 1-5 plans (or whatever the user hint asks for). Output ONLY a JSON object: {"plans": ["PlanName1"], "reason": "one sentence (mention if a user hint was applied)"}'
 
-          USER_PROMPT=$(printf '%s\n\nPR: %s -> %s\nTitle: %s\n\nDescription (first 1200 chars):\n%s\n\nChanged files (with status):\n%s\n\nDiff summary:\n%s\n\nAvailable test plans:\n%s\n\nOutput JSON only.' \
+          if [ -n "${USER_HINT:-}" ]; then
+            HINT_BLOCK=$(printf 'USER HINT (authoritative — overrides heuristics):\n%s\n\n' "$USER_HINT")
+          else
+            HINT_BLOCK=""
+          fi
+
+          USER_PROMPT=$(printf '%s\n\n%sPR: %s -> %s\nTitle: %s\n\nDescription (first 1200 chars):\n%s\n\nChanged files (with status):\n%s\n\nDiff summary:\n%s\n\nAvailable test plans:\n%s\n\nOutput JSON only.' \
             "$SYSTEM_PROMPT" \
+            "$HINT_BLOCK" \
             "${HEAD_BRANCH}" "${BASE_BRANCH}" "${PR_TITLE}" "${PR_BODY:0:1200}" \
             "${CHANGED_FILES}" "${DIFF_STAT}" "${PLANS_TEXT}")
 
@@ -492,7 +547,7 @@ jobs:
               await new Promise(r => setTimeout(r, 60000));
             }
             core.setOutput('conclusion', 'timed_out');
-            throw new Error('Smoke pipeline timed out after 8 hours');
+            console.log('Smoke pipeline timed out after 8 hours — reporting as timed_out (workflow stays green; this run is informational only).');
 
       # ── 8. Resolve PR comment with final result ────────────────────────
       - name: Resolve PR comment with test results
@@ -561,8 +616,10 @@ jobs:
             });
 
             console.log(`Resolved comment ${commentId}: ${conclusion}`);
-            if (!succeeded && conclusion !== 'timed_out') {
-              core.setFailed(`VscUse tests concluded: ${conclusion}. See: ${smokeUrl}`);
+            // Informational workflow: never fail the job, even on test failure or timeout.
+            // The PR comment carries the result; merge gating must not depend on this run.
+            if (!succeeded) {
+              console.log(`VscUse tests concluded: ${conclusion}. See: ${smokeUrl}`);
             }
       # ── 9. Remove atk-vsuse-test label (signals completion) ───────────
       - name: Remove atk-vsuse-test label


### PR DESCRIPTION
## Summary

Two related changes to the VscUse AI-driven test plan selector:

### 1. `/atk-vsuse-test <hint>` PR comment trigger
New workflow `.github/workflows/pr-vscuse-test-comment-trigger.yml` lets reviewers steer the AI plan selector when its automatic choice is wrong.

Comment on a PR:
```
/atk-vsuse-test please run DA_OpenAI_ts_Remote_Debug and skip Feature_* plans
```

What happens:
- Commenter is authorized (must be `OWNER` / `MEMBER` / `COLLABORATOR`).
- The trigger keyword is stripped and the remaining hint is saved in a hidden marker comment `<!-- atk-vsuse-test-hint -->` (the hint sits inside a fenced code block for safe extraction).
- The `atk-vsuse-test` label is removed and re-added, which fires `pull_request: labeled` and re-runs `pr-vscuse-test.yml`.
- 👀 reaction on the triggering comment for acknowledgement.

`pr-vscuse-test.yml` now reads the latest hint marker comment and injects it into the AI prompt as **authoritative guidance** that overrides its own heuristics.

### 2. Make the vscuse workflow an optional PR gate
- Auto-trigger on every PR `opened` / `synchronize` / `reopened` / `ready_for_review` (drafts skipped). Label-based and manual triggers still work.
- The job **never reports failure**: removed the `core.setFailed` on test failure and the `throw` on 8-hour timeout. Result is still surfaced in the PR comment with ✅/❌, but the workflow run itself always concludes green.
- Header comment documents that this workflow is informational only and must not be added to required status checks.

### Action required outside this PR
Branch protection on `dev` (and any other protected branch) should **not** list `PR VscUse Test Plan Selector` under required status checks. Without that admin change, GitHub may still surface it as a pending check on PRs — but since the job no longer fails, it won't actually block merge.

### Files
- `.github/workflows/pr-vscuse-test-comment-trigger.yml` (new)
- `.github/workflows/pr-vscuse-test.yml` (modified)