### PR TITLE
feat(fx-core): emit v4 scaffold template telemetry

### DIFF
--- a/docs/03-specs/operations/scaffolding/dispatch-create-by-engine.md
+++ b/docs/03-specs/operations/scaffolding/dispatch-create-by-engine.md
@@ -91,7 +91,7 @@ adds no new transitional state of its own.
 | `inputs` | `Inputs` (`@microsoft/teamsfx-api`) | the host inputs bag; pre-filled CLI args / URL seeds are read as `entryParams`, and the routing decision + collected answers are merged back so the generator dispatches on them |
 | `ui` | `UserInteraction` (`@microsoft/teamsfx-api`) | the host surface; the only non-v4 type the funnel halves touch (INV-7 preserved) |
 | `surface` | `SurfaceId` (`"vscode"` \| `"cli"` \| …) | scopes option filtering (e.g. `start-with-github-copilot` only on `vscode`) — passed straight through to `runCreateSelector` |
-| `deps` | `{ flagReader?, optionsProvider?, runSelector?, resolveByTemplateId?, runInputs?, collectCreateFloor?, scaffoldDeclarative?, createV3? }` (injected, defaulted) | feature-flag reader (default env-backed), Q2 provider registry (default remote-only `mcp.serverTypes`), the two funnel halves (`runSelector` for the Q1 walk + `resolveByTemplateId` for the preset-`template-name` short-circuit), the v4 create-floor collection (`collectCreateFloor`, reusing the v3 `folderQuestion` / `appNameQuestion`), the declarative scaffold, and the v3 handler (`createV3` defaults to `FxCore.createProject` bound) — all defaulted to the real implementations and stubbable for isolation in tests |
+| `deps` | `{ flagReader?, optionsProvider?, runSelector?, resolveByTemplateId?, runInputs?, collectCreateFloor?, scaffoldDeclarative?, createV3? }` (injected, defaulted) | feature-flag reader (default env-backed), Q2 provider registry (default remote-only `mcp.serverTypes`), the two funnel halves (`runSelector` for the Q1 walk + `resolveByTemplateId` for the preset-`template-name` short-circuit), the v4 create-floor collection (`collectCreateFloor`, using the shared floor question definitions directly through the host UI), the declarative scaffold, and the v3 handler (`createV3` defaults to `FxCore.createProject` bound) — all defaulted to the real implementations and stubbable for isolation in tests |
 
 ## Outputs
 
@@ -124,8 +124,11 @@ adds no new transitional state of its own.
 | DCE-11 | L1 | flag **on**, `inputs["template-name"] = "da/mcp-server"` preset, a selector whose route is `engine:"v4"` | `createProjectFrontDoor` | resolves via `resolveByTemplateId` (no Q1 walk) to `engine:"v4"`; runs Q2 via `runCreateInputs` then `scaffoldDeclarativeFromV4Channel`; `runSelector` is **not** called |
 | DCE-12 | L1 | flag **on**, `inputs["template-name"]` preset to an id with **no** selector route | `createProjectFrontDoor` | `resolveByTemplateId` returns the coexistence default `engine:"v3"` and delegates to `createV3` — any preset `TemplateNames` value scaffolds exactly as flag-off, whether or not the selector happens to expose it |
 | DCE-13 | L1 | flag **on**, `inputs.nonInteractive = true`, **no** preset `template-name` | `createProjectFrontDoor` | walks Q1 via `runSelector` with `interactive:false`, so an un-pre-filled gated dimension is a `BuildTargetMissingDimension` `UserError` (a non-interactive surface never silently prompts) rather than a hang |
-| DCE-14 | L1 | flag **on**, the DA+MCP v4 route, a scripted UI answering Q2 then the floor | `createProjectFrontDoor` | after `runCreateInputs` (Q2) and **before** `scaffoldDeclarativeFromV4Channel`, the front door collects the create floor (`folder` + `app-name`) by reusing the v3 `folderQuestion` / `appNameQuestion`, and the answers land on the same `inputs` bag the scaffold then reads (the v4 path has no `QuestionMW`, so without this step the scaffold hits `MissingRequiredInputError: folder`) |
+| DCE-14 | L1 | flag **on**, the DA+MCP v4 route, a scripted UI answering Q2 then the floor | `createProjectFrontDoor` | after `runCreateInputs` (Q2) and **before** `scaffoldDeclarativeFromV4Channel`, the front door collects the create floor (`folder` + `app-name`) directly through the host UI using the shared floor question definitions, without invoking the v3 question tree visitor; the answers land on the same `inputs` bag the scaffold then reads (without this step the scaffold hits `MissingRequiredInputError: folder`) |
 | DCE-15 | L1 | flag **on**, the v4 route, a scripted UI that cancels the create-floor prompt | `createProjectFrontDoor` | `err` is the cancellation `UserError` propagated unchanged; **no** scaffold occurs |
+| DCE-19 | L1 | flag **on**, a v4 target whose id has a known v3 template equivalent | `createProjectFrontDoor` resolves the target | the front door stores the mapped v3 template id on `inputs["template-name"]` before Q2 runs, so v4 scaffold-level `generate-template` telemetry can report a v3-compatible `template-name` and continue joining with command-level `create-project`; create-floor collection still runs and is not short-circuited by the resolved template name |
+| DCE-20 | L1 | flag **on**, a v4 target whose id has no mapping entry | `createProjectFrontDoor` resolves the target | `inputs["template-name"]` falls back to the v4 target id itself, preserving a stable match key for `generate-template` telemetry |
+| DCE-21 | L1 | flag **on**, the v4 scaffold succeeds or fails after target resolution | `scaffoldV4` | emits `generate-template` success/error telemetry with `template-name = <mapped-or-fallback-template-id>-<language-key>` and the resolved v4 package source/version/digest properties, so existing OKR queries can continue to join `generate-template` with `create-project` by correlation id |
 
 ## Flow
 
@@ -136,7 +139,7 @@ flowchart TD
   flag -- on --> sel["runCreateSelector(floor, ui, surface) → BuildTarget"]
   sel --> eng{"engine"}
   eng -- "surface-action" --> act["return {projectPath:'', shouldInvokeTeamsAgent:true}\n(no Q2, no scaffold)"] --> done
-  eng -- "v4" --> q2v4["runCreateInputs(floor, locator, answers, ui) → Answers"] --> floor["collectCreateFloor(inputs, ui)\n(folder + app-name, via v3 folderQuestion/appNameQuestion)"] --> sc["scaffoldDeclarativeFromV4Channel(locator, answers)"] --> done
+  eng -- "v4" --> q2v4["runCreateInputs(floor, locator, answers, ui) → Answers"] --> floor["collectCreateFloor(inputs, ui)\n(folder + app-name, direct host UI)"] --> sc["scaffoldDeclarativeFromV4Channel(locator, answers)"] --> done
   eng -- "v3" --> pf["pre-fill answers → QuestionNames.*"] --> cv3["createV3(inputs)\n(QuestionMW skips Q1, asks Q2) → v3 generator"] --> done
   sel -. cancel .-> e(["err(UserError)"])
   q2v4 -. cancel/invalid .-> e
@@ -189,13 +192,11 @@ flowchart TD
   shipped v3 CLI is unchanged.
 - **INV-9** — The v4 path collects its own create floor. Because the front door
   carries no `QuestionMW`, the `engine:"v4"` branch asks `folder` + `app-name`
-  itself — **after** Q2, **before** the scaffold — by reusing the v3
-  `folderQuestion` / `appNameQuestion` through `traverse` (DCE-14). This lives in
-  the **seam** (the composition-root `collectCreateFloor`), not `src/v4`, so INV-4
-  / INV-7 hold. The `traverse` short-circuit on a preset `template-name` and the
-  `questionVisitor` preset-skip mean a non-interactive surface (CLI `-f` / `-n`) is
-  never re-prompted — the same floor the v3 `QuestionMW` collects last; a floor
-  cancellation propagates unchanged with no scaffold (DCE-15).
+  itself — **after** Q2, **before** the scaffold — using the shared floor question
+  definitions directly through the host UI (DCE-14). This lives in the **seam**
+  (the composition-root `collectCreateFloor`), not `src/v4`, so INV-4 / INV-7
+  hold. Preset `folder` / `app-name` values are reused and never re-prompted; a
+  floor cancellation propagates unchanged with no scaffold (DCE-15).
 
 ## Notes
 

--- a/packages/fx-core/src/client/teamsGraphClient.ts
+++ b/packages/fx-core/src/client/teamsGraphClient.ts
@@ -5,6 +5,8 @@ import { hooks } from "@feathersjs/hooks";
 import { AxiosInstance } from "axios";
 import { getResourceServiceEndpoint, ResourceServiceType } from "../common/constants";
 import { ErrorContextMW } from "../common/globalVars";
+import { RetryHandler } from "../common/retryHandler";
+import { TEAMS_GRAPH_API_NAMES } from "../common/teamsGraphApiNames";
 import { WrappedAxiosClient } from "../common/wrappedAxiosClient";
 import {
   ApiSecretRegistration,
@@ -14,17 +16,8 @@ import { DcrRegistration } from "../component/driver/teamsApp/interfaces/DcrRegi
 import { OauthConfigurationId } from "../component/driver/teamsApp/interfaces/OauthConfigurationId";
 import { OauthRegistration } from "../component/driver/teamsApp/interfaces/OauthRegistration";
 import { TeamsGraphAPIFailedSystemError } from "../error/teamsGraph";
-import { RetryHandler } from "../common/retryHandler";
 
-export class TEAMS_GRAPH_API_NAMES {
-  static readonly GET_OAUTH = "teams_graph_get_oauth";
-  static readonly CREATE_OAUTH = "teams_graph_create_oauth";
-  static readonly UPDATE_OAUTH = "teams_graph_update_oauth";
-  static readonly CREATE_DCR = "teams_graph_create_dcr";
-  static readonly GET_API_KEY = "teams_graph_get_api_secret_registration";
-  static readonly CREATE_API_KEY = "teams_graph_create_api_secret_registration";
-  static readonly UPDATE_API_KEY = "teams_graph_update_api_secret_registration";
-}
+export { TEAMS_GRAPH_API_NAMES } from "../common/teamsGraphApiNames";
 
 export class TeamsGraphClient {
   getEndpoint(): string {

--- a/packages/fx-core/src/common/teamsGraphApiNames.ts
+++ b/packages/fx-core/src/common/teamsGraphApiNames.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export class TEAMS_GRAPH_API_NAMES {
+  static readonly GET_OAUTH = "teams_graph_get_oauth";
+  static readonly CREATE_OAUTH = "teams_graph_create_oauth";
+  static readonly UPDATE_OAUTH = "teams_graph_update_oauth";
+  static readonly CREATE_DCR = "teams_graph_create_dcr";
+  static readonly GET_API_KEY = "teams_graph_get_api_secret_registration";
+  static readonly CREATE_API_KEY = "teams_graph_create_api_secret_registration";
+  static readonly UPDATE_API_KEY = "teams_graph_update_api_secret_registration";
+}

--- a/packages/fx-core/src/common/wrappedAxiosClient.ts
+++ b/packages/fx-core/src/common/wrappedAxiosClient.ts
@@ -7,7 +7,6 @@ import axios, {
   CreateAxiosDefaults,
   InternalAxiosRequestConfig,
 } from "axios";
-import { TEAMS_GRAPH_API_NAMES } from "../client/teamsGraphClient";
 import { HttpMethod } from "../component/constant/commonConstant";
 import {
   APP_STUDIO_API_NAMES,
@@ -22,6 +21,7 @@ import { MOS3Api, MOS3ApiDefinitions } from "../component/m365/serviceConstant";
 import { DeveloperPortalAPIFailedSystemError } from "../error/teamsApp";
 import { TOOLS } from "./globalVars";
 import { getDefaultString } from "./localizeUtils";
+import { TEAMS_GRAPH_API_NAMES } from "./teamsGraphApiNames";
 import { TelemetryEvent, TelemetryProperty, TelemetrySuccess } from "./telemetry";
 
 /**

--- a/packages/fx-core/src/core/createFrontDoorAdapters.ts
+++ b/packages/fx-core/src/core/createFrontDoorAdapters.ts
@@ -18,27 +18,29 @@
 
 import {
   CreateProjectResult,
+  FuncValidation,
   FxError,
-  IQTreeNode,
   Inputs,
   Result,
   UserInteraction,
   err,
   ok,
 } from "@microsoft/teamsfx-api";
-import fs from "fs-extra";
+import * as fs from "fs-extra";
 import * as jsonschema from "jsonschema";
 import path from "path";
 
+import { Component, TelemetryEvent, TelemetryProperty } from "../common/telemetry";
 import { TOOLS } from "../common/globalVars";
 import { coordinator } from "../component/coordinator";
 import { templateDefaultOnActionError } from "../component/generator/generator";
 import { GeneratorContext } from "../component/generator/generatorAction";
+import { convertToLangKey } from "../component/generator/utils";
 import { scaffoldDeclarativeFromV4Channel } from "../component/generator/v4TemplateBridge";
+import { sendErrorEvent, sendSuccessEvent } from "../component/telemetry";
 import { pathUtils } from "../component/utils/pathUtils";
 import { InputValidationError, MissingRequiredInputError, assembleError } from "../error/common";
 import { AppNamePattern, QuestionNames, appNameQuestion, folderQuestion } from "../question";
-import { traverse } from "../ui/visitor";
 import { Answers, BuildTarget, CallerFloor, DeclarativeLocator } from "../v4";
 
 /** The package namespace the create front door opens v4 packages under. */
@@ -46,6 +48,21 @@ const CREATE_KIND = "create";
 
 /** The language a single-language (language-neutral) v4 package scaffolds under. */
 const COMMON_LANGUAGE = "common";
+
+function scaffoldTelemetryProps(
+  inputs: Inputs,
+  target: BuildTarget,
+  language: string
+): Record<string, string> {
+  const templateName = inputs[QuestionNames.TemplateName];
+  const templateId =
+    typeof templateName === "string" && templateName.length > 0 ? templateName : target.templateId;
+  return {
+    [TelemetryProperty.Component]: Component.core,
+    [TelemetryProperty.TemplateName]: `${templateId}-${convertToLangKey(language)}`,
+    env: process.env.TEAMSFX_ENV || "",
+  };
+}
 
 /**
  * The one module function `scaffoldV4` hands the located package to, behind the
@@ -62,9 +79,8 @@ export const scaffoldV4Deps = {
  * floor (`folder` / `app-name`), then renders the located `create/<templateId>`
  * declarative package onto disk via the v4 distribution channel.
  *
- * Mirrors `FxCore.createProjectByCustomizedGenerator`'s input validation and
- * `ensureTrackingId` tail so a v4 scaffold yields the same `CreateProjectResult`
- * shape as every other create path.
+ * Mirrors the legacy customized-generator validation and tracking-id tail so a
+ * v4 scaffold yields the same `CreateProjectResult` shape as every other create path.
  */
 export async function scaffoldV4(
   inputs: Inputs,
@@ -91,6 +107,7 @@ export async function scaffoldV4(
   // never asks it, so an absent answer falls back to the language-neutral floor.
   const languageAnswer = answers["language"];
   const language = typeof languageAnswer === "string" ? languageAnswer : COMMON_LANGUAGE;
+  const telemetryProps = scaffoldTelemetryProps(inputs, target, language);
   const generatorContext: GeneratorContext = {
     name: appName,
     language,
@@ -107,14 +124,18 @@ export async function scaffoldV4(
       generatorContext,
       locator,
       answers,
-      callerFloor
+      callerFloor,
+      telemetryProps
     );
     if (source.warning) {
       TOOLS.logProvider.warning(source.warning);
     }
   } catch (e) {
-    return err(assembleError(e));
+    const fxError = assembleError(e);
+    sendErrorEvent(TelemetryEvent.GenerateTemplate, fxError, telemetryProps);
+    return err(fxError);
   }
+  sendSuccessEvent(TelemetryEvent.GenerateTemplate, telemetryProps);
 
   const result: CreateProjectResult = { projectPath };
   const ymlPath = pathUtils.getYmlFilePath(projectPath, "dev");
@@ -128,27 +149,107 @@ export async function scaffoldV4(
   return ok(result);
 }
 
+function getStringValidationFunc(
+  validation: FuncValidation<string> | object | undefined
+): FuncValidation<string>["validFunc"] | undefined {
+  if (validation === undefined || !("validFunc" in validation)) {
+    return undefined;
+  }
+  return validation.validFunc;
+}
+
+async function resolveStringValue(
+  value:
+    | string
+    | ((inputs: Inputs) => string | undefined | Promise<string | undefined>)
+    | undefined,
+  inputs: Inputs
+): Promise<string | undefined> {
+  return typeof value === "function" ? await value(inputs) : value;
+}
+
+async function validateAppNameInput(
+  inputs: Inputs,
+  appName: string
+): Promise<Result<undefined, FxError>> {
+  const validation = appNameQuestion().validation;
+  const validFunc = getStringValidationFunc(validation);
+  if (validFunc !== undefined) {
+    const validationMessage = await validFunc(appName, inputs);
+    if (validationMessage !== undefined) {
+      return err(
+        new InputValidationError(QuestionNames.AppName, validationMessage, "createFrontDoor")
+      );
+    }
+  }
+  return ok(undefined);
+}
+
 /**
- * The `engine: "v4"` create-floor collection. The v4 front door carries no
- * `QuestionMW` — `createProjectFrontDoor` drives its own Q1/Q2 — so, unlike the
- * v3 path where `createProject`'s `QuestionMW` asks `folder` / `app-name` last,
- * nothing collects the floor before `scaffoldV4`. This reuses the v3
- * `folderQuestion()` / `appNameQuestion()` through `traverse`, so an interactive
- * surface is prompted for the floor while a non-interactive surface is skipped
- * exactly as v3 is: the `traverse` short-circuit on a preset `template-name` and
- * the `questionVisitor` preset-skip make this the same collection the v3 tree
- * performs (a CLI preset / supplied `-f` / `-n` is never re-asked). The
- * `scaffoldV4` floor validation downstream stays the non-interactive safety net.
+ * The `engine: "v4"` create-floor collection. The front door owns Q1/Q2, so the
+ * remaining surface floor is collected directly here instead of routing through
+ * any legacy question-tree traversal.
  */
 export async function collectCreateFloor(
   inputs: Inputs,
   ui: UserInteraction
 ): Promise<Result<undefined, FxError>> {
-  const node: IQTreeNode = {
-    data: { type: "group" },
-    children: [{ data: folderQuestion() }, { data: appNameQuestion() }],
-  };
-  return traverse(node, inputs, ui, TOOLS.telemetryReporter);
+  const folder = folderQuestion();
+  const appName = appNameQuestion();
+
+  if (inputs[QuestionNames.Folder] === undefined) {
+    const defaultFolder = await resolveStringValue(folder.default, inputs);
+    if (inputs.nonInteractive) {
+      if (defaultFolder !== undefined) {
+        inputs[QuestionNames.Folder] = defaultFolder;
+      }
+    } else {
+      const folderResult = await ui.selectFolder({
+        name: folder.name,
+        title: (await resolveStringValue(folder.title, inputs)) ?? "",
+        placeholder: await resolveStringValue(folder.placeholder, inputs),
+        prompt: await resolveStringValue(folder.prompt, inputs),
+        default: defaultFolder,
+        validation: getStringValidationFunc(folder.validation),
+      });
+      if (folderResult.isErr()) {
+        return err(folderResult.error);
+      }
+      if (typeof folderResult.value.result === "string") {
+        inputs[QuestionNames.Folder] = folderResult.value.result;
+      }
+    }
+  }
+
+  const existingAppName = inputs[QuestionNames.AppName];
+  if (typeof existingAppName === "string") {
+    return validateAppNameInput(inputs, existingAppName);
+  }
+
+  const defaultAppName = await resolveStringValue(appName.default, inputs);
+  if (inputs.nonInteractive) {
+    if (defaultAppName === undefined) {
+      return err(new MissingRequiredInputError(QuestionNames.AppName, "createFrontDoor"));
+    }
+    inputs[QuestionNames.AppName] = defaultAppName;
+    return validateAppNameInput(inputs, defaultAppName);
+  }
+
+  const appNameResult = await ui.inputText({
+    name: appName.name,
+    title: (await resolveStringValue(appName.title, inputs)) ?? "",
+    placeholder: await resolveStringValue(appName.placeholder, inputs),
+    prompt: await resolveStringValue(appName.prompt, inputs),
+    default: defaultAppName,
+    validation: getStringValidationFunc(appName.validation),
+  });
+  if (appNameResult.isErr()) {
+    return err(appNameResult.error);
+  }
+  if (typeof appNameResult.value.result === "string") {
+    inputs[QuestionNames.AppName] = appNameResult.value.result;
+  }
+  return ok(undefined);
 }
 
 const COPILOT_AGENT_PROJECT_TYPE = "copilot-agent-type";

--- a/packages/fx-core/src/core/createProjectFrontDoor.ts
+++ b/packages/fx-core/src/core/createProjectFrontDoor.ts
@@ -60,6 +60,21 @@ const SOURCE = "Scaffold";
 const OPEN_GITHUB_COPILOT_CHAT = "open-github-copilot-chat";
 const STATIC_MCP_TEMPLATE_ID = "da/mcp-server-static";
 const V4_TO_V3_TEMPLATE_ID: Readonly<Record<string, string>> = {
+  "basic-custom-engine-agent": TemplateNames.BasicCustomEngineAgent,
+  "weather-agent": TemplateNames.WeatherAgent,
+  "graph-connector": TemplateNames.GraphConnector,
+  "custom-copilot-basic": TemplateNames.CustomCopilotBasic,
+  "custom-copilot-rag-customize": TemplateNames.CustomCopilotRagCustomize,
+  "custom-copilot-rag-azure-ai-search": TemplateNames.CustomCopilotRagAzureAISearch,
+  "custom-copilot-rag-custom-api": TemplateNames.CustomCopilotRagCustomApi,
+  "teams-collaborator-agent": TemplateNames.TeamsCollaboratorAgent,
+  "non-sso-tab": TemplateNames.Tab,
+  "default-message-extension": TemplateNames.DefaultMessageExtension,
+  "default-bot": TemplateNames.DefaultBot,
+  "office-addin-wxpo-taskpane": TemplateNames.WXPTaskpane,
+  "office-addin-excel-cfshortcut": TemplateNames.ExcelCFShortcut,
+  "declarative-agent-meta-os-upgrade-project": "declarative-agent-meta-os-upgrade-project",
+  "office-addin-config": TemplateNames.OfficeAddinCommon,
   "da/no-action": TemplateNames.DeclarativeAgentBasic,
   "da/graph-connector": TemplateNames.DeclarativeAgentWithGraphConnector,
   "da/typespec": TemplateNames.DeclarativeAgentWithTypeSpec,

--- a/packages/fx-core/src/core/createProjectFrontDoor.ts
+++ b/packages/fx-core/src/core/createProjectFrontDoor.ts
@@ -25,6 +25,7 @@ import {
 import { parseMcpStaticToolsJson } from "../v4/mcp/mcpStaticTools";
 import { FeatureFlags, featureFlagManager } from "../common/featureFlags";
 import { TOOLS } from "../common/globalVars";
+import { TemplateNames } from "../component/generator/templates/templateNames";
 import { QuestionNames } from "../question/questionNames";
 
 /**
@@ -58,6 +59,18 @@ const SOURCE = "Scaffold";
 /** The only shipped create `surface-action`: open GitHub Copilot Chat (the v3 `startWithGithubCopilot` shape). */
 const OPEN_GITHUB_COPILOT_CHAT = "open-github-copilot-chat";
 const STATIC_MCP_TEMPLATE_ID = "da/mcp-server-static";
+const V4_TO_V3_TEMPLATE_ID: Readonly<Record<string, string>> = {
+  "da/no-action": TemplateNames.DeclarativeAgentBasic,
+  "da/graph-connector": TemplateNames.DeclarativeAgentWithGraphConnector,
+  "da/typespec": TemplateNames.DeclarativeAgentWithTypeSpec,
+  "da/skill": TemplateNames.DeclarativeAgentWithSkill,
+  "da/api-plugin-from-scratch": TemplateNames.DeclarativeAgentWithActionFromScratch,
+  "da/api-plugin-from-scratch-bearer": TemplateNames.DeclarativeAgentWithActionFromScratchBearer,
+  "da/api-plugin-from-scratch-oauth": TemplateNames.DeclarativeAgentWithActionFromScratchOAuth,
+  "da/api-plugin-from-existing-api": TemplateNames.DeclarativeAgentWithActionFromExistingApiSpec,
+  "da/mcp-server-static": TemplateNames.DeclarativeAgentWithActionFromMCP,
+  "da/mcp-server": TemplateNames.DeclarativeAgentWithActionFromMCP,
+};
 const NON_V4_INPUT_KEYS: ReadonlySet<string> = new Set([
   "capabilities",
   "folder",
@@ -199,6 +212,10 @@ function selectorPrefillFromInputs(inputs: Inputs): Record<string, string> {
   return answers;
 }
 
+function templateNameForV4(target: BuildTarget): string {
+  return V4_TO_V3_TEMPLATE_ID[target.templateId] ?? target.templateId;
+}
+
 /** Map the host `Platform` onto the selector's `surface` axis (drives option `condition`s). */
 function surfaceOf(platform: Platform | undefined): string {
   switch (platform) {
@@ -289,6 +306,7 @@ export async function createProjectFrontDoor(
       }
       return deps.createV3(inputs);
     case "v4": {
+      inputs[QuestionNames.TemplateName] = templateNameForV4(target.value);
       const runInputs = deps.runInputs ?? runCreateInputs;
       const locator: DeclarativeLocator = { kind: "create", templateId: target.value.templateId };
       // Q2: the template's own inputs, over the same floor.
@@ -309,8 +327,8 @@ export async function createProjectFrontDoor(
       }
       // The v4 path carries no QuestionMW (createProject's, which asks the v3 tree's
       // folder/app-name last), so collect the create floor here — interactive
-      // surfaces are prompted; a non-interactive surface (CLI preset / -f / -n) is
-      // skipped (the traverse short-circuit + questionVisitor preset-skip mirror v3).
+      // surfaces are prompted; a non-interactive surface fails through the same
+      // required-input validation without depending on the v3 question visitor.
       const floorRes = await deps.collectCreateFloor(inputs, ui);
       if (floorRes.isErr()) {
         return err(floorRes.error);

--- a/packages/fx-core/tests/core/createFrontDoorAdapters.test.ts
+++ b/packages/fx-core/tests/core/createFrontDoorAdapters.test.ts
@@ -2,11 +2,13 @@
 // Licensed under the MIT license.
 
 import { Inputs, Platform, UserError, err, ok } from "@microsoft/teamsfx-api";
-import fs from "fs-extra";
+import * as fs from "fs-extra";
+import os from "os";
 import path from "path";
 import { assert, vi } from "vitest";
 
 import { setTools } from "../../src/common/globalVars";
+import { TelemetryEvent, TelemetryProperty, TelemetrySuccess } from "../../src/common/telemetry";
 import { coordinator } from "../../src/component/coordinator";
 import { pathUtils } from "../../src/component/utils/pathUtils";
 import {
@@ -25,6 +27,12 @@ const TEMPLATE_SOURCE: TemplateSource = {
   digest: "sha256:test",
   location: "test",
 };
+
+let tempFolderIndex = 0;
+function tempFolder(): string {
+  tempFolderIndex += 1;
+  return path.join(os.tmpdir(), "create-front-door-adapters", `${process.pid}-${tempFolderIndex}`);
+}
 
 describe("createFrontDoorAdapters", () => {
   const tools = new MockTools();
@@ -375,24 +383,104 @@ describe("createFrontDoorAdapters", () => {
       assert.deepEqual(firstCall[3], { appName: "MyApp", language: "common" });
     });
 
-    it("ensures the tracking id when the scaffold wrote a teamsapp.yml", async () => {
-      vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockResolvedValue(
-        TEMPLATE_SOURCE
+    it("DCE-21: emits v3-compatible generate-template telemetry when v4 scaffold succeeds", async () => {
+      vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockImplementation(
+        async (_context, _locator, _answers, _callerFloor, telemetryProps) => {
+          Object.assign(telemetryProps ?? {}, {
+            [TelemetryProperty.TemplatePackageSource]: TEMPLATE_SOURCE.origin,
+            [TelemetryProperty.TemplatePackageVersion]: TEMPLATE_SOURCE.version,
+            [TelemetryProperty.TemplatePackageDigest]: TEMPLATE_SOURCE.digest,
+          });
+          return TEMPLATE_SOURCE;
+        }
       );
-      vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue("/tmp/MyApp/teamsapp.yml");
-      vi.spyOn(fs, "pathExists").mockResolvedValue(true);
-      const ensure = vi.spyOn(coordinator, "ensureTrackingId").mockResolvedValue(ok("tracking-id"));
+      vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue(undefined);
+      const sendTelemetry = vi.spyOn(tools.telemetryReporter, "sendTelemetryEvent");
       const inputs: Inputs = {
         platform: Platform.VSCode,
         [QuestionNames.Folder]: "/tmp",
         [QuestionNames.AppName]: "MyApp",
+        [QuestionNames.TemplateName]: "declarative-agent-with-action-from-mcp",
+      };
+
+      const res = await scaffoldV4(inputs, v4Target, { language: "typescript" });
+
+      assert.isTrue(res.isOk());
+      assert.equal(sendTelemetry.mock.calls.length, 1);
+      assert.equal(sendTelemetry.mock.calls[0][0], TelemetryEvent.GenerateTemplate);
+      assert.equal(
+        sendTelemetry.mock.calls[0][1]?.[TelemetryProperty.TemplateName],
+        "declarative-agent-with-action-from-mcp-ts"
+      );
+      assert.equal(
+        sendTelemetry.mock.calls[0][1]?.[TelemetryProperty.Success],
+        TelemetrySuccess.Yes
+      );
+      assert.equal(
+        sendTelemetry.mock.calls[0][1]?.[TelemetryProperty.TemplatePackageSource],
+        "bundled"
+      );
+      assert.equal(
+        sendTelemetry.mock.calls[0][1]?.[TelemetryProperty.TemplatePackageVersion],
+        "1.0.0"
+      );
+      assert.equal(
+        sendTelemetry.mock.calls[0][1]?.[TelemetryProperty.TemplatePackageDigest],
+        "sha256:test"
+      );
+    });
+
+    it("DCE-21: emits generate-template error telemetry when v4 scaffold fails", async () => {
+      vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockRejectedValue(
+        new Error("channel boom")
+      );
+      const sendTelemetryError = vi.spyOn(tools.telemetryReporter, "sendTelemetryErrorEvent");
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        [QuestionNames.Folder]: "/tmp",
+        [QuestionNames.AppName]: "MyApp",
+        [QuestionNames.TemplateName]: "declarative-agent-with-action-from-mcp",
       };
 
       const res = await scaffoldV4(inputs, v4Target, {});
 
-      assert.isTrue(res.isOk());
-      assert.equal(res._unsafeUnwrap().projectId, "tracking-id");
-      assert.equal(ensure.mock.calls.length, 1);
+      assert.isTrue(res.isErr());
+      assert.equal(sendTelemetryError.mock.calls.length, 1);
+      assert.equal(sendTelemetryError.mock.calls[0][0], TelemetryEvent.GenerateTemplate);
+      assert.equal(
+        sendTelemetryError.mock.calls[0][1]?.[TelemetryProperty.TemplateName],
+        "declarative-agent-with-action-from-mcp-common"
+      );
+      assert.equal(
+        sendTelemetryError.mock.calls[0][1]?.[TelemetryProperty.Success],
+        TelemetrySuccess.No
+      );
+    });
+
+    it("ensures the tracking id when the scaffold wrote a teamsapp.yml", async () => {
+      vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockResolvedValue(
+        TEMPLATE_SOURCE
+      );
+      const folder = tempFolder();
+      const ymlPath = path.join(folder, "MyApp", "teamsapp.yml");
+      await fs.ensureFile(ymlPath);
+      vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue(ymlPath);
+      const ensure = vi.spyOn(coordinator, "ensureTrackingId").mockResolvedValue(ok("tracking-id"));
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        [QuestionNames.Folder]: folder,
+        [QuestionNames.AppName]: "MyApp",
+      };
+
+      try {
+        const res = await scaffoldV4(inputs, v4Target, {});
+
+        assert.isTrue(res.isOk());
+        assert.equal(res._unsafeUnwrap().projectId, "tracking-id");
+        assert.equal(ensure.mock.calls.length, 1);
+      } finally {
+        await fs.remove(folder);
+      }
     });
 
     it("defaults the caller-floor language to common when the target has none", async () => {
@@ -432,10 +520,9 @@ describe("createFrontDoorAdapters", () => {
     it("skips the floor when folder + app-name are already preset (asks no UI)", async () => {
       // a preset app-name is validated (pattern + path-not-exists) but never re-asked;
       // MockTools UI throws if prompted, so an ok proves the preset-skip path.
-      vi.spyOn(fs, "pathExists").mockResolvedValue(false);
       const inputs: Inputs = {
         platform: Platform.VSCode,
-        [QuestionNames.Folder]: "/tmp",
+        [QuestionNames.Folder]: tempFolder(),
         [QuestionNames.AppName]: "MyApp",
       };
 
@@ -444,26 +531,49 @@ describe("createFrontDoorAdapters", () => {
       assert.isTrue(res.isOk());
     });
 
-    it("short-circuits on a preset template-name (the CLI non-interactive contract)", async () => {
-      // template-name preset ⇒ traverse returns before any question, so an absent
-      // folder/app-name is taken from the CLI options downstream, never prompted.
+    it("does not short-circuit on a preset template-name in interactive v4 floor collection", async () => {
+      const pickedFolder = tempFolder();
+      vi.spyOn(tools.ui, "selectFolder").mockResolvedValue(
+        ok({ type: "success", result: pickedFolder })
+      );
+      vi.spyOn(tools.ui, "inputText").mockResolvedValue(
+        ok({ type: "success", result: "PickedApp" })
+      );
       const inputs: Inputs = {
-        platform: Platform.CLI,
+        platform: Platform.VSCode,
         [QuestionNames.TemplateName]: "da/mcp-server",
       };
 
       const res = await collectCreateFloor(inputs, tools.ui);
 
       assert.isTrue(res.isOk());
+      assert.equal(inputs[QuestionNames.Folder], pickedFolder);
+      assert.equal(inputs[QuestionNames.AppName], "PickedApp");
+    });
+
+    it("uses the folder default and fails on missing app-name in non-interactive mode", async () => {
+      const inputs: Inputs = {
+        platform: Platform.CLI,
+        nonInteractive: true,
+        [QuestionNames.TemplateName]: "da/mcp-server",
+      };
+
+      const res = await collectCreateFloor(inputs, tools.ui);
+
+      assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        assert.equal(res.error.name, "MissingRequiredInputError");
+      }
+      assert.equal(inputs[QuestionNames.Folder], "./");
     });
 
     it("prompts an interactive surface and writes the answers back to inputs", async () => {
       // VS Code interactive, no preset floor ⇒ the floor questions are asked and the
       // answers land on the same inputs bag scaffoldV4 then reads (the bug this fixes:
       // without it the v4 path reached scaffoldV4 with folder undefined).
-      vi.spyOn(fs, "pathExists").mockResolvedValue(false);
+      const pickedFolder = tempFolder();
       vi.spyOn(tools.ui, "selectFolder").mockResolvedValue(
-        ok({ type: "success", result: "/picked" })
+        ok({ type: "success", result: pickedFolder })
       );
       vi.spyOn(tools.ui, "inputText").mockResolvedValue(
         ok({ type: "success", result: "PickedApp" })
@@ -473,7 +583,7 @@ describe("createFrontDoorAdapters", () => {
       const res = await collectCreateFloor(inputs, tools.ui);
 
       assert.isTrue(res.isOk());
-      assert.equal(inputs[QuestionNames.Folder], "/picked");
+      assert.equal(inputs[QuestionNames.Folder], pickedFolder);
       assert.equal(inputs[QuestionNames.AppName], "PickedApp");
     });
 

--- a/packages/fx-core/tests/core/createFrontDoorAdapters.test.ts
+++ b/packages/fx-core/tests/core/createFrontDoorAdapters.test.ts
@@ -269,6 +269,18 @@ describe("createFrontDoorAdapters", () => {
       assert.equal(inputs["teams-other-app-type"], "default-bot");
     });
 
+    it("leaves teams Q2 unfilled when the teams app selector id is unknown", () => {
+      const inputs: Inputs = { platform: Platform.VSCode };
+      applyV3PreFill(inputs, {
+        templateId: "future-teams-template",
+        engine: "v3",
+        answers: { projectType: "teams-agent-and-app-type", teamsApp: "future-teams-template" },
+      });
+
+      assert.equal(inputs[QuestionNames.ProjectType], "teams-agent-and-app-type");
+      assert.isUndefined(inputs[QuestionNames.TeamsAppType]);
+    });
+
     it("maps the office-addin taskpane and config capabilities onto the renamed v3 ids", () => {
       const taskpane: Inputs = { platform: Platform.VSCode };
       applyV3PreFill(taskpane, {
@@ -308,6 +320,21 @@ describe("createFrontDoorAdapters", () => {
 
       assert.equal(inputs[QuestionNames.Capabilities], "office-da-meta-os");
       assert.equal(inputs[QuestionNames.DAMetaOSCapability], "da-meta-os-upgrade-existing-project");
+    });
+
+    it("leaves office Q2 unfilled when the office capability selector id is unknown", () => {
+      const inputs: Inputs = { platform: Platform.VSCode };
+      applyV3PreFill(inputs, {
+        templateId: "future-office-template",
+        engine: "v3",
+        answers: {
+          projectType: "office-meta-os-type",
+          officeAddinCapability: "future-office-template",
+        },
+      });
+
+      assert.equal(inputs[QuestionNames.ProjectType], "office-meta-os-type");
+      assert.isUndefined(inputs[QuestionNames.Capabilities]);
     });
 
     it("sets only projectType for graph-connector (no capability dimension — safe re-ask)", () => {
@@ -353,12 +380,15 @@ describe("createFrontDoorAdapters", () => {
       const inputs: Inputs = {
         platform: Platform.VSCode,
         [QuestionNames.Folder]: "/tmp",
-        [QuestionNames.AppName]: "invalid name!",
+        [QuestionNames.AppName]: "Bad/Name",
       };
 
       const res = await scaffoldV4(inputs, v4Target, {});
 
       assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        assert.equal(res.error.name, "InputValidationError");
+      }
     });
 
     it("scaffolds the located package and returns the project path", async () => {
@@ -500,6 +530,54 @@ describe("createFrontDoorAdapters", () => {
       assert.deepEqual(channel.mock.calls[0][3], { appName: "MyApp", language: "common" });
     });
 
+    it("logs a warning when template source resolution returns one", async () => {
+      vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockResolvedValue({
+        ...TEMPLATE_SOURCE,
+        warning: "Using bundled template fallback.",
+      });
+      vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue(undefined);
+      const warning = vi.spyOn(tools.logProvider, "warning");
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        [QuestionNames.Folder]: "/tmp",
+        [QuestionNames.AppName]: "MyApp",
+      };
+
+      const res = await scaffoldV4(inputs, v4Target, {});
+
+      assert.isTrue(res.isOk());
+      assert.equal(warning.mock.calls[0][0], "Using bundled template fallback.");
+    });
+
+    it("returns the tracking id error when ensureTrackingId fails", async () => {
+      vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockResolvedValue(
+        TEMPLATE_SOURCE
+      );
+      const folder = tempFolder();
+      const ymlPath = path.join(folder, "MyApp", "teamsapp.yml");
+      await fs.ensureFile(ymlPath);
+      vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue(ymlPath);
+      vi.spyOn(coordinator, "ensureTrackingId").mockResolvedValue(
+        err(new UserError({ source: "Test", name: "TrackingIdFailed", message: "failed" }))
+      );
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        [QuestionNames.Folder]: folder,
+        [QuestionNames.AppName]: "MyApp",
+      };
+
+      try {
+        const res = await scaffoldV4(inputs, v4Target, {});
+
+        assert.isTrue(res.isErr());
+        if (res.isErr()) {
+          assert.equal(res.error.name, "TrackingIdFailed");
+        }
+      } finally {
+        await fs.remove(folder);
+      }
+    });
+
     it("surfaces a channel failure as an error", async () => {
       vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockRejectedValue(
         new Error("channel boom")
@@ -529,6 +607,35 @@ describe("createFrontDoorAdapters", () => {
       const res = await collectCreateFloor(inputs, tools.ui);
 
       assert.isTrue(res.isOk());
+    });
+
+    it("validates a preset app-name and returns the validation error", async () => {
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        [QuestionNames.Folder]: tempFolder(),
+        [QuestionNames.AppName]: "Bad/Name",
+      };
+
+      const res = await collectCreateFloor(inputs, tools.ui);
+
+      assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        assert.equal(res.error.name, "InputValidationError");
+      }
+    });
+
+    it("uses the app-name default in non-interactive mode when one is available", async () => {
+      const inputs: Inputs = {
+        platform: Platform.CLI,
+        nonInteractive: true,
+        teamsAppFromTdp: { appName: "Default App" },
+      };
+
+      const res = await collectCreateFloor(inputs, tools.ui);
+
+      assert.isTrue(res.isOk());
+      assert.equal(inputs[QuestionNames.Folder], "./");
+      assert.equal(inputs[QuestionNames.AppName], "DefaultApp");
     });
 
     it("does not short-circuit on a preset template-name in interactive v4 floor collection", async () => {
@@ -590,6 +697,22 @@ describe("createFrontDoorAdapters", () => {
     it("propagates a cancellation from the interactive floor prompt", async () => {
       const cancel = new UserError({ source: "Test", name: "UserCancelError", message: "cancel" });
       vi.spyOn(tools.ui, "selectFolder").mockResolvedValue(err(cancel));
+      const inputs: Inputs = { platform: Platform.VSCode };
+
+      const res = await collectCreateFloor(inputs, tools.ui);
+
+      assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        assert.equal(res.error.name, "UserCancelError");
+      }
+    });
+
+    it("propagates a cancellation from the interactive app-name prompt", async () => {
+      const cancel = new UserError({ source: "Test", name: "UserCancelError", message: "cancel" });
+      vi.spyOn(tools.ui, "selectFolder").mockResolvedValue(
+        ok({ type: "success", result: tempFolder() })
+      );
+      vi.spyOn(tools.ui, "inputText").mockResolvedValue(err(cancel));
       const inputs: Inputs = { platform: Platform.VSCode };
 
       const res = await collectCreateFloor(inputs, tools.ui);

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -1,8 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CreateProjectResult, FxError, Inputs, Platform, UserError } from "@microsoft/teamsfx-api";
-import { UserInteraction } from "@microsoft/teamsfx-api";
+import {
+  CreateProjectResult,
+  FxError,
+  Inputs,
+  Platform,
+  UserError,
+  UserInteraction,
+} from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
 import { Result, err, ok } from "neverthrow";
 import os from "os";
@@ -574,6 +580,7 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     );
     const collectFloor = recorder((_i: Inputs, _ui: UserInteraction) => {
       order.push("floor");
+      assert.equal(_i["template-name"], "declarative-agent-with-action-from-mcp");
       return okFloor();
     });
     const scaffoldV4 = recorder((_i: Inputs, _t: BuildTarget, _a: Answers) => {
@@ -596,6 +603,7 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     assert.deepEqual(order, ["q2", "floor", "scaffold"]); // floor sits between Q2 and the scaffold
     // the floor mutates the same inputs bag scaffoldV4 then scaffolds from.
     assert.strictEqual(collectFloor.calls[0][0], scaffoldV4.calls[0][0]);
+    assert.equal(scaffoldV4.calls[0][0]["template-name"], "declarative-agent-with-action-from-mcp");
   });
 
   it("DCE-15: a create-floor cancellation propagates and does not scaffold", async () => {
@@ -652,12 +660,13 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     }
   });
 
-  it("propagates a Q2 error and does not scaffold", async () => {
+  it("DCE-19: a v4 target maps its template id to the v3 telemetry template before Q2", async () => {
     const q2Failed = new UserError({ source: "Test", name: "Q2Failed", message: "bad inputs" });
     const scaffoldV4 = recorder((_i: Inputs, _t: BuildTarget, _a: Answers) => okResult("/v4"));
+    const inputs = baseInputs();
 
     const res = await createProjectFrontDoor(
-      baseInputs(),
+      inputs,
       deps({
         scaffoldV4: scaffoldV4.fn,
         runSelector: () => okTarget(V4_TARGET),
@@ -670,6 +679,24 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
       assert.equal(res.error.name, "Q2Failed");
     }
     assert.equal(scaffoldV4.calls.length, 0);
+    assert.equal(inputs["template-name"], "declarative-agent-with-action-from-mcp");
+  });
+
+  it("DCE-20: an unmapped v4 telemetry template id falls back to itself", async () => {
+    const q2Failed = new UserError({ source: "Test", name: "Q2Failed", message: "bad inputs" });
+    const target: BuildTarget = { templateId: "future/v4-template", engine: "v4", answers: {} };
+    const inputs = baseInputs();
+
+    const res = await createProjectFrontDoor(
+      inputs,
+      deps({
+        runSelector: () => okTarget(target),
+        runInputs: () => Promise.resolve(err(q2Failed)),
+      })
+    );
+
+    assert.isTrue(res.isErr());
+    assert.equal(inputs["template-name"], "future/v4-template");
   });
 
   it("fails loudly on an unsupported create engine (v3-core-method)", async () => {

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -18,6 +18,7 @@ import { Answers, BuildTarget, DeclarativeLocator } from "../../src/v4";
 import { CreateFrontDoorDeps, createProjectFrontDoor } from "../../src/core/createProjectFrontDoor";
 import { FeatureFlags } from "../../src/common/featureFlags";
 import { QuestionNames } from "../../src/question/questionNames";
+import { TemplateNames } from "../../src/component/generator/templates/templateNames";
 
 /**
  * Tests for docs/03-specs/operations/scaffolding/dispatch-create-by-engine.md.
@@ -662,24 +663,63 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
 
   it("DCE-19: a v4 target maps its template id to the v3 telemetry template before Q2", async () => {
     const q2Failed = new UserError({ source: "Test", name: "Q2Failed", message: "bad inputs" });
-    const scaffoldV4 = recorder((_i: Inputs, _t: BuildTarget, _a: Answers) => okResult("/v4"));
-    const inputs = baseInputs();
+    const expectedMappings: ReadonlyArray<readonly [string, string]> = [
+      ["basic-custom-engine-agent", TemplateNames.BasicCustomEngineAgent],
+      ["weather-agent", TemplateNames.WeatherAgent],
+      ["graph-connector", TemplateNames.GraphConnector],
+      ["custom-copilot-basic", TemplateNames.CustomCopilotBasic],
+      ["custom-copilot-rag-customize", TemplateNames.CustomCopilotRagCustomize],
+      ["custom-copilot-rag-azure-ai-search", TemplateNames.CustomCopilotRagAzureAISearch],
+      ["custom-copilot-rag-custom-api", TemplateNames.CustomCopilotRagCustomApi],
+      ["teams-collaborator-agent", TemplateNames.TeamsCollaboratorAgent],
+      ["non-sso-tab", TemplateNames.Tab],
+      ["default-message-extension", TemplateNames.DefaultMessageExtension],
+      ["default-bot", TemplateNames.DefaultBot],
+      ["office-addin-wxpo-taskpane", TemplateNames.WXPTaskpane],
+      ["office-addin-excel-cfshortcut", TemplateNames.ExcelCFShortcut],
+      ["declarative-agent-meta-os-upgrade-project", "declarative-agent-meta-os-upgrade-project"],
+      ["office-addin-config", TemplateNames.OfficeAddinCommon],
+      ["da/no-action", TemplateNames.DeclarativeAgentBasic],
+      ["da/graph-connector", TemplateNames.DeclarativeAgentWithGraphConnector],
+      ["da/typespec", TemplateNames.DeclarativeAgentWithTypeSpec],
+      ["da/skill", TemplateNames.DeclarativeAgentWithSkill],
+      ["da/api-plugin-from-scratch", TemplateNames.DeclarativeAgentWithActionFromScratch],
+      [
+        "da/api-plugin-from-scratch-bearer",
+        TemplateNames.DeclarativeAgentWithActionFromScratchBearer,
+      ],
+      [
+        "da/api-plugin-from-scratch-oauth",
+        TemplateNames.DeclarativeAgentWithActionFromScratchOAuth,
+      ],
+      [
+        "da/api-plugin-from-existing-api",
+        TemplateNames.DeclarativeAgentWithActionFromExistingApiSpec,
+      ],
+      ["da/mcp-server-static", TemplateNames.DeclarativeAgentWithActionFromMCP],
+      ["da/mcp-server", TemplateNames.DeclarativeAgentWithActionFromMCP],
+    ];
 
-    const res = await createProjectFrontDoor(
-      inputs,
-      deps({
-        scaffoldV4: scaffoldV4.fn,
-        runSelector: () => okTarget(V4_TARGET),
-        runInputs: () => Promise.resolve(err(q2Failed)),
-      })
-    );
+    for (const [templateId, expectedTemplateName] of expectedMappings) {
+      const scaffoldV4 = recorder((_i: Inputs, _t: BuildTarget, _a: Answers) => okResult("/v4"));
+      const inputs = baseInputs();
 
-    assert.isTrue(res.isErr());
-    if (res.isErr()) {
-      assert.equal(res.error.name, "Q2Failed");
+      const res = await createProjectFrontDoor(
+        inputs,
+        deps({
+          scaffoldV4: scaffoldV4.fn,
+          runSelector: () => okTarget({ templateId, engine: "v4", answers: {} }),
+          runInputs: () => Promise.resolve(err(q2Failed)),
+        })
+      );
+
+      assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        assert.equal(res.error.name, "Q2Failed");
+      }
+      assert.equal(scaffoldV4.calls.length, 0);
+      assert.equal(inputs["template-name"], expectedTemplateName, templateId);
     }
-    assert.equal(scaffoldV4.calls.length, 0);
-    assert.equal(inputs["template-name"], "declarative-agent-with-action-from-mcp");
   });
 
   it("DCE-20: an unmapped v4 telemetry template id falls back to itself", async () => {

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -478,6 +478,30 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     });
   });
 
+  it("passes neutral array inputs and office manifest aliases to the v4 input walk", async () => {
+    const runInputs = inputsRecorder({});
+    const inputs: Inputs = {
+      platform: Platform.CLI,
+      nonInteractive: true,
+      apiPermissions: ["User.Read", "Calendars.Read"],
+      [QuestionNames.OfficeAddinManifest]: "manifest.json",
+    };
+
+    const res = await createProjectFrontDoor(
+      inputs,
+      deps({
+        runSelector: selectorRecorder(V4_TARGET).fn,
+        runInputs: runInputs.fn,
+        collectCreateFloor: okFloor,
+        scaffoldV4: okScaffold,
+      })
+    );
+
+    assert.isTrue(res.isOk());
+    assert.deepEqual(runInputs.calls[0][2].apiPermissions, ["User.Read", "Calendars.Read"]);
+    assert.equal(runInputs.calls[0][2].officeAddinManifest, "manifest.json");
+  });
+
   it("DCE-18: legacy CLI MCP tools file is bridged into static v4 MCP Q2 params", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-mcp-tools-"));
     const toolsPath = path.join(tempDir, "mcp-tools.json");
@@ -525,6 +549,52 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
         ],
       });
       assert.deepEqual(runInputs.calls[0][2].selectedMcpTools, ["searchFlights"]);
+    } finally {
+      fs.removeSync(tempDir);
+    }
+  });
+
+  it("returns an error before Q2 when a legacy static MCP tools file cannot be read", async () => {
+    const inputs: Inputs = {
+      platform: Platform.CLI,
+      nonInteractive: true,
+      [QuestionNames.MCPToolsFilePath]: path.join(os.tmpdir(), "missing-mcp-tools.json"),
+    };
+
+    const res = await createProjectFrontDoor(
+      inputs,
+      deps({
+        runSelector: selectorRecorder(STATIC_MCP_TARGET).fn,
+        runInputs: failRunInputs,
+      })
+    );
+
+    assert.isTrue(res.isErr());
+    if (res.isErr()) {
+      assert.equal(res.error.name, "McpToolsFileReadFailed");
+    }
+  });
+
+  it("returns an error before Q2 when a legacy static MCP tools file is invalid", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-mcp-tools-"));
+    const toolsPath = path.join(tempDir, "mcp-tools.json");
+    fs.writeFileSync(toolsPath, "{ invalid json", "utf8");
+    const inputs: Inputs = {
+      platform: Platform.CLI,
+      nonInteractive: true,
+      [QuestionNames.MCPToolsFilePath]: toolsPath,
+    };
+
+    try {
+      const res = await createProjectFrontDoor(
+        inputs,
+        deps({
+          runSelector: selectorRecorder(STATIC_MCP_TARGET).fn,
+          runInputs: failRunInputs,
+        })
+      );
+
+      assert.isTrue(res.isErr());
     } finally {
       fs.removeSync(tempDir);
     }


### PR DESCRIPTION
## Summary
- Emit v3-compatible `generate-template` telemetry from the v4 scaffold path, including mapped/fallback template id plus language suffix.
- Add v4-to-v3 template id mapping before v4 create floor/scaffold so OKR queries can keep joining `generate-template` with command-level `create-project`.
- Keep VS/server behavior on the existing v3 path and remove the need for command-level v3/v4 template telemetry fields.
- Break the `teamsGraphClient` / `wrappedAxiosClient` import cycle by moving Teams Graph API name constants to a common module.

## Validation
- `cd packages/fx-core && npm run lint -- --quiet`
- `cd packages/fx-core && npm run lint` (0 errors; existing warnings remain)
- `cd packages/fx-core && npx vitest run --config vitest.config.ts tests/core/createFrontDoorAdapters.test.ts tests/core/createProjectFrontDoor.test.ts tests/common/wrappedAxiosClient.test.ts`
- `git diff --check`