### PR TITLE
fix: parse Copilot agentMetaData in debug logs

### DIFF
--- a/packages/vscode-extension/src/pluginDebugger/copilotDebugLogOutput.ts
+++ b/packages/vscode-extension/src/pluginDebugger/copilotDebugLogOutput.ts
@@ -54,7 +54,7 @@ interface CapabilityExecution {
   };
 }
 
-interface AgentMetadata {
+interface AgentMetaData {
   agentId: string;
   conversationId: string;
   agentVersion: string;
@@ -110,7 +110,7 @@ export class CopilotDebugLog {
   capabilitiesDeveloperInfo?: CapabilitiesDeveloperInfo;
   pluginDeveloperInfo?: PluginDeveloperInfo;
   prompt?: string;
-  agentMetadata?: AgentMetadata;
+  agentMetaData?: AgentMetaData;
 
   constructor(logAsJson: string, prompt?: string) {
     let message: this;
@@ -132,7 +132,7 @@ export class CopilotDebugLog {
       message.functionExecutions ?? message.pluginDeveloperInfo?.functionExecutions;
     this.capabilitiesDeveloperInfo = message.capabilitiesDeveloperInfo;
     this.pluginDeveloperInfo = message.pluginDeveloperInfo;
-    this.agentMetadata = message.agentMetadata;
+    this.agentMetaData = message.agentMetaData;
 
     if (this.functionExecutions) {
       this.functionExecutions.forEach((functionExecution) => {
@@ -290,9 +290,9 @@ export class CopilotDebugLog {
     debugConsole.appendLine("");
     debugConsole.appendLine(`${ANSIColors.WHITE}User's input prompt: ${this.prompt ?? ""}`); // pull from search query - action/capability execution
     debugConsole.appendLine(
-      `${ANSIColors.WHITE}Agent ID (${this.agentMetadata?.agentId ?? ""}). Conversation ID (${
-        this.agentMetadata?.conversationId ?? ""
-      }). Request ID (${this.agentMetadata?.requestId ?? ""})`
+      `${ANSIColors.WHITE}Agent ID (${this.agentMetaData?.agentId ?? ""}). Conversation ID (${
+        this.agentMetaData?.conversationId ?? ""
+      }). Request ID (${this.agentMetaData?.requestId ?? ""})`
     );
   }
 

--- a/packages/vscode-extension/test/pluginDebugger/copilotDebugLogOutput.test.ts
+++ b/packages/vscode-extension/test/pluginDebugger/copilotDebugLogOutput.test.ts
@@ -371,7 +371,7 @@ describe("copilotDebugLogOutput", () => {
             },
           ],
         },
-        agentMetadata: {
+        agentMetaData: {
           agentId: "agentId",
           agentVersion: "1.0",
           conversationId: "conversationId",
@@ -417,7 +417,7 @@ describe("copilotDebugLogOutput", () => {
           errorMessage: "",
         },
       ]);
-      chai.assert.deepEqual(copilotDebugLog.agentMetadata, {
+      chai.assert.deepEqual(copilotDebugLog.agentMetaData, {
         agentId: "agentId",
         agentVersion: "1.0",
         conversationId: "conversationId",
@@ -427,7 +427,7 @@ describe("copilotDebugLogOutput", () => {
 
     it("should write header details", () => {
       const logJson = JSON.stringify({
-        agentMetadata: {
+        agentMetaData: {
           agentId: "agentId",
           agentVersion: "1.0",
           conversationId: "conversationId",


### PR DESCRIPTION
This PR is to fix ADO bug https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_queries/edit/31758012/?queryId=ed790c6c-5f3e-4945-a272-3a47483d0af2

The property "agentMetadata" in the copilot debug payload is renamed to "agentMetaData". So, we have to update the model to parse.

Smoke test passed:
<img width="339" height="498" alt="image" src="https://github.com/user-attachments/assets/6ead1d95-c709-4950-8e34-576bed8ed2b2" />
