### PR TITLE
feat(fx-core): add DCR auth option to fetch tools

### DIFF
--- a/docs/01-product/scenarios/da/fetch-mcp-tools.html
+++ b/docs/01-product/scenarios/da/fetch-mcp-tools.html
@@ -76,9 +76,11 @@
         <article class="vscode-flow-card" data-kind="action" aria-labelledby="auth-type-title">
           <h3 id="auth-type-title">6. Select Authentication Type <span class="vscode-flow-card__hint">only when MCP server requires auth</span></h3>
           <vscode-single-select title="Select Authentication Type" placeholder="Type to filter authentication types">
-            <vscode-option label="OAuth (with static registration)" selected></vscode-option>
-            <vscode-option label="Entra SSO"></vscode-option>
+            <vscode-option label="OAuth (with dynamic registration)" description="MCP server registers a client at runtime; no extra details needed."></vscode-option>
+            <vscode-option label="OAuth (with static registration)" description="Use a pre-registered OAuth client. The toolkit will ask for client id, client secret, and optional scopes." selected></vscode-option>
+            <vscode-option label="Entra SSO" description="Use a Microsoft Entra app for single sign-on. The toolkit will ask for the Entra app client id."></vscode-option>
           </vscode-single-select>
+          <p class="caption"><code>OAuth (with dynamic registration)</code> is shown only when <code>TEAMSFX_MCP_FOR_DA_DCR</code> is enabled.</p>
         </article>
 
         <article class="vscode-flow-card" data-kind="outcome" data-severity="success" aria-labelledby="success-state-title">
@@ -115,7 +117,7 @@
           <ul class="vscode-flow-card__note">
             <li><code>appPackage/&lt;chosen action manifest&gt;.json</code> &mdash; created when step 3 picks <code>Create a new ai-plugin.json</code> (name from step 4), modified otherwise. Operations from step 5 are written under <code>functions</code> and referenced from the MCP server runtime's <code>run_for_functions</code>; the runtime's <code>auth</code> block is written when step 6 selects an authentication type.</li>
             <li><code>appPackage/declarativeAgent.json</code> &mdash; modified only when a new manifest was created in step 3. A new entry is appended to <code>actions</code> with a non-colliding <code>id</code> (<code>action</code>, <code>action_2</code>, ...) and <code>file</code> set to the new manifest's basename.</li>
-            <li><code>m365agents.yml</code> &mdash; modified only when an authentication type is selected and the matching registration step is not already present. The injected step shape and ordering match <a href="create-da-with-mcp-server.html">SCN-DA-CREATE-WITH-MCP-SERVER</a> and <a href="add-mcp-action-to-da.html">SCN-DA-ADD-MCP-ACTION-TO-DA</a>.</li>
+            <li><code>m365agents.yml</code> &mdash; modified only when an authentication type is selected and the matching registration step is not already present. Static OAuth and Entra SSO inject <code>oauth/register</code>; dynamic OAuth injects <code>dcr/register</code>. The injected step shape and ordering match <a href="create-da-with-mcp-server.html">SCN-DA-CREATE-WITH-MCP-SERVER</a> and <a href="add-mcp-action-to-da.html">SCN-DA-ADD-MCP-ACTION-TO-DA</a>.</li>
           </ul>
         </article>
 
@@ -135,7 +137,7 @@
 
         <article class="vscode-flow-card" data-kind="note" aria-labelledby="outputs-env-title">
           <h3 id="outputs-env-title">Environment and secret writes</h3>
-          <p class="vscode-flow-card__note">The OAuth registration step injected into <code>m365agents.yml</code> reserves a configuration id that is written into <code>env/.env.*</code> when the provision lifecycle runs. This scenario does not write to <code>env/.env.*</code> at picker time; auth secret collection in VS Code follows the convention defined in <a href="create-da-with-mcp-server.html">SCN-DA-CREATE-WITH-MCP-SERVER</a> and <a href="add-mcp-action-to-da.html">SCN-DA-ADD-MCP-ACTION-TO-DA</a>.</p>
+          <p class="vscode-flow-card__note">The <code>oauth/register</code> or <code>dcr/register</code> step injected into <code>m365agents.yml</code> reserves a configuration id that is written into <code>env/.env.*</code> when the provision lifecycle runs. This scenario does not write to <code>env/.env.*</code> at picker time; auth secret collection in VS Code follows the convention defined in <a href="create-da-with-mcp-server.html">SCN-DA-CREATE-WITH-MCP-SERVER</a> and <a href="add-mcp-action-to-da.html">SCN-DA-ADD-MCP-ACTION-TO-DA</a>.</p>
         </article>
 
         <article class="vscode-flow-card" data-kind="note" aria-labelledby="outputs-external-title">

--- a/docs/01-product/scenarios/da/fetch-mcp-tools.md
+++ b/docs/01-product/scenarios/da/fetch-mcp-tools.md
@@ -22,6 +22,10 @@ Success means: a single MCP server is resolved from `.vscode/mcp.json`; a non-em
 - The MCP server entry must be reachable: for a remote (`http`) server, VS Code must be able to start and contact it; for a local (`stdio`) server, the command and any required runtime (for example `odr.exe`) must be installed on the user's machine. The toolkit cannot run this scenario before the server is reported as running by the built-in CodeLens.
 - Produces: an updated action manifest (existing `ai-plugin.json` or a newly created one) and an updated `declarativeAgent.json` with the new action wired in. When the chosen server requires authentication, the toolkit also writes the OAuth registration follow-up actions so provisioning can complete.
 
+## Feature flags
+
+- `TEAMSFX_MCP_FOR_DA_DCR` — gates only the `OAuth (with dynamic registration)` auth-type option in step 6 and the matching `dcr/register` action in `m365agents.yml`. When the flag is off, the fetch-tools auth picker keeps the shipped options only.
+
 ## Surfaces
 
 - VS Code built-in CodeLens: VS Code's MCP runtime owns the `Start`, `tools`, `prompts`, and `More...` actions on each server entry in `.vscode/mcp.json`. Pressing `Start` brings the server up and populates the tools/prompts counts shown next to the server.
@@ -40,7 +44,7 @@ Success means: a single MCP server is resolved from `.vscode/mcp.json`; a non-em
 - Manifest selection: ATK shows a Quick Pick titled `Select the action manifest you want to update`. The list contains the action manifest files already wired into the declarative agent, a `Create a new ai-plugin.json` row, and the `Browse…` row.
 - Name new manifest: when the user picks `Create a new ai-plugin.json`, ATK shows the text input `Name the new action manifest file` with default `ai-plugin.json`. Validation rejects empty input, names without the `.json` extension, absolute or nested paths, and names that already exist in `appPackage/`.
 - Operation selection: the Quick Pick titled `Select Operation(s) Copilot can interact with` lists the operations the toolkit fetched from the server. When the user is updating a manifest that already references this MCP server, the operations already wired in are pre-selected.
-- Auth type selection: when the MCP server requires authentication, the Quick Pick titled `Select Authentication Type` is shown with `OAuth (with static registration)` and `Entra SSO` options. Unauthenticated servers skip this step.
+- Auth type selection: when the MCP server requires authentication, the Quick Pick titled `Select Authentication Type` is shown with `OAuth (with static registration)` and `Entra SSO` options. When `TEAMSFX_MCP_FOR_DA_DCR` is enabled, `OAuth (with dynamic registration)` is inserted as the first option. The option details match the code-backed picker strings: `OAuth (with dynamic registration)` says `MCP server registers a client at runtime; no extra details needed.`, `OAuth (with static registration)` says `Use a pre-registered OAuth client. The toolkit will ask for client id, client secret, and optional scopes.`, and `Entra SSO` says `Use a Microsoft Entra app for single sign-on. The toolkit will ask for the Entra app client id.` Unauthenticated servers skip this step.
 - Success: ATK shows `The operations selected from your MCP server are successfully added for Copilot to interact with. You can go to the 'ai-plugin.json' to check on details. Now you are able to provision your declarative agent to continue.` with `Provision` as the action.
 - Recoverable: tools not found. When the server returns no tools, ATK shows the error notification `No tools found for the MCP server. Please run the server first.` (source: Microsoft 365 Agents Toolkit) and the flow stops before the manifest picker appears. The user starts the server (or fixes the tools file) and re-clicks `⚡ ATK: Fetch action from MCP`.
 - Recoverable: prerequisites missing. When `.vscode/mcp.json` is missing, malformed, has no servers, or the selected server entry is incomplete (no URL for an `http` server, no command for a `stdio` server), ATK shows an error notification describing the missing piece and stops before any picker opens. The user fixes the file and retries.
@@ -79,7 +83,7 @@ This scenario updates an existing DA project; there is no template boilerplate t
 
 - `appPackage/<chosen action manifest>.json` (default `ai-plugin.json`) — created when the user picks `Create a new ai-plugin.json` (file name from the `Name the new action manifest file` input), modified otherwise. The operations selected in `Select Operation(s) Copilot can interact with` are written under `functions` and referenced from the MCP server runtime's `run_for_functions`. When the server requires authentication, the runtime's `auth` block is written to point at the OAuth configuration injected into `m365agents.yml`. When the user is updating a manifest that already references this MCP server, existing operations remain in place; only added/removed operations from the multi-select change the file.
 - `appPackage/declarativeAgent.json` — modified only when a new action manifest was created in step 3. A new entry is appended to `actions` with an `id` that does not collide with existing actions (`action`, `action_2`, ...) and `file` set to the new manifest's basename. When an existing action manifest is reused, this file is not touched.
-- `m365agents.yml` — modified only when the user selected an authentication type for this MCP server runtime and the matching registration step is not already present. The toolkit injects the OAuth registration follow-up step at the same shape and ordering used by `SCN-DA-CREATE-WITH-MCP-SERVER` and `SCN-DA-ADD-MCP-ACTION-TO-DA`, so the manifest's `auth.reference_id` resolves at provision time.
+- `m365agents.yml` — modified only when the user selected an authentication type for this MCP server runtime and the matching registration step is not already present. The toolkit injects `oauth/register` for `OAuth (with static registration)` and `Entra SSO`, or `dcr/register` for `OAuth (with dynamic registration)`, at the same shape and ordering used by `SCN-DA-CREATE-WITH-MCP-SERVER` and `SCN-DA-ADD-MCP-ACTION-TO-DA`, so the manifest's `auth.reference_id` resolves at provision time.
 
 ### Notifications
 
@@ -93,7 +97,7 @@ This scenario updates an existing DA project; there is no template boilerplate t
 
 ### Environment and secret writes
 
-- The injected OAuth registration step in `m365agents.yml` reserves a configuration id that is written into the project's environment files when the provision lifecycle runs. The scenario itself does not write to `env/.env.*` at picker time; auth secret collection in VS Code follows the same convention as `SCN-DA-CREATE-WITH-MCP-SERVER` and `SCN-DA-ADD-MCP-ACTION-TO-DA` and is deferred to those scenarios.
+- The injected `oauth/register` or `dcr/register` step in `m365agents.yml` reserves a configuration id that is written into the project's environment files when the provision lifecycle runs. The scenario itself does not write to `env/.env.*` at picker time; auth secret collection in VS Code follows the same convention as `SCN-DA-CREATE-WITH-MCP-SERVER` and `SCN-DA-ADD-MCP-ACTION-TO-DA` and is deferred to those scenarios.
 
 ### External side effects
 

--- a/packages/fx-core/src/core/FxCore.declarativeAgent.ts
+++ b/packages/fx-core/src/core/FxCore.declarativeAgent.ts
@@ -184,17 +184,24 @@ export class FxCoreDeclarativeAgentPart {
       return err(error);
     }
 
+    const pluginFunctions = Array.isArray(aiPluginContent.functions)
+      ? aiPluginContent.functions
+      : [];
+    const pluginRuntimes = Array.isArray(aiPluginContent.runtimes) ? aiPluginContent.runtimes : [];
+
     const toolsSelectedPrevious: string[] = [];
-    aiPluginContent.runtimes
+    pluginRuntimes
       .filter(
         (runtime: any) =>
-          (runtime.type === "RemoteMCPServer" && runtime.spec.url === mcpServerUrl) ||
+          (runtime.type === "RemoteMCPServer" && runtime.spec?.url === mcpServerUrl) ||
           runtime.type === "LocalPlugin"
       )
       .forEach((runtime: any) => {
-        toolsSelectedPrevious.push(...runtime.run_for_functions);
+        if (Array.isArray(runtime.run_for_functions)) {
+          toolsSelectedPrevious.push(...runtime.run_for_functions);
+        }
       });
-    aiPluginContent.functions = aiPluginContent.functions.filter(
+    aiPluginContent.functions = pluginFunctions.filter(
       (func: any) => !toolsSelectedPrevious.includes(func.name)
     );
     aiPluginContent.functions = [
@@ -221,14 +228,14 @@ export class FxCoreDeclarativeAgentPart {
         }),
     ];
 
-    const matchedRuntime = aiPluginContent.runtimes.find(
-      (runtime: any) => runtime.type === "RemoteMCPServer" && runtime.spec.url === mcpServerUrl
+    const matchedRuntime = pluginRuntimes.find(
+      (runtime: any) => runtime.type === "RemoteMCPServer" && runtime.spec?.url === mcpServerUrl
     );
 
-    aiPluginContent.runtimes = aiPluginContent.runtimes.filter(
+    aiPluginContent.runtimes = pluginRuntimes.filter(
       (runtime: any) =>
         (runtime.type !== "RemoteMCPServer" && runtime.type !== "LocalPlugin") ||
-        runtime.spec.url !== mcpServerUrl
+        runtime.spec?.url !== mcpServerUrl
     );
 
     if (inputs[QuestionNames.MCPLocalServerIdentifier] != null) {

--- a/packages/fx-core/src/question/scaffold/vsc/teamsProjectTypeNode.ts
+++ b/packages/fx-core/src/question/scaffold/vsc/teamsProjectTypeNode.ts
@@ -513,6 +513,30 @@ export function MCPForDAAuthTypeStaticOptions(): OptionItem[] {
   return options;
 }
 
+export function MCPForDAFetchAuthTypeStaticOptions(): OptionItem[] {
+  const options: OptionItem[] = [];
+  if (featureFlagManager.getBooleanValue(FeatureFlags.MCPForDADCR)) {
+    options.push({
+      id: "oauth-dynamic",
+      label: getLocalizedString("core.createProjectQuestion.mcpForDa.Auth.OAuthDynamic"),
+      detail: getLocalizedString("core.createProjectQuestion.mcpForDa.Auth.OAuthDynamic.Detail"),
+    });
+  }
+  options.push(
+    {
+      id: "oauth",
+      label: getLocalizedString("core.createProjectQuestion.mcpForDa.Auth.OAuth"),
+      detail: getLocalizedString("core.createProjectQuestion.mcpForDa.Auth.OAuth.Detail"),
+    },
+    {
+      id: "entra-sso",
+      label: getLocalizedString("core.createProjectQuestion.mcpForDa.Auth.EntraSSO"),
+      detail: getLocalizedString("core.createProjectQuestion.mcpForDa.Auth.EntraSSO.Detail"),
+    }
+  );
+  return options;
+}
+
 /**
  * Follow-up question nodes shown after the user picks an `mcp-da-auth-type`
  * value. Unconditional per SCN-DA-CREATE-WITH-MCP-SERVER step 6a/6b: the
@@ -792,7 +816,7 @@ export function updateActionWithMCP(): IQTreeNode {
           type: "singleSelect",
           name: QuestionNames.MCPForDAAuthType,
           title: getLocalizedString("core.createProjectQuestion.mcpForDa.AuthType.title"),
-          staticOptions: MCPForDAAuthTypeStaticOptions(),
+          staticOptions: MCPForDAFetchAuthTypeStaticOptions(),
           default: "oauth",
         },
         children: MCPForDAAuthCredentialNodes(),

--- a/packages/fx-core/src/question/scaffold/vsc/teamsProjectTypeNode.ts
+++ b/packages/fx-core/src/question/scaffold/vsc/teamsProjectTypeNode.ts
@@ -817,7 +817,9 @@ export function updateActionWithMCP(): IQTreeNode {
           name: QuestionNames.MCPForDAAuthType,
           title: getLocalizedString("core.createProjectQuestion.mcpForDa.AuthType.title"),
           staticOptions: MCPForDAFetchAuthTypeStaticOptions(),
-          default: "oauth",
+          default: featureFlagManager.getBooleanValue(FeatureFlags.MCPForDADCR)
+            ? "oauth-dynamic"
+            : "oauth",
         },
         children: MCPForDAAuthCredentialNodes(),
       },

--- a/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
+++ b/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
@@ -259,6 +259,70 @@ describe("updateActionWithMCP", () => {
     assert.equal(mcpRuntime.spec.mcp_tool_description.file, "existing-mcp-tools.json");
   });
 
+  it("should update DT runtime when functions are omitted and run_for_functions is wildcard", async () => {
+    const core = new FxCore(tools);
+    const inputs: Inputs = {
+      projectPath,
+      platform: Platform.VSCode,
+      [QuestionNames.PluginManifestFilePath]: pluginManifestPath,
+      [QuestionNames.MCPForDAServerUrl]: mcpServerUrl,
+      [QuestionNames.MCPForDAServerName]: serverName,
+      [QuestionNames.MCPForDAAuth]: "None",
+      [QuestionNames.MCPForDAAvailableTools]: [
+        {
+          name: "newTool",
+          description: "New tool description",
+          inputSchema: {
+            type: "object",
+            properties: { param1: { type: "string" } },
+            required: ["param1"],
+          },
+        },
+      ],
+      [QuestionNames.MCPForDAPreFetchTools]: ["newTool"],
+      ignoreLockByUT: true,
+    };
+
+    const existingPlugin = {
+      runtimes: [
+        {
+          type: "RemoteMCPServer",
+          spec: {
+            url: mcpServerUrl,
+          },
+          run_for_functions: ["*"],
+        },
+      ],
+    };
+
+    let writtenPluginData: any;
+    sandbox.stub(fs, "pathExists").callsFake(async (filePath: string) => {
+      return !filePath.includes("mcp-tools");
+    });
+    sandbox.stub(fs, "readJSON").resolves(existingPlugin);
+    sandbox.stub(fs, "writeJSON").callsFake((filePath: string, data) => {
+      if (!filePath.includes("mcp-tools")) {
+        writtenPluginData = data;
+      }
+      return Promise.resolve();
+    });
+    sandbox.stub(pathUtils, "getYmlFilePath").returns("/test/project/teamsapp.yml");
+
+    sandbox.stub(tools.ui, "showMessage").resolves(ok("OK"));
+    sandbox.stub(tools.ui, "openFile").resolves();
+
+    const result = await core.updateActionWithMCP(inputs);
+
+    assert.isTrue(result.isOk());
+    assert.deepEqual(writtenPluginData.functions, [
+      {
+        name: "newTool",
+        description: "New tool description",
+      },
+    ]);
+    assert.deepEqual(writtenPluginData.runtimes[0].run_for_functions, ["newTool"]);
+  });
+
   it("should successfully update action with OAuth authentication", async () => {
     const core = new FxCore(tools);
     const inputs: Inputs = {

--- a/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
+++ b/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
@@ -397,6 +397,88 @@ describe("updateActionWithMCP", () => {
     assert.isTrue(openFileStub.calledOnce);
   });
 
+  it("should inject DCR action when updating action with OAuth dynamic registration", async () => {
+    const core = new FxCore(tools);
+    const inputs: Inputs = {
+      projectPath,
+      platform: Platform.VSCode,
+      [QuestionNames.PluginManifestFilePath]: pluginManifestPath,
+      [QuestionNames.MCPForDAServerUrl]: mcpServerUrl,
+      [QuestionNames.MCPForDAServerName]: serverName,
+      [QuestionNames.MCPForDAAuth]: "OAuthPluginVault",
+      [QuestionNames.MCPForDAAuthType]: "oauth-dynamic",
+      [QuestionNames.MCPForDAAuthWellKnownUrl]:
+        "https://example.com/.well-known/oauth-authorization-server",
+      [QuestionNames.MCPForDAAvailableTools]: [
+        {
+          name: "testTool",
+          description: "Test tool description",
+          inputSchema: {
+            type: "object",
+            properties: { param1: { type: "string" } },
+            required: ["param1"],
+          },
+        },
+      ],
+      [QuestionNames.MCPForDAPreFetchTools]: ["testTool"],
+      ignoreLockByUT: true,
+    };
+
+    const existingPlugin = {
+      functions: [],
+      runtimes: [],
+    };
+
+    sandbox.stub(fs, "pathExists").callsFake(async (filePath: string) => {
+      return !filePath.includes("mcp-tools");
+    });
+    sandbox.stub(fs, "readJSON").resolves(existingPlugin);
+    let writtenPluginData: any;
+    sandbox.stub(fs, "writeJSON").callsFake((filePath: string, data) => {
+      if (!filePath.includes("mcp-tools")) {
+        writtenPluginData = data;
+      }
+      return Promise.resolve();
+    });
+    sandbox.stub(pathUtils, "getYmlFilePath").returns("/test/project/m365agents.yml");
+    sandbox.stub(featureFlagManager, "getBooleanValue").callsFake((flag) => {
+      return flag === FeatureFlags.MCPForDADCR;
+    });
+    sandbox.stub(axios, "get").resolves({
+      status: 200,
+      data: {
+        authorization_endpoint: "https://example.com/oauth/authorize",
+        token_endpoint: "https://example.com/oauth/token",
+      },
+    });
+    const injectDcrStub = sandbox.stub(ActionInjector, "injectCreateDcrActionForMCP").resolves();
+    const injectOAuthStub = sandbox
+      .stub(ActionInjector, "injectCreateOAuthActionForMCP")
+      .resolves();
+
+    sandbox.stub(tools.ui, "showMessage").resolves(ok("OK"));
+    sandbox.stub(tools.ui, "openFile").resolves();
+
+    const result = await core.updateActionWithMCP(inputs);
+
+    if (result.isErr()) {
+      assert.fail(result.error.message);
+    }
+    assert.deepEqual(writtenPluginData.runtimes[0].auth, {
+      type: "OAuthPluginVault",
+      reference_id: `\${{MCP_DA_AUTH_ID_${serverName.toUpperCase()}}}`,
+    });
+    assert.isTrue(injectOAuthStub.notCalled);
+    assert.isTrue(injectDcrStub.calledOnce);
+    assert.deepEqual(injectDcrStub.firstCall.args, [
+      "/test/project/m365agents.yml",
+      serverName,
+      `MCP_DA_AUTH_ID_${serverName.toUpperCase()}`,
+      mcpServerUrl,
+      "https://example.com/.well-known/oauth-authorization-server",
+    ]);
+  });
+
   it("should return error when plugin manifest file does not exist", async () => {
     const core = new FxCore(tools);
     const inputs: Inputs = {

--- a/packages/fx-core/tests/question/question.test.ts
+++ b/packages/fx-core/tests/question/question.test.ts
@@ -1735,32 +1735,30 @@ describe("updateActionWithMCP", async () => {
     };
     assert.isTrue(conditionFunc(inputsVSCode));
 
-    // Test static options - by default oauth-dynamic is hidden behind two flags.
+    // Test static options - by default oauth-dynamic is hidden behind the DCR flag.
     const staticOptions = (authTypeNode?.data as any)?.staticOptions;
     assert.isArray(staticOptions);
-    assert.lengthOf(staticOptions, 3);
-
-    assert.isDefined(staticOptions?.find((opt: any) => opt.id === "oauth"));
-    assert.isDefined(staticOptions?.find((opt: any) => opt.id === "entra-sso"));
-    assert.isDefined(staticOptions?.find((opt: any) => opt.id === "none"));
+    assert.deepEqual(
+      staticOptions.map((opt: any) => opt.id),
+      ["oauth", "entra-sso"]
+    );
     assert.isUndefined(staticOptions?.find((opt: any) => opt.id === "oauth-dynamic"));
     assert.equal((authTypeNode?.data as any)?.default, "oauth");
 
-    // When both TEAMSFX_MCP_FOR_DA_DT and TEAMSFX_MCP_FOR_DA_DCR are enabled,
-    // the dynamic-registration option is surfaced.
+    // When TEAMSFX_MCP_FOR_DA_DCR is enabled, the dynamic-registration option is
+    // surfaced first.
     const flagSandbox = sinon.createSandbox();
     try {
       flagSandbox.stub(featureFlagManager, "getBooleanValue").callsFake((flag) => {
-        if (flag === FeatureFlags.MCPForDADT || flag === FeatureFlags.MCPForDADCR) {
-          return true;
-        }
-        return false;
+        return flag === FeatureFlags.MCPForDADCR;
       });
       const optionsWithFlags = (questionNodes.updateActionWithMCP().children?.[2]?.data as any)
         ?.staticOptions;
       assert.isArray(optionsWithFlags);
-      assert.lengthOf(optionsWithFlags, 4);
-      assert.isDefined(optionsWithFlags?.find((opt: any) => opt.id === "oauth-dynamic"));
+      assert.deepEqual(
+        optionsWithFlags.map((opt: any) => opt.id),
+        ["oauth-dynamic", "oauth", "entra-sso"]
+      );
     } finally {
       flagSandbox.restore();
     }

--- a/packages/fx-core/tests/question/question.test.ts
+++ b/packages/fx-core/tests/question/question.test.ts
@@ -1759,6 +1759,10 @@ describe("updateActionWithMCP", async () => {
         optionsWithFlags.map((opt: any) => opt.id),
         ["oauth-dynamic", "oauth", "entra-sso"]
       );
+      assert.equal(
+        (questionNodes.updateActionWithMCP().children?.[2]?.data as any)?.default,
+        "oauth-dynamic"
+      );
     } finally {
       flagSandbox.restore();
     }


### PR DESCRIPTION
## Summary
- Add a fetch-tools-specific MCP auth option list that shows OAuth dynamic registration first when `TEAMSFX_MCP_FOR_DA_DCR` is enabled.
- Default the fetch-tools auth picker to `OAuth (with dynamic registration)` when DCR is enabled, so VS Code keeps the dynamic option first and selected.
- Handle DT-style MCP runtimes in `updateActionWithMCP` where `run_for_functions` can be `["*"]` and optional plugin manifest arrays such as `functions`, `runtimes`, or runtime `run_for_functions` may be omitted.
- Route `oauth-dynamic` updateActionWithMCP YAML injection through `dcr/register` and update the fetch-tools scenario docs/HTML to match code-backed option details.

## UI changes
- Step 6 `Select Authentication Type` now shows `OAuth (with dynamic registration)` as the first and selected option when `TEAMSFX_MCP_FOR_DA_DCR` is enabled.
- Static OAuth remains available as the second option, followed by Entra SSO.
- Option details in the picker:
  - `OAuth (with dynamic registration)`: `MCP server registers a client at runtime; no extra details needed.`
  - `OAuth (with static registration)`: `Use a pre-registered OAuth client. The toolkit will ask for client id, client secret, and optional scopes.`
  - `Entra SSO`: `Use a Microsoft Entra app for single sign-on. The toolkit will ask for the Entra app client id.`

## Screenshot / visual reference
The screenshot state for this UI change is: `OAuth (with dynamic registration)` is highlighted first, `OAuth (with static registration)` is second, and `Entra SSO` is third.
<img width="871" height="295" alt="{54DD25ED-1AF6-49CC-838B-18CFE64102C9}" src="https://github.com/user-attachments/assets/eaaa39b4-dbf7-44ef-b073-1a0d9f6d7048" />

Visual reference: `docs/01-product/scenarios/da/fetch-mcp-tools.html`, section `6. Select Authentication Type`.

## Validation
- `cd packages/fx-core; npx vitest run --config vitest.config.ts --maxWorkers=75% tests/core/FxCore.declarativeAgent.test.ts tests/question/question.test.ts tests/question/scaffold.test.ts`
- `cd packages/fx-core; npx eslint src/core/FxCore.declarativeAgent.ts src/question/scaffold/vsc/teamsProjectTypeNode.ts tests/core/FxCore.declarativeAgent.test.ts tests/question/question.test.ts` (0 errors; existing warnings remain)
- `npm run build`
