### PR TITLE
fix(fx-core): stop collecting OAuth credentials in fetch-from-MCP flow

### DIFF
--- a/packages/fx-core/src/question/scaffold/vsc/teamsProjectTypeNode.ts
+++ b/packages/fx-core/src/question/scaffold/vsc/teamsProjectTypeNode.ts
@@ -821,7 +821,14 @@ export function updateActionWithMCP(): IQTreeNode {
             ? "oauth-dynamic"
             : "oauth",
         },
-        children: MCPForDAAuthCredentialNodes(),
+        // The fetch-from-MCP flow only asks for the auth *type*. Per
+        // SCN-DA-FETCH-MCP-TOOLS, secret collection is deferred to the provision
+        // oauth/register driver. The fetch backend reads only the auth type and
+        // never persists the client id / secret / scopes answers (it injects the
+        // oauth action without credential env refs), so attaching the credential
+        // follow-ups here would only ask questions whose answers are dropped.
+        // Mirror the DT-off add-action flow and collect nothing.
+        children: [],
       },
     ],
   };

--- a/packages/fx-core/tests/question/scaffold.test.ts
+++ b/packages/fx-core/tests/question/scaffold.test.ts
@@ -1108,6 +1108,15 @@ describe("updateActionWithMCP", () => {
     const inputs: Inputs = { platform: Platform.CLI, [QuestionNames.MCPForDAAuth]: "NoneAuth" };
     assert.isFalse(condition(inputs));
   });
+  it("child[2] (auth type) has no credential follow-up questions", () => {
+    // The fetch-from-MCP flow only collects the auth type; client id / secret /
+    // scopes are not asked here because the backend never persists them and
+    // secret collection is deferred to the provision oauth/register driver.
+    const node = updateActionWithMCP();
+    const child2 = node.children![2];
+    assert.equal((child2.data as any).name, QuestionNames.MCPForDAAuthType);
+    assert.deepEqual(child2.children ?? [], []);
+  });
 });
 
 describe("languageNode", () => {


### PR DESCRIPTION
## Problem

In the **Fetch action from MCP** flow (`ATK: Fetch action from MCP` CodeLens / `ATK: Update Action with MCP`), picking **OAuth (with static registration)** or **Entra SSO** prompted the user for the "behind" credential questions — client id, client secret, scopes (OAuth) or Entra Application (client) ID (Entra SSO).

Those questions are unexpected here: they belong to the scaffold/add-action flows and are gated on the `TEAMSFX_MCP_FOR_DA_DT` feature flag there.

## Root cause

The three MCP-DA auth entry points all share `MCPForDAAuthCredentialNodes()`, but gate it differently:

| Flow | Credential follow-ups | Backend consumes them? |
|---|---|---|
| Scaffold create (`teamsProjectTypeNode`) | attached under the DT-gated auth node | yes — persisted in `helper.ts` |
| Add action (`other.ts` `addPlugin`) | `DT ? nodes : []` (explicitly gated) | yes — persisted in `FxCore.declarativeAgent` |
| **Fetch action from MCP (`updateActionWithMCP`)** | **`MCPForDAAuthCredentialNodes()` — ungated** | **no** |

The fetch-flow backend reads only the auth **type**; it injects the OAuth action **without** `persistCredentialEnvRefs` and never calls `persistMCPAuthCredentialEnvVars`. So the client id / secret / scopes answers were collected and then **silently dropped**.

This also contradicted the source-of-truth scenario `SCN-DA-FETCH-MCP-TOOLS` (`docs/01-product/scenarios/da/fetch-mcp-tools.md`), whose flow is `Select Auth → Apply` with secret collection **deferred to provision** (the `oauth/register` driver).

## Fix

In `updateActionWithMCP()`, the auth-type question now collects **only the auth type** (`children: []`), mirroring the DT-off `addPlugin` behavior and the scenario doc. Secret collection remains deferred to the provision `oauth/register` driver. No backend change is needed since the fetch backend never consumed those answers.

## Testing

- Added a regression test in `scaffold.test.ts` asserting the fetch-flow auth-type node has no credential follow-up children.
- `vitest` green:
  - `tests/question/scaffold.test.ts` + `tests/question/question.test.ts` — 227 passed
  - `tests/core/FxCore.declarativeAgent.test.ts` — 61 passed (backend unchanged)

## Notes

- No doc change needed — the scenario already describes this (deferred) behavior.
- `MCPForDAAuthCredentialNodes()` remains used by the scaffold and add-action flows.