### PR TITLE
fix(fx-core): enable DCR feature flag by default

### DIFF
--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -129,7 +129,7 @@ export class FeatureFlags {
   };
   static readonly MCPForDADCR = {
     name: FeatureFlagName.MCPForDADCR,
-    defaultValue: "false",
+    defaultValue: "true",
   };
   static readonly GenerateConfigFiles = {
     name: FeatureFlagName.GenerateConfigFiles,

--- a/packages/fx-core/tests/common/featureFlags.test.ts
+++ b/packages/fx-core/tests/common/featureFlags.test.ts
@@ -33,6 +33,20 @@ describe("FeatureFlagManager", () => {
     const stringRes = featureFlagManager.getStringValue(FeatureFlags.CLIDotNet);
     chai.assert.equal(stringRes, "false");
   });
+  it("MCPForDADCR defaults to true", async () => {
+    mockedEnvRestore = mockedEnv({ [FeatureFlags.MCPForDADCR.name]: undefined });
+    const booleanRes = featureFlagManager.getBooleanValue(FeatureFlags.MCPForDADCR);
+    chai.assert.isTrue(booleanRes);
+    const stringRes = featureFlagManager.getStringValue(FeatureFlags.MCPForDADCR);
+    chai.assert.equal(stringRes, "true");
+  });
+  it("MCPForDADCR can be disabled by environment variable", async () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_MCP_FOR_DA_DCR: "false" });
+    const booleanRes = featureFlagManager.getBooleanValue(FeatureFlags.MCPForDADCR);
+    chai.assert.isFalse(booleanRes);
+    const stringRes = featureFlagManager.getStringValue(FeatureFlags.MCPForDADCR);
+    chai.assert.equal(stringRes, "false");
+  });
   it("list", async () => {
     const list = featureFlagManager.list();
     chai.assert.deepEqual(list, Object.values(FeatureFlags));

--- a/packages/fx-core/tests/question/question.test.ts
+++ b/packages/fx-core/tests/question/question.test.ts
@@ -1735,33 +1735,31 @@ describe("updateActionWithMCP", async () => {
     };
     assert.isTrue(conditionFunc(inputsVSCode));
 
-    // Test static options - by default oauth-dynamic is hidden behind the DCR flag.
+    // Test static options - by default oauth-dynamic is surfaced first.
     const staticOptions = (authTypeNode?.data as any)?.staticOptions;
     assert.isArray(staticOptions);
     assert.deepEqual(
       staticOptions.map((opt: any) => opt.id),
-      ["oauth", "entra-sso"]
+      ["oauth-dynamic", "oauth", "entra-sso"]
     );
-    assert.isUndefined(staticOptions?.find((opt: any) => opt.id === "oauth-dynamic"));
-    assert.equal((authTypeNode?.data as any)?.default, "oauth");
+    assert.equal((authTypeNode?.data as any)?.default, "oauth-dynamic");
 
-    // When TEAMSFX_MCP_FOR_DA_DCR is enabled, the dynamic-registration option is
-    // surfaced first.
+    // When TEAMSFX_MCP_FOR_DA_DCR is disabled, the dynamic-registration option is hidden.
     const flagSandbox = sinon.createSandbox();
     try {
       flagSandbox.stub(featureFlagManager, "getBooleanValue").callsFake((flag) => {
-        return flag === FeatureFlags.MCPForDADCR;
+        return flag !== FeatureFlags.MCPForDADCR;
       });
       const optionsWithFlags = (questionNodes.updateActionWithMCP().children?.[2]?.data as any)
         ?.staticOptions;
       assert.isArray(optionsWithFlags);
       assert.deepEqual(
         optionsWithFlags.map((opt: any) => opt.id),
-        ["oauth-dynamic", "oauth", "entra-sso"]
+        ["oauth", "entra-sso"]
       );
       assert.equal(
         (questionNodes.updateActionWithMCP().children?.[2]?.data as any)?.default,
-        "oauth-dynamic"
+        "oauth"
       );
     } finally {
       flagSandbox.restore();


### PR DESCRIPTION
## Summary
- Set `MCPForDADCR` default value to `true`.
- Update focused feature flag and MCP question tests for default DCR behavior and explicit opt-out.

## Tests
- `pnpm exec vitest run --config vitest.config.ts --maxWorkers=75% tests/common/featureFlags.test.ts tests/question/question.test.ts -t "FeatureFlagManager|updateActionWithMCP"`