### PR TITLE
feat(cli): seed correlation id from ATK_CLI_CORRELATION_ID env var

### DIFF
--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -66,7 +66,10 @@ class CLIEngine {
    * entry point of the CLI engine
    */
   async start(rootCmd: CLICommand): Promise<void> {
-    Correlator.setId();
+    // Seed the correlation id from ATK_CLI_CORRELATION_ID when a parent process
+    // (e.g. the wiqd CLI) passes one, so this run's telemetry shares the parent's
+    // `correlation-id`. Absent/malformed values fall back to a fresh UUID.
+    Correlator.setId(process.env.ATK_CLI_CORRELATION_ID);
 
     // Fire-and-forget: fetch latest metadata in background, same as VSC extension activation
     void getFxCore().fetchOnlineTemplateMetadata();

--- a/packages/cli/tests/unit/engine.tests.ts
+++ b/packages/cli/tests/unit/engine.tests.ts
@@ -15,6 +15,7 @@ import {
   MissingEnvironmentVariablesError,
   UserCancelError,
   VersionState,
+  Correlator,
 } from "@microsoft/teamsfx-core";
 import { assert } from "chai";
 import mockedEnv from "mocked-env";
@@ -743,6 +744,28 @@ describe("CLI Engine", () => {
       const result = engine.parseArgs(ctx, rootCommand, []);
       assert.isTrue(result.isOk());
       assert.notProperty(ctx.telemetryProperties, TelemetryProperty.Skill);
+      mockedEnvRestore();
+    });
+  });
+
+  describe("ATK_CLI_CORRELATION_ID env var", () => {
+    it("seeds the Correlator with the parent-provided id", async () => {
+      const externalId = "11111111-1111-4111-8111-111111111111";
+      const mockedEnvRestore = mockedEnv({ ATK_CLI_CORRELATION_ID: externalId });
+      const setIdStub = sandbox.stub(Correlator, "setId");
+      sandbox.stub(process, "argv").value(["node", "cli", "-h"]);
+      sandbox.stub(logger, "info");
+      await engine.start(rootCommand);
+      assert.isTrue(setIdStub.calledWith(externalId));
+      mockedEnvRestore();
+    });
+    it("seeds the Correlator with undefined when the env var is not set", async () => {
+      const mockedEnvRestore = mockedEnv({ ATK_CLI_CORRELATION_ID: undefined });
+      const setIdStub = sandbox.stub(Correlator, "setId");
+      sandbox.stub(process, "argv").value(["node", "cli", "-h"]);
+      sandbox.stub(logger, "info");
+      await engine.start(rootCommand);
+      assert.isTrue(setIdStub.calledWith(undefined));
       mockedEnvRestore();
     });
   });

--- a/packages/fx-core/src/common/correlator.ts
+++ b/packages/fx-core/src/common/correlator.ts
@@ -8,10 +8,16 @@ import * as uuid from "uuid";
 const asyncLocalStorage = new AsyncLocalStorage<string>();
 
 export class Correlator {
-  static setId(): string {
-    const id = uuid.v4();
-    asyncLocalStorage.enterWith(id);
-    return id;
+  /**
+   * Sets the ambient correlation id for the current async context. A valid UUID
+   * `id` is adopted as-is — the seam that lets an external caller (e.g. the wiqd
+   * CLI) thread its own correlation id in; absent/malformed values mint a fresh
+   * UUID so the id is always well-formed.
+   */
+  static setId(id?: string): string {
+    const newId = id && uuid.validate(id) ? id : uuid.v4();
+    asyncLocalStorage.enterWith(newId);
+    return newId;
   }
   static run<T extends unknown[], R>(work: (...args: [...T]) => R, ...args: [...T]): R {
     const id = asyncLocalStorage.getStore() || uuid.v4();

--- a/packages/fx-core/tests/common/correlator.test.ts
+++ b/packages/fx-core/tests/common/correlator.test.ts
@@ -27,4 +27,23 @@ describe("Correlator", () => {
     const getId = Correlator.getId();
     chai.assert.isDefined(getId);
   });
+
+  it("setId adopts a valid externally-provided UUID", () => {
+    const externalId = "11111111-1111-4111-8111-111111111111";
+    const setedId = Correlator.setId(externalId);
+    chai.assert.equal(setedId, externalId);
+    chai.assert.equal(Correlator.getId(), externalId);
+  });
+
+  it("setId mints a fresh UUID when the provided id is malformed", () => {
+    const setedId = Correlator.setId("not-a-uuid");
+    chai.assert.notEqual(setedId, "not-a-uuid");
+    chai.assert.equal(Correlator.getId(), setedId);
+  });
+
+  it("setId mints a fresh UUID when no id is provided", () => {
+    const setedId = Correlator.setId();
+    chai.assert.isNotEmpty(setedId);
+    chai.assert.equal(Correlator.getId(), setedId);
+  });
 });


### PR DESCRIPTION
## What

Lets a parent process that spawns the ATK CLI as a subprocess (e.g. the **wiqd** CLI) thread its own correlation id into this run, so both products' telemetry share **one join key per invocation**.

```diff
  // packages/fx-core/src/common/correlator.ts
- static setId(): string {
-   const id = uuid.v4();
+ static setId(id?: string): string {
+   const newId = id && uuid.validate(id) ? id : uuid.v4();

  // packages/cli/src/commands/engine.ts  (start())
- Correlator.setId();
+ Correlator.setId(process.env.ATK_CLI_CORRELATION_ID);
```

- `Correlator.setId(id?)` now **adopts a valid externally-supplied UUID** and falls back to a freshly minted UUID when the value is absent or malformed (`uuid.validate`), so the correlation id is always well-formed.
- The CLI entrypoint seeds it from `process.env.ATK_CLI_CORRELATION_ID`. This makes ATK's **native** `correlation-id` (already stamped on every telemetry event) equal the parent's id — no new dimension, no schema change.

## Why

As wiqd adoption grows as a wrapper around ATK, there's no way today to join an ATK telemetry event back to the wiqd action that triggered it. Seeding `correlation-id` from an env var the parent controls closes that gap with **zero new telemetry attributes** on the ATK side. The env-var prefix follows the existing caller→ATK convention (`ATK_CLI_SKILL`), not the deprecated `TEAMSFX_` brand.

## Safety / backward-compat

- **Env var absent** (ATK run standalone, or by an older parent): `setId(undefined)` → falls through to `uuid.v4()` → **byte-for-byte identical to prior behavior.** The only production caller of `setId` is this entrypoint.
- **Env var malformed / empty:** rejected by `uuid.validate` → fresh UUID. No injection surface (value is only ever used as a correlation id).
- `Correlator.run` / `runWithId` paths are unchanged.

Safe to ship independently and in any order relative to the wiqd side.

## Companion changes (cross-product correlation)

- **wiqd producer** (injects the id): gim-home/wiqd#1339
- **wiqd un-suppress** (so ATK emits in wiqd-driven runs at all): gim-home/wiqd#1332

The join key is `ATK.correlation-id == wiqd.session.id`. Correlation becomes visible once all three are live in the same invocation; until then every partial-deployment state degrades to "ATK mints its own id."

## Testing

- `packages/fx-core` — `vitest run tests/common/correlator.test.ts`: **6/6 pass** (valid id adopted; malformed → fresh; absent → fresh).
- `packages/cli` — `vitest run tests/unit/engine.tests.ts`: **46/46 pass** (env var present → `setId(id)`; absent → `setId(undefined)`).
- eslint + lint-staged precommit pass on both packages.

🤖 Drafted with GitHub Copilot CLI.
