### PR TITLE
ci(vscuse): paginate job lookup so report URL is surfaced on large runs

### DIFF
--- a/.github/workflows/pr-vscuse-test.yml
+++ b/.github/workflows/pr-vscuse-test.yml
@@ -614,10 +614,10 @@ jobs:
             // link straight to the real test report instead of the smoke wrapper.
             const extractUiTestUrl = async () => {
               try {
-                const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
+                const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                   owner, repo, run_id: runId, per_page: 100,
                 });
-                const uiJob = jobs.jobs.find(j => j.name === 'run-ui-test');
+                const uiJob = jobs.find(j => j.name === 'run-ui-test');
                 if (!uiJob) {
                   console.log('run-ui-test job not found on smoke pipeline.');
                   return '';
@@ -650,12 +650,15 @@ jobs:
               const idMatch = (uiUrl || '').match(/\/runs\/(\d+)/);
               if (!idMatch) return '';
               try {
-                const { data: uiJobs } = await github.rest.actions.listJobsForWorkflowRun({
+                // Paginate: a UI-test run has one matrix job per selected test plan and
+                // can exceed 100 jobs. The report job is near the end, so a single
+                // per_page=100 page would miss it and drop the report link.
+                const uiJobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                   owner, repo, run_id: parseInt(idMatch[1]), per_page: 100,
                 });
                 // The report job is invoked via a reusable workflow, so its rendered
                 // name is typically "<caller_job> / report". Match the trailing token.
-                const reportJob = (uiJobs.jobs || []).find(j =>
+                const reportJob = uiJobs.find(j =>
                   /(^|\/\s*)report$/.test((j.name || '').trim())
                 );
                 if (!reportJob) { console.log('report job not found on UI test run.'); return ''; }


### PR DESCRIPTION
## Problem

The AI-selected vscuse PR comment was missing the `📊 Detailed test report` link on runs with more than 100 jobs.

In the `Wait for smoke pipeline to complete` step, `extractReportUrl` listed a UI-test run's jobs with a single un-paginated call (`listJobsForWorkflowRun({ ..., per_page: 100 })`). The GitHub API caps a page at 100 jobs. A UI-test run has one matrix `Case-*` job per selected test plan, so when many plans are impacted (e.g. a PR that changes 100+ plan files), the run exceeds 100 jobs and the `report` job — which sits near the end — falls outside the first page. The script then logged `report job not found on UI test run.` and `report_url` ended up empty, dropping the report line from the resolved PR comment.

Observed on a real UI-test run with **121 jobs** where the `report` job was at position **#119**; the report URL existed and had been uploaded successfully.

## Fix

Switched both `extractReportUrl` and `extractUiTestUrl` to `github.paginate(github.rest.actions.listJobsForWorkflowRun, {...})` so all job pages are scanned. `extractUiTestUrl` searches the smoke pipeline (~3 jobs) so it wasn't broken today, but it's fixed too for consistency/robustness. `github.paginate` is already used elsewhere in this workflow.

## Validation

- YAML still parses.
- No remaining object-call `listJobsForWorkflowRun({` occurrences; both calls use `github.paginate`.
- `git diff` shows only these two hunks.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>