### PR TITLE
fix(manifest): make agentConnectors remoteMcpServer.mcpToolDescription optional in v1.27/v1.28

### DIFF
--- a/packages/manifest/src/generated-types/teams/TeamsManifestV1D27.ts
+++ b/packages/manifest/src/generated-types/teams/TeamsManifestV1D27.ts
@@ -251,7 +251,7 @@ export interface RemoteMCPServer {
      * not both). When this property is present it indicates that dynamic discovery will not be
      * used.
      */
-    mcpToolDescription: MCPToolDescription;
+    mcpToolDescription?: MCPToolDescription;
     /**
      * Authorization configuration for connecting to the local MCP server. The design mirrors
      * that of Plugin Manifests
@@ -2680,7 +2680,7 @@ const typeMap: any = {
     ], false),
     "RemoteMCPServer": o([
         { json: "mcpServerUrl", js: "mcpServerUrl", typ: "" },
-        { json: "mcpToolDescription", js: "mcpToolDescription", typ: r("MCPToolDescription") },
+        { json: "mcpToolDescription", js: "mcpToolDescription", typ: u(undefined, r("MCPToolDescription")) },
         { json: "authorization", js: "authorization", typ: u(undefined, r("RemoteMCPServerAuthorization")) },
     ], false),
     "RemoteMCPServerAuthorization": o([

--- a/packages/manifest/src/generated-types/teams/TeamsManifestV1D28.ts
+++ b/packages/manifest/src/generated-types/teams/TeamsManifestV1D28.ts
@@ -254,7 +254,7 @@ export interface RemoteMCPServer {
     /**
      * Configuration for MCP tool descriptions by file reference.
      */
-    mcpToolDescription: MCPToolDescription;
+    mcpToolDescription?: MCPToolDescription;
     /**
      * Authorization configuration for connecting to the local MCP server. The design mirrors
      * that of Plugin Manifests
@@ -2704,7 +2704,7 @@ const typeMap: any = {
     ], false),
     "RemoteMCPServer": o([
         { json: "mcpServerUrl", js: "mcpServerUrl", typ: "" },
-        { json: "mcpToolDescription", js: "mcpToolDescription", typ: r("MCPToolDescription") },
+        { json: "mcpToolDescription", js: "mcpToolDescription", typ: u(undefined, r("MCPToolDescription")) },
         { json: "authorization", js: "authorization", typ: u(undefined, r("RemoteMCPServerAuthorization")) },
     ], false),
     "RemoteMCPServerAuthorization": o([

--- a/packages/manifest/src/json-schemas/teams/v1.27/MicrosoftTeams.schema.json
+++ b/packages/manifest/src/json-schemas/teams/v1.27/MicrosoftTeams.schema.json
@@ -1513,7 +1513,7 @@
                     }
                   }
                 },
-                    "required": [ "mcpServerUrl", "mcpToolDescription"
+                    "required": [ "mcpServerUrl"
  ]
               }
             },

--- a/packages/manifest/src/json-schemas/teams/v1.28/MicrosoftTeams.schema.json
+++ b/packages/manifest/src/json-schemas/teams/v1.28/MicrosoftTeams.schema.json
@@ -1513,7 +1513,7 @@
                     }
                   }
                 },
-                    "required": [ "mcpServerUrl", "mcpToolDescription"
+                    "required": [ "mcpServerUrl"
  ]
               }
             },

--- a/packages/manifest/test/index.test.ts
+++ b/packages/manifest/test/index.test.ts
@@ -181,6 +181,48 @@ describe("ManifestUtil", () => {
     }
   });
 
+  // An agentConnector that relies on dynamic MCP tool discovery legitimately
+  // omits `mcpToolDescription` — its presence is the opt-out of dynamic
+  // discovery, so requiring it makes dynamic discovery impossible to express.
+  // devPreview keeps it optional; v1.27/v1.28 must match.
+  for (const version of ["1.27", "1.28"]) {
+    it(`accepts an agentConnector remoteMcpServer without mcpToolDescription (v${version})`, () => {
+      const json = {
+        $schema: `https://developer.microsoft.com/en-us/json-schemas/teams/v${version}/MicrosoftTeams.schema.json`,
+        manifestVersion: version,
+        version: "1.0.0",
+        id: "${{TEAMS_APP_ID}}",
+        developer: {
+          name: "Contoso",
+          websiteUrl: "https://www.example.com",
+          privacyUrl: "https://www.example.com/privacy",
+          termsOfUseUrl: "https://www.example.com/termsofuse",
+        },
+        icons: { color: "color.png", outline: "outline.png" },
+        name: { short: "Contoso", full: "Contoso App" },
+        description: { short: "Short", full: "Full description" },
+        accentColor: "#FFFFFF",
+        agentConnectors: [
+          {
+            id: "crm",
+            displayName: "CRM",
+            description: "Contoso CRM MCP",
+            toolSource: {
+              remoteMcpServer: { mcpServerUrl: "https://crm.contoso.com/mcp" },
+            },
+          },
+        ],
+      };
+      const manifest = TeamsManifestConverter.jsonToManifest(JSON.stringify(json)) as any;
+      chai.expect(manifest.agentConnectors).to.have.length(1);
+      chai
+        .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.mcpServerUrl)
+        .to.equal("https://crm.contoso.com/mcp");
+      chai.expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.mcpToolDescription).to.be
+        .undefined;
+    });
+  }
+
   describe("fetchSchema", () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const mockFetch = require("../src/fetchHelper");


### PR DESCRIPTION
Fixes #16141

## Summary

When `agentConnectors` was promoted from the **devPreview** Teams app manifest into the **v1.27** and **v1.28** schemas (#15986), the `remoteMcpServer.mcpToolDescription` property was made **required**. This makes it impossible to declare a remote MCP connector that relies on **dynamic tool discovery** — the default MCP behavior.

The field's own schema description is the authoritative signal:

> "Configuration for MCP tool descriptions by file reference. **When this property is present it indicates that dynamic discovery will not be used.**"

A property whose *presence* opts out of dynamic discovery cannot be **required** — requiring it makes dynamic discovery impossible to express. The **devPreview** schema (where this feature was authored) correctly keeps it optional (`required: ["mcpServerUrl"]`). This PR aligns v1.27/v1.28 with devPreview.

## Repro (before this fix)

A valid remote-MCP `agentConnector` using dynamic tool discovery (no static tool-description file) is **accepted under `manifestVersion: "devPreview"`** but **rejected under `"1.27"`/`"1.28"`**:

```jsonc
"agentConnectors": [
  {
    "id": "crm",
    "displayName": "CRM",
    "description": "Contoso CRM MCP",
    "toolSource": {
      "remoteMcpServer": { "mcpServerUrl": "https://crm.contoso.com/mcp" }
    }
  }
]
```

`atk validate` / `TeamsManifestConverter.jsonToManifest` throws on v1.28 (the converter reports the failure on the `agentConnectors` union; the root cause is the missing-but-required `mcpToolDescription`).

## Fix

Make `remoteMcpServer.mcpToolDescription` **optional** in v1.27 and v1.28, matching devPreview:

- `packages/manifest/src/json-schemas/teams/v1.27/MicrosoftTeams.schema.json` — `required: ["mcpServerUrl", "mcpToolDescription"]` → `["mcpServerUrl"]`
- `packages/manifest/src/json-schemas/teams/v1.28/MicrosoftTeams.schema.json` — same
- `packages/manifest/src/generated-types/teams/TeamsManifestV1D27.ts` — regenerated via `npm run convert` (`mcpToolDescription?: …`, converter `u(undefined, r("MCPToolDescription"))`)
- `packages/manifest/src/generated-types/teams/TeamsManifestV1D28.ts` — same

The generated types were produced by `node convert.js` (not hand-edited), so they match canonical generation from the corrected schema.

## Tests

Added a regression test in `packages/manifest/test/index.test.ts` (parameterized for v1.27 and v1.28) asserting that a manifest with an `agentConnector` whose `remoteMcpServer` omits `mcpToolDescription` round-trips through `TeamsManifestConverter.jsonToManifest`. The test fails when the fix is reverted and passes with it. The full manifest suite (`packages/manifest`, 166 tests) passes.

## Scope / notes

- The `packages/cli/json-schemas/**` copies are gitignored build artifacts copied from `packages/manifest` at build time — no change needed there.
- This restores the documented behavior; it does not add or change any field, only relaxes an over-strict `required`.

## Draft

Opening as a **draft** pending confirmation of intent (preferred fix direction: align v1.27/v1.28 to devPreview, as done here) and a tracking issue to map to.
