### PR TITLE
fix(fx-core): publish v4 templates under clean suffix-free versions

### DIFF
--- a/.github/scripts/v4/publish-v4-channel.sh
+++ b/.github/scripts/v4/publish-v4-channel.sh
@@ -31,7 +31,33 @@ TMP="${3:?Need a temp directory.}"
 SHA="${4:?Need the commit sha to anchor the release.}"
 METADATA_ZIP="${5:-}"
 
-VERSION="${TEMPLATE_TAG#templates@}"
+RAW_VERSION="${TEMPLATE_TAG#templates@}"
+RAW_MINOR="$(echo "$RAW_VERSION" | cut -d. -f2)"
+
+# Clean-version invariant. The v4 channel only ever holds clean versions that a
+# `~major.minor` range can resolve, keyed on the minted version's odd/even minor:
+#   - ODD minor  = prerelease line (6.11.x): published under a clean, date-stamped
+#     version (6.11.<date>) computed by computeV4PublishVersion and recorded as
+#     templates-config.json v4.localVersion by the preceding "sync v4 template
+#     config" step. We reuse that single source of truth here.
+#   - EVEN minor = stable line (6.10.x): already clean, published as-is.
+# An EVEN-minor version that still carries a prerelease suffix means a preview
+# lane was minted on a stable branch (the exact 6.10.3-beta.<date> misfire) —
+# refuse it, since stripping the suffix would collide with the real stable 6.10.3.
+case "$RAW_VERSION" in
+  *-*)
+    if [ $((RAW_MINOR % 2)) -eq 0 ]; then
+      echo "Refusing v4 channel publish: '$RAW_VERSION' is a prerelease-suffixed even-minor (stable) version — a preview lane minted on a stable branch." >&2
+      exit 1
+    fi
+    ;;
+esac
+
+# Reuse the clean publish version the sync step already computed (single source
+# of truth), falling back to the raw version for an even-minor stable release.
+CONFIG_FILE="packages/fx-core/src/common/templates-config.json"
+VERSION="$(node -p "(require('./$CONFIG_FILE').v4 || {}).localVersion || '$RAW_VERSION'")"
+
 TAG="templates-v4@$VERSION"
 NDJSON="$TMP/template-v4-tags.ndjson"
 

--- a/.github/scripts/v4/sync-v4-template-config.js
+++ b/.github/scripts/v4/sync-v4-template-config.js
@@ -6,30 +6,85 @@
  * templates-config.json from the freshly minted templates version and the
  * `goproduct` flag.
  *
- * This is the thin node glue around the unit-tested pure logic in
- * packages/fx-core/src/v4/distribution/templateConfig.ts. It does only IO:
- * read version + flag + previous config, call computeV4TemplateConfig, write
- * back. The `v4` block is fully isolated from v3's `version` / `useLocalTemplate`
- * (different semantics, v3 frozen) — see scaffolding.create.proposal.md §5.1.
+ * This does only IO: read version + flag + previous config, compute the `v4`
+ * block, write back. The `v4` block is fully isolated from v3's `version` /
+ * `useLocalTemplate` (different semantics, v3 frozen) — see
+ * scaffolding.create.proposal.md §5.1.
+ *
+ * The compute logic below is intentionally self-contained plain JS and is NOT
+ * required from fx-core's build output. A template-only release trims the pnpm
+ * workspace to just `templates` (see .github/scripts/lernaDeps.json), so fx-core
+ * is never built in that lane — requiring its compiled output would crash this
+ * step. The canonical, unit-tested definition lives in
+ * packages/fx-core/src/v4/distribution/templateConfig.ts; keep these in sync.
+ *
+ * `semver` is resolved from the `templates` package (always present when this
+ * step runs — it only fires on a `templates@` change) because pnpm's per-package
+ * node_modules (shared-workspace-lockfile=false) means a bare `require("semver")`
+ * from this script's location does not resolve.
  *
  * Usage (run AFTER `lerna version`, with the templates package version minted):
  *   PRODUCTION=<true|false> node .github/scripts/v4/sync-v4-template-config.js
- *
- * Requires fx-core to be built (build/v4/distribution/templateConfig.js).
  */
 
 const path = require("path");
 const fs = require("fs");
+const { createRequire } = require("module");
 
 const repoRoot = path.join(__dirname, "../../..");
-const templateVersion = require(path.join(repoRoot, "templates/package.json")).version;
+const templatesPackageJson = path.join(repoRoot, "templates/package.json");
+const templateVersion = require(templatesPackageJson).version;
+const semver = createRequire(templatesPackageJson)("semver");
 
 const fxCorePath = path.join(repoRoot, "packages/fx-core");
 const configFile = path.join(fxCorePath, "src/common/templates-config.json");
-const { computeV4TemplateConfig } = require(path.join(
-  fxCorePath,
-  "build/v4/distribution/templateConfig.js"
-));
+
+// Mirror of packages/fx-core/src/v4/distribution/templateConfig.ts (canonical,
+// unit-tested). Kept inline so this CD step stays build-independent.
+// `bundled` is just !goproduct. A shipping prerelease (odd-minor preview) is
+// published online under a clean, suffix-free version (computeV4PublishVersion),
+// so a suffix never forces bundling. Keep in sync with the canonical module.
+function computeBundled(goproduct) {
+  return !goproduct;
+}
+
+// Clean, suffix-free version published to the v4 channel: odd minor (prerelease)
+// stamps the build date into the patch (6.11.<date>, read from the -beta.<date>
+// preid); even minor (stable) uses major.minor.patch as-is.
+function computeV4PublishVersion(version) {
+  const parsed = semver.parse(version);
+  if (parsed === null) {
+    throw new Error(`Cannot compute v4 publish version: "${version}" is not valid SemVer.`);
+  }
+  if (parsed.minor % 2 === 1) {
+    const dateStamp = parsed.prerelease.find(
+      (segment) => typeof segment === "number" && segment >= 1000000000
+    );
+    if (dateStamp !== undefined) {
+      return `${parsed.major}.${parsed.minor}.${dateStamp}`;
+    }
+  }
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+}
+
+function computeRange(version, previousRange) {
+  const parsed = semver.parse(version);
+  if (parsed === null) {
+    throw new Error(`Cannot compute v4 template range: "${version}" is not valid SemVer.`);
+  }
+  if (semver.intersects(previousRange, `${parsed.major}.${parsed.minor}.0`)) {
+    return previousRange;
+  }
+  return `~${parsed.major}.${parsed.minor}`;
+}
+
+function computeV4TemplateConfig(input) {
+  return {
+    range: computeRange(input.version, input.previousRange),
+    bundled: computeBundled(input.goproduct),
+    localVersion: computeV4PublishVersion(input.version),
+  };
+}
 
 const goproduct = process.env.PRODUCTION === "true";
 

--- a/packages/fx-core/src/v4/distribution/templateConfig.ts
+++ b/packages/fx-core/src/v4/distribution/templateConfig.ts
@@ -16,7 +16,8 @@ import * as semver from "semver";
  *   - `range`   — the SemVer range the build may resolve within (`~major.minor`)
  *   - `bundled` — `true` for test/offline builds (bundled floor), `false` for
  *                 shipped builds (release channel)
- * plus `localVersion` (the exact minted version, recorded for observability).
+ * plus `localVersion` (the clean, suffix-free version published to / pinned on
+ * the v4 channel — see `computeV4PublishVersion`).
  *
  * Spec: docs/03-specs/operations/scaffolding/resolve-template-source.md
  */
@@ -38,25 +39,65 @@ export interface V4TemplateConfig {
   range: string;
   /** `true` for test/offline builds (bundled floor); `false` for shipped builds. */
   bundled: boolean;
-  /** The exact minted version (observability / floor pin). */
+  /** The clean, suffix-free version published to the v4 channel (floor pin). */
   localVersion: string;
 }
 
 /**
- * `bundled` is the negation of `goproduct`: a build that is NOT shipping to
- * users resolves from the bundled floor (offline-by-default); a shipping build
- * resolves from the online release channel. Independent of `preid` / lane.
+ * `bundled` decides whether a build resolves from the bundled floor
+ * (offline-by-default) or the online release channel: it is simply the negation
+ * of `goproduct`. A build that is NOT shipping to users (internal / daily test
+ * builds) resolves from the bundled floor; a shipping build resolves online.
+ *
+ * A prerelease-SUFFIXED minted version does NOT force bundling: a shipping
+ * prerelease (odd-minor preview, `goproduct=true`) is published online under a
+ * clean, suffix-free version computed by `computeV4PublishVersion` so a
+ * `~major.minor` range can resolve it.
  */
 export function computeBundled(goproduct: boolean): boolean {
   return !goproduct;
 }
 
 /**
- * The range a build may resolve within. templates carries no odd/even-minor
- * split (unlike the VS Code extension), so a prerelease and the stable it
- * graduates into share one `~major.minor`. The range is only widened when the
- * minted version no longer intersects the previous range; otherwise it is kept
- * stable for reproducibility.
+ * The clean, suffix-free version published to the v4 channel for a minted
+ * version, derived purely from the minted version's odd/even minor:
+ *
+ *   - ODD minor  (prerelease line, e.g. `6.11.x`): the build date stamped into
+ *     the patch (`6.11.<YYYYMMDDHH>`). The date is read from the `-beta.<date>`
+ *     preid the preview lane mints, so every preview build gets a unique,
+ *     suffix-free version that satisfies `~major.minor`. Falls back to the raw
+ *     patch when no date stamp is present.
+ *   - EVEN minor (stable line, e.g. `6.10.x`): `major.minor.patch` as-is; the
+ *     stable lane already mints a clean version.
+ *
+ * This is the v4-channel counterpart of the clean `templates@<major>.<minor>.<date>`
+ * pattern the v3 channel uses for prereleases. Refusing to publish an
+ * even-minor SUFFIXED version (a preview lane minted on a stable branch) is
+ * enforced at publish time, not here, so non-shipping test builds keep working.
+ */
+export function computeV4PublishVersion(version: string): string {
+  const parsed = semver.parse(version);
+  if (parsed === null) {
+    throw new Error(`Cannot compute v4 publish version: "${version}" is not valid SemVer.`);
+  }
+  if (parsed.minor % 2 === 1) {
+    const dateStamp = parsed.prerelease.find(
+      (segment): segment is number => typeof segment === "number" && segment >= 1_000_000_000
+    );
+    if (dateStamp !== undefined) {
+      return `${parsed.major}.${parsed.minor}.${dateStamp}`;
+    }
+  }
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+}
+
+/**
+ * The range a build may resolve within: `~major.minor` of the minted version.
+ * v4 templates use an odd/even-minor split — odd-minor prereleases (`6.11.x`)
+ * and even-minor stables (`6.10.x`) live on different minors, so their ranges
+ * are naturally isolated. The range is only widened when the minted version no
+ * longer intersects the previous range; otherwise it is kept stable for
+ * reproducibility.
  */
 export function computeRange(version: string, previousRange: string): string {
   const parsed = semver.parse(version);
@@ -74,6 +115,6 @@ export function computeV4TemplateConfig(input: V4TemplateConfigInput): V4Templat
   return {
     range: computeRange(input.version, input.previousRange),
     bundled: computeBundled(input.goproduct),
-    localVersion: input.version,
+    localVersion: computeV4PublishVersion(input.version),
   };
 }

--- a/packages/fx-core/tests/v4/distribution/templateConfig.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateConfig.test.ts
@@ -5,6 +5,7 @@ import { assert } from "chai";
 import {
   computeBundled,
   computeRange,
+  computeV4PublishVersion,
   computeV4TemplateConfig,
 } from "../../../src/v4/distribution/templateConfig";
 
@@ -18,6 +19,28 @@ describe("templateConfig (v4 build-time)", () => {
     });
   });
 
+  describe("computeV4PublishVersion", () => {
+    it("odd-minor preview → stamps the build date into the patch, drops the suffix", () => {
+      assert.strictEqual(computeV4PublishVersion("6.11.1-beta.2026061609.0"), "6.11.2026061609");
+    });
+
+    it("odd-minor without a date stamp → major.minor.patch", () => {
+      assert.strictEqual(computeV4PublishVersion("6.11.5"), "6.11.5");
+    });
+
+    it("even-minor stable → major.minor.patch as-is", () => {
+      assert.strictEqual(computeV4PublishVersion("6.10.3"), "6.10.3");
+    });
+
+    it("even-minor suffixed (preview minted on stable branch) → stripped (publish-time guard refuses it separately)", () => {
+      assert.strictEqual(computeV4PublishVersion("6.10.3-beta.2026061609.0"), "6.10.3");
+    });
+
+    it("throws on a non-SemVer version (no silent fallback)", () => {
+      assert.throws(() => computeV4PublishVersion("not-semver"), /not valid SemVer/);
+    });
+  });
+
   describe("computeRange", () => {
     it("keeps the previous range when the version still intersects it", () => {
       assert.strictEqual(computeRange("6.10.5", "~6.10"), "~6.10");
@@ -27,8 +50,8 @@ describe("templateConfig (v4 build-time)", () => {
       assert.strictEqual(computeRange("6.11.0", "~6.10"), "~6.11");
     });
 
-    it("derives ~major.minor from a prerelease's stable target", () => {
-      // templates has no odd/even-minor split, so the rc shares the stable range.
+    it("derives ~major.minor from a prerelease's minor", () => {
+      // Odd-minor prerelease lives on its own minor; range follows that minor.
       assert.strictEqual(computeRange("6.11.0-rc.0", "~6.10"), "~6.11");
     });
 
@@ -42,42 +65,42 @@ describe("templateConfig (v4 build-time)", () => {
   });
 
   describe("computeV4TemplateConfig", () => {
-    it("internal rc test build → bundled floor, range from stable target, exact localVersion", () => {
+    it("odd-minor preview shipping (goproduct=true) → online, clean date-stamped localVersion", () => {
       const config = computeV4TemplateConfig({
-        version: "6.11.0-rc.0",
+        version: "6.11.1-beta.2026061609.0",
+        goproduct: true,
+        previousRange: "~6.10",
+      });
+      assert.deepEqual(config, {
+        range: "~6.11",
+        bundled: false,
+        localVersion: "6.11.2026061609",
+      });
+    });
+
+    it("even-minor stable shipping (goproduct=true) → online, version as-is", () => {
+      const config = computeV4TemplateConfig({
+        version: "6.10.3",
+        goproduct: true,
+        previousRange: "~6.10",
+      });
+      assert.deepEqual(config, {
+        range: "~6.10",
+        bundled: false,
+        localVersion: "6.10.3",
+      });
+    });
+
+    it("internal test build (goproduct=false) → bundled floor regardless of suffix", () => {
+      const config = computeV4TemplateConfig({
+        version: "6.11.1-beta.2026061609.0",
         goproduct: false,
         previousRange: "~6.10",
       });
       assert.deepEqual(config, {
         range: "~6.11",
         bundled: true,
-        localVersion: "6.11.0-rc.0",
-      });
-    });
-
-    it("stable shipping build → online channel, widened range", () => {
-      const config = computeV4TemplateConfig({
-        version: "6.11.0",
-        goproduct: true,
-        previousRange: "~6.10",
-      });
-      assert.deepEqual(config, {
-        range: "~6.11",
-        bundled: false,
-        localVersion: "6.11.0",
-      });
-    });
-
-    it("prerelease shipped to marketplace pre-release channel → online (bundled=false)", () => {
-      const config = computeV4TemplateConfig({
-        version: "6.11.0-rc.0",
-        goproduct: true,
-        previousRange: "~6.11",
-      });
-      assert.deepEqual(config, {
-        range: "~6.11",
-        bundled: false,
-        localVersion: "6.11.0-rc.0",
+        localVersion: "6.11.2026061609",
       });
     });
 

--- a/templates/scripts/generateV4Zip.js
+++ b/templates/scripts/generateV4Zip.js
@@ -13,7 +13,14 @@
  *
  * Outputs (both picked up by the `distribute` step → packages/fx-core/templates/v4/):
  *   - build/v4/templates.zip  — the full package
- *   - build/v4/floor.json     — { "version": <templates package version> }
+ *   - build/v4/floor.json     — { "version": <clean v4 publish version> }
+ *
+ * The floor version is the SAME clean, suffix-free version published to the v4
+ * channel (computeV4PublishVersion / templates-config.json v4.localVersion), not
+ * the raw minted package version: an odd-minor preview is minted as
+ * `6.11.1-beta.<date>` but ships everywhere as `6.11.<date>`, so the bundled
+ * floor and the online release report one identical version. Runs at build time
+ * (lerna's `postversion` hook), so the minted version is already in package.json.
  *
  * The digest is NOT written here: it is computed from the bytes at load time
  * so `computeDigest` stays the single authority (resolve-template-source spec
@@ -23,10 +30,33 @@
 const AdmZip = require("adm-zip");
 const { readdirSync, mkdirSync, writeFileSync } = require("node:fs");
 const path = require("path");
+const semver = require("semver");
+
+// Mirror of packages/fx-core/src/v4/distribution/templateConfig.ts
+// `computeV4PublishVersion` (canonical, unit-tested). Kept inline so the
+// templates build needs no fx-core build output. Odd minor (prerelease) stamps
+// the build date into the patch (6.11.<date>, read from the -beta.<date> preid);
+// even minor (stable) uses major.minor.patch as-is. Keep in sync with canonical.
+function computeV4PublishVersion(rawVersion) {
+  const parsed = semver.parse(rawVersion);
+  if (parsed === null) {
+    throw new Error(`Cannot compute v4 publish version: "${rawVersion}" is not valid SemVer.`);
+  }
+  if (parsed.minor % 2 === 1) {
+    const dateStamp = parsed.prerelease.find(
+      (segment) => typeof segment === "number" && segment >= 1000000000
+    );
+    if (dateStamp !== undefined) {
+      return `${parsed.major}.${parsed.minor}.${dateStamp}`;
+    }
+  }
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+}
 
 const LANGUAGES = ["common", "js", "ts", "python"];
 const BUILD_PATH = path.join(__dirname, "..", "build", "v4");
-const version = require(path.join(__dirname, "..", "package.json")).version;
+const rawVersion = require(path.join(__dirname, "..", "package.json")).version;
+const version = computeV4PublishVersion(rawVersion);
 
 mkdirSync(BUILD_PATH, { recursive: true });
 


### PR DESCRIPTION
## Problem

The v4 template channel only resolves **clean** versions. Resolution uses `semver.maxSatisfying(versions, "~major.minor")` with default options (prereleases excluded), so a prerelease-**suffixed** tag can never be matched.

A `preview` build was minted as `6.10.3-beta.2026061609.0` and (with `goproduct=true`) leaked online as `templates-v4@6.10.3-beta.2026061609.0`. That tag is unresolvable by any stable `~major.minor` range — a dead release. Two independent defects combined:

1. The preview lane ran on an **even-minor (stable) branch**, producing a `6.10.x` line.
2. `lerna version prerelease --preid=beta.<date>` mints a `-beta`-**suffixed** version.

## Model

v4 templates use an **odd/even-minor split**, gated by `goproduct`:

- **odd minor** (`6.11.x`) = prerelease line
- **even minor** (`6.10.x`) = stable line
- `goproduct=false` → bundled floor (offline test build); `goproduct=true` → online channel

The channel must only ever hold clean, suffix-free versions a `~major.minor` range can resolve.

## Fix

Derive the published / floor version purely from the minted version's odd/even minor (no branch info needed — it's all in the version string):

| minted (raw) | published / floor | online? |
|---|---|---|
| `6.11.1-beta.2026061609.0` (odd preview) | `6.11.2026061609` (date stamped into patch, suffix dropped) | yes, `~6.11` resolves it |
| `6.10.3` (even stable) | `6.10.3` (as-is) | yes |
| `6.10.3-beta.<date>` (even + suffix = preview on a stable branch) | publish refused | no |

- **`computeBundled` stays `!goproduct`** — a suffix no longer forces bundling; a shipping odd-minor preview publishes online under its clean version.
- **`computeV4PublishVersion`** (new, canonical, unit-tested) does the odd/even derivation; `localVersion` flows through it.
- **`publish-v4-channel.sh`** reuses the synced clean `localVersion` (single source of truth, no version math in bash) for the `templates-v4@<ver>` tag, and **refuses** an even-minor suffixed version (a preview minted on a stable branch) since stripping its suffix would collide with the real stable patch.
- **`generateV4Zip.js`** stamps the same clean version into `floor.json`, so the bundled floor and the online release report **one identical version** (consistent telemetry + the AC-05 "floor is highest satisfier, skip download" optimization fires for previews).

`computeV4PublishVersion` is mirrored inline in the two build-independent scripts (CD sync + templates build), kept in sync with the canonical fx-core module — matching the existing mirror convention that keeps these steps decoupled from an fx-core build (a template-only release trims the workspace to `templates`).

## Verification

- `packages/fx-core` unit tests: **16/16 pass** (`templateConfig.test.ts`).
- `generateV4Zip.js` run end-to-end: `6.10.2` → floor `6.10.2`; dirty `6.11.1-beta.2026061609.0` → floor `6.11.2026061609`.
- CD-mirror parity check: `computeV4PublishVersion` produces identical results across the canonical and mirrored implementations.

## Files

- `packages/fx-core/src/v4/distribution/templateConfig.ts`
- `packages/fx-core/tests/v4/distribution/templateConfig.test.ts`
- `.github/scripts/v4/sync-v4-template-config.js`
- `.github/scripts/v4/publish-v4-channel.sh`
- `templates/scripts/generateV4Zip.js`
