### PR TITLE
fix: add skip_auth for Agents Playground in Python templates

### DIFF
--- a/templates/vsc/python/custom-copilot-basic/src/app.py.tpl
+++ b/templates/vsc/python/custom-copilot-basic/src/app.py.tpl
@@ -35,7 +35,8 @@ def create_token_factory():
     return get_token
 
 app = App(
-    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None
+    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None,
+    skip_auth=not config.APP_ID,
 )
 
 {{#useAzureOpenAI}}

--- a/templates/vsc/python/custom-copilot-rag-azure-ai-search/src/app.py.tpl
+++ b/templates/vsc/python/custom-copilot-rag-azure-ai-search/src/app.py.tpl
@@ -47,7 +47,8 @@ def create_token_factory():
     return get_token
 
 app = App(
-    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None
+    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None,
+    skip_auth=not config.APP_ID,
 )
 
 {{#useAzureOpenAI}}

--- a/templates/vsc/python/custom-copilot-rag-customize/src/app.py.tpl
+++ b/templates/vsc/python/custom-copilot-rag-customize/src/app.py.tpl
@@ -38,7 +38,8 @@ def create_token_factory():
     return get_token
 
 app = App(
-    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None
+    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None,
+    skip_auth=not config.APP_ID,
 )
 
 {{#useAzureOpenAI}}

--- a/templates/vsc/python/default-bot/src/app.py
+++ b/templates/vsc/python/default-bot/src/app.py
@@ -20,7 +20,8 @@ def create_token_factory():
     return get_token
 
 app = App(
-    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None
+    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None,
+    skip_auth=not config.APP_ID,
 )
 
 @app.on_message_pattern(re.compile(r"hello|hi|greetings"))

--- a/templates/vsc/python/message-extension-v2/src/app.py
+++ b/templates/vsc/python/message-extension-v2/src/app.py
@@ -51,7 +51,8 @@ def create_token_factory():
 
 # Initialize the Teams app
 app = App(
-    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None
+    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None,
+    skip_auth=not config.APP_ID,
 )
 
 

--- a/templates/vsc/python/teams-agent-with-data-custom-api-v2/src/app.py.tpl
+++ b/templates/vsc/python/teams-agent-with-data-custom-api-v2/src/app.py.tpl
@@ -44,7 +44,8 @@ def create_token_factory():
     return get_token
 
 app = App(
-    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None
+    token=create_token_factory() if config.APP_TYPE == "UserAssignedMsi" else None,
+    skip_auth=not config.APP_ID,
 )
 
 {{#useAzureOpenAI}}


### PR DESCRIPTION
## Summary

Microsoft Teams SDK changed its behavior to require `skip_auth` to be set when running on the Microsoft 365 Agents Playground. Without bot credentials configured (local debugging), inbound JWT validation must be skipped so anonymous Playground activities are accepted instead of returning a `401 "Authentication not configured"` error.

This PR adds `skip_auth=not config.APP_ID` to the `App()` definition in all Python templates that use the `token=create_token_factory()` pattern.

## Changed templates

- `templates/vsc/python/custom-copilot-basic/src/app.py.tpl`
- `templates/vsc/python/custom-copilot-rag-azure-ai-search/src/app.py.tpl`
- `templates/vsc/python/custom-copilot-rag-customize/src/app.py.tpl`
- `templates/vsc/python/default-bot/src/app.py`
- `templates/vsc/python/message-extension-v2/src/app.py`
- `templates/vsc/python/teams-agent-with-data-custom-api-v2/src/app.py.tpl`

## Related work item

Fixes [Bug 38352976 - [VSC] It returns an 'Authentication not configured' 401 error when debugging in the playground with Python language](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/38352976)