### PR TITLE
fix: scaffold from DP fails

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -7,6 +7,12 @@
 - Make sure changed code is covered by unit tests before completion. Unit tests can be skipped only during temporary developing/validating iterations.
 - Keep code cross-platform (Windows, Linux, and macOS).
 
+## Build scope guidance
+- **When only cli is changed**: Run `pnpm run build` in the cli package directory only. Do NOT rebuild the entire monorepo.
+- **When cli and other packages are changed**: Run `pnpm run setup` from the monorepo root to build all affected packages.
+- **For dependent packages**: If vscode-extension or other packages depend on cli changes, rebuild those packages in their respective directories AFTER cli builds successfully.
+- **Agent instruction**: When presented with changes to a specific package folder, execute build commands scoped to that package directory only to optimize build time and reduce unnecessary compilation.
+
 ## Code style and testability
 - Prefer namespace imports for internal modules when functions may need stubbing in UT. Example: use `import * as templateHelper from "..."` and call `templateHelper.useLocalTemplate()` instead of destructuring imports.
 - Avoid binding external/static dependencies directly at call sites when behavior needs to be mocked. Route them through a deps object or a small wrapper function in the same module.

--- a/packages/fx-core/AGENTS.md
+++ b/packages/fx-core/AGENTS.md
@@ -7,6 +7,12 @@
 - Make sure all of the changed codes are covered by unit tests in completed status. Unit test can be ignored in developing/validating status.
 - Code should work both on Windows, Linux and macOS.
 
+## Build scope guidance
+- **When only fx-core is changed**: Run `pnpm run build` or `tsc -p ./ --incremental` **only in the fx-core package directory**. Do NOT rebuild the entire monorepo.
+- **When fx-core and other packages are changed**: Run `pnpm run setup` from the monorepo root to build all affected packages.
+- **For dependent packages**: If vscode-extension depends on fx-core changes, rebuild vscode-extension in its directory (`packages/vscode-extension`) AFTER fx-core builds successfully.
+- **Agent instruction**: When presented with changes to a specific package folder, execute build commands scoped to that package directory only to optimize build time and reduce unnecessary compilation.
+
 ## Code style and testability
 - Prefer namespace imports for internal modules when functions may need stubbing in UT. Example: use `import * as templateHelper from "..."` and call `templateHelper.useLocalTemplate()` instead of destructuring imports.
 - Avoid binding external/static dependencies directly at call sites when behavior needs to be mocked. Route them through a deps object (for example `fxCoreDeps`) or a small wrapper function.

--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -45,11 +45,11 @@ const manifestFileName = "manifest.json";
 
 export const developerPortalScaffoldUtilsDeps = {
   getAppPackage: appStudio.getAppPackage,
-  readAppManifest: manifestUtils._readAppManifest,
+  readAppManifest: manifestUtils._readAppManifest.bind(manifestUtils),
   writeFile: fs.writeFile,
   pathExists: fs.pathExists,
-  getEnvFilePath: pathUtils.getEnvFilePath,
-  writeEnv: envUtil.writeEnv,
+  getEnvFilePath: pathUtils.getEnvFilePath.bind(pathUtils),
+  writeEnv: envUtil.writeEnv.bind(envUtil),
 };
 
 export const answerToRepaceBotId = "bot";

--- a/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
+++ b/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
@@ -27,6 +27,7 @@ import { MessagingExtension } from "../../src/component/driver/teamsApp/interfac
 import { StaticTab } from "../../src/component/driver/teamsApp/interfaces/appdefinitions/staticTab";
 import { CommandScope, MeetingsContext } from "../../src/component/driver/teamsApp/utils/utils";
 import { DotenvOutput } from "../../src/component/utils/envUtil";
+import { pathUtils } from "../../src/component/utils/pathUtils";
 import { InputValidationError } from "../../src/error";
 import { getProjectTypeAndCapability } from "../../src/question/create";
 import { QuestionNames } from "../../src/question/questionNames";
@@ -1872,6 +1873,25 @@ describe("developPortalScaffoldUtils", () => {
       if (result.isErr()) {
         chai.assert.equal(result.error, error);
       }
+    });
+
+    it("getEnvFilePath through deps maintains this context and can call internal methods", async () => {
+      // This test actually calls getEnvFilePath through the deps object to verify
+      // that the binding fixes the "this.getEnvFolderPath is not a function" error.
+      // Without the .bind() fix, this would fail when getEnvFilePath tries to call this.getEnvFolderPath
+
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("mock-yml-path");
+
+      sandbox.stub(fs, "readFile").resolves("environmentFolderPath: ./env" as any);
+
+      sandbox.stub(fs, "pathExists").resolves(true);
+
+      const result = await developerPortalScaffoldUtilsDeps.getEnvFilePath(
+        "test-project-path",
+        "local"
+      );
+
+      chai.assert.isTrue(result.isOk() || result.isErr(), "Should return a Result");
     });
   });
 });


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/38440045
This pull request improves the build instructions for developers and addresses a bug related to method bindings in dependency objects. The main changes include adding clear build scope guidance to the agent documentation for both the `cli` and `fx-core` packages, and ensuring that methods passed as dependencies retain their correct context, which is also verified by a new unit test.

**Build process documentation improvements:**

* Added a "Build scope guidance" section to `AGENTS.md` in both `cli` and `fx-core` packages, providing detailed instructions on when and how to run build commands based on which packages are changed, and emphasizing the importance of scoped builds to optimize build times. [[1]](diffhunk://#diff-e349a07b862f7e824baf970ee49f66f29a56f7fd5e311e84860e219ffb608fafR10-R15) [[2]](diffhunk://#diff-9b8999c02ba8aee67e4a5aff86f39c6f3812d8092dcae3db32ca0679fe644ecdR10-R15)

**Dependency binding and testing:**

* Updated the `developerPortalScaffoldUtilsDeps` object in `developerPortalScaffoldUtils.ts` to use `.bind()` when referencing methods from `manifestUtils`, `pathUtils`, and `envUtil`, ensuring that their internal `this` context is preserved when called as dependencies.
* Added a unit test in `developerPortalScaffoldUtils.test.ts` to verify that calling `getEnvFilePath` through the dependency object works correctly and maintains the proper context, preventing errors related to missing internal methods.
* Added a missing import for `pathUtils` in the test file to support the new test.