### PR TITLE
test: use shared Teams Agents and Apps group in mislabeled Declarative Agent plans

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Add_App_From_TDP.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Add_App_From_TDP.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2.0,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 13,
+    "total_steps": 12,
     "created_at": "2026-05-18T02:19:09.515002",
     "name": "Feature Add App From TDP",
     "description": {
@@ -26,7 +26,7 @@
       "step_ba470b19",
       "step_5e71293c",
       "plan_a4d84624",
-      "step_7e6b08a7",
+      "plan_r_0624_024810",
       "step_22498d6e",
       "step_b3327844",
       "step_43412fab",
@@ -113,34 +113,6 @@
       "tags": [],
       "screenshot": "step_5e71293c",
       "created_at": "2026-05-18T02:19:09.562153",
-      "plan_id": "plan_06dbd424"
-    },
-    {
-      "step_id": "step_7e6b08a7",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 354,
-        "y": 172
-      },
-      "description": "Click on the \"Apps for Microsoft 365\" option within the dropdown list under the \"New Project\" dialog.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:354:172:16:5:52525292e9556b14",
-        "dhash:354:172:96:5:8a3245164b699400",
-        "dhash:354:172:0:10:c8c09090b2726261"
-      ],
-      "postconditions": [],
-      "tags": [
-        "step_retry_timeout:60"
-      ],
-      "screenshot": "step_7e6b08a7",
-      "created_at": "2026-05-18T02:19:09.568280",
       "plan_id": "plan_06dbd424"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Del_Resource_Group_And_Reprovision_For_Tab.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Del_Resource_Group_And_Reprovision_For_Tab.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 12,
+    "total_steps": 11,
     "created_at": "2026-03-16T08:20:40.499725",
     "name": "Feature Del Resource Group And Reprovision For tab",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-03-16T08:20:40.499718",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_1570f129",
+      "plan_r_0624_024810",
       "step_0f3abd6d",
       "step_2c440fea",
       "step_f27138f4",
@@ -41,32 +41,6 @@
     "updated_at": "2026-03-16T08:22:42.990293"
   },
   "steps": [
-    {
-      "step_id": "step_1570f129",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:53ccc35ac8d2730c",
-        "dhash:361:229:96:5:959834d2da1409c8",
-        "dhash:361:229:0:10:c8c88094b0717c6f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_1570f129",
-      "created_at": "2026-03-16T08:20:40.549702",
-      "plan_id": "plan_82a790fb"
-    },
     {
       "step_id": "step_0f3abd6d",
       "agent": "interaction",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Deploy_Triggered_Codelens_Support.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Deploy_Triggered_Codelens_Support.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 10,
+    "total_steps": 9,
     "created_at": "2026-01-28T02:45:01.730427",
     "name": "Feature Deploy Triggered Codelens Support",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-01-28T02:45:01.730427",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_1e4b44c9",
+      "plan_r_0624_024810",
       "step_b1c7bf35",
       "step_0be4ea59",
       "step_dafef1b7",
@@ -36,32 +36,6 @@
     "updated_at": "2026-02-02T09:33:57.765381"
   },
   "steps": [
-    {
-      "step_id": "step_1e4b44c9",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:53ccc35ac8d2730c",
-        "dhash:361:229:96:5:959834d2da1409c8",
-        "dhash:361:229:0:10:c8c88094b0717c6f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_1e4b44c9",
-      "created_at": "2026-02-02T09:22:29.457526",
-      "plan_id": "plan_724df082"
-    },
     {
       "step_id": "step_b1c7bf35",
       "agent": "interaction",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Port_in_Use.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Port_in_Use.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 27,
+    "total_steps": 26,
     "created_at": "2026-04-30T07:31:08.802500",
     "name": "Feature LocalDebug Port in Use",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-04-30T07:31:08.802496",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_c38c9de2",
+      "plan_r_0624_024810",
       "step_ff8f068a",
       "step_e97e1265",
       "step_a043f2ba",
@@ -55,32 +55,6 @@
     "updated_at": "2026-04-30T07:46:52.932832"
   },
   "steps": [
-    {
-      "step_id": "step_c38c9de2",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:53ccc35ac8d2730c",
-        "dhash:361:229:96:5:959834d2da1409c8",
-        "dhash:361:229:0:10:c8c88094b0717c6f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_c38c9de2",
-      "created_at": "2026-04-30T07:31:08.809166",
-      "plan_id": "plan_f092a0c2"
-    },
     {
       "step_id": "step_ff8f068a",
       "agent": "interaction",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Newproject_In_Exist_Project.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Newproject_In_Exist_Project.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 13,
+    "total_steps": 12,
     "created_at": "2026-01-20T09:13:08.158166",
     "name": "Feature Newproject In Exist Project",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-01-20T09:13:08.158166",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_791fdae9",
+      "plan_r_0624_024810",
       "step_bdf94d9e",
       "step_fd9170e4",
       "step_22221324",
@@ -40,32 +40,6 @@
     "updated_at": "2026-01-21T03:19:06.754015"
   },
   "steps": [
-    {
-      "step_id": "step_791fdae9",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:534cd35ac8d2f328",
-        "dhash:361:229:96:5:959834d3d22706c6",
-        "dhash:361:229:0:10:c8c88094b0717075"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_791fdae9",
-      "created_at": "2026-01-21T03:10:10.104175",
-      "plan_id": "plan_004c8b8e"
-    },
     {
       "step_id": "step_bdf94d9e",
       "agent": "interaction",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Provision_Triggered_Codelens_Support.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Provision_Triggered_Codelens_Support.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 8,
+    "total_steps": 7,
     "created_at": "2026-01-29T08:07:47.663934",
     "name": "Feature Provision Triggered Codelens Support",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-01-29T08:07:47.663934",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_ca3f235d",
+      "plan_r_0624_024810",
       "step_bb1c7ec9",
       "step_de2da0aa",
       "step_58d711a6",
@@ -34,32 +34,6 @@
     "updated_at": "2026-01-29T08:44:27.589129"
   },
   "steps": [
-    {
-      "step_id": "step_ca3f235d",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:53ccc35ac8d2730c",
-        "dhash:361:229:96:5:959834d2da1409c8",
-        "dhash:361:229:0:10:c8c88094b0717c6f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_ca3f235d",
-      "created_at": "2026-01-29T08:07:47.685378",
-      "plan_id": "plan_4cd86312"
-    },
     {
       "step_id": "step_bb1c7ec9",
       "agent": "interaction",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Provision_Without_Account.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Provision_Without_Account.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 18,
+    "total_steps": 17,
     "created_at": "2026-01-29T08:55:17.395274",
     "name": "Feature Provision Without Account",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-01-29T08:55:17.395274",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_2652c2f3",
+      "plan_r_0624_024810",
       "step_a60e64d9",
       "step_4f022cc4",
       "step_a8f39118",
@@ -46,32 +46,6 @@
     "updated_at": "2026-01-29T09:57:58.043149"
   },
   "steps": [
-    {
-      "step_id": "step_2652c2f3",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:53ccc35ac8d2730c",
-        "dhash:361:229:96:5:959834d2da1409c8",
-        "dhash:361:229:0:10:c8c88094b0717c6f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_2652c2f3",
-      "created_at": "2026-01-29T08:55:17.411589",
-      "plan_id": "plan_9603bf77"
-    },
     {
       "step_id": "step_a60e64d9",
       "agent": "interaction",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Remove_App_From_Devportal_And_Reprovision.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Remove_App_From_Devportal_And_Reprovision.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 34,
+    "total_steps": 33,
     "created_at": "2026-06-02T00:43:24.568443",
     "name": "Feature Remove App From Devportal And Reprovision",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-06-02T00:43:24.568443",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_fd26c2c7",
+      "plan_r_0624_024810",
       "step_7d3d5c74",
       "step_6af98db9",
       "step_20908d70",
@@ -66,32 +66,6 @@
     "updated_at": "2026-06-02T00:44:38.011430"
   },
   "steps": [
-    {
-      "step_id": "step_fd26c2c7",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:53ccc35ac8d2730c",
-        "dhash:361:229:96:5:959834d2da1409c8",
-        "dhash:361:229:0:10:c8c88094b0717c6f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_fd26c2c7",
-      "created_at": "2026-06-02T00:43:24.577523",
-      "plan_id": "plan_66c34e56"
-    },
     {
       "step_id": "step_7d3d5c74",
       "agent": "interaction",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Set_Sub_Id_And_Rg_Name.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Set_Sub_Id_And_Rg_Name.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 11,
+    "total_steps": 10,
     "created_at": "2026-03-04T04:46:35.945953",
     "name": "Feature Set Sub Id And Rg Name",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-03-04T04:46:35.945934",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_436e1678",
+      "plan_r_0624_024810",
       "step_0dbd7edc",
       "step_6171ca5f",
       "step_027eb0c7",
@@ -40,32 +40,6 @@
     "updated_at": "2026-03-04T06:09:43.765814"
   },
   "steps": [
-    {
-      "step_id": "step_436e1678",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:53ccc35ac8d2730c",
-        "dhash:361:229:96:5:959834d2da1409c8",
-        "dhash:361:229:0:10:c8c88094b0717c6f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_436e1678",
-      "created_at": "2026-03-04T05:47:13.699925",
-      "plan_id": "plan_6aeb7198"
-    },
     {
       "step_id": "step_0dbd7edc",
       "agent": "interaction",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 30,
+    "total_steps": 29,
     "created_at": "2026-01-06T02:01:16.119023",
     "name": "Feature: UI Layout & Create Project Questions",
     "description": {
@@ -20,7 +20,7 @@
     "generated_at": "2026-01-06T02:01:16.119023",
     "execution_order": [
       "plan_r_0928_012254",
-      "step_8bfedb22",
+      "plan_r_0624_024810",
       "step_34be0072",
       "step_ae8b01b3",
       "step_90d68e68",
@@ -57,32 +57,6 @@
     "updated_at": "2026-01-06T09:56:34.118912"
   },
   "steps": [
-    {
-      "step_id": "step_8bfedb22",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 361,
-        "y": 229
-      },
-      "description": "Click on the \"Declarative Agent\" option within the \"New Project\" dropdown menu to create an agent using instructions and actions.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:361:229:16:5:53ccc35ac8d2730c",
-        "dhash:361:229:96:5:959834d2da1409c8",
-        "dhash:361:229:0:10:c8c88094b0717c6f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_8bfedb22",
-      "created_at": "2026-01-06T09:55:50.934589",
-      "plan_id": "plan_47e4bf4e"
-    },
     {
       "step_id": "step_34be0072",
       "agent": "interaction",


### PR DESCRIPTION
## What

Replace the inline **"Teams Agents and Apps"** New Project click with the shared group `plan_r_0624_024810` in 9 more test plans.

In these plans the first New Project click is labeled **"Declarative Agent"**, but it is actually the **Teams Agents and Apps** option — confirmed because the very next step selects **"General Teams Agent"**, a capability that lives under Teams Agents and Apps. Each plan had that step replaced with a reference to the shared group, the step object removed, and `total_steps` decremented.

## Plans updated

- Feature_Del_Resource_Group_And_Reprovision_For_Tab
- Feature_Deploy_Triggered_Codelens_Support
- Feature_LocalDebug_Port_in_Use
- Feature_Newproject_In_Exist_Project
- Feature_Provision_Triggered_Codelens_Support
- Feature_Provision_Without_Account
- Feature_Remove_App_From_Devportal_And_Reprovision
- Feature_Set_Sub_Id_And_Rg_Name
- Feature_UI_Layout__Create_Project_Questions

## Validation

For every modified plan: JSON parses successfully, `execution_order` contains the group reference, and `steps` count equals `total_steps`.

Note: genuine Declarative Agent (`DA_*`/`Feature_DA_*`) and Custom Engine Agent plans were intentionally left unchanged.
