### PR TITLE
fix: api key related events are redacted

### DIFF
--- a/packages/fx-core/src/client/teamsGraphClient.ts
+++ b/packages/fx-core/src/client/teamsGraphClient.ts
@@ -21,9 +21,9 @@ export class TEAMS_GRAPH_API_NAMES {
   static readonly CREATE_OAUTH = "teams_graph_create_oauth";
   static readonly UPDATE_OAUTH = "teams_graph_update_oauth";
   static readonly CREATE_DCR = "teams_graph_create_dcr";
-  static readonly GET_API_KEY = "teams_graph_get_api_key";
-  static readonly CREATE_API_KEY = "teams_graph_create_api_key";
-  static readonly UPDATE_API_KEY = "teams_graph_update_api_key";
+  static readonly GET_API_KEY = "teams_graph_get_api_secret_registration";
+  static readonly CREATE_API_KEY = "teams_graph_create_api_secret_registration";
+  static readonly UPDATE_API_KEY = "teams_graph_update_api_secret_registration";
 }
 
 export class TeamsGraphClient {

--- a/packages/fx-core/src/component/driver/teamsApp/constants.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/constants.ts
@@ -338,9 +338,9 @@ export class APP_STUDIO_API_NAMES {
   public static readonly LIST_BOT = "list-bot";
   public static readonly DELETE_BOT = "delete-bot";
   public static readonly UPDATE_BOT = "update-bot";
-  public static readonly CREATE_API_KEY = "create-api-key";
-  public static readonly UPDATE_API_KEY = "update-api-key";
-  public static readonly GET_API_KEY = "get-api-key";
+  public static readonly CREATE_API_KEY = "create-api-secret-registration";
+  public static readonly UPDATE_API_KEY = "update-api-secret-registration";
+  public static readonly GET_API_KEY = "get-api-secret-registration";
   public static readonly SUBMIT_APP_VALIDATION = "submit-app-validation";
   public static readonly GET_APP_VALIDATION_RESULT = "get-app-validation-result";
   public static readonly GET_APP_VALIDATION_REQUESTS = "get-app-validation-requests";


### PR DESCRIPTION
The root cause is before event is sent, vscode extension telemetry reporter will redact potential secrets and api key is wrongly involved.
<img width="818" height="132" alt="image" src="https://github.com/user-attachments/assets/39153b83-7ee6-42a6-af30-312eeb60e94d" />
