### PR TITLE
fix: support Teams manifest agentSkills unconditionally

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -458,19 +458,16 @@ export class CreateAppPackageDriver implements StepDriver {
       }
     }
 
-    if (featureFlagManager.getBooleanValue(FeatureFlags.AgentSkillsManifest)) {
-      const teamsManifestAgentSkills = (
-        manifest as TeamsManifestVDevPreview.TeamsManifestVDevPreview
-      ).agentSkills;
-      if (teamsManifestAgentSkills?.length) {
-        const addSkillsRes = await this.addAgentSkillFolders(
-          zip,
-          teamsManifestAgentSkills,
-          appDirectory
-        );
-        if (addSkillsRes.isErr()) {
-          return err(addSkillsRes.error);
-        }
+    const teamsManifestAgentSkills = (manifest as TeamsManifestVDevPreview.TeamsManifestVDevPreview)
+      .agentSkills;
+    if (teamsManifestAgentSkills?.length) {
+      const addSkillsRes = await this.addAgentSkillFolders(
+        zip,
+        teamsManifestAgentSkills,
+        appDirectory
+      );
+      if (addSkillsRes.isErr()) {
+        return err(addSkillsRes.error);
       }
     }
 

--- a/packages/fx-core/src/component/generator/openPlugin/README.md
+++ b/packages/fx-core/src/component/generator/openPlugin/README.md
@@ -98,4 +98,4 @@ openPlugin/
 | Flag | Default | Purpose |
 |---|---|---|
 | `TEAMSFX_OPENPLUGIN_IMPORT_EXPORT` | `true` | Gates registration of `atk import openplugin` and `atk export openplugin`. |
-| `TEAMSFX_AGENT_SKILLS` | `true` | Gates `agentSkills` emission and `createAppPackage` folder walk. |
+| `TEAMSFX_AGENT_SKILLS` | `false` | Gates `createAppPackage` folder walk for the DA-level `agent_skills` property. Top-level Teams manifest `agentSkills` is packaged unconditionally. |

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -2868,13 +2868,6 @@ describe("teamsApp/createAppPackage", async () => {
         "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.teams-manifest-skills.json",
     };
 
-    beforeEach(() => {
-      sinon.stub(featureFlagManager, "getBooleanValue").callsFake((flag: any) => {
-        if (flag.name === FeatureFlagName.AgentSkillsManifest) return true;
-        return false;
-      });
-    });
-
     function createTeamsManifestWithAgentSkills(): TeamsManifestV1D19.TeamsManifestV1D19 & {
       agentSkills?: { folder: string }[];
     } {
@@ -2893,7 +2886,7 @@ describe("teamsApp/createAppPackage", async () => {
       return manifest;
     }
 
-    it("should bundle top-level Teams manifest agentSkills folders", async () => {
+    it("should bundle top-level Teams manifest agentSkills folders unconditionally (no feature flag required)", async () => {
       const manifest = createTeamsManifestWithAgentSkills();
       manifest.agentSkills = [{ folder: "skills/skill1" }];
       const declarativeAgentManifest = {
@@ -2902,6 +2895,7 @@ describe("teamsApp/createAppPackage", async () => {
         actions: [],
       } as any;
 
+      sinon.stub(featureFlagManager, "getBooleanValue").returns(false);
       sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
       sinon.stub(fs, "chmod").callsFake(async () => {});
       sinon.stub(fs, "writeFile").callsFake(async () => {});
@@ -2937,6 +2931,10 @@ describe("teamsApp/createAppPackage", async () => {
         agent_skills: [{ folder: "skills/skill1" }],
       } as any;
 
+      sinon.stub(featureFlagManager, "getBooleanValue").callsFake((flag: any) => {
+        if (flag.name === FeatureFlagName.AgentSkillsManifest) return true;
+        return false;
+      });
       sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
       sinon.stub(fs, "chmod").callsFake(async () => {});
       sinon.stub(fs, "writeFile").callsFake(async () => {});

--- a/packages/fx-core/tests/component/generator/openPlugin/fixtureConversion.test.ts
+++ b/packages/fx-core/tests/component/generator/openPlugin/fixtureConversion.test.ts
@@ -9,7 +9,6 @@ import mockedEnv, { RestoreFn } from "mocked-env";
 import * as os from "os";
 import * as path from "path";
 import sinon from "sinon";
-import { featureFlagManager, FeatureFlags } from "../../../../src/common/featureFlags";
 import { setTools } from "../../../../src/common/globalVars";
 import { CreateAppPackageDriver } from "../../../../src/component/driver/teamsApp/createAppPackage";
 import { CreateAppPackageArgs } from "../../../../src/component/driver/teamsApp/interfaces/CreateAppPackageArgs";
@@ -185,8 +184,6 @@ describe("openPlugin fixture conversion (Contoso Helper)", () => {
     if (convertRes.isErr()) throw new Error(convertRes.error.message);
 
     let envRestore: RestoreFn | undefined;
-    const wasEnabled = featureFlagManager.getBooleanValue(FeatureFlags.AgentSkillsManifest);
-    featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, true);
     try {
       envRestore = mockedEnv({
         TEAMSFX_ENV: "dev",
@@ -227,7 +224,6 @@ describe("openPlugin fixture conversion (Contoso Helper)", () => {
       expect(entries.some((e) => e.startsWith("commands/"))).to.equal(false);
     } finally {
       if (envRestore) envRestore();
-      featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, wasEnabled);
     }
   });
 });

--- a/packages/fx-core/tests/component/generator/openPlugin/packaging.test.ts
+++ b/packages/fx-core/tests/component/generator/openPlugin/packaging.test.ts
@@ -75,7 +75,7 @@ describe("openPlugin → teamsApp/zipAppPackage end-to-end", () => {
     }
   });
 
-  it("zips skill folders when TEAMSFX_AGENT_SKILLS is on", async () => {
+  it("zips skill folders unconditionally for Teams manifest agentSkills", async () => {
     const convertRes = await importOpenPlugin({
       path: pluginDir,
       output: projectDir,
@@ -84,44 +84,38 @@ describe("openPlugin → teamsApp/zipAppPackage end-to-end", () => {
     });
     if (convertRes.isErr()) throw new Error(convertRes.error.message);
 
-    const wasEnabled = featureFlagManager.getBooleanValue(FeatureFlags.AgentSkillsManifest);
-    featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, true);
-    try {
-      const args: CreateAppPackageArgs = {
-        manifestPath: path.join(projectDir, "appPackage", "manifest.json"),
-        outputZipPath: path.join(projectDir, "appPackage", "build", "appPackage.dev.zip"),
-        outputFolder: path.join(projectDir, "appPackage", "build"),
-      };
-      const ctx: any = {
-        m365TokenProvider: new MockedM365Provider(),
-        projectPath: projectDir,
-        platform: Platform.CLI,
-        logProvider: new MockedLogProvider(),
-        ui: new MockedUserInteraction(),
-        addTelemetryProperties: () => {},
-      };
-      const buildRes = (await driver.execute(args, ctx)).result;
-      if (buildRes.isErr()) throw new Error(buildRes.error.message);
+    const args: CreateAppPackageArgs = {
+      manifestPath: path.join(projectDir, "appPackage", "manifest.json"),
+      outputZipPath: path.join(projectDir, "appPackage", "build", "appPackage.dev.zip"),
+      outputFolder: path.join(projectDir, "appPackage", "build"),
+    };
+    const ctx: any = {
+      m365TokenProvider: new MockedM365Provider(),
+      projectPath: projectDir,
+      platform: Platform.CLI,
+      logProvider: new MockedLogProvider(),
+      ui: new MockedUserInteraction(),
+      addTelemetryProperties: () => {},
+    };
+    const buildRes = (await driver.execute(args, ctx)).result;
+    if (buildRes.isErr()) throw new Error(buildRes.error.message);
 
-      const zip = new AdmZip(args.outputZipPath);
-      const entries = zip.getEntries().map((e) => e.entryName);
-      expect(entries).to.include("manifest.json");
-      expect(entries).to.include("color.png");
-      expect(entries).to.include("outline.png");
-      expect(
-        entries.some((e) => e === "skills/hello/SKILL.md" || e === "skills\\hello\\SKILL.md")
-      ).to.equal(true);
-      expect(
-        entries.some(
-          (e) => e === "skills/hello/nested/helper.md" || e === "skills\\hello\\nested\\helper.md"
-        )
-      ).to.equal(true);
-    } finally {
-      featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, wasEnabled);
-    }
+    const zip = new AdmZip(args.outputZipPath);
+    const entries = zip.getEntries().map((e) => e.entryName);
+    expect(entries).to.include("manifest.json");
+    expect(entries).to.include("color.png");
+    expect(entries).to.include("outline.png");
+    expect(
+      entries.some((e) => e === "skills/hello/SKILL.md" || e === "skills\\hello\\SKILL.md")
+    ).to.equal(true);
+    expect(
+      entries.some(
+        (e) => e === "skills/hello/nested/helper.md" || e === "skills\\hello\\nested\\helper.md"
+      )
+    ).to.equal(true);
   });
 
-  it("does NOT zip skill folders when TEAMSFX_AGENT_SKILLS is off", async () => {
+  it("zips skill folders even when TEAMSFX_AGENT_SKILLS is off (Teams manifest agentSkills is unconditional)", async () => {
     const convertRes = await importOpenPlugin({
       path: pluginDir,
       output: projectDir,
@@ -151,9 +145,9 @@ describe("openPlugin → teamsApp/zipAppPackage end-to-end", () => {
 
       const zip = new AdmZip(args.outputZipPath);
       const entries = zip.getEntries().map((e) => e.entryName);
-      expect(entries.some((e) => e.startsWith("skills/") || e.startsWith("skills\\"))).to.equal(
-        false
-      );
+      expect(
+        entries.some((e) => e === "skills/hello/SKILL.md" || e === "skills\\hello\\SKILL.md")
+      ).to.equal(true);
     } finally {
       featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, wasEnabled);
     }
@@ -173,27 +167,21 @@ describe("openPlugin → teamsApp/zipAppPackage end-to-end", () => {
     manifest.agentSkills = [{ folder: "../../escape" }];
     await fs.writeJSON(manifestPath, manifest, { spaces: 4 });
 
-    const wasEnabled = featureFlagManager.getBooleanValue(FeatureFlags.AgentSkillsManifest);
-    featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, true);
-    try {
-      const args: CreateAppPackageArgs = {
-        manifestPath,
-        outputZipPath: path.join(projectDir, "appPackage", "build", "appPackage.dev.zip"),
-        outputFolder: path.join(projectDir, "appPackage", "build"),
-      };
-      const ctx: any = {
-        m365TokenProvider: new MockedM365Provider(),
-        projectPath: projectDir,
-        platform: Platform.CLI,
-        logProvider: new MockedLogProvider(),
-        ui: new MockedUserInteraction(),
-        addTelemetryProperties: () => {},
-      };
-      const buildRes = (await driver.execute(args, ctx)).result;
-      expect(buildRes.isErr()).to.equal(true);
-    } finally {
-      featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, wasEnabled);
-    }
+    const args: CreateAppPackageArgs = {
+      manifestPath,
+      outputZipPath: path.join(projectDir, "appPackage", "build", "appPackage.dev.zip"),
+      outputFolder: path.join(projectDir, "appPackage", "build"),
+    };
+    const ctx: any = {
+      m365TokenProvider: new MockedM365Provider(),
+      projectPath: projectDir,
+      platform: Platform.CLI,
+      logProvider: new MockedLogProvider(),
+      ui: new MockedUserInteraction(),
+      addTelemetryProperties: () => {},
+    };
+    const buildRes = (await driver.execute(args, ctx)).result;
+    expect(buildRes.isErr()).to.equal(true);
   });
 
   it("returns error when agentSkills folder does not exist", async () => {
@@ -210,26 +198,20 @@ describe("openPlugin → teamsApp/zipAppPackage end-to-end", () => {
     manifest.agentSkills = [{ folder: "./skills/nonexistent" }];
     await fs.writeJSON(manifestPath, manifest, { spaces: 4 });
 
-    const wasEnabled = featureFlagManager.getBooleanValue(FeatureFlags.AgentSkillsManifest);
-    featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, true);
-    try {
-      const args: CreateAppPackageArgs = {
-        manifestPath,
-        outputZipPath: path.join(projectDir, "appPackage", "build", "appPackage.dev.zip"),
-        outputFolder: path.join(projectDir, "appPackage", "build"),
-      };
-      const ctx: any = {
-        m365TokenProvider: new MockedM365Provider(),
-        projectPath: projectDir,
-        platform: Platform.CLI,
-        logProvider: new MockedLogProvider(),
-        ui: new MockedUserInteraction(),
-        addTelemetryProperties: () => {},
-      };
-      const buildRes = (await driver.execute(args, ctx)).result;
-      expect(buildRes.isErr()).to.equal(true);
-    } finally {
-      featureFlagManager.setBooleanValue(FeatureFlags.AgentSkillsManifest, wasEnabled);
-    }
+    const args: CreateAppPackageArgs = {
+      manifestPath,
+      outputZipPath: path.join(projectDir, "appPackage", "build", "appPackage.dev.zip"),
+      outputFolder: path.join(projectDir, "appPackage", "build"),
+    };
+    const ctx: any = {
+      m365TokenProvider: new MockedM365Provider(),
+      projectPath: projectDir,
+      platform: Platform.CLI,
+      logProvider: new MockedLogProvider(),
+      ui: new MockedUserInteraction(),
+      addTelemetryProperties: () => {},
+    };
+    const buildRes = (await driver.execute(args, ctx)).result;
+    expect(buildRes.isErr()).to.equal(true);
   });
 });

--- a/templates/vsc/common/open-plugin-import/README.md.tpl
+++ b/templates/vsc/common/open-plugin-import/README.md.tpl
@@ -15,5 +15,3 @@ This project was scaffolded by `atk import openplugin`.
 2. For every `agentConnectors[*].toolSource.remoteMcpServer.authorization` entry with `type === "OAuthPluginVault"`, register a matching credential reference in the Microsoft 365 Developer Portal using the `referenceId` value baked into the manifest.
 3. Build the upload package: `atk teamsapp package`.
 4. Validate: `atk teamsapp validate --file-path ./appPackage/build/appPackage.dev.zip`.
-
-This project requires the `TEAMSFX_AGENT_SKILLS` feature flag while `agentSkills` support is being rolled out.


### PR DESCRIPTION
## Why

The top-level `agentSkills` array in the Teams manifest is part of the published manifest schema. It should not have been gated behind the experimental `TEAMSFX_AGENT_SKILLS` feature flag — projects that legitimately set `agentSkills` in their manifest fail to package skill folders into the zip unless the flag is exported.

This caused `teamsApp/zipAppPackage` to silently skip valid `agentSkills` entries, leading to downstream `InvalidAgentSkill: SKILL.md file not found in skill directory` failures during MOS validation.

## What

- Remove the `TEAMSFX_AGENT_SKILLS` flag check around the top-level Teams manifest `agentSkills` packaging in `createAppPackage.ts`. The skill folders are now bundled unconditionally when the manifest declares them.
- The flag still gates the DA manifest `agent_skills` folder walk (a separate, experimental property on the Declarative Agent manifest). Only the Teams manifest top-level property changes here.
- Update tests:
  - Replace the gated "bundle top-level Teams manifest agentSkills folders" test with one that explicitly stubs the flag to `false` to assert unconditional behavior.
  - Invert the openPlugin `packaging.test.ts` "does NOT zip when flag is off" case to assert skill folders ARE zipped even when the flag is off.
  - Drop the no-longer-needed flag toggles in the fixtureConversion test.
- Update the openPlugin README flag table to reflect the new scope of the flag.
- Drop the "requires TEAMSFX_AGENT_SKILLS feature flag" note from the open-plugin-import scaffold README template.

## Verification

- `npx vitest run tests/component/driver/teamsApp/createAppPackage.test.ts` → 61/61 passing
- `npx vitest run tests/component/generator/openPlugin/` → 92/92 passing
- `tsc --noEmit` clean
- `eslint` clean (0 errors, only pre-existing warnings)