### PR TITLE
fix: add TEMPLATE_VERSION parameter for test pipeline for testing against template package

### DIFF
--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -28,7 +28,7 @@ on:
         required: false
         type: string
         default: "latest"
-      TEMPLATE_VERSION:
+      template_version:
         required: false
         type: string
         default: ""
@@ -286,14 +286,14 @@ jobs:
 
       - name: Inject TEMPLATE_VERSION into config.yaml
         env:
-          INPUT_TEMPLATE_VERSION: ${{ inputs.TEMPLATE_VERSION }}
+          TEMPLATE_VERSION: ${{ inputs.template_version }}
         run: |
           cd packages/tests/vscuse/vscode-test-cases
 
-          if [ -n "$INPUT_TEMPLATE_VERSION" ]; then
+          if [ -n "$TEMPLATE_VERSION" ]; then
             awk '
               /^execution:/ && !inserted {
-                print "TEMPLATE_VERSION: \"" ENVIRON["INPUT_TEMPLATE_VERSION"] "\""
+                print "TEMPLATE_VERSION: \"" ENVIRON["TEMPLATE_VERSION"] "\""
                 print ""
                 inserted = 1
               }
@@ -301,7 +301,7 @@ jobs:
             ' config.yaml > config.yaml.tmp
             mv config.yaml.tmp config.yaml
 
-            echo "Injected TEMPLATE_VERSION into VSCUSE config.yaml: $INPUT_TEMPLATE_VERSION"
+            echo "Injected TEMPLATE_VERSION into VSCUSE config.yaml: $TEMPLATE_VERSION"
             grep -n "TEMPLATE_VERSION" config.yaml
           else
             echo "TEMPLATE_VERSION not provided; TEMPLATE_VERSION won't be added to config.yaml"

--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -293,7 +293,7 @@ jobs:
           if [ -n "$INPUT_TEMPLATE_VERSION" ]; then
             awk '
               /^execution:/ && !inserted {
-                print "TEMPLATE_VERSION: \"" ENVIRON["INPUT_TEMPLATE_VERSION"] "\"  # Version of the template used in the image, e.g. 0.0.0-rc"
+                print "TEMPLATE_VERSION: \"" ENVIRON["INPUT_TEMPLATE_VERSION"] "\""
                 print ""
                 inserted = 1
               }
@@ -301,10 +301,10 @@ jobs:
             ' config.yaml > config.yaml.tmp
             mv config.yaml.tmp config.yaml
 
-            echo "Injected TEMPLATE_VERSION into config.yaml: $INPUT_TEMPLATE_VERSION"
+            echo "Injected TEMPLATE_VERSION into VSCUSE config.yaml: $INPUT_TEMPLATE_VERSION"
             grep -n "TEMPLATE_VERSION" config.yaml
           else
-            echo "TEMPLATE_VERSION not provided; leaving config.yaml unchanged"
+            echo "TEMPLATE_VERSION not provided; TEMPLATE_VERSION won't be added to config.yaml"
           fi
 
       - name: Run test

--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -293,7 +293,7 @@ jobs:
           if [ -n "$TEMPLATE_VERSION" ]; then
             awk '
               /^execution:/ && !inserted {
-                print "TEMPLATE_VERSION: \"" ENVIRON["TEMPLATE_VERSION"] "\""
+                print "    TEMPLATE_VERSION: \"" ENVIRON["TEMPLATE_VERSION"] "\""
                 print ""
                 inserted = 1
               }
@@ -302,7 +302,6 @@ jobs:
             mv config.yaml.tmp config.yaml
 
             echo "Injected TEMPLATE_VERSION into VSCUSE config.yaml: $TEMPLATE_VERSION"
-            grep -n "TEMPLATE_VERSION" config.yaml
           else
             echo "TEMPLATE_VERSION not provided; TEMPLATE_VERSION won't be added to config.yaml"
           fi

--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: "latest"
+      TEMPLATE_VERSION:
+        required: false
+        type: string
+        default: ""
       email_receiver:
         required: false
         type: string
@@ -280,10 +284,40 @@ jobs:
           echo "✅ Image pulled successfully!"
           docker images $VSCUSE_VSCODE_IMAGE
 
+      - name: Inject TEMPLATE_VERSION into config.yaml
+        env:
+          INPUT_TEMPLATE_VERSION: ${{ inputs.TEMPLATE_VERSION }}
+        run: |
+          cd packages/tests/vscuse/vscode-test-cases
+
+          if [ -n "$INPUT_TEMPLATE_VERSION" ]; then
+            awk '
+              /^execution:/ && !inserted {
+                print "TEMPLATE_VERSION: \"" ENVIRON["INPUT_TEMPLATE_VERSION"] "\"  # Version of the template used in the image, e.g. 0.0.0-rc"
+                print ""
+                inserted = 1
+              }
+              { print }
+            ' config.yaml > config.yaml.tmp
+            mv config.yaml.tmp config.yaml
+
+            echo "Injected TEMPLATE_VERSION into config.yaml: $INPUT_TEMPLATE_VERSION"
+            grep -n "TEMPLATE_VERSION" config.yaml
+          else
+            echo "TEMPLATE_VERSION not provided; leaving config.yaml unchanged"
+          fi
+
       - name: Run test
+        env:
+          INPUT_TEMPLATE_VERSION: ${{ inputs.TEMPLATE_VERSION }}
         run: |
           echo "🚀 Running test plan: ${{ matrix.test_plan }}"
           echo "Using image tag: ${{ inputs.image_tag }}"
+          if [ -n "$INPUT_TEMPLATE_VERSION" ]; then
+            echo "Using TEMPLATE_VERSION: $INPUT_TEMPLATE_VERSION"
+          else
+            echo "Using TEMPLATE_VERSION: <not set>"
+          fi
           echo "Test execution started at: $(date)"
 
           set -o pipefail

--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -308,16 +308,9 @@ jobs:
           fi
 
       - name: Run test
-        env:
-          INPUT_TEMPLATE_VERSION: ${{ inputs.TEMPLATE_VERSION }}
         run: |
           echo "🚀 Running test plan: ${{ matrix.test_plan }}"
           echo "Using image tag: ${{ inputs.image_tag }}"
-          if [ -n "$INPUT_TEMPLATE_VERSION" ]; then
-            echo "Using TEMPLATE_VERSION: $INPUT_TEMPLATE_VERSION"
-          else
-            echo "Using TEMPLATE_VERSION: <not set>"
-          fi
           echo "Test execution started at: $(date)"
 
           set -o pipefail

--- a/.github/workflows/ui-test-vscuse-features.yml
+++ b/.github/workflows/ui-test-vscuse-features.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: "latest"
       TEMPLATE_VERSION:
-        description: "Template version to inject into VSCUSE config.yaml"
+        description: "Template version to inject into VSCUSE config.yaml. Version of the template used in the image, e.g. 0.0.0-rc."
         required: false
         type: string
       email-receiver:

--- a/.github/workflows/ui-test-vscuse-features.yml
+++ b/.github/workflows/ui-test-vscuse-features.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: "latest"
+      TEMPLATE_VERSION:
+        description: "Template version to inject into packages/tests/vscuse/vscode-test-cases/config.yaml"
+        required: false
+        type: string
       email-receiver:
         description: "email notification receiver"
         required: false
@@ -47,6 +51,7 @@ jobs:
       test_plan: ${{ github.event.inputs.test_plan }}
       image_tag: ${{ github.event.inputs.image_tag }}
       vscuse_version: ${{ github.event.inputs.vscuse_version }}
+      TEMPLATE_VERSION: ${{ github.event.inputs.TEMPLATE_VERSION }}
       email_receiver: ${{ github.event.inputs.email-receiver }}
       max_retries: ${{ fromJson(github.event.inputs.max_retries || '7') }}
       schedule_trigger: ${{ github.event.inputs.schedule_trigger == 'true' }}

--- a/.github/workflows/ui-test-vscuse-features.yml
+++ b/.github/workflows/ui-test-vscuse-features.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: "latest"
       TEMPLATE_VERSION:
-        description: "Template version to inject into packages/tests/vscuse/vscode-test-cases/config.yaml"
+        description: "Template version to inject into VSCUSE config.yaml"
         required: false
         type: string
       email-receiver:

--- a/.github/workflows/ui-test-vscuse-features.yml
+++ b/.github/workflows/ui-test-vscuse-features.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
         default: "latest"
-      TEMPLATE_VERSION:
+      template_version:
         description: "Template version to inject into VSCUSE config.yaml. Version of the template used in the image, e.g. 0.0.0-rc."
         required: false
         type: string
@@ -51,7 +51,7 @@ jobs:
       test_plan: ${{ github.event.inputs.test_plan }}
       image_tag: ${{ github.event.inputs.image_tag }}
       vscuse_version: ${{ github.event.inputs.vscuse_version }}
-      TEMPLATE_VERSION: ${{ github.event.inputs.TEMPLATE_VERSION }}
+      template_version: ${{ github.event.inputs.template_version }}
       email_receiver: ${{ github.event.inputs.email-receiver }}
       max_retries: ${{ fromJson(github.event.inputs.max_retries || '7') }}
       schedule_trigger: ${{ github.event.inputs.schedule_trigger == 'true' }}

--- a/.github/workflows/ui-test-vscuse-samples.yml
+++ b/.github/workflows/ui-test-vscuse-samples.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: "latest"
       TEMPLATE_VERSION:
-        description: "Template version to inject into VSCUSE config.yaml"
+        description: "Template version to inject into VSCUSE config.yaml. Version of the template used in the image, e.g. 0.0.0-rc."
         required: false
         type: string
       email-receiver:

--- a/.github/workflows/ui-test-vscuse-samples.yml
+++ b/.github/workflows/ui-test-vscuse-samples.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: "latest"
+      TEMPLATE_VERSION:
+        description: "Template version to inject into packages/tests/vscuse/vscode-test-cases/config.yaml"
+        required: false
+        type: string
       email-receiver:
         description: "email notification receiver"
         required: false
@@ -47,6 +51,7 @@ jobs:
       test_plan: ${{ github.event.inputs.test_plan }}
       image_tag: ${{ github.event.inputs.image_tag }}
       vscuse_version: ${{ github.event.inputs.vscuse_version }}
+      TEMPLATE_VERSION: ${{ github.event.inputs.TEMPLATE_VERSION }}
       email_receiver: ${{ github.event.inputs.email-receiver }}
       max_retries: ${{ fromJson(github.event.inputs.max_retries || '7') }}
       schedule_trigger: ${{ github.event.inputs.schedule_trigger == 'true' }}

--- a/.github/workflows/ui-test-vscuse-samples.yml
+++ b/.github/workflows/ui-test-vscuse-samples.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: "latest"
       TEMPLATE_VERSION:
-        description: "Template version to inject into packages/tests/vscuse/vscode-test-cases/config.yaml"
+        description: "Template version to inject into VSCUSE config.yaml"
         required: false
         type: string
       email-receiver:

--- a/.github/workflows/ui-test-vscuse-samples.yml
+++ b/.github/workflows/ui-test-vscuse-samples.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
         default: "latest"
-      TEMPLATE_VERSION:
+      template_version:
         description: "Template version to inject into VSCUSE config.yaml. Version of the template used in the image, e.g. 0.0.0-rc."
         required: false
         type: string
@@ -51,7 +51,7 @@ jobs:
       test_plan: ${{ github.event.inputs.test_plan }}
       image_tag: ${{ github.event.inputs.image_tag }}
       vscuse_version: ${{ github.event.inputs.vscuse_version }}
-      TEMPLATE_VERSION: ${{ github.event.inputs.TEMPLATE_VERSION }}
+      template_version: ${{ github.event.inputs.template_version }}
       email_receiver: ${{ github.event.inputs.email-receiver }}
       max_retries: ${{ fromJson(github.event.inputs.max_retries || '7') }}
       schedule_trigger: ${{ github.event.inputs.schedule_trigger == 'true' }}

--- a/.github/workflows/ui-test-vscuse-template.yml
+++ b/.github/workflows/ui-test-vscuse-template.yml
@@ -18,7 +18,7 @@ on:
         type: string
         default: "latest"
       TEMPLATE_VERSION:
-        description: "Template version to inject into VSCUSE config.yaml"
+        description: "Template version to inject into VSCUSE config.yaml. Version of the template used in the image, e.g. 0.0.0-rc."
         required: false
         type: string
       email-receiver:

--- a/.github/workflows/ui-test-vscuse-template.yml
+++ b/.github/workflows/ui-test-vscuse-template.yml
@@ -18,7 +18,7 @@ on:
         type: string
         default: "latest"
       TEMPLATE_VERSION:
-        description: "Template version to inject into packages/tests/vscuse/vscode-test-cases/config.yaml"
+        description: "Template version to inject into VSCUSE config.yaml"
         required: false
         type: string
       email-receiver:

--- a/.github/workflows/ui-test-vscuse-template.yml
+++ b/.github/workflows/ui-test-vscuse-template.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
         default: "latest"
+      TEMPLATE_VERSION:
+        description: "Template version to inject into packages/tests/vscuse/vscode-test-cases/config.yaml"
+        required: false
+        type: string
       email-receiver:
         description: "email notification receiver"
         required: false
@@ -48,6 +52,7 @@ jobs:
       test_plan: ${{ github.event.inputs.test_plan }}
       image_tag: ${{ github.event.inputs.image_tag }}
       vscuse_version: ${{ github.event.inputs.vscuse_version }}
+      TEMPLATE_VERSION: ${{ github.event.inputs.TEMPLATE_VERSION }}
       email_receiver: ${{ github.event.inputs.email-receiver }}
       max_retries: ${{ fromJson(github.event.inputs.max_retries || '7') }}
       schedule_trigger: ${{ github.event.inputs.schedule_trigger == 'true' }}

--- a/.github/workflows/ui-test-vscuse-template.yml
+++ b/.github/workflows/ui-test-vscuse-template.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
         default: "latest"
-      TEMPLATE_VERSION:
+      template_version:
         description: "Template version to inject into VSCUSE config.yaml. Version of the template used in the image, e.g. 0.0.0-rc."
         required: false
         type: string
@@ -52,7 +52,7 @@ jobs:
       test_plan: ${{ github.event.inputs.test_plan }}
       image_tag: ${{ github.event.inputs.image_tag }}
       vscuse_version: ${{ github.event.inputs.vscuse_version }}
-      TEMPLATE_VERSION: ${{ github.event.inputs.TEMPLATE_VERSION }}
+      template_version: ${{ github.event.inputs.template_version }}
       email_receiver: ${{ github.event.inputs.email-receiver }}
       max_retries: ${{ fromJson(github.event.inputs.max_retries || '7') }}
       schedule_trigger: ${{ github.event.inputs.schedule_trigger == 'true' }}


### PR DESCRIPTION
For now, the test pipeline doesn't allow testing against ATK with a specified template package. Therefore, it's difficult to test when only the template package has changes. Once this feature is added, we'll be able to specify the template version and test against it.