### PR TITLE
feat(ci): surface VscUse blob test report URL in PR comment

### DIFF
--- a/.github/workflows/pr-vscuse-test.yml
+++ b/.github/workflows/pr-vscuse-test.yml
@@ -569,19 +569,55 @@ jobs:
               }
             };
 
+            // On the UI test run, the `report` job (ui-test-vscuse-common.yml) uploads
+            // the aggregated email-body.html to Azure Blob and prints
+            // "Report Summary URL: <url>". The PR-trigger path emails the report to an
+            // unattended mailbox, so this single aggregate blob link is the only
+            // user-facing report surface.
+            const extractReportUrl = async (uiUrl) => {
+              const idMatch = (uiUrl || '').match(/\/runs\/(\d+)/);
+              if (!idMatch) return '';
+              try {
+                const { data: uiJobs } = await github.rest.actions.listJobsForWorkflowRun({
+                  owner, repo, run_id: parseInt(idMatch[1]), per_page: 100,
+                });
+                // The report job is invoked via a reusable workflow, so its rendered
+                // name is typically "<caller_job> / report". Match the trailing token.
+                const reportJob = (uiJobs.jobs || []).find(j =>
+                  /(^|\/\s*)report$/.test((j.name || '').trim())
+                );
+                if (!reportJob) { console.log('report job not found on UI test run.'); return ''; }
+                const log = await github.request(
+                  'GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs',
+                  { owner, repo, job_id: reportJob.id }
+                );
+                const m = String(log.data || '').match(/Report Summary URL:\s*(https?:\/\/\S+)/);
+                if (!m) { console.log('No "Report Summary URL:" marker found in report job logs.'); return ''; }
+                console.log(`Extracted aggregated report URL: ${m[1]}`);
+                return m[1];
+              } catch (err) {
+                console.log(`Failed to extract aggregated report URL: ${err.message}`);
+                return '';
+              }
+            };
+
             while (Date.now() - start < EIGHT_HOURS) {
               const { data: run } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
               console.log(`Smoke pipeline: ${run.status} / ${run.conclusion}`);
               if (run.status === 'completed') {
                 core.setOutput('conclusion',  run.conclusion);
                 core.setOutput('run_url',     run.html_url);
-                core.setOutput('ui_test_url', await extractUiTestUrl());
+                const uiUrl = await extractUiTestUrl();
+                core.setOutput('ui_test_url', uiUrl);
+                core.setOutput('report_url',  await extractReportUrl(uiUrl));
                 return;
               }
               await new Promise(r => setTimeout(r, 60000));
             }
             core.setOutput('conclusion',  'timed_out');
-            core.setOutput('ui_test_url', await extractUiTestUrl());
+            const uiUrl = await extractUiTestUrl();
+            core.setOutput('ui_test_url', uiUrl);
+            core.setOutput('report_url',  await extractReportUrl(uiUrl));
             console.log('Smoke pipeline timed out after 8 hours — reporting as timed_out (workflow stays green; this run is informational only).');
 
       # ── 8. Resolve PR comment with final result ────────────────────────
@@ -595,6 +631,7 @@ jobs:
           CONCLUSION:  ${{ steps.wait-smoke.outputs.conclusion }}
           SMOKE_URL:   ${{ steps.wait-smoke.outputs.run_url }}
           UI_TEST_URL: ${{ steps.wait-smoke.outputs.ui_test_url }}
+          REPORT_URL:  ${{ steps.wait-smoke.outputs.report_url }}
           PR_NUMBER:   ${{ steps.pr-context.outputs.pr_number }}
           HEAD_REF:    ${{ steps.pr-context.outputs.head_ref }}
           BASE_REF:    ${{ steps.pr-context.outputs.base_ref }}
@@ -608,6 +645,7 @@ jobs:
             const conclusion = process.env.CONCLUSION || 'unknown';
             const smokeUrl   = process.env.SMOKE_URL || '';
             const uiTestUrl  = process.env.UI_TEST_URL || '';
+            const reportUrl  = process.env.REPORT_URL || '';
             const headRef    = process.env.HEAD_REF;
             const baseRef    = process.env.BASE_REF;
             const planList   = plans.map(p => `- \`${p}\``).join('\n');
@@ -635,6 +673,7 @@ jobs:
               '',
               uiTestUrl ? `> 🎯 [Actual UI test run](${uiTestUrl})` : '',
               smokeUrl  ? `> 🔗 [Full pipeline results](${smokeUrl})`  : '',
+              reportUrl ? `> 📊 [Detailed test report](${reportUrl})`  : '',
               '',
               '<details>',
               '<summary>ℹ️ How were these tests selected?</summary>',

--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -887,6 +887,39 @@ jobs:
           fi
           echo "Email body file size: $(wc -c < email-body.html) bytes"
 
+      # Upload the aggregated email-body.html to the same blob proxy so PR-triggered
+      # runs (whose email goes to an unattended mailbox) can still surface a single
+      # shareable report URL. Printed marker "Report Summary URL: <url>" is parsed by
+      # pr-vscuse-test.yml to render the link in its PR comment.
+      - name: Upload aggregated report to Azure Blob Storage
+        if: always()
+        shell: pwsh
+        working-directory: packages/tests/vscuse
+        run: |
+          if (-not (Test-Path "email-body.html")) {
+            Write-Host "email-body.html not found; skipping aggregate upload."
+            exit 0
+          }
+
+          $guid = [guid]::NewGuid().ToString()
+          $account = $env:AZURE_STORAGE_ACCOUNT
+          $summaryUrl = "https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/$guid/index.html"
+
+          Copy-Item "email-body.html" "index.html" -Force
+
+          az storage blob upload `
+            --account-name $account `
+            --auth-mode login `
+            --container-name 'content' `
+            --name "$guid/index.html" `
+            --file "index.html" `
+            --content-type "text/html" `
+            --overwrite
+
+          Write-Host "Report Summary URL: $summaryUrl"
+        env:
+          AZURE_STORAGE_ACCOUNT: storproxystvoazuxhhvtgiq
+
       - name: Send E-mail
         uses: ./.github/actions/send-email-report-vscuse
         env:


### PR DESCRIPTION
## Goal

When a PR triggers VscUse tests (via `/atk-vsuse-test` or label), the result lands in two places:

1. A PR comment posted by `.github/workflows/pr-vscuse-test.yml` with links to the smoke pipeline run and the UI test run.
2. An email to `atk-vsuse-test@microsoft.com` — **an unattended mailbox nobody reads**, so the rich aggregated report (HTML table with per-plan status, owner, work items, linked bugs, duration, blob report links, failed step) effectively disappears for PR-triggered runs.

`ui-test-vscuse-common.yml`'s `report` job already assembles that aggregated report into `email-body.html`. This change uploads it to Azure Blob too, and surfaces the single resulting URL in the PR comment.

## Changes

- **`ui-test-vscuse-common.yml`** — In the `report` job, after `Verify email body file`, add an `Upload aggregated report to Azure Blob Storage` step that uploads `email-body.html` as `<guid>/index.html` to the same `content` container the per-plan reports use. Prints `Report Summary URL: <url>` for log-parsing.
- **`pr-vscuse-test.yml`** — In the `Wait for smoke pipeline` step, after resolving the UI test run ID, also locate the `report` job on that run and pull `Report Summary URL:` from its logs. Expose as `report_url` output. The `Resolve PR comment` step renders one extra line:
  ```
  > 📊 [Detailed test report](<url>)
  ```
  If extraction fails (older runs, upload failed, report job skipped), the line is silently omitted so the comment never breaks.

## Why this approach

- The `report` job already produces a single rich aggregate (HTML table covering all plans). Uploading that one file gives the PR comment **one** clean link, much friendlier than a per-plan list.
- pr-vscuse-test.yml stays nearly unchanged — just one extra log-grep and one extra line in the comment template.
- No schema changes to `dev-smoke-test-pipeline.yml` or `ui-test-vscuse-template.yml`; mirrors the existing trick that already pulls `UI Test run ID` from `run-ui-test` job logs.
- `report` job runs whenever there's an `email-receiver`, which is true for PR-triggered runs (`atk-vsuse-test@microsoft.com` is passed in), so the aggregate upload reliably fires for our use case.

## Validation

- `python -c "import yaml; yaml.safe_load(...)"` passes for both edited workflows.
- Data flow: `report` job uploads `email-body.html` → prints `Report Summary URL: <url>` → `pr-vscuse-test.yml` resolves UI test run ID from smoke pipeline → enumerates UI test run jobs → finds the `report` job (handles reusable-workflow naming `<caller> / report`) → reads log → extracts URL → renders in PR comment.

## Out of scope

- Email logic untouched.
- Blob upload destination/container unchanged.
- No new secrets.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>