### PR TITLE
fix(ci): vscuse comment trigger + surface real UI test run URL

### DIFF
--- a/.github/workflows/pr-vscuse-test-comment-trigger.yml
+++ b/.github/workflows/pr-vscuse-test-comment-trigger.yml
@@ -7,8 +7,15 @@ name: PR VscUse Test Plan Comment Trigger
 #   2. Extracts the hint text after `/atk-vsuse-test`.
 #   3. Posts a hidden marker comment (<!-- atk-vsuse-test-hint -->) carrying the hint
 #      so the existing pr-vscuse-test.yml workflow can feed it to the AI plan selector.
-#   4. Removes and re-adds the `atk-vsuse-test` label on the PR — the `pull_request: labeled`
-#      event then re-runs pr-vscuse-test.yml, which will now pick up the hint.
+#   4. Dispatches pr-vscuse-test.yml via workflow_dispatch with the PR number, so it
+#      re-runs and reads the hint comment we just posted.
+#
+# Why workflow_dispatch instead of cycling the `atk-vsuse-test` label?
+# GitHub's anti-recursion protection means actions performed with the default
+# GITHUB_TOKEN (such as remove/add label) do NOT trigger other workflows — so a
+# `pull_request: labeled` listener would silently never fire. workflow_dispatch
+# IS allowed from GITHUB_TOKEN and runs as expected, so it is the supported
+# manual-trigger path for chaining workflows.
 
 on:
   issue_comment:
@@ -18,6 +25,7 @@ permissions:
   pull-requests: write
   issues: write
   contents: read
+  actions: write
 
 concurrency:
   group: pr-vscuse-test-comment-trigger-${{ github.event.issue.number }}
@@ -96,7 +104,7 @@ jobs:
               body,
             });
 
-      - name: (Re)apply atk-vsuse-test label to fire pr-vscuse-test.yml
+      - name: Dispatch pr-vscuse-test.yml with the user's hint applied
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.authorize.outputs.pr_number }}
@@ -104,21 +112,44 @@ jobs:
           script: |
             const owner    = context.repo.owner;
             const repo     = context.repo.repo;
-            const issueNum = parseInt(process.env.PR_NUMBER);
-            const label    = 'atk-vsuse-test';
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const workflow = 'pr-vscuse-test.yml';
+            const fallback = 'dev';
 
-            // Remove first (ignore 404 if not present) so re-adding always fires `labeled`.
+            // Resolve the PR's head ref so we dispatch the workflow against the PR branch.
+            // Forked-PR head refs live on the fork repo, so workflow_dispatch on that ref
+            // will 422 — fall back to `dev` in that case.
+            let ref = fallback;
             try {
-              await github.rest.issues.removeLabel({
-                owner, repo, issue_number: issueNum, name: label,
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo, pull_number: prNumber,
               });
-              console.log(`Removed existing '${label}' label.`);
+              if (pr.head && pr.head.repo && pr.head.repo.full_name === `${owner}/${repo}`) {
+                ref = pr.head.ref;
+              } else {
+                console.log(`PR #${prNumber} head is from a fork — dispatching against '${fallback}'.`);
+              }
             } catch (err) {
-              if (err.status !== 404) throw err;
-              console.log(`Label '${label}' was not present — adding fresh.`);
+              console.log(`Failed to resolve PR head ref (${err.message}); dispatching against '${fallback}'.`);
             }
 
-            await github.rest.issues.addLabels({
-              owner, repo, issue_number: issueNum, labels: [label],
-            });
-            console.log(`Applied '${label}' label to PR #${issueNum}.`);
+            const dispatch = async (targetRef) => {
+              await github.rest.actions.createWorkflowDispatch({
+                owner, repo,
+                workflow_id: workflow,
+                ref: targetRef,
+                inputs: { pr_number: String(prNumber) },
+              });
+              console.log(`Dispatched ${workflow} on ref '${targetRef}' for PR #${prNumber}.`);
+            };
+
+            try {
+              await dispatch(ref);
+            } catch (err) {
+              if (ref !== fallback && err.status === 422) {
+                console.log(`Dispatch on '${ref}' failed with 422 — retrying on '${fallback}'.`);
+                await dispatch(fallback);
+              } else {
+                throw err;
+              }
+            }

--- a/.github/workflows/pr-vscuse-test.yml
+++ b/.github/workflows/pr-vscuse-test.yml
@@ -536,17 +536,52 @@ jobs:
             const start  = Date.now();
             const EIGHT_HOURS = 8 * 60 * 60 * 1000;
 
+            // Try to extract the actual UI-test run URL from the smoke pipeline's
+            // `run-ui-test` job logs. That job dispatches ui-test-vscuse-template.yml
+            // and prints "UI Test run ID: <id>" — surfacing it lets the PR comment
+            // link straight to the real test report instead of the smoke wrapper.
+            const extractUiTestUrl = async () => {
+              try {
+                const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
+                  owner, repo, run_id: runId, per_page: 100,
+                });
+                const uiJob = jobs.jobs.find(j => j.name === 'run-ui-test');
+                if (!uiJob) {
+                  console.log('run-ui-test job not found on smoke pipeline.');
+                  return '';
+                }
+                const logs = await github.request(
+                  'GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs',
+                  { owner, repo, job_id: uiJob.id }
+                );
+                const match = String(logs.data || '').match(/UI Test run ID:\s*(\d+)/);
+                if (!match) {
+                  console.log('Could not find "UI Test run ID:" line in run-ui-test logs.');
+                  return '';
+                }
+                const uiRunId = match[1];
+                const uiUrl   = `https://github.com/${owner}/${repo}/actions/runs/${uiRunId}`;
+                console.log(`Extracted UI test run: ${uiUrl}`);
+                return uiUrl;
+              } catch (err) {
+                console.log(`Failed to extract UI test run URL: ${err.message}`);
+                return '';
+              }
+            };
+
             while (Date.now() - start < EIGHT_HOURS) {
               const { data: run } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
               console.log(`Smoke pipeline: ${run.status} / ${run.conclusion}`);
               if (run.status === 'completed') {
-                core.setOutput('conclusion', run.conclusion);
-                core.setOutput('run_url',    run.html_url);
+                core.setOutput('conclusion',  run.conclusion);
+                core.setOutput('run_url',     run.html_url);
+                core.setOutput('ui_test_url', await extractUiTestUrl());
                 return;
               }
               await new Promise(r => setTimeout(r, 60000));
             }
-            core.setOutput('conclusion', 'timed_out');
+            core.setOutput('conclusion',  'timed_out');
+            core.setOutput('ui_test_url', await extractUiTestUrl());
             console.log('Smoke pipeline timed out after 8 hours — reporting as timed_out (workflow stays green; this run is informational only).');
 
       # ── 8. Resolve PR comment with final result ────────────────────────
@@ -559,6 +594,7 @@ jobs:
           REASON:      ${{ steps.ai-select.outputs.reason }}
           CONCLUSION:  ${{ steps.wait-smoke.outputs.conclusion }}
           SMOKE_URL:   ${{ steps.wait-smoke.outputs.run_url }}
+          UI_TEST_URL: ${{ steps.wait-smoke.outputs.ui_test_url }}
           PR_NUMBER:   ${{ steps.pr-context.outputs.pr_number }}
           HEAD_REF:    ${{ steps.pr-context.outputs.head_ref }}
           BASE_REF:    ${{ steps.pr-context.outputs.base_ref }}
@@ -571,6 +607,7 @@ jobs:
             const reason     = process.env.REASON || '-';
             const conclusion = process.env.CONCLUSION || 'unknown';
             const smokeUrl   = process.env.SMOKE_URL || '';
+            const uiTestUrl  = process.env.UI_TEST_URL || '';
             const headRef    = process.env.HEAD_REF;
             const baseRef    = process.env.BASE_REF;
             const planList   = plans.map(p => `- \`${p}\``).join('\n');
@@ -596,7 +633,8 @@ jobs:
               '| 2️⃣ Build Docker image | ✅ Done |',
               `| 3️⃣ Run UI tests | ${icon} ${statusText} |`,
               '',
-              smokeUrl ? `> 🔗 [Full pipeline results](${smokeUrl})` : '',
+              uiTestUrl ? `> 🎯 [Actual UI test run](${uiTestUrl})` : '',
+              smokeUrl  ? `> 🔗 [Full pipeline results](${smokeUrl})`  : '',
               '',
               '<details>',
               '<summary>ℹ️ How were these tests selected?</summary>',


### PR DESCRIPTION
Two related fixes to the `/atk-vsuse-test` PR comment flow.

## 1. Comment trigger silently failed to re-fire `pr-vscuse-test.yml`

The previous comment-trigger removed and re-added the `atk-vsuse-test` label to re-fire `pr-vscuse-test.yml`. GitHub's [anti-recursion protection](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) prevents actions performed with the default `GITHUB_TOKEN` (including label changes) from triggering other workflows, so the `pull_request: labeled` listener never fired — silent no-op observed on PR #16111.

**Fix:** Replace the label cycle with a direct `workflow_dispatch` of `pr-vscuse-test.yml`. `workflow_dispatch` IS allowed from `GITHUB_TOKEN` and runs as expected. `pr-vscuse-test.yml` already supports this manual path:
- declares a `workflow_dispatch` input `pr_number`,
- job `if:` gate accepts `github.event_name == 'workflow_dispatch'`,
- its "Fetch latest user hint from PR comments" step reads the most recent hint comment we just posted.

Notes:
- Resolves the PR's head ref via `pulls.get` and dispatches against that branch.
- Forked-PR head refs live on the fork repo (dispatching against them 422s), so falls back to `dev` (and as a retry on 422).
- Adds `actions: write` permission so the workflow can call `createWorkflowDispatch`.

## 2. PR comment didn't expose the actual UI test run URL

The result comment posted by `pr-vscuse-test.yml` linked to the `dev-smoke-test-pipeline` run, but the real UI tests run inside a further-downstream `ui-test-vscuse-template.yml` dispatch from the smoke pipeline's `run-ui-test` job. The downstream run ID is only printed in that job's logs (`UI Test run ID: <id>`), so users had to drill smoke pipeline → run-ui-test → scroll logs to find the test report. For example, smoke run `27192860438` actually dispatched `27193907009`, which is buried in job-log line "UI Test run ID: 27193907009".

**Fix:** After the smoke pipeline completes, the wait-smoke step now lists the smoke pipeline's jobs, finds `run-ui-test`, downloads its logs, and regexes out the UI test run ID. A new `🎯 Actual UI test run` link is added to the final PR comment alongside the existing `🔗 Full pipeline results` link. Extraction failures are tolerated (the link is just omitted).

## Validation

```
python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-vscuse-test-comment-trigger.yml', encoding='utf-8'))"
python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-vscuse-test.yml', encoding='utf-8'))"
```
both pass.