### PR TITLE
test(vscuse): tag Teams Agents and Apps New Project click with ocr:true

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Tab_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Tab_Remote_Debug.json
@@ -66,7 +66,9 @@
         "dhash:372:212:0:10:c8c88094b0717c6f"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_8e5aad69",
       "created_at": "2026-02-10T08:34:52.487714",
       "plan_id": "plan_8d094778"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Featrue_Open_DeveloperPortal_Publish.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Featrue_Open_DeveloperPortal_Publish.json
@@ -73,7 +73,9 @@
         "dhash:391:230:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_6d3e3b14",
       "created_at": "2026-01-08T10:04:34.860487",
       "plan_id": "plan_b1cfb283"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Arm_Deoploy_Support_Json_Format_And_Multiple_Templates.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Arm_Deoploy_Support_Json_Format_And_Multiple_Templates.json
@@ -61,7 +61,9 @@
         "dhash:385:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_2ce46bd8",
       "created_at": "2026-02-24T10:07:51.320620",
       "plan_id": "plan_5c08ded4"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Bot_Collaboration_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Bot_Collaboration_Remote_Debug.json
@@ -97,7 +97,9 @@
         "dhash:290:230:0:10:c0c9808694a46179"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_c15bff46",
       "created_at": "2026-06-16T00:23:52.043661",
       "plan_id": "plan_52912e24"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Del_Resource_Group_And_Reprovision_For_Bot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Del_Resource_Group_And_Reprovision_For_Bot.json
@@ -62,7 +62,9 @@
         "dhash:311:223:0:10:c0c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_103d786f",
       "created_at": "2026-03-27T06:54:58.878418",
       "plan_id": "plan_0fbdd53e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_AI_Search_without_AzureOpenAI_Keys.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_AI_Search_without_AzureOpenAI_Keys.json
@@ -74,7 +74,9 @@
         "dhash:352:227:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_618576b9",
       "created_at": "2026-04-30T07:23:59.658482",
       "plan_id": "plan_feedd4e6"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_AI_Search_without_OpenAI_Keys.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_AI_Search_without_OpenAI_Keys.json
@@ -70,7 +70,9 @@
         "dhash:352:227:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a6c07138",
       "created_at": "2026-04-30T07:25:47.871337",
       "plan_id": "plan_78dd916b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Custom_API_without_AzureOpenAI_Keys.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Custom_API_without_AzureOpenAI_Keys.json
@@ -75,7 +75,9 @@
         "dhash:352:227:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a12d8897",
       "created_at": "2026-04-30T07:28:56.308167",
       "plan_id": "plan_866dc22b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Custom_API_without_OpenAI_Keys.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Custom_API_without_OpenAI_Keys.json
@@ -74,7 +74,9 @@
         "dhash:352:227:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_81361ff9",
       "created_at": "2026-04-30T07:30:13.437076",
       "plan_id": "plan_72dfb31e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Port_in_Use.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Port_in_Use.json
@@ -410,7 +410,9 @@
         "dhash:302:222:0:10:c8c84062aae324a0"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_2801cf83",
       "created_at": "2026-04-30T07:31:08.897659",
       "plan_id": "plan_f092a0c2"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Second_Press_F5_for_Bot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Second_Press_F5_for_Bot.json
@@ -67,7 +67,9 @@
         "dhash:325:230:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_62ae0853",
       "created_at": "2026-03-10T01:23:58.768165",
       "plan_id": "plan_96b2e7e3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_bot_with_existing_AAD.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_bot_with_existing_AAD.json
@@ -71,7 +71,9 @@
         "dhash:325:230:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_cd805e44",
       "created_at": "2026-06-08T07:33:48.368007",
       "plan_id": "plan_716a0b94"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_with_Workbench.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_with_Workbench.json
@@ -64,7 +64,9 @@
         "dhash:325:230:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a305b5f4",
       "created_at": "2026-04-30T08:06:43.567478",
       "plan_id": "plan_fb453bdc"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Message_Extension_With_Action_Command_ts_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Message_Extension_With_Action_Command_ts_Playground_Debug.json
@@ -96,7 +96,9 @@
         "dhash:404:212:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_d5f5f9bb",
       "created_at": "2026-03-31T06:19:07.231319",
       "plan_id": "plan_0315cf6f"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Newproject_In_Exist_Project.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Newproject_In_Exist_Project.json
@@ -217,7 +217,9 @@
         "dhash:349:203:0:10:c8c84823a32a2421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_3d56209d",
       "created_at": "2026-01-21T03:10:10.278098",
       "plan_id": "plan_004c8b8e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Open_DeveloperPortal_Publish.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Open_DeveloperPortal_Publish.json
@@ -73,7 +73,9 @@
         "dhash:391:230:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_6d3e3b14",
       "created_at": "2026-01-08T10:04:34.860487",
       "plan_id": "plan_b1cfb283"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Prompt_Use_Run_From_Package.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Prompt_Use_Run_From_Package.json
@@ -68,7 +68,9 @@
         "dhash:372:212:0:10:c8c88094b0717c6f"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_063d58c7",
       "created_at": "2026-05-20T00:27:25.387782",
       "plan_id": "plan_280b8261"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Publish_to_Teams_Build_Package_If_Not_Provision.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Publish_to_Teams_Build_Package_If_Not_Provision.json
@@ -90,7 +90,9 @@
         "dhash:389:223:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_09c4bd9e",
       "created_at": "2026-05-13T05:42:38.976659",
       "plan_id": "plan_080d52d2"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Publish_to_Teams_from_Codelens.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Publish_to_Teams_from_Codelens.json
@@ -64,7 +64,9 @@
         "dhash:389:223:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_165acd1e",
       "created_at": "2026-03-16T02:29:54.928793",
       "plan_id": "plan_1658052d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Report_Issue.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Report_Issue.json
@@ -75,7 +75,9 @@
         "dhash:325:230:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_942590d8",
       "created_at": "2026-05-21T02:04:47.493898",
       "plan_id": "plan_9edb8886"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_Remote_Template_Verification.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_Remote_Template_Verification.json
@@ -75,7 +75,9 @@
         "dhash:341:225:0:10:c0c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_fa4e2fc9",
       "created_at": "2026-05-25T10:06:39.812907",
       "plan_id": "plan_a94bb561"
@@ -489,7 +491,9 @@
         "dhash:351:217:0:10:c8c88097a269696b"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_60fda345",
       "created_at": "2026-05-25T10:06:40.067929",
       "plan_id": "plan_a94bb561"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_Single_Progress_Bar_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_Single_Progress_Bar_ts_Remote_Debug.json
@@ -81,7 +81,9 @@
         "dhash:389:223:0:10:c8c89094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_2c8d3ed1",
       "created_at": "2026-04-28T07:51:13.662726",
       "plan_id": "plan_1c4ca2a1"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_With_Symbol_Link_Target_js_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_With_Symbol_Link_Target_js_playground.json
@@ -67,7 +67,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_dbaaff41",
       "created_at": "2026-05-20T03:22:51.728682",
       "plan_id": "plan_35f71b94"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_ts_Local_Debug_With_Different_Account.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_ts_Local_Debug_With_Different_Account.json
@@ -90,7 +90,9 @@
         "dhash:325:230:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_559bc142",
       "created_at": "2026-05-27T02:00:01.500026",
       "plan_id": "plan_68e70b6d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Tab_Collaboration_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Tab_Collaboration_Remote_Debug.json
@@ -101,7 +101,9 @@
         "dhash:372:212:0:10:c8c88094b0717c6f"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_08fac04c",
       "created_at": "2026-06-09T00:21:06.525723",
       "plan_id": "plan_17745f0d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
@@ -328,7 +328,9 @@
         "dhash:421:176:0:10:6869602626222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_98e1650f",
       "created_at": "2026-01-06T09:55:51.041855",
       "plan_id": "plan_47e4bf4e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Update_App.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Update_App.json
@@ -85,7 +85,9 @@
         "dhash:372:212:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_e5cc4fe4",
       "created_at": "2026-05-08T03:45:52.940332",
       "plan_id": "plan_96938623"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Verify_Sub_Options_On_App_Created_By_TDP.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Verify_Sub_Options_On_App_Created_By_TDP.json
@@ -1057,7 +1057,9 @@
         "dhash:363:173:0:10:c4c8448684848001"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a27c6dcb",
       "created_at": "2026-05-22T02:44:53.649485",
       "plan_id": "plan_dcd102cb"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Zip_Teams_Package.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Zip_Teams_Package.json
@@ -74,7 +74,9 @@
         "dhash:372:212:0:10:c8c88094b0717c6f"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_e5ec3349",
       "created_at": "2026-02-10T03:16:21.945800",
       "plan_id": "plan_d8e9996b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature__Debug_All_Telemetry_Check_And_Terminated_Previous_Tasks.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature__Debug_All_Telemetry_Check_And_Terminated_Previous_Tasks.json
@@ -81,7 +81,9 @@
         "dhash:390:219:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_e9554cf6",
       "created_at": "2025-11-15T16:25:46.696198",
       "plan_id": "plan_r_1016_081758"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature__Recommend_TTK.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature__Recommend_TTK.json
@@ -365,7 +365,9 @@
         "dhash:397:220:0:10:c0c9808684a46179"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_72979469",
       "created_at": "2026-06-09T02:21:30.477368",
       "plan_id": "plan_r_0107_063004"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature__Test_Bot_AAD.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature__Test_Bot_AAD.json
@@ -60,7 +60,9 @@
         "dhash:325:230:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_e0a20c72",
       "created_at": "2026-01-29T06:41:47.220541",
       "plan_id": "plan_67ff691d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_Copilot_Local_Debug.json
@@ -56,7 +56,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_afb43e67",
       "created_at": "2025-11-27T06:13:16.911186",
       "plan_id": "plan_5ee748e8"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_fba36d38",
       "created_at": "2025-11-14T05:09:41.694923",
       "plan_id": "plan_b2c9f888"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_playground.json
@@ -54,7 +54,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_e266a94e",
       "created_at": "2026-02-24T10:18:33.965475",
       "plan_id": "plan_9326a440"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Copilot_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_c7609bdd",
       "created_at": "2025-11-27T08:07:35.307780",
       "plan_id": "plan_cc13dbcf"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Copilot_Remote_Debug.json
@@ -59,7 +59,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_ca34e25c",
       "created_at": "2025-11-28T02:22:37.474147",
       "plan_id": "plan_264bfe5c"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Local_Debug.json
@@ -57,7 +57,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_ece915e9",
       "created_at": "2025-11-26T03:53:36.280029",
       "plan_id": "plan_2e918645"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Remote_Debug.json
@@ -59,7 +59,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a222c44b",
       "created_at": "2026-02-24T10:32:41.720673",
       "plan_id": "plan_a0ce5e4f"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_playground.json
@@ -55,7 +55,9 @@
         "dhash:355:223:0:10:c8c88094b0717065"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_f977155b",
       "created_at": "2026-01-27T02:07:13.336383",
       "plan_id": "plan_7fb5e663"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_ts_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_ts_Copilot_Local_Debug.json
@@ -56,7 +56,9 @@
         "dhash:378:220:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_676649b2",
       "created_at": "2026-02-24T09:07:49.267495",
       "plan_id": "plan_7788c288"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_ts_Copilot_Remote_Debug.json
@@ -58,7 +58,9 @@
         "dhash:298:217:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_18b231e6",
       "created_at": "2025-11-28T02:44:37.278609",
       "plan_id": "plan_d3732982"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_ts_Local_Debug.json
@@ -56,7 +56,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_41062f51",
       "created_at": "2025-12-29T09:02:41.057654",
       "plan_id": "plan_a644cde2"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_ts_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_ts_playground.json
@@ -54,7 +54,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_01729411",
       "created_at": "2026-02-24T15:13:01.110148",
       "plan_id": "plan_22824786"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_js_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_da80d556",
       "created_at": "2026-02-24T08:22:47.236589",
       "plan_id": "plan_2545a770"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_py_Local_Debug.json
@@ -61,7 +61,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_529ef231",
       "created_at": "2026-01-26T07:46:39.128293",
       "plan_id": "plan_8434a481"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_ts_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:378:220:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_46eaa4cf",
       "created_at": "2025-11-26T02:07:10.576454",
       "plan_id": "plan_e92d6998"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_py_Local_Debug.json
@@ -56,7 +56,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_7adc163a",
       "created_at": "2025-12-18T02:28:32.735073",
       "plan_id": "plan_5f1b5c8a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_py_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_py_Playground_Debug.json
@@ -55,7 +55,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_fc2970df",
       "created_at": "2026-02-02T02:51:38.460113",
       "plan_id": "plan_44ea2362"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_py_Remote_Debug.json
@@ -59,7 +59,9 @@
         "dhash:364:214:0:10:c8c88094b0717c6f"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_24473757",
       "created_at": "2025-12-08T08:49:48.848026",
       "plan_id": "plan_d4fc40d0"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_ts_Local_Debug.json
@@ -57,7 +57,9 @@
         "dhash:404:212:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_eb7224d1",
       "created_at": "2025-12-29T09:10:09.688534",
       "plan_id": "plan_db3c78ac"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_ts_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_ts_Playground_Debug.json
@@ -54,7 +54,9 @@
         "dhash:404:212:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a96857cc",
       "created_at": "2025-12-17T09:52:18.004917",
       "plan_id": "plan_7c9ad3b3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_js_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:325:230:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_c0a69177",
       "created_at": "2025-11-14T06:26:06.445502",
       "plan_id": "plan_832d85ef"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_js_Remote_Debug.json
@@ -58,7 +58,9 @@
         "dhash:389:223:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_46f13fa8",
       "created_at": "2025-11-14T06:38:17.505810",
       "plan_id": "plan_ec322e24"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_py_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_py_playground.json
@@ -59,7 +59,9 @@
         "dhash:364:214:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_6e8f0c3c",
       "created_at": "2026-05-20T10:54:04.245336",
       "plan_id": "plan_25edc1c7"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_ts_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:325:230:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_55f91835",
       "created_at": "2025-11-14T06:44:58.806846",
       "plan_id": "plan_3273b80b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_ts_Remote_Debug.json
@@ -58,7 +58,9 @@
         "dhash:389:223:0:10:c8c89094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_c62fac3a",
       "created_at": "2026-02-02T09:05:52.190951",
       "plan_id": "plan_4c75349e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_ts_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_ts_playground.json
@@ -57,7 +57,9 @@
         "dhash:341:225:0:10:c0c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_0e26eed2",
       "created_at": "2026-01-29T05:35:36.676693",
       "plan_id": "plan_82273f1e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_bot_py_local_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_bot_py_local_debug.json
@@ -60,7 +60,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_6395141f",
       "created_at": "2025-12-01T01:32:19.718187",
       "plan_id": "plan_fc95f19d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_bot_py_remote_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_bot_py_remote_debug.json
@@ -60,7 +60,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a809a3dc",
       "created_at": "2025-12-01T01:48:25.037411",
       "plan_id": "plan_7e56c81b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Local_Debug.json
@@ -57,7 +57,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_84ceebb7",
       "created_at": "2025-12-02T11:09:24.871996",
       "plan_id": "plan_60e462d3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Playground_Debug.json
@@ -56,7 +56,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a5cf6da4",
       "created_at": "2025-12-18T09:55:56.097120",
       "plan_id": "plan_6a562e08"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Remote_Debug.json
@@ -59,7 +59,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_d155f818",
       "created_at": "2025-12-02T07:57:36.529491",
       "plan_id": "plan_b9fab3e1"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_3658ce6b",
       "created_at": "2025-12-02T07:58:08.252741",
       "plan_id": "plan_46ed1075"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Playground_Debug.json
@@ -57,7 +57,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_3f8a623f",
       "created_at": "2025-12-18T09:43:44.834341",
       "plan_id": "plan_b003fd4d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Remote_Debug.json
@@ -61,7 +61,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_fd1d3a30",
       "created_at": "2026-02-12T06:24:49.727931",
       "plan_id": "plan_ec48f68b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Local_Debug.json
@@ -57,7 +57,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_568fe5b7",
       "created_at": "2026-02-24T07:41:44.496214",
       "plan_id": "plan_d23ea72f"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Playground_Debug.json
@@ -56,7 +56,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_794b75f8",
       "created_at": "2025-12-18T09:18:36.993644",
       "plan_id": "plan_b3f28e47"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Remote_Debug.json
@@ -59,7 +59,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_90a051a6",
       "created_at": "2026-02-24T10:55:30.998325",
       "plan_id": "plan_656b5c31"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Local_Debug.json
@@ -60,7 +60,9 @@
         "dhash:326:221:0:10:c4c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_9c2189b7",
       "created_at": "2026-04-14T12:27:54.012361",
       "plan_id": "plan_01ed5e7e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Remote_Debug.json
@@ -63,7 +63,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_4fd4fe69",
       "created_at": "2025-12-16T07:54:06.575679",
       "plan_id": "plan_35215a46"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_44a5d76d",
       "created_at": "2025-12-15T05:51:44.547284",
       "plan_id": "plan_7bbcbd8a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Remote_Debug.json
@@ -63,7 +63,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_780f506c",
       "created_at": "2025-12-17T01:14:47.472496",
       "plan_id": "plan_45c7b843"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Local_Debug.json
@@ -60,7 +60,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_8dd1fb0c",
       "created_at": "2025-12-15T05:41:11.014877",
       "plan_id": "plan_3bd8afbd"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Remote_Debug.json
@@ -63,7 +63,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_b06e1dde",
       "created_at": "2025-12-16T10:26:26.792296",
       "plan_id": "plan_f7818fc3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Local_Debug.json
@@ -61,7 +61,9 @@
         "dhash:326:221:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_74406a55",
       "created_at": "2025-11-26T14:28:29.004519",
       "plan_id": "plan_b8dd182a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_PlayGround.json
@@ -60,7 +60,9 @@
         "dhash:326:221:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_7e3b6981",
       "created_at": "2025-12-18T03:55:00.641831",
       "plan_id": "plan_43836b26"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Remote_Debug.json
@@ -65,7 +65,9 @@
         "dhash:415:233:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_6d43683f",
       "created_at": "2026-02-24T14:47:44.625241",
       "plan_id": "plan_69bc5546"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Local_Debug.json
@@ -63,7 +63,9 @@
         "dhash:326:221:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_298ebffb",
       "created_at": "2025-11-27T04:28:37.450825",
       "plan_id": "plan_8912358f"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_PlayGround.json
@@ -61,7 +61,9 @@
         "dhash:326:221:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_76946e08",
       "created_at": "2025-12-18T08:27:09.197083",
       "plan_id": "plan_fbbf2806"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Remote_Debug.json
@@ -66,7 +66,9 @@
         "dhash:415:233:0:10:c8c89094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_330d505c",
       "created_at": "2025-11-27T08:25:37.258126",
       "plan_id": "plan_9ed004c0"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_Local_Debug.json
@@ -62,7 +62,9 @@
         "dhash:326:221:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_ebf34a2e",
       "created_at": "2025-12-29T09:35:45.194740",
       "plan_id": "plan_5405cbbc"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_PlayGround.json
@@ -60,7 +60,9 @@
         "dhash:326:221:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_491e8f75",
       "created_at": "2025-12-18T05:22:26.374469",
       "plan_id": "plan_2257b581"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_Remote_Debug.json
@@ -65,7 +65,9 @@
         "dhash:415:233:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_1ce7814a",
       "created_at": "2025-11-28T01:42:41.830072",
       "plan_id": "plan_3042a55d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Local_Debug.json
@@ -67,7 +67,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_7f61d30b",
       "created_at": "2025-12-01T07:30:52.980359",
       "plan_id": "plan_f422c281"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Remote_Debug.json
@@ -70,7 +70,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_1adb592d",
       "created_at": "2025-12-02T01:51:58.419665",
       "plan_id": "plan_4b408295"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Local_Debug.json
@@ -69,7 +69,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_30b52efe",
       "created_at": "2025-12-01T09:32:51.516733",
       "plan_id": "plan_f40826db"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Remote_Debug.json
@@ -70,7 +70,9 @@
         "dhash:378:219:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_8e27a81a",
       "created_at": "2026-02-24T07:20:20.182944",
       "plan_id": "plan_1a551e3b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Local_Debug.json
@@ -67,7 +67,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_aa555a84",
       "created_at": "2025-12-01T08:02:20.483911",
       "plan_id": "plan_86ac6a02"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Remote_Debug.json
@@ -70,7 +70,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_167e7fcb",
       "created_at": "2025-12-02T02:27:32.913604",
       "plan_id": "plan_42cb7b61"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Local_Debug.json
@@ -64,7 +64,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_c53a7b27",
       "created_at": "2025-12-01T08:04:07.366736",
       "plan_id": "plan_13b50d3c"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Remote_Debug.json
@@ -65,7 +65,9 @@
         "dhash:335:225:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_74f76ed8",
       "created_at": "2026-03-18T11:00:43.991276",
       "plan_id": "plan_c9402085"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Local_Debug.json
@@ -61,7 +61,9 @@
         "dhash:378:219:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_bd3c9df1",
       "created_at": "2025-11-14T04:27:50.734978",
       "plan_id": "plan_a1d862ad"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Remote_Debug.json
@@ -63,7 +63,9 @@
         "dhash:335:225:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_acd3707c",
       "created_at": "2025-11-14T04:32:48.604865",
       "plan_id": "plan_f78663e2"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_f7619883",
       "created_at": "2025-12-02T07:18:21.110075",
       "plan_id": "plan_287cbe00"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Remote_Debug.json
@@ -66,7 +66,9 @@
         "dhash:335:225:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a8af9d27",
       "created_at": "2025-12-01T10:17:43.344881",
       "plan_id": "plan_b60e2d29"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Local_Debug.json
@@ -57,7 +57,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_5f8ab980",
       "created_at": "2026-05-21T01:51:38.631845",
       "plan_id": "plan_bc76e4ef"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Remote_Debug.json
@@ -62,7 +62,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_cc96c389",
       "created_at": "2026-03-17T01:47:12.441614",
       "plan_id": "plan_c24b1c2e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Local_Debug.json
@@ -64,7 +64,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_52d5bea8",
       "created_at": "2025-12-01T08:11:03.933450",
       "plan_id": "plan_5c512c58"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Remote_Debug.json
@@ -65,7 +65,9 @@
         "dhash:335:225:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_f9dff8e5",
       "created_at": "2025-12-01T08:59:25.961717",
       "plan_id": "plan_aab1f3fd"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Local_Debug.json
@@ -61,7 +61,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_c0391b40",
       "created_at": "2025-11-14T04:40:00.170054",
       "plan_id": "plan_49162d78"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Remote_Debug.json
@@ -63,7 +63,9 @@
         "dhash:335:225:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_059653ca",
       "created_at": "2025-11-14T04:51:07.250847",
       "plan_id": "plan_b3d77ed6"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Local_Debug.json
@@ -64,7 +64,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_90504450",
       "created_at": "2025-11-28T04:00:03.017558",
       "plan_id": "plan_4fac1aa9"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Remote_Debug.json
@@ -66,7 +66,9 @@
         "dhash:335:225:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_e28ed0de",
       "created_at": "2025-11-27T23:54:21.698021",
       "plan_id": "plan_d86fba79"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Local_Debug.json
@@ -62,7 +62,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_14f6d930",
       "created_at": "2025-11-28T04:01:28.046560",
       "plan_id": "plan_da37980a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Remote_Debug.json
@@ -64,7 +64,9 @@
         "dhash:335:225:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_8ba377d3",
       "created_at": "2026-02-24T14:29:16.205736",
       "plan_id": "plan_3db4a923"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Local_Debug.json
@@ -66,7 +66,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_d7529fa9",
       "created_at": "2025-11-28T04:11:43.060540",
       "plan_id": "plan_90bbe15a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Remote_Debug.json
@@ -67,7 +67,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_6845b108",
       "created_at": "2025-12-02T03:38:06.735392",
       "plan_id": "plan_b6860879"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Local_Debug.json
@@ -59,7 +59,9 @@
         "dhash:364:214:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_d6aaf420",
       "created_at": "2025-12-08T09:11:18.273988",
       "plan_id": "plan_3347d139"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Remote_Debug.json
@@ -64,7 +64,9 @@
         "dhash:335:225:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_bd0f5f21",
       "created_at": "2025-12-02T03:12:00.822587",
       "plan_id": "plan_358d3548"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Copilot_Local_Debug.json
@@ -64,7 +64,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_521402ad",
       "created_at": "2025-11-28T04:07:54.695519",
       "plan_id": "plan_d214ccb2"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Copilot_Remote_Debug.json
@@ -66,7 +66,9 @@
         "dhash:335:225:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_a1071444",
       "created_at": "2026-06-03T02:23:24.163309",
       "plan_id": "plan_bb4064ab"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Local_Debug.json
@@ -62,7 +62,9 @@
         "dhash:378:219:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_fa25f2d2",
       "created_at": "2025-11-28T04:09:08.648796",
       "plan_id": "plan_8d65e96b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Remote_Debug.json
@@ -64,7 +64,9 @@
         "dhash:335:225:0:10:c8c88094b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_3b7edb70",
       "created_at": "2025-11-28T03:57:39.881324",
       "plan_id": "plan_8076024c"


### PR DESCRIPTION
## What

Adds the `ocr:true` tag to the first-click step that selects the **"Teams Agents and Apps"** option under the **"New Project"** dialog in the vscuse VS Code UI test plans, so the runner locates that element via OCR instead of relying solely on fixed coordinates + dhash preconditions.

## Details

- **Scope:** all `click` steps whose description references clicking "Teams Agents and Apps" (the New Project selection), across `packages/tests/vscuse/vscode-test-cases/plans/`.
- **117 files / 118 steps** tagged (one plan creates a project twice, so it gets two clicks tagged).
- Matching is case-insensitive, so both `"Teams Agents and Apps"` and the `"Teams Agents and apps"` wording variants are covered.
- **Idempotent:** steps that already carried `ocr:true` were left untouched; `@assertion` steps that merely verify the option exists, and pure project-type verification plans (no click), are intentionally excluded.

## Format

Matches the existing convention (e.g. `groups/group__validation_DA_no_action.json`):

```json
      "postconditions": [],
      "tags": [
        "ocr:true"
      ],
      "screenshot": "...",
```

## Verification

- All modified plan files parse as valid JSON (0 errors).
- Diff is minimal and mechanical: every changed line is only the `"tags": []` → `"tags": ["ocr:true"]` replacement (354 insertions / 118 deletions = 3 added + 1 removed per step).
- LF line endings preserved (`*.json eol=lf`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>