### PR TITLE
fix(fx-core): set 60s timeout on MOS package upload axios client

### DIFF
--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -47,6 +47,12 @@ const M365ErrorComponent = "PackageService";
 // MOS/Titles API maximum upload size (10 MB)
 const MOS_MAX_PACKAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
+// Per-request timeout for MOS/Titles API calls (60 s).
+// Restores a client-side timeout removed in #16017; 60 s is double the prior 30 s,
+// which was hitting timeouts on larger package uploads. A follow-up should move
+// uploads to the documented async polling flow rather than further raising this.
+export const MOS_AXIOS_TIMEOUT_MS = 60 * 1000;
+
 export enum AppScope {
   Personal = "Personal",
   Shared = "Shared",
@@ -79,6 +85,7 @@ export class PackageService {
 
   public constructor(endpoint: string, logger?: LogProvider) {
     this.axiosInstance = WrappedAxiosClient.create({
+      timeout: MOS_AXIOS_TIMEOUT_MS,
       httpsAgent: new https.Agent({ keepAlive: true }),
     });
     this.initEndpoint = endpoint;

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -13,6 +13,7 @@ import { advancedDASettingUrl } from "../../../src/component/m365/constants";
 import { NotExtendedToM365Error } from "../../../src/component/m365/errors";
 import {
   AppScope,
+  MOS_AXIOS_TIMEOUT_MS,
   PackageService,
   packageServiceDeps,
 } from "../../../src/component/m365/packageService";
@@ -96,6 +97,22 @@ describe("Package Service", () => {
     chai.assert.isDefined(instance);
     instance = PackageService.GetSharedInstance();
     chai.assert.isDefined(instance);
+  });
+
+  it("constructor configures axios with a 60s upload timeout", () => {
+    const axiosCreateStub = axios.create as unknown as {
+      resetHistory: () => void;
+      firstCall: any;
+      called: boolean;
+    };
+    axiosCreateStub.resetHistory();
+
+    new PackageService("https://test-endpoint", logger);
+
+    chai.assert.strictEqual(MOS_AXIOS_TIMEOUT_MS, 60 * 1000);
+    chai.assert.isTrue(axiosCreateStub.called);
+    const config = axiosCreateStub.firstCall.args[0];
+    chai.assert.strictEqual(config.timeout, MOS_AXIOS_TIMEOUT_MS);
   });
 
   it("sideLoadXmlManifest happy path with 200 return code", async () => {


### PR DESCRIPTION
## Why

PR #16017 removed the previous client-side 	imeout: 30000 on the `PackageService` axios instance. Since then, MOS / Titles API uploads have **no client-side timeout** at all — failures only surface when the OS socket or an intermediate proxy eventually gives up, which is currently leading to hung / miserable upload experiences for declarative agent and Teams app packages in the field.

## What

Restore an explicit per-request timeout on the MOS axios client, set to **60 s** (double the prior 30 s that was hitting the limit on larger packages).

- Add exported `MOS_AXIOS_TIMEOUT_MS = 60_000` next to the existing `MOS_MAX_PACKAGE_SIZE_BYTES` so the value is named and reusable.
- Wire it into `WrappedAxiosClient.create` alongside the existing keep-alive `httpsAgent` (no other behavior change).
- Add a focused unit test that constructs `PackageService` and asserts the axios config carries `timeout === 60_000`.

## Scope

Deliberately narrow. This is a **short-term fix** to stop uploads from hanging indefinitely. A follow-up should move uploads to the documented async polling flow rather than further raising this value.

## Verification

- `npx vitest run tests/component/m365/packageService.test.ts` → 67 / 67 passed (incl. new test).
- `npx tsc -p ./ --incremental` in `packages/fx-core` → clean.
- `pnpm exec eslint --fix` on touched files → 0 errors (only pre-existing `no-explicit-any` warnings remain).
