### PR TITLE
test: isolate vscuse report artifacts by run_attempt to avoid stale failed-step mapping

### DIFF
--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -342,7 +342,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: error-file-${{ matrix.test_plan }}-${{ github.run_id }}
+          name: error-file-${{ matrix.test_plan }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: error.txt
           retention-days: 7
           if-no-files-found: ignore
@@ -425,7 +425,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: storage-url-${{ matrix.test_plan }}-${{ github.run_id }}
+          name: storage-url-${{ matrix.test_plan }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: storage_url.txt
           retention-days: 7
           if-no-files-found: ignore
@@ -516,11 +516,12 @@ jobs:
 
             find /tmp/storage-urls -type f -name "storage_url.txt" | while read file; do
               dir_name=$(basename $(dirname "$file"))
-              run_id=$(echo "$dir_name" | rev | cut -d'-' -f1 | rev)
-              test_plan=$(echo "$dir_name" | sed "s/^storage-url-//" | sed "s/-${run_id}$//")
-              case_run_id="${test_plan}-${run_id}"
+              run_attempt=$(echo "$dir_name" | rev | cut -d'-' -f1 | rev)
+              run_id=$(echo "$dir_name" | rev | cut -d'-' -f2 | rev)
+              test_plan=$(echo "$dir_name" | sed "s/^storage-url-//" | sed "s/-${run_id}-${run_attempt}$//")
+              case_run_id="${test_plan}-${run_id}-${run_attempt}"
 
-              echo "Processing: dir_name=$dir_name, test_plan=$test_plan, run_id=$run_id, case_run_id=$case_run_id"
+              echo "Processing: dir_name=$dir_name, test_plan=$test_plan, run_id=$run_id, run_attempt=$run_attempt, case_run_id=$case_run_id"
 
               content_json=$(cat "$file" | tr -d '\n' | tr -d '\r' | jq -Rs .)
 
@@ -559,11 +560,12 @@ jobs:
 
             find /tmp/error-files -type f -name "error.txt" | while read file; do
               dir_name=$(basename $(dirname "$file"))
-              run_id=$(echo "$dir_name" | rev | cut -d'-' -f1 | rev)
-              test_plan=$(echo "$dir_name" | sed "s/^error-file-//" | sed "s/-${run_id}$//")
-              case_run_id="${test_plan}-${run_id}"
+              run_attempt=$(echo "$dir_name" | rev | cut -d'-' -f1 | rev)
+              run_id=$(echo "$dir_name" | rev | cut -d'-' -f2 | rev)
+              test_plan=$(echo "$dir_name" | sed "s/^error-file-//" | sed "s/-${run_id}-${run_attempt}$//")
+              case_run_id="${test_plan}-${run_id}-${run_attempt}"
 
-              echo "Processing error: dir_name=$dir_name, test_plan=$test_plan, run_id=$run_id, case_run_id=$case_run_id"
+              echo "Processing error: dir_name=$dir_name, test_plan=$test_plan, run_id=$run_id, run_attempt=$run_attempt, case_run_id=$case_run_id"
 
               content_json=$(cat "$file" | tr -d '\n' | tr -d '\r' | jq -Rs .)
 
@@ -723,7 +725,7 @@ jobs:
 
             status=$(echo "$jobs" | jq --arg case "$case" -r '[.[] | select(.name == $case)] | last | .conclusion // "unknown"')
             run_id=$(echo "$jobs" | jq --arg case "$case" -r '[.[] | select(.name == $case)] | last | .run_id')
-            lookup_key="${case_id}-${run_id}"
+            lookup_key="${case_id}-${run_id}-${{ github.run_attempt }}"
 
             report_url=$(jq -r --arg key "$lookup_key" '.[$key]' "$report_map_json_file_path")
             if [ -z "$report_url" ] || [ "$report_url" = "null" ]; then
@@ -737,6 +739,12 @@ jobs:
               error_info=""
             fi
             if [ "$FILTER_NO_ERRORS_FOUND" = "true" ] && [ "$error_info" = "No errors found" ]; then
+              error_info=""
+            fi
+
+            # Only show failed-step details for failed jobs.
+            # Also guards against any unexpected stale artifact entries.
+            if [ "$status" = "success" ]; then
               error_info=""
             fi
 


### PR DESCRIPTION
This fix addresses stale Failed Step and Report data in VSCUse UI test emails when workflows are retried multiple times.
Previously, artifact names and mapping keys did not include run attempt, so data from earlier failed attempts could be mixed into later successful results for the same case.
The update isolates artifacts and mapping by run attempt, and aligns lookup with the current attempt when generating the report.
As a safeguard, Failed Step is cleared for successful cases to prevent misleading output if stale data appears unexpectedly.
This change only affects report data mapping.