### PR TITLE
fix(vsc): resolve sample gallery a11y bugs on toggle and detail page

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.scss
@@ -121,6 +121,14 @@
         margin: 45px 0 0 0;
         padding: 0;
     }
+
+    h2:focus-visible,
+    .tags .tag span:focus-visible,
+    .readme:focus-visible,
+    .readme :focus-visible {
+        outline: 2px solid var(--vscode-focusBorder, #007FD4);
+        outline-offset: 2px;
+    }
 }
 
 body.vscode-light {
@@ -131,6 +139,30 @@ body.vscode-light {
 
     .upgrade-banner {
         background-color: #F0F0F0;
+    }
+
+    /* TC-007: Focus indicator contrast >= 3:1 on the sample detail (readme) page.
+     * --vscode-focusBorder resolves to ~2.26:1 on the white readme background in
+     * Light 2026; override with #005FB8 (~6.3:1 on white) to meet WCAG non-text 3:1. */
+    .sample-detail-page {
+        h2:focus-visible,
+        .tags .tag span:focus-visible,
+        .readme:focus-visible,
+        .readme :focus-visible {
+            outline-color: #005FB8;
+        }
+
+        /* TC-008: README link text contrast >= 4.5:1 in Light 2026.
+         * --vscode-textLink-foreground is ~2.53:1 on white; #005B9E gives ~7:1. */
+        .readme a {
+            color: #005B9E;
+
+            &:hover,
+            &:focus,
+            &:active {
+                color: #004480;
+            }
+        }
     }
 }
 

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
@@ -119,7 +119,7 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
           <VSCodeButton
             onClick={() => this.props.onLayoutChanged("grid")}
             appearance="icon"
-            aria-label="Gallery view"
+            aria-label={this.props.layout === "grid" ? "Gallery view, selected" : "Gallery view"}
             aria-pressed={this.props.layout === "grid"}
             className={`layout-button ${this.props.layout === "grid" ? "layout-selected" : ""}`}
           >
@@ -128,7 +128,7 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
           <VSCodeButton
             onClick={() => this.props.onLayoutChanged("list")}
             appearance="icon"
-            aria-label="List view"
+            aria-label={this.props.layout === "list" ? "List view, selected" : "List view"}
             aria-pressed={this.props.layout === "list"}
             className={`layout-button ${this.props.layout === "list" ? "layout-selected" : ""}`}
           >


### PR DESCRIPTION
## Summary
Fixes three Sample Gallery accessibility bugs in the **Light 2026 (Default Light Modern)** theme.

### 1. Screen reader does not announce the selected state for Gallery/List view toggle buttons
`aria-pressed` alone was not announced because `@vscode/webview-ui-toolkit`'s `Button` only forwards `aria-label` to its internal shadow-DOM `<button>`. The selected state is now encoded into the accessible name (e.g. `"Gallery view, selected"`) while `aria-pressed` is retained for correct toggle semantics.

### 2. Focus indicator contrast 2.257:1 (< 3:1) on the Sample detail (README) page
Added `:focus-visible` outlines on the detail page's native-focus elements (`h2`, tag spans, the `.readme` container and its descendants). In light theme the outline color is overridden to `#005FB8` -> **6.31:1** on white (WCAG non-text >= 3:1).

### 3. Link text contrast 2.526:1 (< 4.5:1) in the rendered README
Added a light-theme `.readme a` color of `#005B9E` -> **7.02:1**, with hover/focus/active `#004480` -> 9.82:1 (WCAG text >= 4.5:1). Dark theme is unchanged.

Bugs 2 & 3 mirror the existing TC-006 / TC-001a fixes already applied to the gallery cards, extended to the detail/README page.

## Verification
- IDE diagnostics clean; `eslint` 0 errors; `prettier --check` clean on the TSX.
- SCSS compiles via `sass`; full **vite webview build succeeds**.
- Contrast ratios computed with the WCAG relative-luminance formula on `#FFFFFF` and `#F8F8F8` -- all pass.

## Files changed
- `packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx`
- `packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.scss`
