### PR TITLE
feat(fx-core): stage v4 template artifacts

### DIFF
--- a/.github/scripts/v4/generate-v4-tag-list.js
+++ b/.github/scripts/v4/generate-v4-tag-list.js
@@ -2,22 +2,26 @@
 // Licensed under the MIT license.
 
 /**
- * CD wrapper (v4-isolated): compute the digest of the v4 `templates.zip` and
- * append a `{ version, digest }` entry to the v4 channel's NDJSON tag-list.
+ * CD wrapper (v4-isolated): compute the digests of the staged v4 artifacts and
+ * append a `{ version, artifacts }` entry to the v4 channel's NDJSON tag-list.
  *
  * The v4 channel tag-list is one JSON object per line (NDJSON), unlike v3's
  * newline-separated git-tag text — because v4 carries a content digest that is
- * not derivable from git tags. `parseTagList` in
- * packages/fx-core/src/v4/distribution/templateSourcePort.ts reads exactly this
- * format. The digest is `sha256:<hex>` over the raw zip bytes, matching
- * `computeDigest` in templateSource.ts (the single digest authority).
+ * not derivable from git tags. `parseArtifactTagList` in
+ * packages/fx-core/src/v4/distribution/templateArtifacts.ts reads exactly this
+ * format. Each artifact digest is `sha256:<hex>` over that artifact's raw
+ * bytes, matching `computeDigest` in templateSource.ts (the single digest
+ * authority).
  *
  * Re-running for an already-published version replaces that version's line
  * (idempotent), so a CD re-run does not duplicate entries.
  *
- * Usage (run AFTER the templates build, with build/v4/templates.zip present):
+ * Usage (run AFTER the templates build, with build/v4 artifacts present):
  *   node .github/scripts/v4/generate-v4-tag-list.js \
- *     --zip <path to templates.zip> \
+ *     --create-selector <path to create-selector.json> \
+ *     --modify-selector <path to modify-selector.json> \
+ *     --metadata <path to templates-metadata.zip> \
+ *     --templates <path to templates.zip> \
  *     --version <semver> \
  *     --ndjson <path to read existing + write merged NDJSON>
  *
@@ -40,13 +44,52 @@ function parseArgs(argv) {
   return args;
 }
 
-const { zip, version, ndjson } = parseArgs(process.argv.slice(2));
-if (!zip || !version || !ndjson) {
-  throw new Error("Missing required argument. Need --zip, --version and --ndjson.");
+const args = parseArgs(process.argv.slice(2));
+const createSelector = args["create-selector"];
+const modifySelector = args["modify-selector"];
+const metadata = args.metadata;
+const templates = args.templates;
+const version = args.version;
+const ndjson = args.ndjson;
+if (!createSelector || !modifySelector || !metadata || !templates || !version || !ndjson) {
+  throw new Error(
+    "Missing required argument. Need --create-selector, --modify-selector, --metadata, --templates, --version and --ndjson."
+  );
 }
 
-const bytes = fs.readFileSync(zip);
-const digest = "sha256:" + crypto.createHash("sha256").update(bytes).digest("hex");
+function digestFile(filePath) {
+  const bytes = fs.readFileSync(filePath);
+  return "sha256:" + crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function artifact(file, filePath) {
+  return { file, digest: digestFile(filePath) };
+}
+
+function isFinalEntry(value) {
+  if (!value || typeof value !== "object" || typeof value.version !== "string") {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "digest")) {
+    return false;
+  }
+  const existingArtifacts = value.artifacts;
+  return (
+    existingArtifacts &&
+    typeof existingArtifacts === "object" &&
+    existingArtifacts["create-selector"]?.file === "create-selector.json" &&
+    existingArtifacts["modify-selector"]?.file === "modify-selector.json" &&
+    existingArtifacts.metadata?.file === "templates-metadata.zip" &&
+    existingArtifacts.templates?.file === "templates.zip"
+  );
+}
+
+const artifacts = {
+  "create-selector": artifact("create-selector.json", createSelector),
+  "modify-selector": artifact("modify-selector.json", modifySelector),
+  metadata: artifact("templates-metadata.zip", metadata),
+  templates: artifact("templates.zip", templates),
+};
 
 // Read the existing NDJSON (if any) and index by version so a re-run replaces
 // rather than duplicates. Missing file = first release.
@@ -65,14 +108,19 @@ for (const line of existing.split("\n")) {
     continue;
   }
   const parsed = JSON.parse(trimmed);
+  if (!isFinalEntry(parsed)) {
+    throw new Error(
+      `Existing v4 tag-list entry for "${parsed.version ?? "unknown"}" is not in final { version, artifacts } shape.`
+    );
+  }
   entries.set(parsed.version, parsed);
 }
 
-entries.set(version, { version, digest });
+entries.set(version, { version, artifacts });
 
 const merged = [...entries.values()].map((entry) => JSON.stringify(entry)).join("\n") + "\n";
 fs.writeFileSync(ndjson, merged);
 
 console.log(
-  `================== v4 tag-list entry: ${JSON.stringify({ version, digest })} (${entries.size} total) ==================`
+  `================== v4 tag-list entry: ${JSON.stringify(entries.get(version))} (${entries.size} total) ==================`
 );

--- a/.github/scripts/v4/publish-v4-channel.sh
+++ b/.github/scripts/v4/publish-v4-channel.sh
@@ -3,7 +3,7 @@
 # Licensed under the MIT license.
 #
 # CD wrapper (v4-isolated): publish one immutable v4 template release and append
-# its digest entry to the v4 channel's NDJSON tag-list. This collapses the five
+# its staged artifact digest entry to the v4 channel's NDJSON tag-list. This collapses the five
 # release-action steps that previously lived inline in cd.yml into one step so
 # the v4 footprint in the workflow stays small while the single-coordination
 # point (the lerna-minted templates version) is preserved.
@@ -12,24 +12,22 @@
 # and `template-v4-tag-list`); the v3 `templates@` channel is never read or
 # written here.
 #
-# Usage (run AFTER the templates build, with build/v4/templates.zip present):
+# Usage (run AFTER the templates build, with build/v4 artifacts present):
 #   bash .github/scripts/v4/publish-v4-channel.sh \
-#     <templates@<ver> tag> <path to templates.zip> <temp dir> <commit sha> \
-#     [path to metadata.zip]
-#
-# The optional 5th argument is transitional: it mirrors the v3 `metadata.zip`
-# onto the v4 release so `fetchOnlineTemplateMetadata` can pull metadata from
-# the v4 tag when TEAMSFX_V4_ENABLED is on. Remove once selector.json drives
-# metadata distribution.
+#     <templates@<ver> tag> <path to create-selector.json> \
+#     <path to modify-selector.json> <path to templates-metadata.zip> \
+#     <path to templates.zip> <temp dir> <commit sha>
 #
 # Requires: gh CLI authenticated via GH_TOKEN, node on PATH.
 set -euo pipefail
 
 TEMPLATE_TAG="${1:?Need the templates@<ver> tag (steps.version-change.outputs.TEMPLATE_VERSION).}"
-ZIP="${2:?Need the path to templates.zip.}"
-TMP="${3:?Need a temp directory.}"
-SHA="${4:?Need the commit sha to anchor the release.}"
-METADATA_ZIP="${5:-}"
+CREATE_SELECTOR="${2:?Need the path to create-selector.json.}"
+MODIFY_SELECTOR="${3:?Need the path to modify-selector.json.}"
+METADATA_ZIP="${4:?Need the path to templates-metadata.zip.}"
+TEMPLATES_ZIP="${5:?Need the path to templates.zip.}"
+TMP="${6:?Need a temp directory.}"
+SHA="${7:?Need the commit sha to anchor the release.}"
 
 RAW_VERSION="${TEMPLATE_TAG#templates@}"
 
@@ -50,27 +48,27 @@ fi
 TAG="templates-v4@$VERSION"
 NDJSON="$TMP/template-v4-tags.ndjson"
 
-# 1. Upsert the immutable per-version release and (re)upload the package.
+# 1. Upsert the immutable per-version release and (re)upload the artifacts.
 if ! gh release view "$TAG" >/dev/null 2>&1; then
   gh release create "$TAG" \
     --title "$TAG" \
     --notes "v4 template package for $TAG" \
     --target "$SHA"
 fi
-gh release upload "$TAG" "$ZIP" --clobber
-
-# 1b. Transitional: mirror the v3 metadata.zip onto the v4 release so the
-#     engine can fetch metadata from the v4 tag when TEAMSFX_V4_ENABLED is on.
-if [ -n "$METADATA_ZIP" ]; then
-  gh release upload "$TAG" "$METADATA_ZIP" --clobber
-fi
+gh release upload "$TAG" "$CREATE_SELECTOR" --clobber
+gh release upload "$TAG" "$MODIFY_SELECTOR" --clobber
+gh release upload "$TAG" "$METADATA_ZIP" --clobber
+gh release upload "$TAG" "$TEMPLATES_ZIP" --clobber
 
 # 2. Pull the existing NDJSON tag-list (absent on the first release).
 gh release download template-v4-tag-list --pattern template-v4-tags.ndjson --dir "$TMP" || true
 
-# 3. Append (or replace) this version's { version, digest } line.
+# 3. Append (or replace) this version's { version, artifacts } line.
 node .github/scripts/v4/generate-v4-tag-list.js \
-  --zip "$ZIP" \
+  --create-selector "$CREATE_SELECTOR" \
+  --modify-selector "$MODIFY_SELECTOR" \
+  --metadata "$METADATA_ZIP" \
+  --templates "$TEMPLATES_ZIP" \
   --version "$VERSION" \
   --ndjson "$NDJSON"
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -323,22 +323,17 @@ jobs:
       # the v4-owned releases; the v3 templates@ channel above is untouched.
       - name: Publish v4 template channel
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.goproduct == 'true' }}
-        # continue-on-error is intentional ONLY while no shipped engine consumes
-        # the v4 channel yet (generator wiring is pending, plan item #7): a v4
-        # publish failure here has zero production impact and must not block the
-        # v3 CD. Remove this line once the v4 generator goes live, so a failed
-        # channel update fails the shipping build instead of silently leaving
-        # the channel behind the engine config.
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           bash .github/scripts/v4/publish-v4-channel.sh \
             "${{ steps.version-change.outputs.TEMPLATE_VERSION }}" \
+            "${{ github.workspace }}/templates/build/v4/create-selector.json" \
+            "${{ github.workspace }}/templates/build/v4/modify-selector.json" \
+            "${{ github.workspace }}/templates/build/v4/templates-metadata.zip" \
             "${{ github.workspace }}/templates/build/v4/templates.zip" \
             "${{ runner.temp }}" \
-            "${{ github.sha }}" \
-            "${{ github.workspace }}/templates/build/metadata.zip"
+            "${{ github.sha }}"
 
       - name: Release RC VS templates to GitHub
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' }}

--- a/docs/02-architecture/adr/ADR-0006-template-distribution-channel.md
+++ b/docs/02-architecture/adr/ADR-0006-template-distribution-channel.md
@@ -138,9 +138,9 @@ exactly two things — `range` and `bundled` — through one pure function.
    prerelease versions from a stable `range` unless the range itself names
    the segment (`>=6.11.0-beta`). Lane isolation is therefore free from
    SemVer. "alpha" stops being a third lane — it was only ever
-   `bundled=true`, now expressed directly. Because selector, descriptor,
-   and content also travel in one artifact resolved at one point, content
-   and metadata can no longer disagree.
+  `bundled=true`, now expressed directly. Because selector, descriptor,
+  and content are pinned by one resolved v4 artifact snapshot, content and
+  metadata can no longer disagree.
 
 3. **Digest-addressed pinning replaces both `0.0.0-rc` and a fixed version
    (fixes deficiency 2).** The mutable hand-written `0.0.0-rc` tag is
@@ -148,10 +148,12 @@ exactly two things — `range` and `bundled` — through one pure function.
    (e.g. `templates@6.11.0-rc.0`) in independent mode. Rather than pinning
    one concrete version (permanently reproducible, but templates could
    never update independently of the engine), the build pins the `range`
-   and records the *resolved* `{version, digest}` on the scaffold outcome
-   and telemetry. The on-disk cache is keyed by `digest`
-   (`~/.fx/templates-cache/templates@<version>/`), strengthening the
-   immutable tag against a re-push. This yields **auditable strong
+  and records the resolved version plus digest evidence on the scaffold outcome
+  and telemetry. In the final v4 channel, digest pinning is per staged
+  artifact (`create-selector`, `modify-selector`, `metadata`, `templates`)
+  rather than one top-level package digest. The on-disk cache is keyed by
+  version and artifact kind under `~/.fx/templates-cache/templates-v4@<version>/`,
+  strengthening the immutable tag against a re-push. This yields **auditable strong
    reproducibility** — a recorded digest always re-fetches the same bytes
    — without sacrificing post-ship template updates, restoring
    [`../scaffolding.md`](../scaffolding.md) §3.4 across the rc window.
@@ -247,121 +249,45 @@ final removal of `getTemplateVSCUrl` / `getTemplateVSUrl` /
   non-obvious constraint is that `rc` must also set `goproduct=true`, since
   the upload switch lives on `goproduct`, not on `preid`.
 - Decomposes into the cluster C fix tracked alongside the v4 proposal
-  [§5.2 distribution seam](../scaffolding.create.proposal.md); the seam
-  contract is unchanged — the engine still assumes `(range, bundled)`
-  resolves to one `(source, version, digest)` and reads only
-  `minEngineVersion` plus the `scaffold-v4-template` telemetry properties
-  across it.
+  [§5.2 distribution seam](../scaffolding.create.proposal.md). The legacy
+  full-package seam still resolves `(source, version, digest)`; the final v4
+  seam resolves a `TemplateArtifactSnapshot` that pins one version and one
+  artifact digest set across Q1, Q2, and scaffold.
 
-## Transitional follow-up — selector/content consistency during the metadata-cache phase
+## Final v4 staged artifact follow-up
 
-*Added 2026-06-12. Scope: the window AFTER the two-field
-`resolveTemplateSource((range, bundled, port))` seam lands but BEFORE
-`selector.json` drives metadata distribution. Deleted once metadata +
-content travel in the single resolved artifact (Decision §2).*
+*Added 2026-07-01. Replaces the earlier metadata-cache transition. There is no
+online v4 channel using the older draft shape, so the first published v4 channel
+uses this final protocol directly.*
 
-### The gap
+The v4 release unit `templates-v4@<version>` publishes four assets:
+`create-selector.json`, `modify-selector.json`, `templates-metadata.zip`, and
+`templates.zip`. The separate v4 tag-list asset is NDJSON with one entry per
+line in the shape `{ "version": "6.11.0", "artifacts": { ... } }`. Each
+artifact ref carries its own file name and `sha256:` digest; there is no
+top-level `digest`.
 
-The Decision unifies **content** behind one resolution point, but the
-**selector / metadata / NLS** that the question phase reads is, in the v4
-channel, still distributed through a *second* path. A successful background
-[`fetchOnlineTemplateMetadata`](../../../packages/fx-core/src/core/FxCore.ts)
-writes `~/.fx/metadata`, `~/.fx/ui`, and `~/.fx/template-version-v4.txt`,
-and the readers gate on
-[`useBundledMetadataForV4()`](../../../packages/fx-core/src/component/generator/templateHelper.ts)
-(version-file absent → bundled floor; present → cache). Content, by
-contrast, resolves at scaffold time through
-[`resolveChannelPackageBytes`](../../../packages/fx-core/src/component/generator/v4TemplateBridge.ts)
-→ `resolveTemplateSource({ bundled: false })`, which prefers the newest
-satisfying *online* version.
+### Staged invariants
 
-Two gates, two on-disk locations, evaluated at two different moments inside
-one `createProject` invocation (the selector read runs in the
-`QuestionMW("createProject")` hook; content resolves later in the method
-body). This transitionally re-opens the **cluster C split-brain**
-([`../scaffolding.current-state.md` §C](../scaffolding.current-state.md))
-that the Decision set out to close: during the first-run window — before
-the background warm has written the version file — the question phase
-builds options from the **bundled floor** version *X*, while scaffold
-resolves and downloads the newest **online** version *Y*. If *X ≠ Y* and
-their template sets differ, the `templateId` chosen from *X* may not exist
-in *Y* (or *Y*'s new templates never appear in the questions).
+- **INV-S1 — resolve once per invocation.** A create or modify invocation
+  resolves one `TemplateArtifactSnapshot` and pins it for the whole run. Q1,
+  Q2, and scaffold never mix artifact versions.
+- **INV-S2 — Q1 uses selector assets.** Interactive create reads
+  `create-selector.json`; interactive modify reads `modify-selector.json`.
+  The selector routes are sufficient to identify v4 template ids without
+  opening `templates.zip`.
+- **INV-S3 — Q2 uses metadata assets.** Input collection reads
+  `templates-metadata.zip`, which contains selectors, descriptors, questions,
+  and pipelines, but no `content/**`.
+- **INV-S4 — scaffold uses full templates.** The full `templates.zip` asset is
+  required only when rendering content, or immediately for non-interactive
+  template-id resolution.
+- **INV-S5 — cache retention is per artifact kind and minor line.** For each
+  artifact kind and each `major.minor`, keep only the highest cached patch.
+  A new `6.11.x` cache entry does not evict `6.10.x`.
 
-That same first-run window is where the cost lands. In the v4 channel
-`fetchOnlineTemplateMetadata` now resolves through
-`resolveTemplateSource(bundled=false)`, which downloads the **full
-`templates.zip`** (not just the small `metadata.zip` v3 fetched). It runs
-fire-and-forget (`void runBackgroundAsyncTasks` /
-`void …fetchOnlineTemplateMetadata()`), so it never blocks the first
-question — Q1 is already pure local I/O — but it is the heavy
-"first download is slow" work, and it overlaps exactly the inconsistency
-window.
-
-### Decision (transitional invariants)
-
-- **INV-T1 — resolve once per invocation.** A single create / modify
-  invocation resolves the template source exactly once and pins it for the
-  whole invocation; the selector/metadata read and the content read use
-  that one snapshot. The per-invocation gate never flips mid-run, so a
-  concurrent background warm writing the version file cannot tear the
-  selector away from the content.
-- **INV-T2 — prefer-local, no network on the create/modify path.** The
-  per-invocation resolution is local-only: `max(cache, floor)` consistent
-  with the metadata gate, computed without a network round-trip. The
-  online channel resolve + download is confined to the background
-  cache-warmer (`fetchOnlineTemplateMetadata`), whose job is to prepare the
-  cache for the *next* invocation, not to source the current one.
-- **Consequence — one-invocation-deferred adoption.** A newly published
-  `templates-v4@<version>` is adopted on the first invocation *after* the
-  background warm has populated the cache and written the version file.
-  This trades "always the absolute latest" for determinism, an instant Q1,
-  and elimination of the split-brain — consistent with
-  [`../scaffolding.md`](../scaffolding.md) §3.1 (deterministic) and §3.2
-  (offline-by-default); the bundled floor stays the floor. The resolved
-  `{origin, version, digest}` is still recorded on telemetry, so a
-  cache-vs-floor outcome remains observable, never silent (Decision §4).
-
-These invariants are **transitional**. When `selector.json` drives metadata
-distribution, selector + descriptor + content again travel in the single
-resolved artifact (Decision §2) and INV-T1 holds structurally — "one
-artifact" *is* the snapshot — so this section is deleted with the rest of
-the metadata-cache scaffolding.
-
-### Minimal change points (for review — not yet implemented)
-
-1. **Local session resolver (new, no network).** A pure helper returning
-   the single `TemplateSource` for this invocation by replaying the
-   metadata gate locally: `TEMPLATE_VERSION=local` / `useLocalTemplate()` →
-   floor; v4 version-file absent → floor (bundled); else → the cached
-   `templates-v4@<version>` named by `template-version-v4.txt` (digest from
-   the channel cache). Natural home: the v4 distribution layer, beside
-   [`resolveV4MetadataSource`](../../../packages/fx-core/src/component/generator/v4MetadataSource.ts).
-2. **Snapshot + carry (key seam).** Capture (1) once per invocation and
-   thread it so both phases read it; it must be set no later than the first
-   selector/metadata read. *Open question for review — placement:* (a) as
-   the first step of `QuestionMW` for the create/modify stages; (b) a
-   dedicated middleware ahead of `QuestionMW`; (c) on `createContext()` if
-   the readers can reach the context. Carried on `inputs`/`context` as a
-   reserved internal key, not a question.
-3. **Selector/metadata readers honor the snapshot.**
-   `useBundledMetadataForV4()` /
-   [`getTemplateMetadataConfig()`](../../../packages/fx-core/src/component/generator/templates/metadata/index.ts)
-   / [`loadUiNode()`](../../../packages/fx-core/src/question/scaffold/vsc/rootNode.ts)
-   choose bundled-vs-cache to **match** the snapshot rather than each
-   re-reading the version file independently. This is the most invasive
-   point — the static readers currently take no `inputs`/context, so the
-   snapshot (or its `origin` + `version`) must be passed down.
-4. **Content reader honors the snapshot.** `resolveChannelPackageBytes`
-   uses the snapshot source (`loadResolvedPackage(snapshot, port)` from
-   cache/floor by version + digest) instead of calling
-   `resolveTemplateSource({ bundled: false })`. Falls back to current
-   behavior when no snapshot is present (non-create callers).
-5. **Background fetch reframed, role unchanged.**
-   `fetchOnlineTemplateMetadata` / `resolveV4MetadataSource` remain the
-   *only* online-resolving path; they download + verify + cache + write the
-   version file as the cache-warmer for the next invocation, no longer the
-   source for the current run.
-
-Net effect: Q1 stays instant (local), the create/modify path never blocks
-on the network, content and selector are guaranteed to agree, and the heavy
-`templates.zip` download is purely a background cache-warmer.
+`fetchOnlineTemplateMetadata` no longer downloads the legacy v3-style
+`metadata.zip` for v4. When v4 is enabled, it warms `templates-metadata.zip`
+through the same staged artifact resolver and leaves the legacy `~/.fx`
+metadata directory untouched; legacy metadata readers continue to use bundled
+v4 data while the create/modify front doors use staged artifacts directly.

--- a/docs/02-architecture/adr/ADR-0015-templates-version-artifact-shape.md
+++ b/docs/02-architecture/adr/ADR-0015-templates-version-artifact-shape.md
@@ -34,13 +34,16 @@ shared `v4/schema/`.
 
 ## Decision
 
-1. **One release artifact `templates-v4@<version>`** carries all v4 starters,
-   published under the dedicated `templates-v4@` tag prefix on its own model-A
-   tag list (ADR-0006 §5) — never the legacy `templates@` channel a v3 client
-   reads. Its version tracks the engine's `6.x` line (e.g. `templates-v4@6.11.0`)
-   rather than forcing a MAJOR jump. Inside it,
-   packages are partitioned by lifecycle **kind** at the top level:
-   `v4/{create,modify}/<id>/`. Each `<id>` package is **four-file isomorphic**:
+1. **One release unit `templates-v4@<version>` publishes four assets** under
+  the dedicated `templates-v4@` tag prefix on its own model-A tag list
+  (ADR-0006 §5) — never the legacy `templates@` channel a v3 client reads.
+  Its version tracks the engine's `6.x` line (e.g. `templates-v4@6.11.0`)
+  rather than forcing a MAJOR jump. The assets are `create-selector.json`,
+  `modify-selector.json`, `templates-metadata.zip`, and `templates.zip`.
+  The tag-list entry is `{ version, artifacts }`, with a digest per artifact;
+  there is no top-level digest compatibility field. Inside `templates.zip`,
+  packages are partitioned by lifecycle **kind** at the top level:
+  `v4/{create,modify}/<id>/`. Each `<id>` package is **four-file isomorphic**:
    `descriptor.json` + `questions.json` + `pipeline.json` + optional `content/`
    (§3). `content/` is **optional** (a `modify` package that adds no files omits
    it entirely — emptiness is absence, not a marker file), while
@@ -57,16 +60,18 @@ shared `v4/schema/`.
    `.tpl` the author can hand-edit.
 
 3. **Each kind carries one `selector.json`** at `v4/<kind>/selector.json`
-   (§5); the artifact therefore contains both the routable templates and the
-   per-kind routing that indexes them. Routing is derived from the descriptors
-   present (ADR-0014 §5.3), so the artifact is internally consistent by
-   construction.
+  (§5). The same selector is also published as the small selector-only asset
+  for Q1. `templates-metadata.zip` carries both selectors plus every
+  `descriptor.json`, `questions.json`, and `pipeline.json`, but excludes all
+  `content/**`; Q2 can therefore collect inputs without downloading the full
+  scaffold content. `templates.zip` remains the full-content asset used for
+  direct template-id resolution and scaffold.
 
 4. **Compatibility is bidirectional, not a lockstep.** *Forward* (which artifact
-   the engine resolves) is **ADR-0006's**: the engine pins a SemVer `range` over
-   `templates-v4@<version>`, resolves it through the
-   `(package-source, package-version)` hand-off, and records the resolved
-   `{version, digest}`. *Reverse* (whether a resolved package may run on this
+  the engine resolves) is **ADR-0006's**: the engine pins a SemVer `range` over
+  `templates-v4@<version>`, resolves one staged artifact snapshot through the
+  `(package-source, package-version)` hand-off, and records the resolved
+  version plus per-artifact digests. *Reverse* (whether a resolved package may run on this
    engine) is **this ADR's**: each template carries `descriptor.minEngineVersion`
    (both MCP scenarios pin `5.20.0`), checked before the package runs. Starter
    edits therefore ship as a new `templates-v4@<version>` within the engine's

--- a/docs/03-specs/domains/01-scaffolding.md
+++ b/docs/03-specs/domains/01-scaffolding.md
@@ -34,15 +34,16 @@ it is retired template-by-template per the migration ratchet
 
 - **Template** — a versioned, declarative starting point (descriptor +
   questions + pipeline + content) that the engine renders into a project.
-- **Template package** — the single distributable artifact
-  (`templates-v4@<version>`) that carries every template plus its selector and
-  metadata.
+- **Template package** — the `templates-v4@<version>` release unit. It publishes
+  selector, metadata, and full-template assets derived from the same
+  `templates/v4` source.
 - **Bundled floor** — the copy of the template package shipped inside the
   engine binary; the offline / deterministic baseline.
 - **Release channel** — the GitHub-release-hosted template packages that let
   templates ship independently of the engine.
-- **Template source** — a resolved `(origin, version, digest, location)` that
-  names exactly which bytes a scaffold run will use.
+- **Template source** — a resolved `(origin, version, digest, location)` for one
+  artifact, or a staged artifact snapshot that pins one version and digest set
+  across selector, metadata, and full-template bytes.
 - **Range** — the SemVer range a build is permitted to resolve within.
 - **Lane** — `stable` vs `beta`, expressed purely through SemVer prerelease
   semantics (a `-beta` segment), not a separate field.

--- a/docs/03-specs/operations/scaffolding/resolve-template-source.md
+++ b/docs/03-specs/operations/scaffolding/resolve-template-source.md
@@ -15,6 +15,12 @@ Given a build-pinned `range`, a build-pinned `bundled` flag, and an injected
 any template is read or rendered. This is the single decision point that
 replaces v3's three `package.json#version`-sniffing call sites.
 
+For the final v4 channel, interactive create/modify resolve a staged
+`TemplateArtifactSnapshot` instead of one full zip up front. The snapshot pins
+one `templates-v4@<version>` and one digest set across `create-selector`,
+`modify-selector`, `metadata`, and `templates`, so Q1, Q2, and scaffold never
+mix bytes from different releases.
+
 ## Inputs
 
 | Input | Type | Origin |
@@ -32,7 +38,7 @@ the full runtime composes later:
 | Port face | Shape | Responsibility |
 |-----------|-------|----------------|
 | `env` | `(name) => string \| undefined` | read `TEMPLATE_VERSION` |
-| `tagList` | `() => Promise<Array<{ version: string; digest: string }>>` | the channel's published `{version, digest}` entries (model A — the tag list carries the expected digest per version) |
+| `tagList` | `() => Promise<Array<{ version: string; digest: string }>>` or staged `{ version, artifacts }` entries | the channel's published digest entries (model A — the tag list carries the expected digest per version/artifact) |
 | `packages` | `(version, expectedDigest) => Promise<bytes>` | download a package; the digest the caller verifies against is the tag-list's expected digest |
 | `cache` | `{ get(version): { digest, bytes } \| undefined; put(version, digest, bytes): void; keys(): string[] }` | the local digest-keyed package cache (`keys` enumerates cached versions for the offline `max(cache, floor)` fallback) |
 | `floor` | `{ version: string; digest: string; bytes: ... }` | the bundled floor baked into the engine |
@@ -85,52 +91,33 @@ outcome and telemetry; it is never written back into committed config.
 | AC-19 | L1 | `bundled=false`, a version is picked from the tag-list, but `port.packages(...)` (download) rejects | resolve | returns `err(FxError)` (an existing FxError is preserved; otherwise wrapped as `TemplateDownloadFailed`); the rejection never escapes as a thrown promise — the neverthrow contract holds for the download path too |
 
 
-## Transitional local resolution — `resolveLocalTemplateSource` (INV-T2)
+## Final v4 staged artifact resolution — `resolveTemplateArtifactSnapshot`
 
-> **Scope — transitional.** Added by the [ADR-0006](../../../02-architecture/adr/ADR-0006-template-distribution-channel.md)
-> "selector/content consistency during the metadata-cache phase" follow-up.
-> Deleted together with that phase once `selector.json` drives metadata
-> distribution.
+The final v4 channel resolves a staged `TemplateArtifactSnapshot` rather than
+one full package for every interactive run. The snapshot pins a single
+`templates-v4@<version>` and the digest refs for all four artifact kinds:
+`create-selector`, `modify-selector`, `metadata`, and `templates`.
 
-`resolveTemplateSource` (above) may go to the network when `bundled=false`. On
-the **create / modify path** the engine resolves the content package and the
-selector/metadata from two different gates at two moments in one invocation,
-which re-opens the cluster-C split-brain (questions from the bundled floor,
-content from a newer online version). `resolveLocalTemplateSource` is the
-no-network sibling the create/modify chokepoint calls instead, so the content
-resolves to the same local source the selector/metadata gate sees and the
-scaffold never blocks on a download (the online fetch is confined to the
-background cache-warmer `fetchOnlineTemplateMetadata`, which serves the *next*
-invocation — one-invocation-deferred adoption, INV-T1/INV-T2).
+Interactive create/modify requests the selector artifact first. Q2 later reads
+the metadata artifact from the same snapshot, and scaffold reads the full
+templates artifact from that same snapshot. Non-interactive template-id paths
+request the full `templates` artifact directly. A failed later artifact fetch is
+an error for the invocation; it does not silently switch from online selector
+bytes to bundled metadata or content.
 
-It is **synchronous and total** (no `tagList`/`packages` faces are touched, no
-expected failure) and returns `max(cached-satisfying-range, floor)`:
-
-1. `TEMPLATE_VERSION=local` → bundled floor (`origin=bundled`), mirroring
-   `resolveTemplateSource` AC-02.
-2. otherwise → the highest cached version satisfying `range` if it strictly
-   beats the floor (`origin=cache`); a tie or empty/out-of-range cache resolves
-   the floor (`origin=bundled`) — the same `max(cache, floor)` selection as the
-   offline fallback, but with `origin=bundled` (not `bundled-fallback`) and **no**
-   "channel unreachable" warning, because local-first is deliberate, not a
-   degraded fallback.
+The artifact cache is shared by create and modify. For each artifact kind and
+each `major.minor` line, GC keeps only the highest patch version; a `6.11.x`
+write does not delete the latest cached `6.10.x` artifact.
 
 | ID | Tier | Given | When | Then |
 |----|------|-------|------|------|
-| AC-T1 | L1 | `port.env("TEMPLATE_VERSION")="local"`, cache holds `6.10.5` (> floor) | resolve local | `origin=bundled`, `version`=floor; `port.httpCalls===0`, no download |
-| AC-T2 | L1 | no `TEMPLATE_VERSION`, cache empty, floor `6.10.1` satisfies `~6.10` | resolve local | `origin=bundled`, `version=6.10.1`; `port.httpCalls===0` |
-| AC-T3 | L1 | no `TEMPLATE_VERSION`, cache holds `6.10.5` (digest `D5`, > floor) satisfying `~6.10` | resolve local | `origin=cache`, `version=6.10.5`, `digest=D5`; `port.httpCalls===0`, no download |
-| AC-T4 | L1 | cache holds only `6.9.0` (does **not** satisfy `~6.10`), floor `6.10.1` | resolve local | `origin=bundled`, `version=6.10.1` — out-of-range cache entry ignored (INV-5) |
-| AC-T5 | L1 | cache holds `6.10.1` equal to the floor `6.10.1` | resolve local | `origin=bundled` (tie goes to the floor, decision #2); `port.httpCalls===0` |
-| AC-T6 | L1 | any of the above | resolve local | the result never has the offline `warning` set (local-first is not a degraded fallback) |
-| AC-T7 | L1 | identical `(range, port state)` | resolve local twice | both return the identical `{origin, version, digest}` (INV-6) |
-
-The v3→v4 content chokepoint (`v4TemplateBridge.resolveChannelPackageBytes`)
-calls `resolveLocalTemplateSource` rather than `resolveTemplateSource`, so a
-create/modify run reads only local bytes (`max(cache, floor)`) and stays off the
-network; closing the residual mid-invocation race (a background fetch landing
-between the selector read and the content read) requires the resolve-once
-snapshot tracked separately in ADR-0006 (CP2/CP3).
+| AC-S1 | L1 | interactive create, online `6.11.2` satisfies `range` | Q1 starts | `create-selector.json` is downloaded/verified/cached before selector walk; `templates.zip` is not required |
+| AC-S2 | L1 | interactive modify, online `6.11.2` satisfies `range` | Q1 starts | `modify-selector.json` is downloaded/verified/cached before selector walk; `templates.zip` is not required |
+| AC-S3 | L1 | Q1 selected a v4 template from snapshot version `6.11.2` | Q2 starts | `templates-metadata.zip` from `6.11.2` is used; no `content/**` is required |
+| AC-S4 | L1 | Q2 completed from metadata snapshot version `6.11.2` | scaffold starts | `templates.zip` from `6.11.2` is used; scaffold receives full content bytes from the same snapshot |
+| AC-S5 | L1 | non-interactive create/modify names a concrete v4 template id | resolve | `templates.zip` is the required first artifact; selector-only Q1 is skipped |
+| AC-S6 | L1 | metadata download fails after an online selector succeeded | continue invocation | returns `err(FxError)`; bundled metadata/content are not mixed into the same invocation |
+| AC-S7 | L1 | cache contains `6.10.5` and `6.11.1`, then writes `6.11.2` for `metadata` | cache GC runs | keeps `6.10.5` and `6.11.2`, deletes lower `6.11.x` metadata entries only |
 
 
 ## Flow
@@ -190,10 +177,11 @@ This operation does **not**:
   substitutes a different source without recording it.
 - **INV-2 — Never sniff `package.json#version`.** Resolution depends only on
   `range`, `bundled`, `runtime`, and `TEMPLATE_VERSION`.
-- **INV-3 — Digest integrity.** The tag list publishes a `{version, digest}`
-  per version (model A); downloaded bytes are never returned or cached unless
-  their computed digest matches the tag-list's expected digest for that
-  version; a mismatch is a hard error, not a fallback.
+- **INV-3 — Digest integrity.** The legacy full-package resolver uses
+  `{version, digest}` entries; the final v4 staged resolver uses
+  `{ version, artifacts }` entries with a digest per artifact. Downloaded bytes
+  are never returned or cached unless their computed digest matches the
+  tag-list's expected digest; a mismatch is a hard error, not a fallback.
 - **INV-4 — Stable excludes prerelease.** A `range` without a prerelease
   segment never resolves a `-beta` version (SemVer `maxSatisfying` semantics).
 - **INV-5 — Fallback satisfies `range`.** Every fallback candidate (cache
@@ -220,13 +208,13 @@ This operation does **not**:
    during the transition window, with identical values
    (`bundled | online | cache | bundled-fallback`); `package-source` is removed
    once consumers have migrated to `origin`.
-4. **Expected digest comes from the tag list (model A).** The published tag
-   list is a list of `{version, digest}` entries, not bare versions. Every
-   online resolve has an a-priori expected digest to verify the downloaded
-   bytes against (INV-3, AC-11), and the cache key is trustworthy. This is a
-   **new** channel artifact: the v3 bare-version tag-list URL is never altered
-   (ADR-0006 v3-non-blocking constraint); model A ships a separate
-   digest-bearing list for v4.
+4. **Expected digests come from the tag list (model A).** The final v4 tag
+  list is NDJSON with one `{ version, artifacts }` entry per line. Each
+  artifact ref carries its file name and expected digest. There is no
+  top-level `digest`; every online resolve verifies the specific downloaded
+  artifact bytes against the artifact digest (INV-3, AC-11), and the cache key
+  is trustworthy. This is a **new** channel artifact: the v3 bare-version
+  tag-list URL is never altered (ADR-0006 v3-non-blocking constraint).
 5. **v4 uses a dedicated `templates-v4@` tag prefix.** v4 template releases
    publish under `templates-v4@<version>` on a separate tag list (mirroring
    the existing `templates-vs@` split), so a v3 `templates@` client can never
@@ -234,13 +222,17 @@ This operation does **not**:
    isolation). v4 versions therefore stay in sync with the engine's `6.x`
    line; no MAJOR jump. `location` / cache keys use the `templates-v4@`
    prefix.
-6. **`digest` = `sha256` of the package `.zip` raw bytes.** The digest is the
-   `sha256` hash of the exact downloaded `.zip` byte stream, prefixed
-   `sha256:`. The publish side computes it over the same artifact bytes; any
-   single-byte difference (zip metadata, line endings) is a deliberate
-   mismatch, not tolerated. `computeDigest(bytes)` is the one authority.
+6. **Artifact digests are `sha256` of raw artifact bytes.** The digest is the
+  `sha256` hash of the exact downloaded asset byte stream, prefixed
+  `sha256:`. The publish side computes it over the same artifact bytes; any
+  single-byte difference (zip metadata, line endings) is a deliberate
+  mismatch, not tolerated.
 7. **The v4 tag list is NDJSON.** The model-A tag list is newline-delimited
-   JSON: one `{"version":"6.11.0","digest":"sha256:…"}` object per line.
-   Blank lines and `\r` are ignored; a malformed line is a hard parse error
-   (no silent skip). Served at a **new** URL (`templatesV4TagListURL`),
-   separate from the frozen v3 `tagListURL`.
+  JSON: one `{ "version": "6.11.0", "artifacts": { ... } }` object per
+  line. Blank lines and `\r` are ignored; a malformed line is a hard parse
+  error (no silent skip). Served at a **new** URL (`templatesV4TagListURL`),
+  separate from the frozen v3 `tagListURL`.
+8. **Staged cache retention is per minor line and per artifact kind.** The
+  cache keeps only the highest patch version for each `major.minor` line and
+  artifact kind, so stable, prerelease, and CLI clients do not evict each
+  other's usable cache while stale lower patches are collected.

--- a/packages/fx-core/.gitignore
+++ b/packages/fx-core/.gitignore
@@ -8,7 +8,7 @@ coverage
 .fx
 templates/**/*.zip
 templates/configs
-templates/v4/floor.json
+templates/v4
 tests/**/TeamsSPFxApp.zip
 resource/templates
 tsconfig.tsbuildinfo

--- a/packages/fx-core/src/component/generator/templateHelper.ts
+++ b/packages/fx-core/src/component/generator/templateHelper.ts
@@ -30,18 +30,10 @@ export function useLocalTemplate(): boolean {
 }
 
 /**
- * Transitional: in the v4 channel the metadata/UI readers must read the bundled
- * copy and ignore any (possibly stale v3) `~/.fx` cache UNLESS the v4 online
- * fetch populated its cache. `fetchOnlineTemplateMetadata` writes
- * `~/.fx/template-version-v4.txt` only after a successful v4 download, so its
- * presence is the single signal that downloaded v4 metadata is available:
- *   - present → read the downloaded v4 cache;
- *   - absent  → bundled build / channel unreachable / not yet published, so
- *               read the bundled copy (never a stale v3 cache).
- * This mirrors the `resolveTemplateSource` decision in
- * `fetchOnlineTemplateMetadata`.
- *
- * Remove once selector.json drives metadata distribution.
+ * V4 front doors resolve selector/metadata through the staged artifact cache.
+ * The legacy metadata/UI readers still read bundled data unless a pre-existing
+ * v4 metadata cache marker is present; final staged metadata warming does not
+ * write this marker.
  */
 export function useBundledMetadataForV4(): boolean {
   if (!featureFlagManager.getBooleanValue(FeatureFlags.V4Enabled)) {

--- a/packages/fx-core/src/component/generator/v4MetadataSource.ts
+++ b/packages/fx-core/src/component/generator/v4MetadataSource.ts
@@ -5,40 +5,37 @@ import { FxError } from "@microsoft/teamsfx-api";
 import { Result } from "neverthrow";
 import templateConfig from "../../common/templates-config.json";
 import * as bundledFloor from "../../v4/distribution/bundledFloor";
-import * as templateSource from "../../v4/distribution/templateSource";
-import * as templateSourcePort from "../../v4/distribution/templateSourcePort";
+import {
+  TemplateArtifactSnapshot,
+  createTemplateArtifactPort,
+  resolveTemplateArtifactSnapshot,
+} from "../../v4/distribution/templateArtifacts";
 import { defaultTryLimits } from "./constant";
 
 /**
- * Resolve which v4 template release the metadata should come from, using the
- * SAME single decision point as the template package:
- * `resolveTemplateSource((v4.range, v4.bundled, port))`.
+ * Resolve and warm the v4 metadata artifact using the same staged artifact
+ * resolver as create/modify front doors.
  *
- * `bundled` is CD-baked (= !goproduct), so goproduct builds (stable AND
- * prerelease) resolve to an `online`/`cache` source while non-goproduct/daily
- * builds resolve to the bundled floor. The metadata.zip asset lives in the same
- * `templates-v4@<version>` release as the resolved package, so the resolved
- * version names the release that `fetchOnlineTemplateMetadata` pulls metadata
- * from. Resolving here also downloads, verifies, and caches the template
- * package, so a later content scaffold reuses it with no re-download.
+ * The final v4 channel publishes `templates-metadata.zip`, not the legacy v3
+ * `metadata.zip`. Resolving this snapshot downloads, verifies, and caches the
+ * metadata artifact without writing the legacy `~/.fx` metadata directory.
  *
  * An unreachable channel resolves to a bundled-fallback origin (not an error);
  * only a malformed tag list or a digest mismatch surfaces as `Result.err`.
- *
- * Transitional: remove once selector.json drives metadata distribution.
  */
-export function resolveV4MetadataSource(): Promise<Result<templateSource.TemplateSource, FxError>> {
-  const port = templateSourcePort.createTemplateSourcePort(
+export function resolveV4MetadataSource(): Promise<Result<TemplateArtifactSnapshot, FxError>> {
+  const port = createTemplateArtifactPort(
     {
       templatesV4TagListURL: templateConfig.templatesV4TagListURL,
       templateDownloadBaseURL: templateConfig.templateDownloadBaseURL,
       tryLimits: defaultTryLimits,
     },
-    bundledFloor.loadBundledFloor()
+    bundledFloor.loadBundledTemplateArtifacts()
   );
-  return templateSource.resolveTemplateSource({
+  return resolveTemplateArtifactSnapshot({
     range: templateConfig.v4.range,
     bundled: templateConfig.v4.bundled,
+    requiredKind: "metadata",
     port,
   });
 }

--- a/packages/fx-core/src/component/generator/v4TemplateBridge.ts
+++ b/packages/fx-core/src/component/generator/v4TemplateBridge.ts
@@ -33,6 +33,11 @@ export const v4TemplateBridgeDeps = {
   openTemplatePackage: templatePackageMod.openTemplatePackage,
 };
 
+export interface ResolvedV4ChannelPackage {
+  source: TemplateSource;
+  bytes: Buffer;
+}
+
 /**
  * Resolve a template entry's relative name to an absolute path and verify it
  * stays within `destination`. The entry name originates from the (untrusted)
@@ -114,8 +119,18 @@ export async function renderTemplateEntries(
  */
 function resolveChannelPackageBytes(
   context: GeneratorContext,
-  telemetryProps?: Record<string, string>
-): { source: TemplateSource; bytes: Buffer } {
+  telemetryProps?: Record<string, string>,
+  resolvedPackage?: ResolvedV4ChannelPackage
+): ResolvedV4ChannelPackage {
+  if (resolvedPackage !== undefined) {
+    merge(telemetryProps, {
+      [TelemetryProperty.TemplatePackageSource]: resolvedPackage.source.origin,
+      [TelemetryProperty.TemplatePackageVersion]: resolvedPackage.source.version,
+      [TelemetryProperty.TemplatePackageDigest]: resolvedPackage.source.digest,
+    });
+    return resolvedPackage;
+  }
+
   const channelConfig = {
     templatesV4TagListURL: templateConfig.templatesV4TagListURL,
     templateDownloadBaseURL: templateConfig.templateDownloadBaseURL,
@@ -151,9 +166,10 @@ function resolveChannelPackageBytes(
 export async function scaffoldFromV4Channel(
   context: GeneratorContext,
   locator: TemplateLocator,
-  telemetryProps?: Record<string, string>
+  telemetryProps?: Record<string, string>,
+  resolvedPackage?: ResolvedV4ChannelPackage
 ): Promise<TemplateSource> {
-  const { source, bytes } = resolveChannelPackageBytes(context, telemetryProps);
+  const { source, bytes } = resolveChannelPackageBytes(context, telemetryProps, resolvedPackage);
 
   const entriesResult = v4TemplateBridgeDeps.openTemplatePackage(bytes, locator);
   if (entriesResult.isErr()) {
@@ -212,9 +228,10 @@ export async function scaffoldDeclarativeFromV4Channel(
   answers: Answers,
   callerFloor: CallerFloor,
   telemetryProps?: Record<string, string>,
-  flagReader?: (name: string) => boolean
+  flagReader?: (name: string) => boolean,
+  resolvedPackage?: ResolvedV4ChannelPackage
 ): Promise<TemplateSource> {
-  const { source, bytes } = resolveChannelPackageBytes(context, telemetryProps);
+  const { source, bytes } = resolveChannelPackageBytes(context, telemetryProps, resolvedPackage);
 
   const loaded = openDeclarativePackage(bytes, locator);
   if (loaded.isErr()) {

--- a/packages/fx-core/src/core/FxCore.declarativeAgent.ts
+++ b/packages/fx-core/src/core/FxCore.declarativeAgent.ts
@@ -39,7 +39,10 @@ import { templateDefaultOnActionError } from "../component/generator/generator";
 import { GeneratorContext } from "../component/generator/generatorAction";
 import * as openApiSpecHelperModule from "../component/generator/openApiSpec/helper";
 import { getParserOptions } from "../component/generator/openApiSpec/helper";
-import { scaffoldDeclarativeFromV4Channel } from "../component/generator/v4TemplateBridge";
+import {
+  ResolvedV4ChannelPackage,
+  scaffoldDeclarativeFromV4Channel,
+} from "../component/generator/v4TemplateBridge";
 import { QuestionMW } from "../component/middleware/questionMW";
 import { outputScaffoldingWarningMessage } from "../component/utils/common";
 import {
@@ -56,6 +59,7 @@ import type { Answers, BuildTarget } from "../v4";
 import { ConcurrentLockerMW } from "./middleware/concurrentLocker";
 import { ErrorHandlerMW } from "./middleware/errorHandler";
 import { modifyProjectFrontDoor } from "./modifyProjectFrontDoor";
+import { resolveV4TemplateArtifactSnapshot } from "./v4ArtifactSnapshot";
 
 export interface ScaffoldAddMcpServerFromV4Options {
   templateId: string;
@@ -65,6 +69,7 @@ export interface ScaffoldAddMcpServerFromV4Options {
   appName: string;
   mcpServerUrl: string;
   authType: string;
+  resolvedPackage?: ResolvedV4ChannelPackage;
 }
 
 function targetRelativePath(projectPath: string, filePath: string): string {
@@ -105,7 +110,10 @@ async function scaffoldAddMcpServerFromV4(
         teamsManifestPath: targetRelativePath(options.projectPath, options.teamsManifestPath),
         authType: options.authType,
       },
-      { appName: options.appName, language: "common" }
+      { appName: options.appName, language: "common" },
+      undefined,
+      undefined,
+      options.resolvedPackage
     );
     if (source.warning) {
       TOOLS.logProvider.warning(source.warning);
@@ -127,6 +135,7 @@ export const fxCoreDeclarativeAgentDeps = {
   generateFromApiSpec: openApiSpecHelperModule.generateFromApiSpec,
   generateScaffoldingSummary: openApiSpecHelperModule.generateScaffoldingSummary,
   modifyProjectFrontDoor,
+  resolveV4TemplateArtifactSnapshot,
   scaffoldAddMcpServerFromV4,
 };
 export class FxCoreDeclarativeAgentPart {
@@ -656,7 +665,12 @@ export class FxCoreDeclarativeAgentPart {
             authType: authType || "none",
           },
           {
-            scaffoldV4: async (_inputs: Inputs, target: BuildTarget, answers: Answers) => {
+            scaffoldV4: async (
+              _inputs: Inputs,
+              target: BuildTarget,
+              answers: Answers,
+              resolvedPackage?: ResolvedV4ChannelPackage
+            ) => {
               if (target.engine !== "v4") {
                 return err(unsupportedModifyTarget(target));
               }
@@ -679,10 +693,12 @@ export class FxCoreDeclarativeAgentPart {
                 appName: manifestRes.value.name?.short ?? path.basename(projectPath),
                 mcpServerUrl: answerMcpServerUrl,
                 authType: answerAuthType,
+                resolvedPackage,
               });
             },
             callCoreMethod: (_inputs: Inputs, target: BuildTarget) =>
               Promise.resolve(err(unsupportedModifyTarget(target))),
+            resolveArtifactSnapshot: fxCoreDeclarativeAgentDeps.resolveV4TemplateArtifactSnapshot,
           }
         );
         if (dispatchRes.isErr()) {

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -192,6 +192,7 @@ import { LocalCrypto } from "./crypto";
 import { environmentNameManager } from "./environmentName";
 import { FxCoreOpenPluginPart } from "./FxCore.openPlugin";
 import { generateConfigFiles } from "./generateConfigFiles";
+import { resolveV4TemplateArtifactSnapshot } from "./v4ArtifactSnapshot";
 import { ConcurrentLockerMW } from "./middleware/concurrentLocker";
 import { ContextInjectorMW } from "./middleware/contextInjector";
 import { ErrorHandlerMW } from "./middleware/errorHandler";
@@ -277,6 +278,7 @@ export class FxCore extends FxCoreOpenPluginPart {
       scaffoldV4,
       collectCreateFloor,
       applyV3PreFill,
+      resolveArtifactSnapshot: resolveV4TemplateArtifactSnapshot,
     });
   }
 
@@ -3103,15 +3105,9 @@ export class FxCore extends FxCoreOpenPluginPart {
 
       let latestVersion: string;
       if (useV4Channel) {
-        // Transitional: in the v4 channel the metadata rides the SAME single
-        // decision point as the template package —
-        // `resolveTemplateSource((v4.range, v4.bundled, port))`. The `bundled`
-        // field is CD-baked (= !goproduct), so goproduct builds (stable AND
-        // prerelease) resolve to an online/cache source while non-goproduct or
-        // daily builds resolve to the bundled floor. metadata.zip lives in the
-        // same `templates-v4@<ver>` release as the resolved package, so the
-        // resolved version names the release to pull metadata from. Remove once
-        // selector.json drives metadata distribution.
+        // V4 publishes templates-metadata.zip as a staged artifact. Resolve it
+        // through the shared artifact cache and leave the legacy ~/.fx metadata
+        // directory untouched so old metadata readers keep using bundled v4 data.
         const resolved = await resolveV4MetadataSource();
         if (resolved.isErr()) {
           // Malformed tag list / digest mismatch are hard errors (no silent
@@ -3119,13 +3115,7 @@ export class FxCore extends FxCoreOpenPluginPart {
           // resolved to a bundled-fallback origin handled below.
           return err(resolved.error);
         }
-        const source = resolved.value;
-        if (source.origin === "bundled" || source.origin === "bundled-fallback") {
-          // Bundled build or unreachable channel: read the bundled metadata
-          // (the readers fall back via `useBundledMetadataForV4`). No download.
-          return ok(undefined);
-        }
-        latestVersion = source.version;
+        return ok(undefined);
       } else {
         // v3: prerelease builds use the mutable rolling `0.0.0-rc` tag; stable
         // builds resolve the latest published templates version.

--- a/packages/fx-core/src/core/createFrontDoorAdapters.ts
+++ b/packages/fx-core/src/core/createFrontDoorAdapters.ts
@@ -36,7 +36,10 @@ import { coordinator } from "../component/coordinator";
 import { templateDefaultOnActionError } from "../component/generator/generator";
 import { GeneratorContext } from "../component/generator/generatorAction";
 import { convertToLangKey } from "../component/generator/utils";
-import { scaffoldDeclarativeFromV4Channel } from "../component/generator/v4TemplateBridge";
+import {
+  ResolvedV4ChannelPackage,
+  scaffoldDeclarativeFromV4Channel,
+} from "../component/generator/v4TemplateBridge";
 import { sendErrorEvent, sendSuccessEvent } from "../component/telemetry";
 import { pathUtils } from "../component/utils/pathUtils";
 import { InputValidationError, MissingRequiredInputError, assembleError } from "../error/common";
@@ -86,7 +89,8 @@ export async function scaffoldV4(
   inputs: Inputs,
   target: BuildTarget,
   answers: Answers,
-  flagReader?: (name: string) => boolean
+  flagReader?: (name: string) => boolean,
+  resolvedPackage?: ResolvedV4ChannelPackage
 ): Promise<Result<CreateProjectResult, FxError>> {
   const folderInput = inputs[QuestionNames.Folder];
   if (!folderInput) {
@@ -127,7 +131,8 @@ export async function scaffoldV4(
       answers,
       callerFloor,
       telemetryProps,
-      flagReader
+      flagReader,
+      resolvedPackage
     );
     if (source.warning) {
       TOOLS.logProvider.warning(source.warning);

--- a/packages/fx-core/src/core/createProjectFrontDoor.ts
+++ b/packages/fx-core/src/core/createProjectFrontDoor.ts
@@ -17,15 +17,19 @@ import {
   Answers,
   BuildTarget,
   DeclarativeLocator,
+  TemplateArtifactKind,
+  TemplateArtifactSnapshot,
   bundledFloorDir,
   resolveCreateTargetByTemplateId,
   runCreateInputs,
   runCreateSelector,
+  templateSourceFromArtifactSnapshot,
 } from "../v4";
 import { parseMcpStaticToolsJson } from "../v4/mcp/mcpStaticTools";
 import { FeatureFlags, readBooleanFeatureFlag } from "../common/featureFlags";
 import { TOOLS } from "../common/globalVars";
 import { TemplateNames } from "../component/generator/templates/templateNames";
+import type { ResolvedV4ChannelPackage } from "../component/generator/v4TemplateBridge";
 import { QuestionNames } from "../question/questionNames";
 import { fetchMCPTools, MCPFetchResult } from "../component/utils/mcpToolFetcher";
 
@@ -114,7 +118,8 @@ export interface CreateFrontDoorDeps {
     inputs: Inputs,
     target: BuildTarget,
     answers: Answers,
-    flagReader: (name: string) => boolean
+    flagReader: (name: string) => boolean,
+    resolvedPackage?: ResolvedV4ChannelPackage
   ) => Promise<Result<CreateProjectResult, FxError>>;
   /**
    * The engine=v4 create-floor collection: ask `folder` + `app-name`. The v4 path
@@ -130,6 +135,14 @@ export interface CreateFrontDoorDeps {
   flagReader?: (name: string) => boolean;
   /** The bundled-floor channel-zip reader (default: the shipped `templates.zip`; injectable for tests, INV-6). */
   readFloorBytes?: () => Buffer;
+  /** Per-invocation staged artifact snapshot. When supplied, Q1/Q2/full staging read from this snapshot. */
+  artifactSnapshot?: TemplateArtifactSnapshot;
+  /** Resolves a per-invocation staged artifact snapshot after the v4 flag is known to be on. */
+  resolveArtifactSnapshot?: (
+    requiredKind: TemplateArtifactKind
+  ) => Promise<Result<TemplateArtifactSnapshot, FxError>>;
+  /** Membership test supplied with selector-only artifacts. */
+  v4Registry?: (templateId: string) => boolean;
   /** The host surface (default: `TOOLS.ui`). */
   ui?: UserInteraction;
   /** The Q1 selector walk (default: the real `runCreateSelector`). */
@@ -150,6 +163,13 @@ function defaultFlagReader(name: string): boolean {
 /** Read the shipped bundled-floor channel zip (the default `readFloorBytes`). */
 function readBundledFloorBytes(): Buffer {
   return fs.readFileSync(path.join(bundledFloorDir(), "templates.zip"));
+}
+
+function readSnapshotBytes(
+  snapshot: TemplateArtifactSnapshot,
+  kind: TemplateArtifactKind
+): Promise<Result<Buffer, FxError>> {
+  return snapshot.bytes(kind);
 }
 
 function isV4NeutralInput(key: string, value: unknown): value is string | string[] {
@@ -295,7 +315,8 @@ export async function createProjectFrontDoor(
 
   const ui = deps.ui ?? TOOLS.ui;
   const surface = surfaceOf(inputs.platform);
-  const floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
+  let snapshot = deps.artifactSnapshot;
+  let floorBytes: Buffer | undefined;
   const interactive = !inputs.nonInteractive;
 
   // A surface that already resolved the leaf template — the CLI in non-interactive
@@ -308,15 +329,57 @@ export async function createProjectFrontDoor(
   const presetTemplateId = inputs[QuestionNames.TemplateName];
   let target: Result<BuildTarget, FxError>;
   if (presetTemplateId) {
+    if (snapshot === undefined && deps.resolveArtifactSnapshot !== undefined) {
+      const resolved = await deps.resolveArtifactSnapshot("templates");
+      if (resolved.isErr()) {
+        return err(resolved.error);
+      }
+      snapshot = resolved.value;
+    }
+    if (snapshot === undefined) {
+      floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
+    } else {
+      const fullBytes = await readSnapshotBytes(snapshot, "templates");
+      if (fullBytes.isErr()) {
+        return err(fullBytes.error);
+      }
+      floorBytes = fullBytes.value;
+    }
     const resolveByTemplateId = deps.resolveByTemplateId ?? resolveCreateTargetByTemplateId;
     target = resolveByTemplateId(floorBytes, presetTemplateId);
   } else {
+    if (snapshot === undefined && deps.resolveArtifactSnapshot !== undefined) {
+      const resolved = await deps.resolveArtifactSnapshot("create-selector");
+      if (resolved.isErr()) {
+        return err(resolved.error);
+      }
+      snapshot = resolved.value;
+    }
+    let selectorBytes: Buffer;
+    if (snapshot === undefined) {
+      floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
+      selectorBytes = floorBytes;
+    } else {
+      const selector = await readSnapshotBytes(snapshot, "create-selector");
+      if (selector.isErr()) {
+        return err(selector.error);
+      }
+      selectorBytes = selector.value;
+    }
     const runSelector = deps.runSelector ?? runCreateSelector;
-    target = await runSelector(floorBytes, ui, surface, {
+    const selectorDeps = {
       flagReader,
       interactive,
       prefilled: selectorPrefillFromInputs(inputs),
-    });
+    };
+    target =
+      snapshot === undefined
+        ? await runSelector(selectorBytes, ui, surface, selectorDeps)
+        : await runSelector(selectorBytes, ui, surface, {
+            ...selectorDeps,
+            selectorBytesKind: "json",
+            v4Registry: deps.v4Registry,
+          });
   }
   if (target.isErr()) {
     return err(target.error);
@@ -353,7 +416,20 @@ export async function createProjectFrontDoor(
       if (bridgedEntryParams.isErr()) {
         return err(bridgedEntryParams.error);
       }
-      const answers = await runInputs(floorBytes, locator, bridgedEntryParams.value, ui, {
+      let inputBytes: Buffer;
+      if (snapshot === undefined) {
+        if (floorBytes === undefined) {
+          floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
+        }
+        inputBytes = floorBytes;
+      } else {
+        const metadataBytes = await readSnapshotBytes(snapshot, "metadata");
+        if (metadataBytes.isErr()) {
+          return err(metadataBytes.error);
+        }
+        inputBytes = metadataBytes.value;
+      }
+      const answers = await runInputs(inputBytes, locator, bridgedEntryParams.value, ui, {
         flagReader,
         surface,
       });
@@ -367,6 +443,16 @@ export async function createProjectFrontDoor(
       const floorRes = await deps.collectCreateFloor(inputs, ui);
       if (floorRes.isErr()) {
         return err(floorRes.error);
+      }
+      if (snapshot !== undefined) {
+        const fullBytes = await readSnapshotBytes(snapshot, "templates");
+        if (fullBytes.isErr()) {
+          return err(fullBytes.error);
+        }
+        return deps.scaffoldV4(inputs, target.value, answers.value, flagReader, {
+          source: templateSourceFromArtifactSnapshot(snapshot),
+          bytes: fullBytes.value,
+        });
       }
       return deps.scaffoldV4(inputs, target.value, answers.value, flagReader);
     }

--- a/packages/fx-core/src/core/modifyProjectFrontDoor.ts
+++ b/packages/fx-core/src/core/modifyProjectFrontDoor.ts
@@ -14,8 +14,18 @@ import path from "path";
 import { Result } from "neverthrow";
 import { featureFlagManager } from "../common/featureFlags";
 import { TOOLS } from "../common/globalVars";
-import { Answers, BuildTarget, DeclarativeLocator, bundledFloorDir, runCreateInputs } from "../v4";
+import {
+  Answers,
+  BuildTarget,
+  DeclarativeLocator,
+  TemplateArtifactKind,
+  TemplateArtifactSnapshot,
+  bundledFloorDir,
+  runCreateInputs,
+  templateSourceFromArtifactSnapshot,
+} from "../v4";
 import { runModifySelector } from "../v4/surface/modifySelectorWalk";
+import type { ResolvedV4ChannelPackage } from "../component/generator/v4TemplateBridge";
 
 const SOURCE = "Scaffold";
 
@@ -23,11 +33,17 @@ export interface ModifyFrontDoorDeps {
   scaffoldV4: (
     inputs: Inputs,
     target: BuildTarget,
-    answers: Answers
+    answers: Answers,
+    resolvedPackage?: ResolvedV4ChannelPackage
   ) => Promise<Result<undefined, FxError>>;
   callCoreMethod: (inputs: Inputs, target: BuildTarget) => Promise<Result<undefined, FxError>>;
   flagReader?: (name: string) => boolean;
   readFloorBytes?: () => Buffer;
+  artifactSnapshot?: TemplateArtifactSnapshot;
+  resolveArtifactSnapshot?: (
+    requiredKind: TemplateArtifactKind
+  ) => Promise<Result<TemplateArtifactSnapshot, FxError>>;
+  v4Registry?: (templateId: string) => boolean;
   ui?: UserInteraction;
   runSelector?: typeof runModifySelector;
   runInputs?: typeof runCreateInputs;
@@ -39,6 +55,13 @@ function defaultFlagReader(name: string): boolean {
 
 function readBundledFloorBytes(): Buffer {
   return fs.readFileSync(path.join(bundledFloorDir(), "templates.zip"));
+}
+
+async function readSnapshotBytes(
+  snapshot: TemplateArtifactSnapshot,
+  kind: TemplateArtifactKind
+): Promise<Result<Buffer, FxError>> {
+  return snapshot.bytes(kind);
 }
 
 function surfaceOf(platform: Platform | undefined): string {
@@ -80,19 +103,45 @@ export async function modifyProjectFrontDoor(
 ): Promise<Result<undefined, FxError>> {
   const flagReader = deps.flagReader ?? defaultFlagReader;
   const ui = deps.ui ?? TOOLS.ui;
-  let floorBytes: Buffer;
-  try {
-    floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
-  } catch (error) {
-    return err(floorReadError(error));
+  let snapshot = deps.artifactSnapshot;
+  let floorBytes: Buffer | undefined;
+  let selectorBytes: Buffer;
+  if (snapshot === undefined && deps.resolveArtifactSnapshot !== undefined) {
+    const resolved = await deps.resolveArtifactSnapshot("modify-selector");
+    if (resolved.isErr()) {
+      return err(resolved.error);
+    }
+    snapshot = resolved.value;
+  }
+  if (snapshot === undefined) {
+    try {
+      floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
+    } catch (error) {
+      return err(floorReadError(error));
+    }
+    selectorBytes = floorBytes;
+  } else {
+    const selector = await readSnapshotBytes(snapshot, "modify-selector");
+    if (selector.isErr()) {
+      return err(selector.error);
+    }
+    selectorBytes = selector.value;
   }
   const surface = surfaceOf(inputs.platform);
   const runSelector = deps.runSelector ?? runModifySelector;
-  const target = await runSelector(floorBytes, ui, surface, {
+  const selectorDeps = {
     flagReader,
     interactive: !inputs.nonInteractive,
     prefilled: selectorPrefill,
-  });
+  };
+  const target =
+    snapshot === undefined
+      ? await runSelector(selectorBytes, ui, surface, selectorDeps)
+      : await runSelector(selectorBytes, ui, surface, {
+          ...selectorDeps,
+          selectorBytesKind: "json",
+          v4Registry: deps.v4Registry,
+        });
   if (target.isErr()) {
     return err(target.error);
   }
@@ -101,8 +150,25 @@ export async function modifyProjectFrontDoor(
     case "v4": {
       const runInputs = deps.runInputs ?? runCreateInputs;
       const locator: DeclarativeLocator = { kind: "modify", templateId: target.value.templateId };
+      let inputBytes: Buffer;
+      if (snapshot === undefined) {
+        if (floorBytes === undefined) {
+          try {
+            floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
+          } catch (error) {
+            return err(floorReadError(error));
+          }
+        }
+        inputBytes = floorBytes;
+      } else {
+        const metadataBytes = await readSnapshotBytes(snapshot, "metadata");
+        if (metadataBytes.isErr()) {
+          return err(metadataBytes.error);
+        }
+        inputBytes = metadataBytes.value;
+      }
       const answers = await runInputs(
-        floorBytes,
+        inputBytes,
         locator,
         { ...(target.value.answers ?? {}), ...entryParams },
         ui,
@@ -110,6 +176,16 @@ export async function modifyProjectFrontDoor(
       );
       if (answers.isErr()) {
         return err(answers.error);
+      }
+      if (snapshot !== undefined) {
+        const fullBytes = await readSnapshotBytes(snapshot, "templates");
+        if (fullBytes.isErr()) {
+          return err(fullBytes.error);
+        }
+        return deps.scaffoldV4(inputs, target.value, answers.value, {
+          source: templateSourceFromArtifactSnapshot(snapshot),
+          bytes: fullBytes.value,
+        });
       }
       return deps.scaffoldV4(inputs, target.value, answers.value);
     }

--- a/packages/fx-core/src/core/v4ArtifactSnapshot.ts
+++ b/packages/fx-core/src/core/v4ArtifactSnapshot.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { FxError } from "@microsoft/teamsfx-api";
+import { Result } from "neverthrow";
+import templateConfig from "../common/templates-config.json";
+import { defaultTryLimits } from "../component/generator/constant";
+import {
+  TemplateArtifactKind,
+  TemplateArtifactSnapshot,
+  createTemplateArtifactPort,
+  loadBundledTemplateArtifacts,
+  resolveTemplateArtifactSnapshot,
+} from "../v4";
+
+export function resolveV4TemplateArtifactSnapshot(
+  requiredKind: TemplateArtifactKind
+): Promise<Result<TemplateArtifactSnapshot, FxError>> {
+  const port = createTemplateArtifactPort(
+    {
+      templatesV4TagListURL: templateConfig.templatesV4TagListURL,
+      templateDownloadBaseURL: templateConfig.templateDownloadBaseURL,
+      tryLimits: defaultTryLimits,
+    },
+    loadBundledTemplateArtifacts()
+  );
+  return resolveTemplateArtifactSnapshot({
+    range: templateConfig.v4.range,
+    bundled: templateConfig.v4.bundled,
+    requiredKind,
+    port,
+  });
+}

--- a/packages/fx-core/src/v4/buildTarget/resolveBuildTarget.ts
+++ b/packages/fx-core/src/v4/buildTarget/resolveBuildTarget.ts
@@ -41,6 +41,17 @@ export interface SelectorSpec {
   routes: SelectorRoute[];
 }
 
+/** Build a v4 membership test from the selector's own v4 routes. */
+export function v4RouteRegistryFromSelector(spec: SelectorSpec): (templateId: string) => boolean {
+  const templateIds = new Set<string>();
+  for (const route of spec.routes) {
+    if (route.engine === "v4" && route.templateId !== undefined) {
+      templateIds.add(route.templateId);
+    }
+  }
+  return (templateId: string) => templateIds.has(templateId);
+}
+
 /** One interactive Q1 prompt outcome. */
 export type PromptResult = { kind: "value"; value: string } | { kind: "back" };
 

--- a/packages/fx-core/src/v4/distribution/bundledFloor.ts
+++ b/packages/fx-core/src/v4/distribution/bundledFloor.ts
@@ -5,6 +5,12 @@ import { SystemError } from "@microsoft/teamsfx-api";
 import * as fs from "fs-extra";
 import * as path from "path";
 import { getTemplatesFolder } from "../../folder";
+import {
+  BundledTemplateArtifacts,
+  TemplateArtifactKind,
+  artifactFileName,
+  computeArtifactDigest,
+} from "./templateArtifacts";
 import { BundledFloor, computeDigest } from "./templateSource";
 
 /** Bundled v4 template floor for offline-by-default resolution. */
@@ -68,4 +74,55 @@ export function loadBundledFloor(floorDir: string = bundledFloorDir()): BundledF
   }
 
   return bundledFloorFrom(manifest.version, bytes, zipPath);
+}
+
+function bundledArtifactDigest(floorDir: string, kind: TemplateArtifactKind): string {
+  const location = path.join(floorDir, artifactFileName(kind));
+  try {
+    return computeArtifactDigest(fs.readFileSync(location));
+  } catch {
+    throw new SystemError({
+      source: SOURCE,
+      name: "BundledTemplateArtifactMissing",
+      message: `The bundled v4 template artifact is missing or unreadable at "${location}".`,
+    });
+  }
+}
+
+/** Load the baked staged artifacts used by the final v4 distribution resolver. */
+export function loadBundledTemplateArtifacts(
+  floorDir: string = bundledFloorDir()
+): BundledTemplateArtifacts {
+  const floor = loadBundledFloor(floorDir);
+  const createSelectorFile = artifactFileName("create-selector");
+  const modifySelectorFile = artifactFileName("modify-selector");
+  const metadataFile = artifactFileName("metadata");
+  const templatesFile = artifactFileName("templates");
+  return {
+    version: floor.version,
+    artifacts: {
+      "create-selector": {
+        kind: "create-selector",
+        file: createSelectorFile,
+        digest: bundledArtifactDigest(floorDir, "create-selector"),
+      },
+      "modify-selector": {
+        kind: "modify-selector",
+        file: modifySelectorFile,
+        digest: bundledArtifactDigest(floorDir, "modify-selector"),
+      },
+      metadata: {
+        kind: "metadata",
+        file: metadataFile,
+        digest: bundledArtifactDigest(floorDir, "metadata"),
+      },
+      templates: { kind: "templates", file: templatesFile, digest: floor.digest },
+    },
+    locations: {
+      "create-selector": path.join(floorDir, createSelectorFile),
+      "modify-selector": path.join(floorDir, modifySelectorFile),
+      metadata: path.join(floorDir, metadataFile),
+      templates: floor.location,
+    },
+  };
 }

--- a/packages/fx-core/src/v4/distribution/createSelector.ts
+++ b/packages/fx-core/src/v4/distribution/createSelector.ts
@@ -11,19 +11,36 @@ import {
   parseSelectorSpec,
 } from "../buildTarget/parseSelector";
 
-/** Load the bundled-floor create selector. See resolve-build-target spec. */
+/** Load the v4 create/modify selectors. See resolve-build-target spec. */
 
 const SOURCE = "Scaffold";
 
-type SelectorKind = "create" | "modify";
+export type SelectorKind = "create" | "modify";
 
 /** The selector's fixed entry path inside the channel `templates.zip`. */
 function selectorEntry(kind: SelectorKind): string {
   return `v4/${kind}/selector.json`;
 }
 
-/** Read and JSON-parse the single selector entry shared by both projections. */
-function readSelectorRaw(bytes: Buffer, kind: SelectorKind): Result<unknown, FxError> {
+function parseSelectorJson(selectorRaw: string, sourcePath: string): Result<unknown, FxError> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(selectorRaw);
+  } catch {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "PackageFileInvalid",
+        message: `The template package file "${sourcePath}" is not valid JSON.`,
+      })
+    );
+  }
+
+  return ok(parsed);
+}
+
+/** Read and JSON-parse the single selector entry from the full package zip. */
+function readSelectorRawFromZip(bytes: Buffer, kind: SelectorKind): Result<unknown, FxError> {
   let zip: AdmZip;
   try {
     zip = new AdmZip(bytes);
@@ -60,24 +77,11 @@ function readSelectorRaw(bytes: Buffer, kind: SelectorKind): Result<unknown, FxE
     );
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(selectorRaw);
-  } catch {
-    return err(
-      new SystemError({
-        source: SOURCE,
-        name: "PackageFileInvalid",
-        message: `The template package file "${selectorPath}" is not valid JSON.`,
-      })
-    );
-  }
-
-  return ok(parsed);
+  return parseSelectorJson(selectorRaw, selectorPath);
 }
 
 export function openSelector(bytes: Buffer, kind: SelectorKind): Result<SelectorSpec, FxError> {
-  const raw = readSelectorRaw(bytes, kind);
+  const raw = readSelectorRawFromZip(bytes, kind);
   if (raw.isErr()) {
     return err(raw.error);
   }
@@ -88,7 +92,31 @@ export function openSelectorPresentation(
   bytes: Buffer,
   kind: SelectorKind
 ): Result<SelectorPresentation, FxError> {
-  const raw = readSelectorRaw(bytes, kind);
+  const raw = readSelectorRawFromZip(bytes, kind);
+  if (raw.isErr()) {
+    return err(raw.error);
+  }
+  return parseSelectorPresentation(raw.value);
+}
+
+export function openSelectorFromJsonBytes(
+  bytes: Buffer,
+  kind: SelectorKind
+): Result<SelectorSpec, FxError> {
+  const selectorPath = selectorEntry(kind);
+  const raw = parseSelectorJson(bytes.toString("utf8"), selectorPath);
+  if (raw.isErr()) {
+    return err(raw.error);
+  }
+  return parseSelectorSpec(raw.value);
+}
+
+export function openSelectorPresentationFromJsonBytes(
+  bytes: Buffer,
+  kind: SelectorKind
+): Result<SelectorPresentation, FxError> {
+  const selectorPath = selectorEntry(kind);
+  const raw = parseSelectorJson(bytes.toString("utf8"), selectorPath);
   if (raw.isErr()) {
     return err(raw.error);
   }

--- a/packages/fx-core/src/v4/distribution/declarativePackage.ts
+++ b/packages/fx-core/src/v4/distribution/declarativePackage.ts
@@ -4,6 +4,7 @@
 import { FxError, SystemError } from "@microsoft/teamsfx-api";
 import AdmZip from "adm-zip";
 import { Result, err, ok } from "neverthrow";
+import { QuestionSpec } from "../collectInputs/collectInputs";
 import { DeclarativeLocator, TemplateFileEntry } from "../model/dataModel";
 import { LoadedPackage } from "./packageDir";
 
@@ -46,14 +47,56 @@ function missingFile(file: string): FxError {
   });
 }
 
-/** Open the channel package and return the located declarative package. */
-export function openDeclarativePackage(
-  bytes: Buffer,
-  locator: DeclarativeLocator
-): Result<LoadedPackage, FxError> {
-  let zip: AdmZip;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const QUESTION_TYPES: ReadonlySet<string> = new Set([
+  "singleSelect",
+  "multiSelect",
+  "text",
+  "confirm",
+  "singleFile",
+  "folder",
+  "singleFileOrText",
+]);
+
+function isQuestionSpecArray(value: unknown): value is QuestionSpec[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        isRecord(item) &&
+        typeof item.name === "string" &&
+        typeof item.type === "string" &&
+        QUESTION_TYPES.has(item.type)
+    )
+  );
+}
+
+function parseQuestions(raw: unknown, file: string): Result<QuestionSpec[], FxError> {
+  if (!isRecord(raw) || !isQuestionSpecArray(raw.questions)) {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "PackageFileInvalid",
+        message: `The template package file "${file}" must be an object with a "questions" array.`,
+      })
+    );
+  }
+  return ok(raw.questions);
+}
+
+interface PackageMetadataEntries {
+  descriptorRaw?: string;
+  questionsRaw?: string;
+  pipelineRaw?: string;
+  content: TemplateFileEntry[];
+}
+
+function openZip(bytes: Buffer): Result<AdmZip, FxError> {
   try {
-    zip = new AdmZip(bytes);
+    return ok(new AdmZip(bytes));
   } catch {
     return err(
       new SystemError({
@@ -63,12 +106,16 @@ export function openDeclarativePackage(
       })
     );
   }
+}
 
+function readPackageEntries(
+  zip: AdmZip,
+  locator: DeclarativeLocator,
+  includeContent: boolean
+): Result<PackageMetadataEntries, FxError> {
   const root = packageRoot(locator);
   const contentPrefix = `${root}content/`;
-  let descriptorRaw: string | undefined;
-  let pipelineRaw: string | undefined;
-  const content: TemplateFileEntry[] = [];
+  const entries: PackageMetadataEntries = { content: [] };
 
   for (const entry of zip.getEntries()) {
     if (entry.isDirectory) {
@@ -79,6 +126,9 @@ export function openDeclarativePackage(
       continue;
     }
     if (name.startsWith(contentPrefix)) {
+      if (!includeContent) {
+        continue;
+      }
       const rel = name.slice(contentPrefix.length);
       if (!isSafeRelativePath(rel)) {
         return err(
@@ -89,33 +139,105 @@ export function openDeclarativePackage(
           })
         );
       }
-      content.push({ path: rel, data: entry.getData() });
+      entries.content.push({ path: rel, data: entry.getData() });
       continue;
     }
     const rel = name.slice(root.length);
     if (rel === "descriptor.json") {
-      descriptorRaw = entry.getData().toString("utf8");
+      entries.descriptorRaw = entry.getData().toString("utf8");
+    } else if (rel === "questions.json") {
+      entries.questionsRaw = entry.getData().toString("utf8");
     } else if (rel === "pipeline.json") {
-      pipelineRaw = entry.getData().toString("utf8");
+      entries.pipelineRaw = entry.getData().toString("utf8");
     }
-    // Other root-level files (e.g. questions.json) are not part of LoadedPackage.
   }
 
-  if (descriptorRaw === undefined) {
+  entries.content.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return ok(entries);
+}
+
+export interface LoadedPackageMetadata {
+  descriptor: unknown;
+  questions: QuestionSpec[];
+  pipeline: unknown;
+}
+
+/** Open the channel package and return the located declarative package. */
+export function openDeclarativePackage(
+  bytes: Buffer,
+  locator: DeclarativeLocator
+): Result<LoadedPackage, FxError> {
+  const zip = openZip(bytes);
+  if (zip.isErr()) {
+    return err(zip.error);
+  }
+  const root = packageRoot(locator);
+  const entries = readPackageEntries(zip.value, locator, true);
+  if (entries.isErr()) {
+    return err(entries.error);
+  }
+
+  if (entries.value.descriptorRaw === undefined) {
     return err(missingFile(`${root}descriptor.json`));
   }
-  if (pipelineRaw === undefined) {
+  if (entries.value.pipelineRaw === undefined) {
     return err(missingFile(`${root}pipeline.json`));
   }
-  const descriptor = parseEntryJson(descriptorRaw, `${root}descriptor.json`);
+  const descriptor = parseEntryJson(entries.value.descriptorRaw, `${root}descriptor.json`);
   if (descriptor.isErr()) {
     return err(descriptor.error);
   }
-  const pipeline = parseEntryJson(pipelineRaw, `${root}pipeline.json`);
+  const pipeline = parseEntryJson(entries.value.pipelineRaw, `${root}pipeline.json`);
   if (pipeline.isErr()) {
     return err(pipeline.error);
   }
 
-  content.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
-  return ok({ descriptor: descriptor.value, pipeline: pipeline.value, content });
+  return ok({
+    descriptor: descriptor.value,
+    pipeline: pipeline.value,
+    content: entries.value.content,
+  });
+}
+
+export function openDeclarativePackageMetadata(
+  bytes: Buffer,
+  locator: DeclarativeLocator
+): Result<LoadedPackageMetadata, FxError> {
+  const zip = openZip(bytes);
+  if (zip.isErr()) {
+    return err(zip.error);
+  }
+  const root = packageRoot(locator);
+  const entries = readPackageEntries(zip.value, locator, false);
+  if (entries.isErr()) {
+    return err(entries.error);
+  }
+  if (entries.value.descriptorRaw === undefined) {
+    return err(missingFile(`${root}descriptor.json`));
+  }
+  if (entries.value.questionsRaw === undefined) {
+    return err(missingFile(`${root}questions.json`));
+  }
+  if (entries.value.pipelineRaw === undefined) {
+    return err(missingFile(`${root}pipeline.json`));
+  }
+
+  const descriptor = parseEntryJson(entries.value.descriptorRaw, `${root}descriptor.json`);
+  if (descriptor.isErr()) {
+    return err(descriptor.error);
+  }
+  const questionsRaw = parseEntryJson(entries.value.questionsRaw, `${root}questions.json`);
+  if (questionsRaw.isErr()) {
+    return err(questionsRaw.error);
+  }
+  const questions = parseQuestions(questionsRaw.value, `${root}questions.json`);
+  if (questions.isErr()) {
+    return err(questions.error);
+  }
+  const pipeline = parseEntryJson(entries.value.pipelineRaw, `${root}pipeline.json`);
+  if (pipeline.isErr()) {
+    return err(pipeline.error);
+  }
+
+  return ok({ descriptor: descriptor.value, questions: questions.value, pipeline: pipeline.value });
 }

--- a/packages/fx-core/src/v4/distribution/templateArtifacts.ts
+++ b/packages/fx-core/src/v4/distribution/templateArtifacts.ts
@@ -1,0 +1,621 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { FxError, SystemError, UserError } from "@microsoft/teamsfx-api";
+import axios, { AxiosResponse } from "axios";
+import * as fs from "fs-extra";
+import { Result, err, ok } from "neverthrow";
+import * as path from "path";
+import os from "os";
+import semver from "semver";
+import { sendRequestWithRetry } from "../../common/requestUtils";
+import { TemplateSource, computeDigest } from "./templateSource";
+
+/** Shared v4 staged artifact distribution model. */
+
+const SOURCE = "Scaffold";
+
+// eslint-disable-next-line no-secrets/no-secrets
+const V4_TAG_PREFIX = "templates-v4@";
+
+export type TemplateArtifactKind = "create-selector" | "modify-selector" | "metadata" | "templates";
+
+export type TemplateArtifactOrigin = "bundled" | "online" | "cache" | "bundled-fallback";
+
+export interface TemplateArtifactRef {
+  kind: TemplateArtifactKind;
+  file: string;
+  digest: string;
+}
+
+export interface V4TemplateTagEntry {
+  version: string;
+  artifacts: Record<TemplateArtifactKind, TemplateArtifactRef>;
+}
+
+export interface CachedTemplateArtifact {
+  digest: string;
+  bytes: Buffer;
+}
+
+export interface BundledTemplateArtifacts {
+  version: string;
+  artifacts: Record<TemplateArtifactKind, TemplateArtifactRef>;
+  locations: Record<TemplateArtifactKind, string>;
+}
+
+export interface TemplateArtifactPort {
+  env(name: string): string | undefined;
+  tagList(): Promise<V4TemplateTagEntry[]>;
+  download(version: string, ref: TemplateArtifactRef): Promise<Buffer>;
+  cache: {
+    get(version: string, kind: TemplateArtifactKind): CachedTemplateArtifact | undefined;
+    put(version: string, kind: TemplateArtifactKind, digest: string, bytes: Buffer): void;
+    keys(kind: TemplateArtifactKind): string[];
+    delete(version: string, kind: TemplateArtifactKind): void;
+  };
+  bundled: BundledTemplateArtifacts;
+}
+
+export interface TemplateArtifactSnapshot {
+  version: string;
+  origin: TemplateArtifactOrigin;
+  artifacts: Record<TemplateArtifactKind, TemplateArtifactRef>;
+  bytes(kind: TemplateArtifactKind): Promise<Result<Buffer, FxError>>;
+}
+
+export interface ResolveTemplateArtifactSnapshotInput {
+  range: string;
+  bundled: boolean;
+  requiredKind: TemplateArtifactKind;
+  port: TemplateArtifactPort;
+}
+
+export interface TemplateArtifactChannelConfig {
+  templatesV4TagListURL: string;
+  templateDownloadBaseURL: string;
+  tryLimits: number;
+}
+
+export const computeArtifactDigest = computeDigest;
+
+export function templateSourceFromArtifactSnapshot(
+  snapshot: TemplateArtifactSnapshot
+): TemplateSource {
+  const templates = snapshot.artifacts.templates;
+  return {
+    origin: snapshot.origin,
+    version: snapshot.version,
+    digest: templates.digest,
+    location: templates.file,
+  };
+}
+
+export function artifactUrl(baseURL: string, version: string, ref: TemplateArtifactRef): string {
+  return `${baseURL}/${V4_TAG_PREFIX}${version}/${ref.file}`;
+}
+
+export function artifactCacheFile(version: string, kind: TemplateArtifactKind): string {
+  return path.join(artifactCacheVersionDir(version), artifactFileName(kind));
+}
+
+export function parseArtifactTagList(ndjson: string): V4TemplateTagEntry[] {
+  const entries: V4TemplateTagEntry[] = [];
+  const lines = ndjson.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].replace(/\r$/, "").trim();
+    if (line.length === 0) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw malformedTagList(i, "not valid JSON");
+    }
+    const entry = readTagEntry(parsed);
+    if (!entry) {
+      throw malformedTagList(i, "missing final v4 staged artifacts");
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+export async function resolveTemplateArtifactSnapshot(
+  input: ResolveTemplateArtifactSnapshotInput
+): Promise<Result<TemplateArtifactSnapshot, FxError>> {
+  const { range, bundled, requiredKind, port } = input;
+  if (bundled || port.env("TEMPLATE_VERSION") === "local") {
+    return ok(bundledSnapshot(port));
+  }
+
+  let tags: V4TemplateTagEntry[];
+  const templateVersion = port.env("TEMPLATE_VERSION");
+  try {
+    tags = await port.tagList();
+  } catch (e) {
+    if (e instanceof UserError || e instanceof SystemError) {
+      return err(e);
+    }
+    if (templateVersion) {
+      return err(asTagListError(e));
+    }
+    return fallbackSnapshot(range, port);
+  }
+
+  const entryResult = templateVersion
+    ? pinnedEntry(templateVersion, tags)
+    : rangedEntry(range, tags);
+  if (entryResult.isErr()) {
+    return err(entryResult.error);
+  }
+
+  const entry = entryResult.value;
+  const artifactResult = await ensureCachedArtifact(entry, requiredKind, port, templateVersion);
+  if (artifactResult.isErr()) {
+    return err(artifactResult.error);
+  }
+
+  return ok(onlineSnapshot(entry, artifactResult.value, port, templateVersion));
+}
+
+function readTagEntry(value: unknown): V4TemplateTagEntry | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+  const version = Reflect.get(value, "version");
+  const artifacts = Reflect.get(value, "artifacts");
+  if (typeof version !== "string" || !isObject(artifacts) || Reflect.has(value, "digest")) {
+    return undefined;
+  }
+
+  const createSelector = readArtifactRef(artifacts, "create-selector");
+  const modifySelector = readArtifactRef(artifacts, "modify-selector");
+  const metadata = readArtifactRef(artifacts, "metadata");
+  const templates = readArtifactRef(artifacts, "templates");
+  if (!createSelector || !modifySelector || !metadata || !templates) {
+    return undefined;
+  }
+
+  return {
+    version,
+    artifacts: {
+      "create-selector": createSelector,
+      "modify-selector": modifySelector,
+      metadata,
+      templates,
+    },
+  };
+}
+
+function readArtifactRef(
+  artifacts: object,
+  kind: TemplateArtifactKind
+): TemplateArtifactRef | undefined {
+  const value = Reflect.get(artifacts, kind);
+  if (!isObject(value)) {
+    return undefined;
+  }
+  const file = Reflect.get(value, "file");
+  const digest = Reflect.get(value, "digest");
+  if (file !== artifactFileName(kind) || typeof digest !== "string") {
+    return undefined;
+  }
+  return { kind, file, digest };
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+function malformedTagList(lineIndex: number, reason: string): SystemError {
+  return new SystemError({
+    source: SOURCE,
+    name: "TemplateTagListMalformed",
+    message: `Malformed v4 tag-list entry on line ${lineIndex + 1}: ${reason}.`,
+  });
+}
+
+export function artifactFileName(kind: TemplateArtifactKind): string {
+  switch (kind) {
+    case "create-selector":
+      return "create-selector.json";
+    case "modify-selector":
+      return "modify-selector.json";
+    case "metadata":
+      return "templates-metadata.zip";
+    case "templates":
+      return "templates.zip";
+  }
+}
+
+function artifactCacheVersionDir(version: string): string {
+  return path.join(artifactCacheRootDir(), `${V4_TAG_PREFIX}${version}`);
+}
+
+function artifactCacheRootDir(): string {
+  return path.join(os.homedir(), ".fx", "templates-cache");
+}
+
+function pinnedEntry(
+  version: string,
+  tags: V4TemplateTagEntry[]
+): Result<V4TemplateTagEntry, FxError> {
+  const entry = tags.find((t) => t.version === version);
+  if (!entry) {
+    return err(
+      new UserError({
+        source: SOURCE,
+        name: "TemplatePinnedVersionNotFound",
+        message: `Pinned template version "${version}" is not published on the release channel.`,
+      })
+    );
+  }
+  return ok(entry);
+}
+
+function rangedEntry(
+  range: string,
+  tags: V4TemplateTagEntry[]
+): Result<V4TemplateTagEntry, FxError> {
+  const picked = semver.maxSatisfying(
+    tags.map((t) => t.version),
+    range
+  );
+  if (!picked) {
+    return err(
+      new UserError({
+        source: SOURCE,
+        name: "TemplateVersionMismatch",
+        message: `No published template version satisfies range "${range}".`,
+      })
+    );
+  }
+  const entry = tags.find((t) => t.version === picked);
+  if (!entry) {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "TemplateTagListInconsistent",
+        message: `Resolved version "${picked}" is no longer present in the tag list.`,
+      })
+    );
+  }
+  return ok(entry);
+}
+
+async function ensureCachedArtifact(
+  entry: V4TemplateTagEntry,
+  kind: TemplateArtifactKind,
+  port: TemplateArtifactPort,
+  protectedVersion?: string
+): Promise<Result<"online" | "cache", FxError>> {
+  const ref = entry.artifacts[kind];
+  const cached = port.cache.get(entry.version, kind);
+  if (cached && cached.digest === ref.digest) {
+    return ok("cache");
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = await port.download(entry.version, ref);
+  } catch (e) {
+    return err(asDownloadError(e, entry.version, kind));
+  }
+
+  const digest = computeArtifactDigest(bytes);
+  if (digest !== ref.digest) {
+    return err(
+      new SystemError({
+        source: SOURCE,
+        name: "TemplateDigestMismatch",
+        message: `Downloaded template artifact "${kind}" for "${entry.version}" failed integrity check: expected ${ref.digest}, got ${digest}.`,
+      })
+    );
+  }
+
+  try {
+    port.cache.put(entry.version, kind, ref.digest, bytes);
+  } catch (e) {
+    return err(asCacheWriteError(e, entry.version, kind));
+  }
+  gcOlderVersionsForLine(entry.version, kind, port, protectedVersion);
+  return ok("online");
+}
+
+function onlineSnapshot(
+  entry: V4TemplateTagEntry,
+  origin: "online" | "cache",
+  port: TemplateArtifactPort,
+  protectedVersion?: string
+): TemplateArtifactSnapshot {
+  return {
+    version: entry.version,
+    origin,
+    artifacts: entry.artifacts,
+    bytes: async (kind: TemplateArtifactKind): Promise<Result<Buffer, FxError>> => {
+      const artifactResult = await ensureCachedArtifact(entry, kind, port, protectedVersion);
+      if (artifactResult.isErr()) {
+        return err(artifactResult.error);
+      }
+      const cached = port.cache.get(entry.version, kind);
+      if (!cached) {
+        return err(
+          new SystemError({
+            source: SOURCE,
+            name: "TemplateArtifactNotCached",
+            message: `Template artifact "${kind}" for "${entry.version}" is not present in the local cache.`,
+          })
+        );
+      }
+      return ok(cached.bytes);
+    },
+  };
+}
+
+function bundledSnapshot(
+  port: TemplateArtifactPort,
+  origin: TemplateArtifactOrigin = "bundled"
+): TemplateArtifactSnapshot {
+  return {
+    version: port.bundled.version,
+    origin,
+    artifacts: port.bundled.artifacts,
+    bytes: (kind: TemplateArtifactKind): Promise<Result<Buffer, FxError>> => {
+      const location = port.bundled.locations[kind];
+      try {
+        return Promise.resolve(ok(fs.readFileSync(location)));
+      } catch {
+        return Promise.resolve(
+          err(
+            new SystemError({
+              source: SOURCE,
+              name: "BundledArtifactUnreadable",
+              message: `The bundled template artifact "${kind}" is missing or unreadable.`,
+            })
+          )
+        );
+      }
+    },
+  };
+}
+
+function gcOlderVersionsForLine(
+  version: string,
+  kind: TemplateArtifactKind,
+  port: TemplateArtifactPort,
+  protectedVersion?: string
+): void {
+  const parsed = semver.parse(version);
+  if (!parsed) {
+    return;
+  }
+  const versionsInLine = port.cache.keys(kind).filter((candidate) => {
+    const candidateVersion = semver.parse(candidate);
+    return (
+      candidateVersion !== null &&
+      candidateVersion.major === parsed.major &&
+      candidateVersion.minor === parsed.minor
+    );
+  });
+  const highest = semver.maxSatisfying(versionsInLine, `${parsed.major}.${parsed.minor}.x`);
+  if (!highest) {
+    return;
+  }
+  for (const candidate of versionsInLine) {
+    if (candidate !== highest && candidate !== protectedVersion) {
+      port.cache.delete(candidate, kind);
+    }
+  }
+}
+
+function fallbackSnapshot(
+  range: string,
+  port: TemplateArtifactPort
+): Result<TemplateArtifactSnapshot, FxError> {
+  const cached = highestCompleteCachedVersion(range, port);
+  const floorSatisfies = semver.satisfies(port.bundled.version, range);
+  if (cached && (!floorSatisfies || semver.gt(cached.version, port.bundled.version))) {
+    return ok(cachedSnapshot(cached.version, port));
+  }
+  if (floorSatisfies) {
+    return ok(bundledSnapshot(port, "bundled-fallback"));
+  }
+  return err(
+    new UserError({
+      source: SOURCE,
+      name: "TemplateVersionMismatch",
+      message: `No cached or bundled template artifact version satisfies range "${range}".`,
+    })
+  );
+}
+
+function highestCompleteCachedVersion(
+  range: string,
+  port: TemplateArtifactPort
+): { version: string } | undefined {
+  const kinds: TemplateArtifactKind[] = [
+    "create-selector",
+    "modify-selector",
+    "metadata",
+    "templates",
+  ];
+  const versions = port.cache
+    .keys("templates")
+    .filter((version) => kinds.every((kind) => port.cache.get(version, kind) !== undefined));
+  const picked = semver.maxSatisfying(versions, range);
+  return picked ? { version: picked } : undefined;
+}
+
+function cachedSnapshot(version: string, port: TemplateArtifactPort): TemplateArtifactSnapshot {
+  const artifacts: Record<TemplateArtifactKind, TemplateArtifactRef> = {
+    "create-selector": cachedRef(version, "create-selector", port),
+    "modify-selector": cachedRef(version, "modify-selector", port),
+    metadata: cachedRef(version, "metadata", port),
+    templates: cachedRef(version, "templates", port),
+  };
+  return {
+    version,
+    origin: "cache",
+    artifacts,
+    bytes: (kind: TemplateArtifactKind): Promise<Result<Buffer, FxError>> => {
+      const cached = port.cache.get(version, kind);
+      if (!cached) {
+        return Promise.resolve(
+          err(
+            new SystemError({
+              source: SOURCE,
+              name: "TemplateArtifactNotCached",
+              message: `Template artifact "${kind}" for "${version}" is not present in the local cache.`,
+            })
+          )
+        );
+      }
+      return Promise.resolve(ok(cached.bytes));
+    },
+  };
+}
+
+function cachedRef(
+  version: string,
+  kind: TemplateArtifactKind,
+  port: TemplateArtifactPort
+): TemplateArtifactRef {
+  const cached = port.cache.get(version, kind);
+  return { kind, file: artifactFileName(kind), digest: cached?.digest ?? "" };
+}
+
+function asTagListError(e: unknown): FxError {
+  if (e instanceof UserError || e instanceof SystemError) {
+    return e;
+  }
+  const message = e instanceof Error ? e.message : String(e);
+  return new SystemError({
+    source: SOURCE,
+    name: "TemplateTagListUnavailable",
+    message: `Failed to read the template release channel: ${message}.`,
+  });
+}
+
+function asDownloadError(e: unknown, version: string, kind: TemplateArtifactKind): FxError {
+  if (e instanceof UserError || e instanceof SystemError) {
+    return e;
+  }
+  const message = e instanceof Error ? e.message : String(e);
+  return new SystemError({
+    source: SOURCE,
+    name: "TemplateDownloadFailed",
+    message: `Failed to download template artifact "${kind}" for "${version}" from the release channel: ${message}.`,
+  });
+}
+
+function asCacheWriteError(e: unknown, version: string, kind: TemplateArtifactKind): FxError {
+  if (e instanceof UserError || e instanceof SystemError) {
+    return e;
+  }
+  const message = e instanceof Error ? e.message : String(e);
+  return new SystemError({
+    source: SOURCE,
+    name: "TemplateArtifactCacheWriteFailed",
+    message: `Failed to cache template artifact "${kind}" for "${version}": ${message}.`,
+  });
+}
+
+export function createTemplateArtifactPort(
+  config: TemplateArtifactChannelConfig,
+  bundled: BundledTemplateArtifacts
+): TemplateArtifactPort {
+  const memo = new Map<TemplateArtifactKind, Map<string, CachedTemplateArtifact>>();
+  const warmed = new Set<TemplateArtifactKind>();
+
+  function artifactMap(kind: TemplateArtifactKind): Map<string, CachedTemplateArtifact> {
+    let map = memo.get(kind);
+    if (map === undefined) {
+      map = new Map<string, CachedTemplateArtifact>();
+      memo.set(kind, map);
+    }
+    return map;
+  }
+
+  function warm(kind: TemplateArtifactKind): void {
+    if (warmed.has(kind)) {
+      return;
+    }
+    warmed.add(kind);
+    let names: string[] = [];
+    try {
+      names = fs.readdirSync(artifactCacheRootDir());
+    } catch {
+      return;
+    }
+    const fileName = artifactFileName(kind);
+    for (const name of names) {
+      if (!name.startsWith(V4_TAG_PREFIX)) {
+        continue;
+      }
+      const version = name.slice(V4_TAG_PREFIX.length);
+      const filePath = path.join(artifactCacheRootDir(), name, fileName);
+      try {
+        const bytes = fs.readFileSync(filePath);
+        artifactMap(kind).set(version, { digest: computeArtifactDigest(bytes), bytes });
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return {
+    env: (name: string): string | undefined => process.env[name],
+
+    tagList: async (): Promise<V4TemplateTagEntry[]> => {
+      const res: AxiosResponse<string> = await sendRequestWithRetry(
+        () => axios.get(config.templatesV4TagListURL, { responseType: "text" }),
+        config.tryLimits
+      );
+      return parseArtifactTagList(res.data);
+    },
+
+    download: async (version: string, ref: TemplateArtifactRef): Promise<Buffer> => {
+      const res: AxiosResponse<ArrayBuffer> = await sendRequestWithRetry(
+        () =>
+          axios.get(artifactUrl(config.templateDownloadBaseURL, version, ref), {
+            responseType: "arraybuffer",
+          }),
+        config.tryLimits
+      );
+      return Buffer.from(res.data);
+    },
+
+    cache: {
+      get: (version: string, kind: TemplateArtifactKind): CachedTemplateArtifact | undefined => {
+        warm(kind);
+        return artifactMap(kind).get(version);
+      },
+      put: (version: string, kind: TemplateArtifactKind, digest: string, bytes: Buffer): void => {
+        const target = artifactCacheFile(version, kind);
+        fs.ensureDirSync(path.dirname(target));
+        const temp = `${target}.${process.pid}.${Date.now()}.tmp`;
+        fs.writeFileSync(temp, bytes);
+        fs.renameSync(temp, target);
+        artifactMap(kind).set(version, { digest, bytes });
+        warmed.add(kind);
+      },
+      keys: (kind: TemplateArtifactKind): string[] => {
+        warm(kind);
+        return [...artifactMap(kind).keys()];
+      },
+      delete: (version: string, kind: TemplateArtifactKind): void => {
+        const file = artifactCacheFile(version, kind);
+        try {
+          fs.removeSync(file);
+        } catch {
+          // Best-effort cache GC; an undeletable stale cache file should not fail resolution.
+        }
+        artifactMap(kind).delete(version);
+      },
+    },
+
+    bundled,
+  };
+}

--- a/packages/fx-core/src/v4/index.ts
+++ b/packages/fx-core/src/v4/index.ts
@@ -6,6 +6,7 @@
 export * from "./model/dataModel";
 export * from "./distribution/templateSource";
 export * from "./distribution/templateSourcePort";
+export * from "./distribution/templateArtifacts";
 export * from "./distribution/bundledFloor";
 export * from "./distribution/templateConfig";
 export * from "./distribution/templatePackage";

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -19,7 +19,7 @@ import {
   collectInputs,
 } from "../collectInputs/collectInputs";
 import { openCreateQuestions } from "../distribution/createQuestions";
-import { openDeclarativePackage } from "../distribution/declarativePackage";
+import { openDeclarativePackageMetadata } from "../distribution/declarativePackage";
 import { evaluateExpression } from "../expression/evaluateExpression";
 import { parseMcpStaticToolsJson } from "../mcp/mcpStaticTools";
 import { Answers, DeclarativeLocator } from "../model/dataModel";
@@ -284,12 +284,7 @@ export async function runCreateInputs(
   ui: UserInteraction,
   deps: CreateInputsDeps = {}
 ): Promise<Result<Answers, FxError>> {
-  const questions = openCreateQuestions(floorBytes, locator);
-  if (questions.isErr()) {
-    return err(questions.error);
-  }
-
-  const opened = openDeclarativePackage(floorBytes, locator);
+  const opened = openDeclarativePackageMetadata(floorBytes, locator);
   if (opened.isErr()) {
     return err(opened.error);
   }
@@ -310,7 +305,7 @@ export async function runCreateInputs(
   };
 
   return collectInputs(
-    questions.value,
+    opened.value.questions,
     declaredOptionsSchema(descriptor),
     entryParams,
     languages,

--- a/packages/fx-core/src/v4/surface/createSelectorWalk.ts
+++ b/packages/fx-core/src/v4/surface/createSelectorWalk.ts
@@ -14,8 +14,14 @@ import {
   RouteQuestion,
   RouteResolverPort,
   resolveBuildTarget,
+  v4RouteRegistryFromSelector,
 } from "../buildTarget/resolveBuildTarget";
-import { openCreateSelector, openCreateSelectorPresentation } from "../distribution/createSelector";
+import {
+  openCreateSelector,
+  openCreateSelectorPresentation,
+  openSelectorFromJsonBytes,
+  openSelectorPresentationFromJsonBytes,
+} from "../distribution/createSelector";
 import { openDeclarativePackage } from "../distribution/declarativePackage";
 import { ExpressionRuntimePort, Scope, evaluateExpression } from "../expression/evaluateExpression";
 import { readBooleanFeatureFlag } from "../../common/featureFlags";
@@ -28,6 +34,10 @@ const SOURCE = "Scaffold";
 export interface CreateSelectorDeps {
   /** The feature-flag reader (default: env-backed); v4 imports no `featureFlagManager`. */
   flagReader?: (name: string) => boolean;
+  /** Selector bytes shape. Defaults to the full package zip for current callers. */
+  selectorBytesKind?: "zip" | "json";
+  /** Membership test supplied by a staged artifact snapshot or metadata index. */
+  v4Registry?: (templateId: string) => boolean;
   /** Q1 answers known up front. */
   prefilled?: Record<string, string>;
   /** Whether unfilled required dimensions may be prompted. */
@@ -54,7 +64,8 @@ function buildPort(
   presentation: SelectorPresentation,
   ui: UserInteraction,
   surface: string,
-  flagReader: (name: string) => boolean
+  flagReader: (name: string) => boolean,
+  v4Registry: ((templateId: string) => boolean) | undefined
 ): RouteResolverPort {
   const exprPort: ExpressionRuntimePort = { functions: () => undefined, flags: flagReader };
   const byName = new Map<string, PresentationQuestion>(
@@ -114,6 +125,9 @@ function buildPort(
     prompt,
     featureFlag: flagReader,
     v4Registry(templateId: string): boolean {
+      if (v4Registry !== undefined) {
+        return v4Registry(templateId);
+      }
       return openDeclarativePackage(floorBytes, { kind: "create", templateId }).isOk();
     },
     v3Registry(): boolean {
@@ -133,17 +147,32 @@ export async function runCreateSelector(
   deps: CreateSelectorDeps = {}
 ): Promise<Result<BuildTarget, FxError>> {
   const flagReader = deps.flagReader ?? envFlagReader;
+  const selectorBytesKind = deps.selectorBytesKind ?? "zip";
   const prefilled = deps.prefilled ?? {};
   const interactive = deps.interactive ?? true;
-  const spec = openCreateSelector(floorBytes);
+  const spec =
+    selectorBytesKind === "json"
+      ? openSelectorFromJsonBytes(floorBytes, "create")
+      : openCreateSelector(floorBytes);
   if (spec.isErr()) {
     return err(spec.error);
   }
-  const presentation = openCreateSelectorPresentation(floorBytes);
+  const presentation =
+    selectorBytesKind === "json"
+      ? openSelectorPresentationFromJsonBytes(floorBytes, "create")
+      : openCreateSelectorPresentation(floorBytes);
   if (presentation.isErr()) {
     return err(presentation.error);
   }
-  const port = buildPort(floorBytes, presentation.value, ui, surface, flagReader);
+  const port = buildPort(
+    floorBytes,
+    presentation.value,
+    ui,
+    surface,
+    flagReader,
+    deps.v4Registry ??
+      (selectorBytesKind === "json" ? v4RouteRegistryFromSelector(spec.value) : undefined)
+  );
   try {
     return await resolveBuildTarget(spec.value, prefilled, interactive, port);
   } catch (e) {

--- a/packages/fx-core/src/v4/surface/modifySelectorWalk.ts
+++ b/packages/fx-core/src/v4/surface/modifySelectorWalk.ts
@@ -14,8 +14,14 @@ import {
   RouteQuestion,
   RouteResolverPort,
   resolveBuildTarget,
+  v4RouteRegistryFromSelector,
 } from "../buildTarget/resolveBuildTarget";
-import { openModifySelector, openModifySelectorPresentation } from "../distribution/createSelector";
+import {
+  openModifySelector,
+  openModifySelectorPresentation,
+  openSelectorFromJsonBytes,
+  openSelectorPresentationFromJsonBytes,
+} from "../distribution/createSelector";
 import { openDeclarativePackage } from "../distribution/declarativePackage";
 import { ExpressionRuntimePort, Scope, evaluateExpression } from "../expression/evaluateExpression";
 import { readBooleanFeatureFlag } from "../../common/featureFlags";
@@ -24,6 +30,8 @@ const SOURCE = "Scaffold";
 
 export interface ModifySelectorDeps {
   flagReader?: (name: string) => boolean;
+  selectorBytesKind?: "zip" | "json";
+  v4Registry?: (templateId: string) => boolean;
   prefilled?: Record<string, string>;
   interactive?: boolean;
 }
@@ -45,7 +53,8 @@ function buildPort(
   presentation: SelectorPresentation,
   ui: UserInteraction,
   surface: string,
-  flagReader: (name: string) => boolean
+  flagReader: (name: string) => boolean,
+  v4Registry: ((templateId: string) => boolean) | undefined
 ): RouteResolverPort {
   const exprPort: ExpressionRuntimePort = { functions: () => undefined, flags: flagReader };
   const byName = new Map<string, PresentationQuestion>(
@@ -105,6 +114,9 @@ function buildPort(
     prompt,
     featureFlag: flagReader,
     v4Registry(templateId: string): boolean {
+      if (v4Registry !== undefined) {
+        return v4Registry(templateId);
+      }
       return openDeclarativePackage(floorBytes, { kind: "modify", templateId }).isOk();
     },
     v3Registry(): boolean {
@@ -123,17 +135,32 @@ export async function runModifySelector(
   deps: ModifySelectorDeps = {}
 ): Promise<Result<BuildTarget, FxError>> {
   const flagReader = deps.flagReader ?? envFlagReader;
+  const selectorBytesKind = deps.selectorBytesKind ?? "zip";
   const prefilled = deps.prefilled ?? {};
   const interactive = deps.interactive ?? true;
-  const spec = openModifySelector(floorBytes);
+  const spec =
+    selectorBytesKind === "json"
+      ? openSelectorFromJsonBytes(floorBytes, "modify")
+      : openModifySelector(floorBytes);
   if (spec.isErr()) {
     return err(spec.error);
   }
-  const presentation = openModifySelectorPresentation(floorBytes);
+  const presentation =
+    selectorBytesKind === "json"
+      ? openSelectorPresentationFromJsonBytes(floorBytes, "modify")
+      : openModifySelectorPresentation(floorBytes);
   if (presentation.isErr()) {
     return err(presentation.error);
   }
-  const port = buildPort(floorBytes, presentation.value, ui, surface, flagReader);
+  const port = buildPort(
+    floorBytes,
+    presentation.value,
+    ui,
+    surface,
+    flagReader,
+    deps.v4Registry ??
+      (selectorBytesKind === "json" ? v4RouteRegistryFromSelector(spec.value) : undefined)
+  );
   try {
     return await resolveBuildTarget(spec.value, prefilled, interactive, port);
   } catch (e) {

--- a/packages/fx-core/tests/component/generator/v4MetadataSource.test.ts
+++ b/packages/fx-core/tests/component/generator/v4MetadataSource.test.ts
@@ -1,34 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FxError } from "@microsoft/teamsfx-api";
-import { Result } from "neverthrow";
 import templateConfig from "../../../src/common/templates-config.json";
 import { resolveV4MetadataSource } from "../../../src/component/generator/v4MetadataSource";
 import * as bundledFloor from "../../../src/v4/distribution/bundledFloor";
-import * as templateSource from "../../../src/v4/distribution/templateSource";
-import * as templateSourcePort from "../../../src/v4/distribution/templateSourcePort";
+import * as templateArtifacts from "../../../src/v4/distribution/templateArtifacts";
 import { assert } from "vitest";
 
 describe("resolveV4MetadataSource", () => {
-  it("resolves through the same single decision point as the template package", async () => {
-    const floor = bundledFloor.loadBundledFloor();
-    const port = templateSourcePort.createTemplateSourcePort(
+  it("resolves the staged metadata artifact through the shared artifact resolver", async () => {
+    const bundled = bundledFloor.loadBundledTemplateArtifacts();
+    const port = templateArtifacts.createTemplateArtifactPort(
       {
         templatesV4TagListURL: templateConfig.templatesV4TagListURL,
         templateDownloadBaseURL: templateConfig.templateDownloadBaseURL,
       },
-      floor
+      bundled
     );
-    const expected: Result<templateSource.TemplateSource, FxError> =
-      await templateSource.resolveTemplateSource({
-        range: templateConfig.v4.range,
-        bundled: templateConfig.v4.bundled,
-        port,
-      });
+    const expected = await templateArtifacts.resolveTemplateArtifactSnapshot({
+      range: templateConfig.v4.range,
+      bundled: templateConfig.v4.bundled,
+      requiredKind: "metadata",
+      port,
+    });
 
     const result = await resolveV4MetadataSource();
 
-    assert.deepEqual(result, expected);
+    assert.isTrue(result.isOk());
+    assert.isTrue(expected.isOk());
+    if (result.isOk() && expected.isOk()) {
+      assert.equal(result.value.version, expected.value.version);
+      assert.equal(result.value.origin, expected.value.origin);
+      assert.deepEqual(result.value.artifacts.metadata, expected.value.artifacts.metadata);
+      const bytes = await result.value.bytes("metadata");
+      assert.isTrue(bytes.isOk());
+    }
   });
 });

--- a/packages/fx-core/tests/component/generator/v4TemplateBridge.test.ts
+++ b/packages/fx-core/tests/component/generator/v4TemplateBridge.test.ts
@@ -346,6 +346,45 @@ describe("v4TemplateBridge.scaffoldDeclarativeFromV4Channel", () => {
     assert.strictEqual(telemetryProps[TelemetryProperty.TemplatePackageVersion], "6.10.1");
   });
 
+  it("uses supplied staged package bytes without resolving the local channel", async () => {
+    const ctx = makeContext("da-mcp", tmpDir, {});
+    const stagedSource: TemplateSource = {
+      origin: "online",
+      version: "6.11.0",
+      digest: "sha256:staged",
+      location: "templates.zip",
+    };
+    const resolveLocal = vi
+      .spyOn(v4TemplateBridgeDeps, "resolveLocalTemplateSource")
+      .mockImplementation(() => {
+        throw new Error("local resolver must not run");
+      });
+    const loadResolved = vi
+      .spyOn(v4TemplateBridgeDeps, "loadResolvedPackage")
+      .mockImplementation(() => {
+        throw new Error("local package loader must not run");
+      });
+    const telemetryProps: Record<string, string> = {};
+
+    const result = await scaffoldDeclarativeFromV4Channel(
+      ctx,
+      locator,
+      { mcpServerType: "remote", mcpServerUrl: "https://api.github.com/mcp", authType: "none" },
+      { appName: "MyMcpAgent", language: "common" },
+      telemetryProps,
+      undefined,
+      { source: stagedSource, bytes: channelBytes() }
+    );
+
+    assert.deepEqual(result, stagedSource);
+    assert.equal(resolveLocal.mock.calls.length, 0);
+    assert.equal(loadResolved.mock.calls.length, 0);
+    assert.strictEqual(telemetryProps[TelemetryProperty.TemplatePackageSource], "online");
+    assert.strictEqual(telemetryProps[TelemetryProperty.TemplatePackageVersion], "6.11.0");
+    assert.strictEqual(telemetryProps[TelemetryProperty.TemplatePackageDigest], "sha256:staged");
+    assert.include(ctx.outputs ?? [], "appPackage/ai-plugin.json");
+  });
+
   it("threads the answers into the engine (oauth selects the vault auth block)", async () => {
     const ctx = makeContext("da-mcp", tmpDir, {});
     vi.spyOn(v4TemplateBridgeDeps, "resolveLocalTemplateSource").mockReturnValue(source);

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -14,7 +14,14 @@ import { Result, err, ok } from "neverthrow";
 import os from "os";
 import path from "path";
 import { assert } from "vitest";
-import { Answers, BuildTarget, DeclarativeLocator } from "../../src/v4";
+import {
+  Answers,
+  BuildTarget,
+  DeclarativeLocator,
+  TemplateArtifactKind,
+  TemplateArtifactSnapshot,
+} from "../../src/v4";
+import type { ResolvedV4ChannelPackage } from "../../src/component/generator/v4TemplateBridge";
 import { CreateFrontDoorDeps, createProjectFrontDoor } from "../../src/core/createProjectFrontDoor";
 import { FeatureFlags } from "../../src/common/featureFlags";
 import { QuestionNames } from "../../src/question/questionNames";
@@ -91,7 +98,8 @@ const okScaffold = (
   _inputs: Inputs,
   _target: BuildTarget,
   _answers: Answers,
-  _flagReader?: (name: string) => boolean
+  _flagReader?: (name: string) => boolean,
+  _resolvedPackage?: ResolvedV4ChannelPackage
 ): Promise<Result<CreateProjectResult, FxError>> => okResult("/v4");
 
 /** A typed `runCreateSelector` stub that records its `(floor, ui, surface, deps)` args. */
@@ -105,6 +113,8 @@ function selectorRecorder(target: BuildTarget) {
         flagReader?: (name: string) => boolean;
         interactive?: boolean;
         prefilled?: Record<string, string>;
+        selectorBytesKind?: "zip" | "json";
+        v4Registry?: (templateId: string) => boolean;
       }
     ): Promise<Result<BuildTarget, FxError>> => okTarget(target)
   );
@@ -123,6 +133,38 @@ function inputsRecorder(answers: Answers) {
   );
 }
 
+function artifactSnapshotRecorder(bytesByKind: Record<TemplateArtifactKind, Buffer>): {
+  snapshot: TemplateArtifactSnapshot;
+  calls: TemplateArtifactKind[];
+} {
+  const calls: TemplateArtifactKind[] = [];
+  return {
+    calls,
+    snapshot: {
+      version: "6.11.0",
+      origin: "online",
+      artifacts: {
+        "create-selector": {
+          kind: "create-selector",
+          file: "create-selector.json",
+          digest: "sha256:create",
+        },
+        "modify-selector": {
+          kind: "modify-selector",
+          file: "modify-selector.json",
+          digest: "sha256:modify",
+        },
+        metadata: { kind: "metadata", file: "templates-metadata.zip", digest: "sha256:metadata" },
+        templates: { kind: "templates", file: "templates.zip", digest: "sha256:templates" },
+      },
+      bytes(kind: TemplateArtifactKind): Promise<Result<Buffer, FxError>> {
+        calls.push(kind);
+        return Promise.resolve(ok(bytesByKind[kind]));
+      },
+    },
+  };
+}
+
 /** A typed `resolveCreateTargetByTemplateId` stub that records its `(floor, templateId)` args. */
 function resolveByTemplateIdRecorder(target: BuildTarget) {
   return recorder(
@@ -138,7 +180,8 @@ const failScaffoldV4 = (
   _inputs: Inputs,
   _target: BuildTarget,
   _answers: Answers,
-  _flagReader?: (name: string) => boolean
+  _flagReader?: (name: string) => boolean,
+  _resolvedPackage?: ResolvedV4ChannelPackage
 ): Promise<Result<CreateProjectResult, FxError>> => {
   throw new Error("scaffoldV4 must not run on this path");
 };
@@ -240,6 +283,57 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     assert.deepEqual(scaffoldV4.calls[0][1], V4_TARGET);
     assert.deepEqual(scaffoldV4.calls[0][2], q2);
     assert.strictEqual(scaffoldV4.calls[0][3], flagReader);
+  });
+
+  it("DCE-02b: interactive v4 uses one staged snapshot for selector, metadata, and templates", async () => {
+    const selectorBytes = Buffer.from("selector-json");
+    const metadataBytes = Buffer.from("metadata-zip");
+    const templatesBytes = Buffer.from("templates-zip");
+    const artifactSnapshot = artifactSnapshotRecorder({
+      "create-selector": selectorBytes,
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: metadataBytes,
+      templates: templatesBytes,
+    });
+    const runSelector = selectorRecorder(V4_TARGET);
+    const runInputs = inputsRecorder({ authType: "none" });
+    const scaffoldV4 = recorder(
+      (
+        _i: Inputs,
+        _t: BuildTarget,
+        _a: Answers,
+        _flagReader: (name: string) => boolean,
+        _resolvedPackage?: ResolvedV4ChannelPackage
+      ) => okResult("/v4")
+    );
+
+    const res = await createProjectFrontDoor(
+      baseInputs(),
+      deps({
+        artifactSnapshot: artifactSnapshot.snapshot,
+        v4Registry: () => true,
+        runSelector: runSelector.fn,
+        runInputs: runInputs.fn,
+        scaffoldV4: scaffoldV4.fn,
+        collectCreateFloor: okFloor,
+      })
+    );
+
+    assert.isTrue(res.isOk());
+    assert.deepEqual(artifactSnapshot.calls, ["create-selector", "metadata", "templates"]);
+    assert.strictEqual(runSelector.calls[0][0], selectorBytes);
+    assert.strictEqual(runSelector.calls[0][3]?.selectorBytesKind, "json");
+    assert.strictEqual(runSelector.calls[0][3]?.v4Registry?.("da/mcp-server"), true);
+    assert.strictEqual(runInputs.calls[0][0], metadataBytes);
+    assert.deepEqual(scaffoldV4.calls[0][4], {
+      source: {
+        origin: "online",
+        version: "6.11.0",
+        digest: "sha256:templates",
+        location: "templates.zip",
+      },
+      bytes: templatesBytes,
+    });
   });
 
   it("DCE-03: the Q2 answers reach scaffoldV4 under the create locator", async () => {

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -6,6 +6,7 @@ import {
   FxError,
   Inputs,
   Platform,
+  SystemError,
   UserError,
   UserInteraction,
 } from "@microsoft/teamsfx-api";
@@ -381,6 +382,89 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     assert.strictEqual(scaffoldV4.calls[0][4]?.bytes, templatesBytes);
   });
 
+  it("returns staged artifact resolver and selector-byte errors before dispatching create", async () => {
+    const artifactError = new SystemError({
+      source: "Test",
+      name: "ArtifactResolveFailed",
+      message: "artifact failed",
+    });
+    const selectorError = new SystemError({
+      source: "Test",
+      name: "SelectorBytesFailed",
+      message: "selector bytes failed",
+    });
+    const selectorSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("selector-json"),
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: Buffer.from("metadata-zip"),
+      templates: Buffer.from("templates-zip"),
+    });
+    selectorSnapshot.snapshot.bytes = (kind: TemplateArtifactKind) =>
+      Promise.resolve(kind === "create-selector" ? err(selectorError) : ok(Buffer.from(kind)));
+
+    const resolverResult = await createProjectFrontDoor(
+      baseInputs(),
+      deps({ resolveArtifactSnapshot: () => Promise.resolve(err(artifactError)) })
+    );
+    const selectorResult = await createProjectFrontDoor(
+      baseInputs(),
+      deps({ artifactSnapshot: selectorSnapshot.snapshot })
+    );
+
+    assert.strictEqual(resolverResult._unsafeUnwrapErr(), artifactError);
+    assert.strictEqual(selectorResult._unsafeUnwrapErr(), selectorError);
+  });
+
+  it("returns staged metadata and template bytes errors before v4 scaffold", async () => {
+    const metadataError = new SystemError({
+      source: "Test",
+      name: "MetadataBytesFailed",
+      message: "metadata failed",
+    });
+    const templatesError = new SystemError({
+      source: "Test",
+      name: "TemplatesBytesFailed",
+      message: "templates failed",
+    });
+    const metadataSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("selector-json"),
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: Buffer.from("metadata-zip"),
+      templates: Buffer.from("templates-zip"),
+    });
+    metadataSnapshot.snapshot.bytes = (kind: TemplateArtifactKind) =>
+      Promise.resolve(kind === "metadata" ? err(metadataError) : ok(Buffer.from(kind)));
+    const templatesSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("selector-json"),
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: Buffer.from("metadata-zip"),
+      templates: Buffer.from("templates-zip"),
+    });
+    templatesSnapshot.snapshot.bytes = (kind: TemplateArtifactKind) =>
+      Promise.resolve(kind === "templates" ? err(templatesError) : ok(Buffer.from(kind)));
+
+    const metadataResult = await createProjectFrontDoor(
+      baseInputs(),
+      deps({
+        artifactSnapshot: metadataSnapshot.snapshot,
+        runSelector: selectorRecorder(V4_TARGET).fn,
+        runInputs: failRunInputs,
+      })
+    );
+    const templatesResult = await createProjectFrontDoor(
+      baseInputs(),
+      deps({
+        artifactSnapshot: templatesSnapshot.snapshot,
+        runSelector: selectorRecorder(V4_TARGET).fn,
+        runInputs: inputsRecorder({}).fn,
+        collectCreateFloor: okFloor,
+      })
+    );
+
+    assert.strictEqual(metadataResult._unsafeUnwrapErr(), metadataError);
+    assert.strictEqual(templatesResult._unsafeUnwrapErr(), templatesError);
+  });
+
   it("DCE-03: the Q2 answers reach scaffoldV4 under the create locator", async () => {
     const q2: Answers = {
       mcpServerType: "remote",
@@ -594,6 +678,39 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     assert.deepEqual(resolveArtifactSnapshot.calls, [["templates"]]);
     assert.strictEqual(resolveByTemplateId.calls[0][0].toString(), "templates-zip");
     assert.deepEqual(artifactSnapshot.calls, ["templates", "metadata", "templates"]);
+  });
+
+  it("returns preset staged artifact resolver and template-byte errors before resolving by template id", async () => {
+    const resolverError = new SystemError({
+      source: "Test",
+      name: "PresetArtifactResolveFailed",
+      message: "artifact failed",
+    });
+    const templatesError = new SystemError({
+      source: "Test",
+      name: "PresetTemplatesBytesFailed",
+      message: "templates failed",
+    });
+    const snapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("selector-json"),
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: Buffer.from("metadata-zip"),
+      templates: Buffer.from("templates-zip"),
+    });
+    snapshot.snapshot.bytes = (kind: TemplateArtifactKind) =>
+      Promise.resolve(kind === "templates" ? err(templatesError) : ok(Buffer.from(kind)));
+
+    const resolverResult = await createProjectFrontDoor(
+      presetInputs("da/mcp-server"),
+      deps({ resolveArtifactSnapshot: () => Promise.resolve(err(resolverError)) })
+    );
+    const templatesResult = await createProjectFrontDoor(
+      presetInputs("da/mcp-server"),
+      deps({ artifactSnapshot: snapshot.snapshot })
+    );
+
+    assert.strictEqual(resolverResult._unsafeUnwrapErr(), resolverError);
+    assert.strictEqual(templatesResult._unsafeUnwrapErr(), templatesError);
   });
 
   it("DCE-13: a non-interactive walk (no preset template-name) threads interactive:false into runSelector", async () => {

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -336,6 +336,51 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     });
   });
 
+  it("DCE-02c: interactive v4 resolves one staged artifact snapshot before walking Q1", async () => {
+    const selectorBytes = Buffer.from("selector-json");
+    const metadataBytes = Buffer.from("metadata-zip");
+    const templatesBytes = Buffer.from("templates-zip");
+    const artifactSnapshot = artifactSnapshotRecorder({
+      "create-selector": selectorBytes,
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: metadataBytes,
+      templates: templatesBytes,
+    });
+    const resolveArtifactSnapshot = recorder((_kind: TemplateArtifactKind) =>
+      Promise.resolve(ok(artifactSnapshot.snapshot))
+    );
+    const runSelector = selectorRecorder(V4_TARGET);
+    const runInputs = inputsRecorder({ authType: "none" });
+    const scaffoldV4 = recorder(
+      (
+        _i: Inputs,
+        _t: BuildTarget,
+        _a: Answers,
+        _flagReader: (name: string) => boolean,
+        _resolvedPackage?: ResolvedV4ChannelPackage
+      ) => okResult("/v4")
+    );
+
+    const res = await createProjectFrontDoor(
+      baseInputs(),
+      deps({
+        resolveArtifactSnapshot: resolveArtifactSnapshot.fn,
+        v4Registry: () => true,
+        runSelector: runSelector.fn,
+        runInputs: runInputs.fn,
+        scaffoldV4: scaffoldV4.fn,
+        collectCreateFloor: okFloor,
+      })
+    );
+
+    assert.isTrue(res.isOk());
+    assert.deepEqual(resolveArtifactSnapshot.calls, [["create-selector"]]);
+    assert.deepEqual(artifactSnapshot.calls, ["create-selector", "metadata", "templates"]);
+    assert.strictEqual(runSelector.calls[0][0], selectorBytes);
+    assert.strictEqual(runInputs.calls[0][0], metadataBytes);
+    assert.strictEqual(scaffoldV4.calls[0][4]?.bytes, templatesBytes);
+  });
+
   it("DCE-03: the Q2 answers reach scaffoldV4 under the create locator", async () => {
     const q2: Answers = {
       mcpServerType: "remote",
@@ -515,6 +560,40 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     assert.equal(runInputs.calls.length, 1);
     assert.equal(scaffoldV4.calls.length, 1);
     assert.deepEqual(runInputs.calls[0][1], { kind: "create", templateId: "da/mcp-server" });
+  });
+
+  it("DCE-11b: preset v4 resolves templates artifact before resolving by template id", async () => {
+    const artifactSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("selector-json"),
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: Buffer.from("metadata-zip"),
+      templates: Buffer.from("templates-zip"),
+    });
+    const resolveArtifactSnapshot = recorder((_kind: TemplateArtifactKind) =>
+      Promise.resolve(ok(artifactSnapshot.snapshot))
+    );
+    const resolveByTemplateId = resolveByTemplateIdRecorder({
+      templateId: "da/mcp-server",
+      engine: "v4",
+      answers: {},
+    });
+    const runInputs = inputsRecorder({});
+
+    const res = await createProjectFrontDoor(
+      presetInputs("da/mcp-server"),
+      deps({
+        resolveArtifactSnapshot: resolveArtifactSnapshot.fn,
+        resolveByTemplateId: resolveByTemplateId.fn,
+        runInputs: runInputs.fn,
+        collectCreateFloor: okFloor,
+        scaffoldV4: okScaffold,
+      })
+    );
+
+    assert.isTrue(res.isOk());
+    assert.deepEqual(resolveArtifactSnapshot.calls, [["templates"]]);
+    assert.strictEqual(resolveByTemplateId.calls[0][0].toString(), "templates-zip");
+    assert.deepEqual(artifactSnapshot.calls, ["templates", "metadata", "templates"]);
   });
 
   it("DCE-13: a non-interactive walk (no preset template-name) threads interactive:false into runSelector", async () => {

--- a/packages/fx-core/tests/core/modifyProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/modifyProjectFrontDoor.test.ts
@@ -330,6 +330,79 @@ describe("modifyProjectFrontDoor", () => {
     assert.strictEqual(res._unsafeUnwrapErr().name, "ArtifactResolveFailed");
   });
 
+  it("MDE-01e: modify returns staged selector, metadata, and template byte errors", async () => {
+    const selectorError = new SystemError({
+      source: "Test",
+      name: "SelectorBytesFailed",
+      message: "selector failed",
+    });
+    const metadataError = new SystemError({
+      source: "Test",
+      name: "MetadataBytesFailed",
+      message: "metadata failed",
+    });
+    const templatesError = new SystemError({
+      source: "Test",
+      name: "TemplatesBytesFailed",
+      message: "templates failed",
+    });
+    const selectorSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("create-selector-json"),
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: Buffer.from("metadata-zip"),
+      templates: Buffer.from("templates-zip"),
+    });
+    selectorSnapshot.snapshot.bytes = (kind: TemplateArtifactKind) =>
+      Promise.resolve(kind === "modify-selector" ? err(selectorError) : ok(Buffer.from(kind)));
+    const metadataSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("create-selector-json"),
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: Buffer.from("metadata-zip"),
+      templates: Buffer.from("templates-zip"),
+    });
+    metadataSnapshot.snapshot.bytes = (kind: TemplateArtifactKind) =>
+      Promise.resolve(kind === "metadata" ? err(metadataError) : ok(Buffer.from(kind)));
+    const templatesSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("create-selector-json"),
+      "modify-selector": Buffer.from("modify-selector-json"),
+      metadata: Buffer.from("metadata-zip"),
+      templates: Buffer.from("templates-zip"),
+    });
+    templatesSnapshot.snapshot.bytes = (kind: TemplateArtifactKind) =>
+      Promise.resolve(kind === "templates" ? err(templatesError) : ok(Buffer.from(kind)));
+
+    const selectorResult = await modifyProjectFrontDoor(
+      { platform: Platform.VSCode },
+      {},
+      {},
+      deps({ artifactSnapshot: selectorSnapshot.snapshot })
+    );
+    const metadataResult = await modifyProjectFrontDoor(
+      { platform: Platform.VSCode },
+      {},
+      {},
+      deps({
+        artifactSnapshot: metadataSnapshot.snapshot,
+        runSelector: selectorRecorder(V4_TARGET).fn,
+        runInputs: failRunInputs,
+      })
+    );
+    const templatesResult = await modifyProjectFrontDoor(
+      { platform: Platform.VSCode },
+      {},
+      {},
+      deps({
+        artifactSnapshot: templatesSnapshot.snapshot,
+        runSelector: selectorRecorder(V4_TARGET).fn,
+        runInputs: inputsRecorder({}).fn,
+      })
+    );
+
+    assert.strictEqual(selectorResult._unsafeUnwrapErr(), selectorError);
+    assert.strictEqual(metadataResult._unsafeUnwrapErr(), metadataError);
+    assert.strictEqual(templatesResult._unsafeUnwrapErr(), templatesError);
+  });
+
   it("MDE-02: engine v3-core-method dispatches to the core-method handler without v4 Q2", async () => {
     const runSelector = selectorRecorder(V3_CORE_TARGET);
     const coreMethod = recorder((_inputs: Inputs, _target: BuildTarget) => {

--- a/packages/fx-core/tests/core/modifyProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/modifyProjectFrontDoor.test.ts
@@ -264,6 +264,72 @@ describe("modifyProjectFrontDoor", () => {
     });
   });
 
+  it("MDE-01c: modify resolves one staged artifact snapshot before walking Q1", async () => {
+    const selectorBytes = Buffer.from("modify-selector-json");
+    const metadataBytes = Buffer.from("metadata-zip");
+    const templatesBytes = Buffer.from("templates-zip");
+    const artifactSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("create-selector-json"),
+      "modify-selector": selectorBytes,
+      metadata: metadataBytes,
+      templates: templatesBytes,
+    });
+    const resolveArtifactSnapshot = recorder((_kind: TemplateArtifactKind) =>
+      Promise.resolve(ok(artifactSnapshot.snapshot))
+    );
+    const runSelector = selectorRecorder(V4_TARGET);
+    const runInputs = inputsRecorder({ authType: "none" });
+    const scaffoldV4 = recorder((_inputs: Inputs, _target: BuildTarget, _answers: Answers) => {
+      void _inputs;
+      void _target;
+      void _answers;
+      return okUndefined();
+    });
+
+    const res = await modifyProjectFrontDoor(
+      { platform: Platform.VSCode },
+      { addCapability: "add-action", actionSource: "mcp" },
+      {},
+      deps({
+        resolveArtifactSnapshot: resolveArtifactSnapshot.fn,
+        v4Registry: () => true,
+        runSelector: runSelector.fn,
+        runInputs: runInputs.fn,
+        scaffoldV4: scaffoldV4.fn,
+      })
+    );
+
+    assert.isTrue(res.isOk());
+    assert.deepEqual(resolveArtifactSnapshot.calls, [["modify-selector"]]);
+    assert.deepEqual(artifactSnapshot.calls, ["modify-selector", "metadata", "templates"]);
+    assert.strictEqual(runSelector.calls[0][0], selectorBytes);
+    assert.strictEqual(runInputs.calls[0][0], metadataBytes);
+    assert.strictEqual(scaffoldV4.calls[0][3]?.bytes, templatesBytes);
+  });
+
+  it("MDE-01d: modify returns staged artifact resolution errors before reading bundled floor", async () => {
+    const artifactError = new SystemError({
+      source: "Test",
+      name: "ArtifactResolveFailed",
+      message: "artifact failed",
+    });
+
+    const res = await modifyProjectFrontDoor(
+      { platform: Platform.VSCode },
+      {},
+      {},
+      deps({
+        resolveArtifactSnapshot: () => Promise.resolve(err(artifactError)),
+        readFloorBytes: () => {
+          throw new Error("readFloorBytes must not run");
+        },
+      })
+    );
+
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "ArtifactResolveFailed");
+  });
+
   it("MDE-02: engine v3-core-method dispatches to the core-method handler without v4 Q2", async () => {
     const runSelector = selectorRecorder(V3_CORE_TARGET);
     const coreMethod = recorder((_inputs: Inputs, _target: BuildTarget) => {

--- a/packages/fx-core/tests/core/modifyProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/modifyProjectFrontDoor.test.ts
@@ -3,9 +3,16 @@
 
 import { FxError, Inputs, Platform, SystemError, UserInteraction } from "@microsoft/teamsfx-api";
 import { Result, err, ok } from "neverthrow";
-import { Answers, BuildTarget, DeclarativeLocator } from "../../src/v4";
+import {
+  Answers,
+  BuildTarget,
+  DeclarativeLocator,
+  TemplateArtifactKind,
+  TemplateArtifactSnapshot,
+} from "../../src/v4";
 import { ModifyFrontDoorDeps, modifyProjectFrontDoor } from "../../src/core/modifyProjectFrontDoor";
 import { assert } from "vitest";
+import type { ResolvedV4ChannelPackage } from "../../src/component/generator/v4TemplateBridge";
 
 const EMPTY_FLOOR = Buffer.alloc(0);
 
@@ -51,6 +58,8 @@ function selectorRecorder(target: BuildTarget) {
         flagReader?: (name: string) => boolean;
         interactive?: boolean;
         prefilled?: Record<string, string>;
+        selectorBytesKind?: "zip" | "json";
+        v4Registry?: (templateId: string) => boolean;
       }
     ): Promise<Result<BuildTarget, FxError>> => {
       void _floor;
@@ -81,13 +90,50 @@ function inputsRecorder(answers: Answers) {
   );
 }
 
+function artifactSnapshotRecorder(bytesByKind: Record<TemplateArtifactKind, Buffer>): {
+  snapshot: TemplateArtifactSnapshot;
+  calls: TemplateArtifactKind[];
+} {
+  const calls: TemplateArtifactKind[] = [];
+  return {
+    calls,
+    snapshot: {
+      version: "6.11.0",
+      origin: "online",
+      artifacts: {
+        "create-selector": {
+          kind: "create-selector",
+          file: "create-selector.json",
+          digest: "sha256:create",
+        },
+        "modify-selector": {
+          kind: "modify-selector",
+          file: "modify-selector.json",
+          digest: "sha256:modify",
+        },
+        metadata: { kind: "metadata", file: "templates-metadata.zip", digest: "sha256:metadata" },
+        templates: { kind: "templates", file: "templates.zip", digest: "sha256:templates" },
+      },
+      bytes(kind: TemplateArtifactKind): Promise<Result<Buffer, FxError>> {
+        calls.push(kind);
+        return Promise.resolve(ok(bytesByKind[kind]));
+      },
+    },
+  };
+}
+
 const failRunSelector = (): Promise<Result<BuildTarget, FxError>> => {
   throw new Error("runSelector must not run on this path");
 };
 const failRunInputs = (): Promise<Result<Answers, FxError>> => {
   throw new Error("runInputs must not run on this path");
 };
-const failScaffoldV4 = (): Promise<Result<undefined, FxError>> => {
+const failScaffoldV4 = (
+  _inputs?: Inputs,
+  _target?: BuildTarget,
+  _answers?: Answers,
+  _resolvedPackage?: ResolvedV4ChannelPackage
+): Promise<Result<undefined, FxError>> => {
   throw new Error("scaffoldV4 must not run on this path");
 };
 const failCoreMethod = (): Promise<Result<undefined, FxError>> => {
@@ -116,12 +162,20 @@ describe("modifyProjectFrontDoor", () => {
       authType: "none",
     };
     const runInputs = inputsRecorder(q2);
-    const scaffoldV4 = recorder((_inputs: Inputs, _target: BuildTarget, _answers: Answers) => {
-      void _inputs;
-      void _target;
-      void _answers;
-      return okUndefined();
-    });
+    const scaffoldV4 = recorder(
+      (
+        _inputs: Inputs,
+        _target: BuildTarget,
+        _answers: Answers,
+        _resolvedPackage?: ResolvedV4ChannelPackage
+      ) => {
+        void _inputs;
+        void _target;
+        void _answers;
+        void _resolvedPackage;
+        return okUndefined();
+      }
+    );
     const coreMethod = recorder((_inputs: Inputs, _target: BuildTarget) => {
       void _inputs;
       void _target;
@@ -159,6 +213,55 @@ describe("modifyProjectFrontDoor", () => {
     assert.deepEqual(scaffoldV4.calls[0][1], V4_TARGET);
     assert.deepEqual(scaffoldV4.calls[0][2], q2);
     assert.equal(coreMethod.calls.length, 0);
+  });
+
+  it("MDE-01b: interactive modify uses one staged snapshot for selector, metadata, and templates", async () => {
+    const selectorBytes = Buffer.from("modify-selector-json");
+    const metadataBytes = Buffer.from("metadata-zip");
+    const templatesBytes = Buffer.from("templates-zip");
+    const artifactSnapshot = artifactSnapshotRecorder({
+      "create-selector": Buffer.from("create-selector-json"),
+      "modify-selector": selectorBytes,
+      metadata: metadataBytes,
+      templates: templatesBytes,
+    });
+    const runSelector = selectorRecorder(V4_TARGET);
+    const runInputs = inputsRecorder({ authType: "none" });
+    const scaffoldV4 = recorder((_inputs: Inputs, _target: BuildTarget, _answers: Answers) => {
+      void _inputs;
+      void _target;
+      void _answers;
+      return okUndefined();
+    });
+
+    const res = await modifyProjectFrontDoor(
+      { platform: Platform.VSCode },
+      { addCapability: "add-action", actionSource: "mcp" },
+      {},
+      deps({
+        artifactSnapshot: artifactSnapshot.snapshot,
+        v4Registry: () => true,
+        runSelector: runSelector.fn,
+        runInputs: runInputs.fn,
+        scaffoldV4: scaffoldV4.fn,
+      })
+    );
+
+    assert.isTrue(res.isOk());
+    assert.deepEqual(artifactSnapshot.calls, ["modify-selector", "metadata", "templates"]);
+    assert.strictEqual(runSelector.calls[0][0], selectorBytes);
+    assert.strictEqual(runSelector.calls[0][3]?.selectorBytesKind, "json");
+    assert.strictEqual(runSelector.calls[0][3]?.v4Registry?.("add-mcp-server"), true);
+    assert.strictEqual(runInputs.calls[0][0], metadataBytes);
+    assert.deepEqual(scaffoldV4.calls[0][3], {
+      source: {
+        origin: "online",
+        version: "6.11.0",
+        digest: "sha256:templates",
+        location: "templates.zip",
+      },
+      bytes: templatesBytes,
+    });
   });
 
   it("MDE-02: engine v3-core-method dispatches to the core-method handler without v4 Q2", async () => {

--- a/packages/fx-core/tests/core/v4ArtifactSnapshot.test.ts
+++ b/packages/fx-core/tests/core/v4ArtifactSnapshot.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert, vi } from "vitest";
+import { ok } from "neverthrow";
+import templateConfig from "../../src/common/templates-config.json";
+import { defaultTryLimits } from "../../src/component/generator/constant";
+import type {
+  BundledTemplateArtifacts,
+  TemplateArtifactKind,
+  TemplateArtifactPort,
+  TemplateArtifactSnapshot,
+} from "../../src/v4";
+
+const mocks = vi.hoisted(() => ({
+  createTemplateArtifactPort: vi.fn(),
+  loadBundledTemplateArtifacts: vi.fn(),
+  resolveTemplateArtifactSnapshot: vi.fn(),
+}));
+
+vi.mock("../../src/v4", () => ({
+  createTemplateArtifactPort: mocks.createTemplateArtifactPort,
+  loadBundledTemplateArtifacts: mocks.loadBundledTemplateArtifacts,
+  resolveTemplateArtifactSnapshot: mocks.resolveTemplateArtifactSnapshot,
+}));
+
+import { resolveV4TemplateArtifactSnapshot } from "../../src/core/v4ArtifactSnapshot";
+
+describe("resolveV4TemplateArtifactSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a production artifact port from template config and delegates snapshot resolution", async () => {
+    const bundled = bundledArtifacts("6.10.5");
+    const port = artifactPort(bundled);
+    const snapshot = artifactSnapshot("6.11.0", bundled);
+    mocks.loadBundledTemplateArtifacts.mockReturnValue(bundled);
+    mocks.createTemplateArtifactPort.mockReturnValue(port);
+    mocks.resolveTemplateArtifactSnapshot.mockResolvedValue(ok(snapshot));
+
+    const result = await resolveV4TemplateArtifactSnapshot("metadata");
+
+    assert.isTrue(result.isOk());
+    assert.strictEqual(result._unsafeUnwrap(), snapshot);
+    assert.deepEqual(mocks.createTemplateArtifactPort.mock.calls[0][0], {
+      templatesV4TagListURL: templateConfig.templatesV4TagListURL,
+      templateDownloadBaseURL: templateConfig.templateDownloadBaseURL,
+      tryLimits: defaultTryLimits,
+    });
+    assert.strictEqual(mocks.createTemplateArtifactPort.mock.calls[0][1], bundled);
+    assert.deepEqual(mocks.resolveTemplateArtifactSnapshot.mock.calls[0][0], {
+      range: templateConfig.v4.range,
+      bundled: templateConfig.v4.bundled,
+      requiredKind: "metadata",
+      port,
+    });
+  });
+});
+
+function artifactSnapshot(
+  version: string,
+  bundled: BundledTemplateArtifacts
+): TemplateArtifactSnapshot {
+  return {
+    version,
+    origin: "online",
+    artifacts: bundled.artifacts,
+    bytes: () => Promise.resolve(ok(Buffer.from("artifact"))),
+  };
+}
+
+function artifactPort(bundled: BundledTemplateArtifacts): TemplateArtifactPort {
+  return {
+    env: () => undefined,
+    tagList: () => Promise.resolve([]),
+    download: () => Promise.resolve(Buffer.from("artifact")),
+    cache: {
+      get: () => undefined,
+      put: () => undefined,
+      keys: () => [],
+      delete: () => undefined,
+    },
+    bundled,
+  };
+}
+
+function bundledArtifacts(version: string): BundledTemplateArtifacts {
+  const artifacts = {
+    "create-selector": artifactRef("create-selector", "create-selector.json", version),
+    "modify-selector": artifactRef("modify-selector", "modify-selector.json", version),
+    metadata: artifactRef("metadata", "templates-metadata.zip", version),
+    templates: artifactRef("templates", "templates.zip", version),
+  };
+  return {
+    version,
+    artifacts,
+    locations: {
+      "create-selector": `bundled://${version}/create-selector.json`,
+      "modify-selector": `bundled://${version}/modify-selector.json`,
+      metadata: `bundled://${version}/templates-metadata.zip`,
+      templates: `bundled://${version}/templates.zip`,
+    },
+  };
+}
+
+function artifactRef(kind: TemplateArtifactKind, file: string, version: string): CachedArtifactRef {
+  return { kind, file, digest: `sha256:${kind}-${version}` };
+}
+
+type CachedArtifactRef = BundledTemplateArtifacts["artifacts"][TemplateArtifactKind];

--- a/packages/fx-core/tests/v4/distribution/bundledFloor.test.ts
+++ b/packages/fx-core/tests/v4/distribution/bundledFloor.test.ts
@@ -100,5 +100,16 @@ describe("bundledFloor (v4)", () => {
       fs.writeFileSync(path.join(dir, "templates.zip"), Buffer.from("z"));
       expect(() => loadBundledFloor(dir)).toThrow(/BundledFloorMalformed|no string "version"/);
     });
+
+    it("throws BundledTemplateArtifactMissing when a staged artifact is absent", () => {
+      fs.writeJsonSync(path.join(dir, "floor.json"), { version: "6.11.0" });
+      fs.writeFileSync(path.join(dir, "modify-selector.json"), Buffer.from("modify-selector"));
+      fs.writeFileSync(path.join(dir, "templates-metadata.zip"), Buffer.from("metadata"));
+      fs.writeFileSync(path.join(dir, "templates.zip"), Buffer.from("templates"));
+
+      expect(() => loadBundledTemplateArtifacts(dir)).toThrow(
+        /BundledTemplateArtifactMissing|missing or unreadable/
+      );
+    });
   });
 });

--- a/packages/fx-core/tests/v4/distribution/bundledFloor.test.ts
+++ b/packages/fx-core/tests/v4/distribution/bundledFloor.test.ts
@@ -8,7 +8,9 @@ import {
   bundledFloorDir,
   bundledFloorFrom,
   loadBundledFloor,
+  loadBundledTemplateArtifacts,
 } from "../../../src/v4/distribution/bundledFloor";
+import { computeArtifactDigest } from "../../../src/v4/distribution/templateArtifacts";
 import { computeDigest } from "../../../src/v4/distribution/templateSource";
 import { assert } from "vitest";
 
@@ -51,6 +53,37 @@ describe("bundledFloor (v4)", () => {
       assert.strictEqual(floor.version, "6.11.0");
       assert.strictEqual(floor.digest, computeDigest(bytes));
       assert.strictEqual(floor.location, path.join(dir, "templates.zip"));
+    });
+
+    it("reads staged artifact locations and computes their digests", () => {
+      const createSelector = Buffer.from("create-selector");
+      const modifySelector = Buffer.from("modify-selector");
+      const metadata = Buffer.from("metadata");
+      const templates = Buffer.from("templates");
+      fs.writeJsonSync(path.join(dir, "floor.json"), { version: "6.11.0" });
+      fs.writeFileSync(path.join(dir, "create-selector.json"), createSelector);
+      fs.writeFileSync(path.join(dir, "modify-selector.json"), modifySelector);
+      fs.writeFileSync(path.join(dir, "templates-metadata.zip"), metadata);
+      fs.writeFileSync(path.join(dir, "templates.zip"), templates);
+
+      const artifacts = loadBundledTemplateArtifacts(dir);
+
+      assert.strictEqual(artifacts.version, "6.11.0");
+      assert.strictEqual(
+        artifacts.artifacts["create-selector"].digest,
+        computeArtifactDigest(createSelector)
+      );
+      assert.strictEqual(
+        artifacts.artifacts["modify-selector"].digest,
+        computeArtifactDigest(modifySelector)
+      );
+      assert.strictEqual(artifacts.artifacts.metadata.digest, computeArtifactDigest(metadata));
+      assert.strictEqual(artifacts.artifacts.templates.digest, computeDigest(templates));
+      assert.strictEqual(
+        artifacts.locations["create-selector"],
+        path.join(dir, "create-selector.json")
+      );
+      assert.strictEqual(artifacts.locations.templates, path.join(dir, "templates.zip"));
     });
 
     it("throws BundledFloorMissing when the manifest is absent", () => {

--- a/packages/fx-core/tests/v4/distribution/createSelector.test.ts
+++ b/packages/fx-core/tests/v4/distribution/createSelector.test.ts
@@ -43,6 +43,13 @@ describe("openCreateSelector (resolve-build-target AC-22)", () => {
     }
   });
 
+  it("AC-23: invalid raw selector JSON returns PackageFileInvalid", () => {
+    const result = openSelectorFromJsonBytes(Buffer.from("{"), "create");
+
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr().name, "PackageFileInvalid");
+  });
+
   it("AC-23: reads selector presentation from raw selector bytes", () => {
     const bytes = fs.readFileSync(path.join(TEMPLATES_V4_DIR, "modify", "selector.json"));
 

--- a/packages/fx-core/tests/v4/distribution/createSelector.test.ts
+++ b/packages/fx-core/tests/v4/distribution/createSelector.test.ts
@@ -3,8 +3,13 @@
 
 import { SystemError } from "@microsoft/teamsfx-api";
 import AdmZip from "adm-zip";
+import fs from "fs-extra";
 import path from "path";
-import { openCreateSelector } from "../../../src/v4/distribution/createSelector";
+import {
+  openCreateSelector,
+  openSelectorFromJsonBytes,
+  openSelectorPresentationFromJsonBytes,
+} from "../../../src/v4/distribution/createSelector";
 import { SelectorRoute } from "../../../src/v4/buildTarget/resolveBuildTarget";
 import { assert } from "vitest";
 
@@ -24,6 +29,31 @@ function buildFloor(): Buffer {
 }
 
 describe("openCreateSelector (resolve-build-target AC-22)", () => {
+  it("AC-23: reads and parses raw create-selector.json bytes without a full package", () => {
+    const bytes = fs.readFileSync(path.join(TEMPLATES_V4_DIR, "create", "selector.json"));
+
+    const result = openSelectorFromJsonBytes(bytes, "create");
+
+    assert.isTrue(result.isOk());
+    if (result.isOk()) {
+      const v4Route = result.value.routes.find(
+        (route: SelectorRoute) => route.engine === "v4" && route.templateId === "da/mcp-server"
+      );
+      assert.isDefined(v4Route, "the raw create selector carries the v4 da/mcp-server route");
+    }
+  });
+
+  it("AC-23: reads selector presentation from raw selector bytes", () => {
+    const bytes = fs.readFileSync(path.join(TEMPLATES_V4_DIR, "modify", "selector.json"));
+
+    const result = openSelectorPresentationFromJsonBytes(bytes, "modify");
+
+    assert.isTrue(result.isOk());
+    if (result.isOk()) {
+      assert.isArray(result.value.questions);
+    }
+  });
+
   it("AC-22: reads and parses the real shipped create selector from the floor", () => {
     const result = openCreateSelector(buildFloor());
 

--- a/packages/fx-core/tests/v4/distribution/declarativePackage.test.ts
+++ b/packages/fx-core/tests/v4/distribution/declarativePackage.test.ts
@@ -7,7 +7,10 @@ import * as os from "os";
 import * as path from "path";
 import { SystemError } from "@microsoft/teamsfx-api";
 import { loadPackageDir } from "../../../src/v4/distribution/packageDir";
-import { openDeclarativePackage } from "../../../src/v4/distribution/declarativePackage";
+import {
+  openDeclarativePackage,
+  openDeclarativePackageMetadata,
+} from "../../../src/v4/distribution/declarativePackage";
 import { createRealRuntime } from "../../../src/v4/runtime/realRuntime";
 import { scaffold } from "../../../src/v4/runtime/scaffold";
 import { assert } from "vitest";
@@ -127,6 +130,47 @@ describe("openDeclarativePackage (v4, zip declarative-subtree reader)", () => {
     const result = openDeclarativePackage(Buffer.from("not a zip at all"), LOCATOR);
     assert.isTrue(result.isErr(), "expected an error for non-zip bytes");
     assert.strictEqual(result._unsafeUnwrapErr().name, "TemplatePackageCorrupt");
+  });
+
+  it("DECL-04b: metadata reader returns errors for invalid archive and missing metadata files", () => {
+    const invalidZip = openDeclarativePackageMetadata(Buffer.from("not a zip at all"), LOCATOR);
+    assert.isTrue(invalidZip.isErr());
+    assert.strictEqual(invalidZip._unsafeUnwrapErr().name, "TemplatePackageCorrupt");
+
+    const missingQuestions = new AdmZip();
+    missingQuestions.addFile(
+      "v4/create/da/mcp-server/descriptor.json",
+      Buffer.from(JSON.stringify({ id: "da/mcp-server" }))
+    );
+    missingQuestions.addFile(
+      "v4/create/da/mcp-server/pipeline.json",
+      Buffer.from(JSON.stringify({ pipeline: "default" }))
+    );
+
+    const missingQuestionsResult = openDeclarativePackageMetadata(
+      missingQuestions.toBuffer(),
+      LOCATOR
+    );
+    assert.isTrue(missingQuestionsResult.isErr());
+    assert.strictEqual(missingQuestionsResult._unsafeUnwrapErr().name, "PackageFileMissing");
+  });
+
+  it("DECL-04c: metadata reader validates questions JSON shape", () => {
+    const zip = new AdmZip();
+    zip.addFile(
+      "v4/create/da/mcp-server/descriptor.json",
+      Buffer.from(JSON.stringify({ id: "da/mcp-server" }))
+    );
+    zip.addFile("v4/create/da/mcp-server/questions.json", Buffer.from(JSON.stringify({})));
+    zip.addFile(
+      "v4/create/da/mcp-server/pipeline.json",
+      Buffer.from(JSON.stringify({ pipeline: "default" }))
+    );
+
+    const result = openDeclarativePackageMetadata(zip.toBuffer(), LOCATOR);
+
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr().name, "PackageFileInvalid");
   });
 
   it("DECL-05: a Zip-Slip content entry is rejected", () => {

--- a/packages/fx-core/tests/v4/distribution/declarativePackage.test.ts
+++ b/packages/fx-core/tests/v4/distribution/declarativePackage.test.ts
@@ -155,6 +155,75 @@ describe("openDeclarativePackage (v4, zip declarative-subtree reader)", () => {
     assert.strictEqual(missingQuestionsResult._unsafeUnwrapErr().name, "PackageFileMissing");
   });
 
+  it("DECL-04d: metadata reader reports missing descriptor and pipeline files", () => {
+    const missingDescriptor = new AdmZip();
+    missingDescriptor.addFile(
+      "v4/create/da/mcp-server/questions.json",
+      Buffer.from(JSON.stringify({ questions: [] }))
+    );
+    missingDescriptor.addFile(
+      "v4/create/da/mcp-server/pipeline.json",
+      Buffer.from(JSON.stringify({ pipeline: "default" }))
+    );
+    const missingPipeline = new AdmZip();
+    missingPipeline.addFile(
+      "v4/create/da/mcp-server/descriptor.json",
+      Buffer.from(JSON.stringify({ id: "da/mcp-server" }))
+    );
+    missingPipeline.addFile(
+      "v4/create/da/mcp-server/questions.json",
+      Buffer.from(JSON.stringify({ questions: [] }))
+    );
+
+    const descriptorResult = openDeclarativePackageMetadata(missingDescriptor.toBuffer(), LOCATOR);
+    const pipelineResult = openDeclarativePackageMetadata(missingPipeline.toBuffer(), LOCATOR);
+
+    assert.strictEqual(descriptorResult._unsafeUnwrapErr().name, "PackageFileMissing");
+    assert.strictEqual(pipelineResult._unsafeUnwrapErr().name, "PackageFileMissing");
+  });
+
+  it("DECL-04e: metadata reader reports invalid descriptor and questions JSON", () => {
+    const invalidDescriptor = new AdmZip();
+    invalidDescriptor.addFile("v4/create/da/mcp-server/descriptor.json", Buffer.from("{"));
+    invalidDescriptor.addFile(
+      "v4/create/da/mcp-server/questions.json",
+      Buffer.from(JSON.stringify({ questions: [] }))
+    );
+    invalidDescriptor.addFile(
+      "v4/create/da/mcp-server/pipeline.json",
+      Buffer.from(JSON.stringify({ pipeline: "default" }))
+    );
+    const invalidQuestions = new AdmZip();
+    invalidQuestions.addFile(
+      "v4/create/da/mcp-server/descriptor.json",
+      Buffer.from(JSON.stringify({ id: "da/mcp-server" }))
+    );
+    invalidQuestions.addFile("v4/create/da/mcp-server/questions.json", Buffer.from("{"));
+    invalidQuestions.addFile(
+      "v4/create/da/mcp-server/pipeline.json",
+      Buffer.from(JSON.stringify({ pipeline: "default" }))
+    );
+
+    const descriptorResult = openDeclarativePackageMetadata(invalidDescriptor.toBuffer(), LOCATOR);
+    const questionsResult = openDeclarativePackageMetadata(invalidQuestions.toBuffer(), LOCATOR);
+
+    assert.strictEqual(descriptorResult._unsafeUnwrapErr().name, "PackageFileInvalid");
+    assert.strictEqual(questionsResult._unsafeUnwrapErr().name, "PackageFileInvalid");
+  });
+
+  it("DECL-04f: package reader reports invalid pipeline JSON", () => {
+    const invalidPipeline = new AdmZip();
+    invalidPipeline.addFile(
+      "v4/create/da/mcp-server/descriptor.json",
+      Buffer.from(JSON.stringify({ id: "da/mcp-server" }))
+    );
+    invalidPipeline.addFile("v4/create/da/mcp-server/pipeline.json", Buffer.from("{"));
+
+    const result = openDeclarativePackage(invalidPipeline.toBuffer(), LOCATOR);
+
+    assert.strictEqual(result._unsafeUnwrapErr().name, "PackageFileInvalid");
+  });
+
   it("DECL-04c: metadata reader validates questions JSON shape", () => {
     const zip = new AdmZip();
     zip.addFile(

--- a/packages/fx-core/tests/v4/distribution/templateArtifacts.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateArtifacts.test.ts
@@ -141,6 +141,10 @@ describe("templateArtifacts (v4 staged artifacts)", () => {
 
   it("AC-SA-02c: rejects invalid JSON and malformed artifact references", () => {
     expect(() => parseArtifactTagList("not-json")).toThrow(/not valid JSON/);
+    expect(() =>
+      parseArtifactTagList("\r\n  \n" + JSON.stringify(tagEntry("6.11.0")))
+    ).not.toThrow();
+    expect(() => parseArtifactTagList("null")).toThrow(/Malformed/);
 
     const wrongFile = tagEntry("6.11.0");
     wrongFile.artifacts.metadata.file = "metadata.zip";
@@ -350,6 +354,54 @@ describe("templateArtifacts (v4 staged artifacts)", () => {
       }),
     });
     assert.strictEqual(digestFailure._unsafeUnwrapErr().name, "TemplateDigestMismatch");
+
+    const rangeMismatch = await resolveTemplateArtifactSnapshot({
+      range: "^7.0.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port: new FakeArtifactPort({ tags: [tagEntry("6.11.0")] }),
+    });
+    assert.strictEqual(rangeMismatch._unsafeUnwrapErr().name, "TemplateVersionMismatch");
+  });
+
+  it("AC-SA-08d: propagates artifact download and cache write SystemErrors unchanged", async () => {
+    const downloadError = new SystemError({
+      source: "Test",
+      name: "DownloadSystemError",
+      message: "download failed",
+    });
+    const downloadPort = new FakeArtifactPort({ tags: [tagEntry("6.11.0")] });
+    downloadPort.download = () => Promise.reject(downloadError);
+
+    const downloadResult = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port: downloadPort,
+    });
+    assert.strictEqual(downloadResult._unsafeUnwrapErr(), downloadError);
+
+    const bytes = bytesFor("metadata", "6.11.0");
+    const cacheError = new SystemError({
+      source: "Test",
+      name: "CacheSystemError",
+      message: "cache failed",
+    });
+    const cachePort = new FakeArtifactPort({
+      tags: [tagEntry("6.11.0", { metadata: computeArtifactDigest(bytes) })],
+      served: { "6.11.0": servedArtifacts({ metadata: bytes }) },
+    });
+    cachePort.cache.put = () => {
+      throw cacheError;
+    };
+
+    const cacheResult = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port: cachePort,
+    });
+    assert.strictEqual(cacheResult._unsafeUnwrapErr(), cacheError);
   });
 
   it("AC-SA-09: returns the bundled snapshot when bundled=true or TEMPLATE_VERSION=local", async () => {
@@ -453,6 +505,59 @@ describe("templateArtifacts (v4 staged artifacts)", () => {
     ]);
   });
 
+  it("AC-SA-10c: lazy artifact reads return download and missing-cache errors", async () => {
+    const selectorBytes = bytesFor("create-selector", "6.11.0");
+    const metadataBytes = bytesFor("metadata", "6.11.0");
+    const downloadPort = new FakeArtifactPort({
+      tags: [
+        tagEntry("6.11.0", {
+          "create-selector": computeArtifactDigest(selectorBytes),
+          metadata: computeArtifactDigest(metadataBytes),
+        }),
+      ],
+      served: { "6.11.0": servedArtifacts({ "create-selector": selectorBytes }) },
+    });
+    const snapshotResult = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "create-selector",
+      port: downloadPort,
+    });
+
+    const lazyDownload = await snapshotResult._unsafeUnwrap().bytes("metadata");
+    assert.strictEqual(lazyDownload._unsafeUnwrapErr().name, "TemplateDownloadFailed");
+
+    const missingCachePort = new FakeArtifactPort({
+      tags: [
+        tagEntry("6.11.0", {
+          "create-selector": computeArtifactDigest(selectorBytes),
+          metadata: computeArtifactDigest(metadataBytes),
+        }),
+      ],
+      served: {
+        "6.11.0": servedArtifacts({
+          "create-selector": selectorBytes,
+          metadata: metadataBytes,
+        }),
+      },
+    });
+    const originalPut = missingCachePort.cache.put;
+    missingCachePort.cache.put = (version, kind, digest, bytes): void => {
+      if (kind !== "metadata") {
+        originalPut(version, kind, digest, bytes);
+      }
+    };
+    const missingCacheSnapshot = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "create-selector",
+      port: missingCachePort,
+    });
+
+    const missingCache = await missingCacheSnapshot._unsafeUnwrap().bytes("metadata");
+    assert.strictEqual(missingCache._unsafeUnwrapErr().name, "TemplateArtifactNotCached");
+  });
+
   it("AC-SA-15: falls back to bundled floor when the ranged tag list is unreachable", async () => {
     const port = new FakeArtifactPort({
       tagListError: new Error("offline"),
@@ -490,6 +595,45 @@ describe("templateArtifacts (v4 staged artifacts)", () => {
     assert.strictEqual(result._unsafeUnwrap().version, "6.10.6");
     const bytes = await result._unsafeUnwrap().bytes("metadata");
     assert.strictEqual(bytes._unsafeUnwrap().toString(), bytesFor("metadata", "6.10.6").toString());
+
+    port.cache.delete("6.10.6", "metadata");
+    const missing = await result._unsafeUnwrap().bytes("metadata");
+    assert.strictEqual(missing._unsafeUnwrapErr().name, "TemplateArtifactNotCached");
+  });
+
+  it("AC-SA-16b: reports mismatch when no fallback cache or bundled floor satisfies the range", async () => {
+    const port = new FakeArtifactPort({
+      tagListError: new Error("offline"),
+      bundled: bundledArtifacts("6.10.0"),
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^7.0.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.strictEqual(result._unsafeUnwrapErr().name, "TemplateVersionMismatch");
+  });
+
+  it("AC-SA-16c: pinned non-semver cache does not run line-based GC", async () => {
+    const bytes = bytesFor("metadata", "not-semver");
+    const port = new FakeArtifactPort({
+      env: { TEMPLATE_VERSION: "not-semver" },
+      tags: [tagEntry("not-semver", { metadata: computeArtifactDigest(bytes) })],
+      served: { "not-semver": servedArtifacts({ metadata: bytes }) },
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    assert.deepEqual(port.deleted, []);
   });
 
   it("AC-SA-17: does not fall back when a pinned version cannot read the tag list", async () => {
@@ -638,6 +782,12 @@ describe("createTemplateArtifactPort (v4 staged artifacts, real fs)", () => {
     assert.strictEqual(cached?.digest, computeArtifactDigest(Buffer.from("metadata-from-disk")));
     assert.isUndefined(port.cache.get("6.11.1", "metadata"));
     assert.deepEqual(port.cache.keys("metadata"), ["6.11.0"]);
+  });
+
+  it("AC-SA-14c: cache warm treats a missing cache root as empty", () => {
+    const port = createTemplateArtifactPort(config, bundledArtifacts("6.10.0"));
+
+    assert.deepEqual(port.cache.keys("metadata"), []);
   });
 });
 

--- a/packages/fx-core/tests/v4/distribution/templateArtifacts.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateArtifacts.test.ts
@@ -139,6 +139,17 @@ describe("templateArtifacts (v4 staged artifacts)", () => {
     expect(() => parseArtifactTagList(ndjson)).toThrow(/Malformed/);
   });
 
+  it("AC-SA-02c: rejects invalid JSON and malformed artifact references", () => {
+    expect(() => parseArtifactTagList("not-json")).toThrow(/not valid JSON/);
+
+    const wrongFile = tagEntry("6.11.0");
+    wrongFile.artifacts.metadata.file = "metadata.zip";
+    expect(() => parseArtifactTagList(JSON.stringify(wrongFile))).toThrow(/Malformed/);
+
+    const missingArtifacts = JSON.stringify({ version: "6.11.0", artifacts: {} });
+    expect(() => parseArtifactTagList(missingArtifacts)).toThrow(/Malformed/);
+  });
+
   it("AC-SA-03: builds artifact URLs and cache paths from known artifact kinds", () => {
     const ref = tagEntry("6.11.0").artifacts.metadata;
 
@@ -309,6 +320,38 @@ describe("templateArtifacts (v4 staged artifacts)", () => {
     assert.deepEqual(port.deleted, []);
   });
 
+  it("AC-SA-08c: reports pinned version, download, and digest errors", async () => {
+    const missingPinned = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port: new FakeArtifactPort({
+        env: { TEMPLATE_VERSION: "6.11.9" },
+        tags: [tagEntry("6.11.0")],
+      }),
+    });
+    assert.strictEqual(missingPinned._unsafeUnwrapErr().name, "TemplatePinnedVersionNotFound");
+
+    const downloadFailure = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port: new FakeArtifactPort({ tags: [tagEntry("6.11.0")] }),
+    });
+    assert.strictEqual(downloadFailure._unsafeUnwrapErr().name, "TemplateDownloadFailed");
+
+    const digestFailure = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port: new FakeArtifactPort({
+        tags: [tagEntry("6.11.0", { metadata: "sha256:expected" })],
+        served: { "6.11.0": servedArtifacts({ metadata: Buffer.from("actual") }) },
+      }),
+    });
+    assert.strictEqual(digestFailure._unsafeUnwrapErr().name, "TemplateDigestMismatch");
+  });
+
   it("AC-SA-09: returns the bundled snapshot when bundled=true or TEMPLATE_VERSION=local", async () => {
     const bundled = bundledArtifacts("6.10.5");
     const bundledPort = new FakeArtifactPort({ tags: [tagEntry("6.11.0")], bundled });
@@ -337,6 +380,28 @@ describe("templateArtifacts (v4 staged artifacts)", () => {
     assert.strictEqual(localPort.tagListCalls, 0);
   });
 
+  it("AC-SA-09b: reads bundled artifact bytes and reports unreadable bundled files", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "v4-bundled-bytes-"));
+    const selectorPath = path.join(tmp, "create-selector.json");
+    fs.writeFileSync(selectorPath, "selector-bytes");
+    const bundled = bundledArtifacts("6.10.5");
+    bundled.locations["create-selector"] = selectorPath;
+    const readable = await resolveTemplateArtifactSnapshot({
+      range: "^6.10.0",
+      bundled: true,
+      requiredKind: "create-selector",
+      port: new FakeArtifactPort({ bundled }),
+    });
+
+    const bytes = await readable._unsafeUnwrap().bytes("create-selector");
+    assert.strictEqual(bytes._unsafeUnwrap().toString(), "selector-bytes");
+
+    bundled.locations["modify-selector"] = path.join(tmp, "missing.json");
+    const missing = await readable._unsafeUnwrap().bytes("modify-selector");
+    assert.strictEqual(missing._unsafeUnwrapErr().name, "BundledArtifactUnreadable");
+    fs.removeSync(tmp);
+  });
+
   it("AC-SA-10: non-interactive direct resolution downloads templates.zip only", async () => {
     const bytes = bytesFor("templates", "6.11.0");
     const port = new FakeArtifactPort({
@@ -353,6 +418,39 @@ describe("templateArtifacts (v4 staged artifacts)", () => {
 
     assert.isTrue(result.isOk());
     assert.deepEqual(port.downloads, [{ version: "6.11.0", kind: "templates" }]);
+  });
+
+  it("AC-SA-10b: one snapshot lazily downloads later artifact kinds against the same version", async () => {
+    const selectorBytes = bytesFor("create-selector", "6.11.0");
+    const metadataBytes = bytesFor("metadata", "6.11.0");
+    const port = new FakeArtifactPort({
+      tags: [
+        tagEntry("6.11.0", {
+          "create-selector": computeArtifactDigest(selectorBytes),
+          metadata: computeArtifactDigest(metadataBytes),
+        }),
+      ],
+      served: {
+        "6.11.0": servedArtifacts({
+          "create-selector": selectorBytes,
+          metadata: metadataBytes,
+        }),
+      },
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "create-selector",
+      port,
+    });
+    const metadata = await result._unsafeUnwrap().bytes("metadata");
+
+    assert.strictEqual(metadata._unsafeUnwrap().toString(), metadataBytes.toString());
+    assert.deepEqual(port.downloads, [
+      { version: "6.11.0", kind: "create-selector" },
+      { version: "6.11.0", kind: "metadata" },
+    ]);
   });
 
   it("AC-SA-15: falls back to bundled floor when the ranged tag list is unreachable", async () => {
@@ -524,6 +622,22 @@ describe("createTemplateArtifactPort (v4 staged artifacts, real fs)", () => {
     assert.isFalse(fs.existsSync(artifactCacheFile("6.11.0", "metadata")));
     assert.isTrue(fs.existsSync(artifactCacheFile("6.10.9", "metadata")));
     assert.isTrue(fs.existsSync(artifactCacheFile("6.11.2", "metadata")));
+  });
+
+  it("AC-SA-14b: cache get warms pre-existing disk artifacts and skips unrelated or incomplete entries", () => {
+    const artifactPath = artifactCacheFile("6.11.0", "metadata");
+    fs.ensureDirSync(path.dirname(artifactPath));
+    fs.writeFileSync(artifactPath, "metadata-from-disk");
+    fs.ensureDirSync(path.join(tmpHome, ".fx", "templates-cache", "not-v4@6.11.0"));
+    fs.ensureDirSync(path.dirname(artifactCacheFile("6.11.1", "metadata")));
+
+    const port = createTemplateArtifactPort(config, bundledArtifacts("6.10.0"));
+    const cached = port.cache.get("6.11.0", "metadata");
+
+    assert.strictEqual(cached?.bytes.toString(), "metadata-from-disk");
+    assert.strictEqual(cached?.digest, computeArtifactDigest(Buffer.from("metadata-from-disk")));
+    assert.isUndefined(port.cache.get("6.11.1", "metadata"));
+    assert.deepEqual(port.cache.keys("metadata"), ["6.11.0"]);
   });
 });
 

--- a/packages/fx-core/tests/v4/distribution/templateArtifacts.test.ts
+++ b/packages/fx-core/tests/v4/distribution/templateArtifacts.test.ts
@@ -1,0 +1,628 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { SystemError } from "@microsoft/teamsfx-api";
+import axios, { AxiosResponse } from "axios";
+import * as fs from "fs-extra";
+import os from "os";
+import * as path from "path";
+import { assert, vi } from "vitest";
+import {
+  BundledTemplateArtifacts,
+  CachedTemplateArtifact,
+  TemplateArtifactKind,
+  TemplateArtifactPort,
+  V4TemplateTagEntry,
+  artifactCacheFile,
+  artifactUrl,
+  computeArtifactDigest,
+  createTemplateArtifactPort,
+  parseArtifactTagList,
+  resolveTemplateArtifactSnapshot,
+} from "../../../src/v4/distribution/templateArtifacts";
+
+class FakeArtifactPort implements TemplateArtifactPort {
+  public tagListCalls = 0;
+  public downloads: Array<{ version: string; kind: TemplateArtifactKind }> = [];
+  public deleted: Array<{ version: string; kind: TemplateArtifactKind }> = [];
+  private readonly envMap: Record<string, string | undefined>;
+  private readonly tags: V4TemplateTagEntry[];
+  private readonly tagListError: Error | undefined;
+  private readonly served: Record<string, Record<TemplateArtifactKind, Buffer | undefined>>;
+  private readonly store = new Map<string, CachedTemplateArtifact>();
+  private readonly putFailures = new Set<string>();
+  public readonly bundled: BundledTemplateArtifacts;
+
+  constructor(opts: {
+    env?: Record<string, string | undefined>;
+    tags?: V4TemplateTagEntry[];
+    tagListError?: Error;
+    served?: Record<string, Record<TemplateArtifactKind, Buffer | undefined>>;
+    cache?: Array<{ version: string; kind: TemplateArtifactKind; digest: string; bytes: Buffer }>;
+    putFailures?: Array<{ version: string; kind: TemplateArtifactKind }>;
+    bundled?: BundledTemplateArtifacts;
+  }) {
+    this.envMap = opts.env ?? {};
+    this.tags = opts.tags ?? [];
+    this.tagListError = opts.tagListError;
+    this.served = opts.served ?? {};
+    this.bundled = opts.bundled ?? bundledArtifacts("6.10.0");
+    for (const cached of opts.cache ?? []) {
+      this.store.set(cacheKey(cached.version, cached.kind), {
+        digest: cached.digest,
+        bytes: cached.bytes,
+      });
+    }
+    for (const failure of opts.putFailures ?? []) {
+      this.putFailures.add(cacheKey(failure.version, failure.kind));
+    }
+  }
+
+  env(name: string): string | undefined {
+    return this.envMap[name];
+  }
+
+  tagList(): Promise<V4TemplateTagEntry[]> {
+    this.tagListCalls++;
+    if (this.tagListError) {
+      return Promise.reject(this.tagListError);
+    }
+    return Promise.resolve(this.tags);
+  }
+
+  download(version: string, ref: { kind: TemplateArtifactKind }): Promise<Buffer> {
+    this.downloads.push({ version, kind: ref.kind });
+    const versionArtifacts = this.served[version];
+    const bytes = versionArtifacts?.[ref.kind];
+    if (!bytes) {
+      return Promise.reject(new Error(`No artifact ${ref.kind} for ${version}`));
+    }
+    return Promise.resolve(bytes);
+  }
+
+  cache = {
+    get: (version: string, kind: TemplateArtifactKind): CachedTemplateArtifact | undefined =>
+      this.store.get(cacheKey(version, kind)),
+    put: (version: string, kind: TemplateArtifactKind, digest: string, bytes: Buffer): void => {
+      const key = cacheKey(version, kind);
+      if (this.putFailures.has(key)) {
+        throw new Error(`put failed for ${key}`);
+      }
+      this.store.set(key, { digest, bytes });
+    },
+    keys: (kind: TemplateArtifactKind): string[] => {
+      const versions: string[] = [];
+      for (const key of this.store.keys()) {
+        const parsed = parseCacheKey(key);
+        if (parsed?.kind === kind) {
+          versions.push(parsed.version);
+        }
+      }
+      return versions;
+    },
+    delete: (version: string, kind: TemplateArtifactKind): void => {
+      this.deleted.push({ version, kind });
+      this.store.delete(cacheKey(version, kind));
+    },
+  };
+}
+
+describe("templateArtifacts (v4 staged artifacts)", () => {
+  it("AC-SA-01: parses final multi-artifact tag-list entries without a top-level digest", () => {
+    const ndjson = JSON.stringify({
+      version: "6.11.0",
+      artifacts: tagArtifacts("6.11.0"),
+    });
+
+    const entries = parseArtifactTagList(ndjson);
+
+    assert.lengthOf(entries, 1);
+    assert.strictEqual(entries[0].version, "6.11.0");
+    assert.strictEqual(entries[0].artifacts["create-selector"].kind, "create-selector");
+    assert.strictEqual(entries[0].artifacts.templates.file, "templates.zip");
+    assert.notProperty(entries[0], "digest");
+  });
+
+  it("AC-SA-02: rejects earlier single-digest v4 tag-list entries", () => {
+    expect(() => parseArtifactTagList(`{"version":"6.11.0","digest":"sha256:aaa"}`)).toThrow(
+      /Malformed/
+    );
+  });
+
+  it("AC-SA-02b: rejects final entries that still carry a top-level digest", () => {
+    const ndjson = JSON.stringify({
+      version: "6.11.0",
+      digest: "sha256:legacy",
+      artifacts: tagArtifacts("6.11.0"),
+    });
+
+    expect(() => parseArtifactTagList(ndjson)).toThrow(/Malformed/);
+  });
+
+  it("AC-SA-03: builds artifact URLs and cache paths from known artifact kinds", () => {
+    const ref = tagEntry("6.11.0").artifacts.metadata;
+
+    assert.strictEqual(
+      artifactUrl("https://example.com/releases", "6.11.0", ref),
+      "https://example.com/releases/templates-v4@6.11.0/templates-metadata.zip"
+    );
+    assert.match(artifactCacheFile("6.11.0", "metadata"), /templates-v4@6\.11\.0/);
+    assert.match(artifactCacheFile("6.11.0", "metadata"), /templates-metadata\.zip$/);
+  });
+
+  it("AC-SA-04: resolves online refs and downloads the required artifact after digest verification", async () => {
+    const bytes = bytesFor("create-selector", "6.11.0");
+    const port = new FakeArtifactPort({
+      tags: [tagEntry("6.11.0", { "create-selector": computeArtifactDigest(bytes) })],
+      served: { "6.11.0": servedArtifacts({ "create-selector": bytes }) },
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "create-selector",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    const snapshot = result._unsafeUnwrap();
+    assert.strictEqual(snapshot.version, "6.11.0");
+    assert.strictEqual(snapshot.origin, "online");
+    assert.deepEqual(port.downloads, [{ version: "6.11.0", kind: "create-selector" }]);
+    const cached = port.cache.get("6.11.0", "create-selector");
+    assert.strictEqual(cached?.bytes.toString(), bytes.toString());
+  });
+
+  it("AC-SA-05: loads a cached required artifact without network", async () => {
+    const bytes = bytesFor("metadata", "6.11.1");
+    const digest = computeArtifactDigest(bytes);
+    const port = new FakeArtifactPort({
+      tags: [tagEntry("6.11.1", { metadata: digest })],
+      cache: [{ version: "6.11.1", kind: "metadata", digest, bytes }],
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.strictEqual(result._unsafeUnwrap().origin, "cache");
+    assert.deepEqual(port.downloads, []);
+  });
+
+  it("AC-SA-06: keeps only the highest cached version per major.minor and artifact kind", async () => {
+    const oldBytes = bytesFor("metadata", "6.11.0");
+    const newBytes = bytesFor("metadata", "6.11.2");
+    const port = new FakeArtifactPort({
+      tags: [tagEntry("6.11.2", { metadata: computeArtifactDigest(newBytes) })],
+      cache: [
+        {
+          version: "6.11.0",
+          kind: "metadata",
+          digest: computeArtifactDigest(oldBytes),
+          bytes: oldBytes,
+        },
+      ],
+      served: { "6.11.2": servedArtifacts({ metadata: newBytes }) },
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    assert.deepEqual(port.cache.keys("metadata"), ["6.11.2"]);
+    assert.deepEqual(port.deleted, [{ version: "6.11.0", kind: "metadata" }]);
+  });
+
+  it("AC-SA-07: does not delete another major.minor line when caching a newer artifact", async () => {
+    const retainedBytes = bytesFor("templates", "6.10.9");
+    const newBytes = bytesFor("templates", "6.11.0");
+    const port = new FakeArtifactPort({
+      tags: [tagEntry("6.11.0", { templates: computeArtifactDigest(newBytes) })],
+      cache: [
+        {
+          version: "6.10.9",
+          kind: "templates",
+          digest: computeArtifactDigest(retainedBytes),
+          bytes: retainedBytes,
+        },
+      ],
+      served: { "6.11.0": servedArtifacts({ templates: newBytes }) },
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "templates",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    assert.sameMembers(port.cache.keys("templates"), ["6.10.9", "6.11.0"]);
+    assert.deepEqual(port.deleted, []);
+  });
+
+  it("AC-SA-08: does not delete old cache when writing the new artifact fails", async () => {
+    const oldBytes = bytesFor("metadata", "6.11.0");
+    const newBytes = bytesFor("metadata", "6.11.1");
+    const port = new FakeArtifactPort({
+      tags: [tagEntry("6.11.1", { metadata: computeArtifactDigest(newBytes) })],
+      cache: [
+        {
+          version: "6.11.0",
+          kind: "metadata",
+          digest: computeArtifactDigest(oldBytes),
+          bytes: oldBytes,
+        },
+      ],
+      served: { "6.11.1": servedArtifacts({ metadata: newBytes }) },
+      putFailures: [{ version: "6.11.1", kind: "metadata" }],
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.isTrue(result.isErr());
+    assert.instanceOf(result._unsafeUnwrapErr(), SystemError);
+    assert.deepEqual(port.cache.keys("metadata"), ["6.11.0"]);
+    assert.deepEqual(port.deleted, []);
+  });
+
+  it("AC-SA-08b: keeps a pinned lower patch readable when a higher patch is cached", async () => {
+    const pinnedBytes = bytesFor("metadata", "6.11.1");
+    const higherBytes = bytesFor("metadata", "6.11.2");
+    const port = new FakeArtifactPort({
+      env: { TEMPLATE_VERSION: "6.11.1" },
+      tags: [tagEntry("6.11.1", { metadata: computeArtifactDigest(pinnedBytes) })],
+      cache: [
+        {
+          version: "6.11.2",
+          kind: "metadata",
+          digest: computeArtifactDigest(higherBytes),
+          bytes: higherBytes,
+        },
+      ],
+      served: { "6.11.1": servedArtifacts({ metadata: pinnedBytes }) },
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    const bytes = await result._unsafeUnwrap().bytes("metadata");
+    assert.strictEqual(bytes._unsafeUnwrap().toString(), pinnedBytes.toString());
+    assert.sameMembers(port.cache.keys("metadata"), ["6.11.1", "6.11.2"]);
+    assert.deepEqual(port.deleted, []);
+  });
+
+  it("AC-SA-09: returns the bundled snapshot when bundled=true or TEMPLATE_VERSION=local", async () => {
+    const bundled = bundledArtifacts("6.10.5");
+    const bundledPort = new FakeArtifactPort({ tags: [tagEntry("6.11.0")], bundled });
+    const localPort = new FakeArtifactPort({
+      env: { TEMPLATE_VERSION: "local" },
+      tags: [tagEntry("6.11.0")],
+      bundled,
+    });
+
+    const bundledResult = await resolveTemplateArtifactSnapshot({
+      range: "^6.10.0",
+      bundled: true,
+      requiredKind: "create-selector",
+      port: bundledPort,
+    });
+    const localResult = await resolveTemplateArtifactSnapshot({
+      range: "^6.10.0",
+      bundled: false,
+      requiredKind: "create-selector",
+      port: localPort,
+    });
+
+    assert.strictEqual(bundledResult._unsafeUnwrap().origin, "bundled");
+    assert.strictEqual(localResult._unsafeUnwrap().origin, "bundled");
+    assert.strictEqual(bundledPort.tagListCalls, 0);
+    assert.strictEqual(localPort.tagListCalls, 0);
+  });
+
+  it("AC-SA-10: non-interactive direct resolution downloads templates.zip only", async () => {
+    const bytes = bytesFor("templates", "6.11.0");
+    const port = new FakeArtifactPort({
+      tags: [tagEntry("6.11.0", { templates: computeArtifactDigest(bytes) })],
+      served: { "6.11.0": servedArtifacts({ templates: bytes }) },
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "templates",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    assert.deepEqual(port.downloads, [{ version: "6.11.0", kind: "templates" }]);
+  });
+
+  it("AC-SA-15: falls back to bundled floor when the ranged tag list is unreachable", async () => {
+    const port = new FakeArtifactPort({
+      tagListError: new Error("offline"),
+      bundled: bundledArtifacts("6.10.5"),
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "~6.10.0",
+      bundled: false,
+      requiredKind: "create-selector",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    assert.strictEqual(result._unsafeUnwrap().origin, "bundled-fallback");
+    assert.strictEqual(result._unsafeUnwrap().version, "6.10.5");
+  });
+
+  it("AC-SA-16: falls back to the highest complete cached snapshot when tag list is unreachable", async () => {
+    const port = new FakeArtifactPort({
+      tagListError: new Error("offline"),
+      bundled: bundledArtifacts("6.10.0"),
+      cache: cachedArtifactSet("6.10.6"),
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "~6.10.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    assert.strictEqual(result._unsafeUnwrap().origin, "cache");
+    assert.strictEqual(result._unsafeUnwrap().version, "6.10.6");
+    const bytes = await result._unsafeUnwrap().bytes("metadata");
+    assert.strictEqual(bytes._unsafeUnwrap().toString(), bytesFor("metadata", "6.10.6").toString());
+  });
+
+  it("AC-SA-17: does not fall back when a pinned version cannot read the tag list", async () => {
+    const port = new FakeArtifactPort({
+      env: { TEMPLATE_VERSION: "6.10.6" },
+      tagListError: new Error("offline"),
+      bundled: bundledArtifacts("6.10.5"),
+      cache: cachedArtifactSet("6.10.6"),
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "~6.10.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.isTrue(result.isErr());
+  });
+
+  it("AC-SA-18: propagates malformed tag-list errors instead of falling back", async () => {
+    const port = new FakeArtifactPort({
+      tagListError: new SystemError({
+        source: "Scaffold",
+        name: "TemplateTagListMalformed",
+        message: "malformed",
+      }),
+      bundled: bundledArtifacts("6.10.5"),
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "~6.10.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr().name, "TemplateTagListMalformed");
+  });
+});
+
+describe("createTemplateArtifactPort (v4 staged artifacts, real fs)", () => {
+  const config = {
+    templatesV4TagListURL: "https://example.com/tags.ndjson",
+    templateDownloadBaseURL: "https://example.com/releases",
+    tryLimits: 1,
+  };
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = path.join(
+      os.tmpdir(),
+      `v4-artifacts-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.removeSync(tmpHome);
+  });
+
+  it("AC-SA-11: tagList fetches and parses final staged-artifact NDJSON", async () => {
+    const ndjson = JSON.stringify(tagEntry("6.11.0"));
+    vi.spyOn(axios, "get").mockResolvedValue({ status: 200, data: ndjson } as AxiosResponse);
+
+    const port = createTemplateArtifactPort(config, bundledArtifacts("6.10.0"));
+    const entries = await port.tagList();
+
+    assert.strictEqual(entries[0].version, "6.11.0");
+    assert.strictEqual(entries[0].artifacts.metadata.file, "templates-metadata.zip");
+  });
+
+  it("AC-SA-12: download reads one release artifact by file name", async () => {
+    const payload = Buffer.from("metadata-payload");
+    const axiosGet = vi
+      .spyOn(axios, "get")
+      .mockResolvedValue({ status: 200, data: payload } as AxiosResponse);
+
+    const port = createTemplateArtifactPort(config, bundledArtifacts("6.10.0"));
+    const bytes = await port.download("6.11.0", tagEntry("6.11.0").artifacts.metadata);
+
+    assert.strictEqual(bytes.toString(), "metadata-payload");
+    assert.strictEqual(
+      axiosGet.mock.calls[0][0],
+      "https://example.com/releases/templates-v4@6.11.0/templates-metadata.zip"
+    );
+  });
+
+  it("AC-SA-13: cache put writes through a temp file then indexes the artifact", () => {
+    const bytes = Buffer.from("create-selector-cache");
+    const digest = computeArtifactDigest(bytes);
+    const port = createTemplateArtifactPort(config, bundledArtifacts("6.10.0"));
+
+    port.cache.put("6.11.0", "create-selector", digest, bytes);
+
+    assert.isTrue(fs.existsSync(artifactCacheFile("6.11.0", "create-selector")));
+    assert.strictEqual(port.cache.get("6.11.0", "create-selector")?.digest, digest);
+    const leftovers = fs.readdirSync(path.dirname(artifactCacheFile("6.11.0", "create-selector")));
+    assert.notInclude(leftovers.join("\n"), ".tmp");
+  });
+
+  it("AC-SA-14: resolver GC deletes only older versions in the same major.minor/kind on disk", async () => {
+    const oldBytes = Buffer.from("old-metadata");
+    const retainedBytes = Buffer.from("retained-metadata");
+    const newBytes = Buffer.from("new-metadata");
+    const port = createTemplateArtifactPort(config, bundledArtifacts("6.10.0"));
+    port.cache.put("6.11.0", "metadata", computeArtifactDigest(oldBytes), oldBytes);
+    port.cache.put("6.10.9", "metadata", computeArtifactDigest(retainedBytes), retainedBytes);
+
+    vi.spyOn(axios, "get").mockImplementation((url: string) => {
+      if (url === config.templatesV4TagListURL) {
+        return Promise.resolve({
+          status: 200,
+          data: JSON.stringify(tagEntry("6.11.2", { metadata: computeArtifactDigest(newBytes) })),
+        } as AxiosResponse);
+      }
+      return Promise.resolve({ status: 200, data: newBytes } as AxiosResponse);
+    });
+
+    const result = await resolveTemplateArtifactSnapshot({
+      range: "^6.11.0",
+      bundled: false,
+      requiredKind: "metadata",
+      port,
+    });
+
+    assert.isTrue(result.isOk());
+    assert.isFalse(fs.existsSync(artifactCacheFile("6.11.0", "metadata")));
+    assert.isTrue(fs.existsSync(artifactCacheFile("6.10.9", "metadata")));
+    assert.isTrue(fs.existsSync(artifactCacheFile("6.11.2", "metadata")));
+  });
+});
+
+function tagEntry(
+  version: string,
+  digestOverrides: Partial<Record<TemplateArtifactKind, string>> = {}
+): V4TemplateTagEntry {
+  return { version, artifacts: tagArtifacts(version, digestOverrides) };
+}
+
+function tagArtifacts(
+  version: string,
+  digestOverrides: Partial<Record<TemplateArtifactKind, string>> = {}
+): V4TemplateTagEntry["artifacts"] {
+  return {
+    "create-selector": {
+      kind: "create-selector",
+      file: "create-selector.json",
+      digest: digestOverrides["create-selector"] ?? `sha256:create-selector-${version}`,
+    },
+    "modify-selector": {
+      kind: "modify-selector",
+      file: "modify-selector.json",
+      digest: digestOverrides["modify-selector"] ?? `sha256:modify-selector-${version}`,
+    },
+    metadata: {
+      kind: "metadata",
+      file: "templates-metadata.zip",
+      digest: digestOverrides.metadata ?? `sha256:metadata-${version}`,
+    },
+    templates: {
+      kind: "templates",
+      file: "templates.zip",
+      digest: digestOverrides.templates ?? `sha256:templates-${version}`,
+    },
+  };
+}
+
+function bundledArtifacts(version: string): BundledTemplateArtifacts {
+  return {
+    version,
+    artifacts: tagArtifacts(version),
+    locations: {
+      "create-selector": `bundled://${version}/create-selector.json`,
+      "modify-selector": `bundled://${version}/modify-selector.json`,
+      metadata: `bundled://${version}/templates-metadata.zip`,
+      templates: `bundled://${version}/templates.zip`,
+    },
+  };
+}
+
+function servedArtifacts(
+  artifacts: Partial<Record<TemplateArtifactKind, Buffer>>
+): Record<TemplateArtifactKind, Buffer | undefined> {
+  return {
+    "create-selector": artifacts["create-selector"],
+    "modify-selector": artifacts["modify-selector"],
+    metadata: artifacts.metadata,
+    templates: artifacts.templates,
+  };
+}
+
+function bytesFor(kind: TemplateArtifactKind, version: string): Buffer {
+  return Buffer.from(`${kind}:${version}`);
+}
+
+function cachedArtifactSet(
+  version: string
+): Array<{ version: string; kind: TemplateArtifactKind; digest: string; bytes: Buffer }> {
+  const kinds: TemplateArtifactKind[] = [
+    "create-selector",
+    "modify-selector",
+    "metadata",
+    "templates",
+  ];
+  return kinds.map((kind) => {
+    const bytes = bytesFor(kind, version);
+    return { version, kind, digest: computeArtifactDigest(bytes), bytes };
+  });
+}
+
+function cacheKey(version: string, kind: TemplateArtifactKind): string {
+  return `${kind}:${version}`;
+}
+
+function parseCacheKey(key: string): { kind: TemplateArtifactKind; version: string } | undefined {
+  const separator = key.indexOf(":");
+  if (separator < 1) {
+    return undefined;
+  }
+  const kind = key.slice(0, separator);
+  const version = key.slice(separator + 1);
+  if (
+    kind !== "create-selector" &&
+    kind !== "modify-selector" &&
+    kind !== "metadata" &&
+    kind !== "templates"
+  ) {
+    return undefined;
+  }
+  return { kind, version };
+}

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -22,6 +22,7 @@ import {
   OptionsProvider,
 } from "../../../src/v4/collectInputs/collectInputs";
 import { openCreateQuestions } from "../../../src/v4/distribution/createQuestions";
+import { openDeclarativePackageMetadata } from "../../../src/v4/distribution/declarativePackage";
 import { DeclarativeLocator } from "../../../src/v4/model/dataModel";
 import { createUiPromptUI } from "../../../src/v4/surface/uiPromptUI";
 import { gateLanguagesBySurface, runCreateInputs } from "../../../src/v4/surface/createInputs";
@@ -157,6 +158,21 @@ function asUI(scripted: ScriptedUserInteraction): UserInteraction {
 }
 
 describe("runCreateInputs (collect-create-inputs)", () => {
+  it("CCI-00: metadata-only bytes drive Q2 language gating without content", async () => {
+    const ui = new ScriptedUserInteraction({});
+
+    const res = await runCreateInputs(buildLanguageFloor(), LANGUAGE_DA, {}, asUI(ui), {
+      flagReader: () => true,
+      surface: "vscode",
+    });
+
+    assert.isTrue(res.isOk(), res.isErr() ? `${res.error.name}: ${res.error.message}` : "ok");
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { language: "typescript" });
+    }
+    assert.deepEqual(ui.selectNames, []);
+  });
+
   it("CCI-01: remote-only provider auto-skips mcpServerType, asks url + authType=none", async () => {
     const ui = new ScriptedUserInteraction({
       text: { mcpServerUrl: "https://api.example.com/mcp" },
@@ -511,6 +527,19 @@ describe("createUiPromptUI (collect-create-inputs)", () => {
 });
 
 describe("openCreateQuestions (collect-create-inputs)", () => {
+  it("CCI-09b: metadata-only package reader returns descriptor/questions/pipeline and no content", () => {
+    const res = openDeclarativePackageMetadata(buildLanguageFloor(), LANGUAGE_DA);
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(
+        res.value.questions.map((question) => question.name),
+        []
+      );
+      assert.notProperty(res.value, "content");
+    }
+  });
+
   it("CCI-09: reads the three authored da/mcp-server questions from the floor", () => {
     const res = openCreateQuestions(buildFloor(), MCP_DA);
 

--- a/packages/fx-core/tests/v4/surface/createSelectorWalk.test.ts
+++ b/packages/fx-core/tests/v4/surface/createSelectorWalk.test.ts
@@ -11,6 +11,7 @@ import {
   UserInteraction,
 } from "@microsoft/teamsfx-api";
 import AdmZip from "adm-zip";
+import fs from "fs-extra";
 import path from "path";
 import { Result, err, ok } from "neverthrow";
 import { openCreateSelectorPresentation } from "../../../src/v4/distribution/createSelector";
@@ -117,6 +118,27 @@ const MCP_DA_PICKS: Record<string, string> = {
 const LANGUAGE_QUESTION = ["lang", "uage"].join("");
 
 describe("runCreateSelector (walk-create-selector)", () => {
+  it("WCS-00: selector-only Q1 can resolve from the selector's own v4 routes", async () => {
+    const selectorBytes = fs.readFileSync(path.join(TEMPLATES_V4_DIR, "create", "selector.json"));
+    const picks = {
+      projectType: "custom-engine-agent-type",
+      customEngineAgent: "weather-agent",
+    };
+    const ui = new ScriptedUI(picks);
+
+    const res = await runCreateSelector(selectorBytes, asUI(ui), "vscode", {
+      flagReader: () => false,
+      selectorBytesKind: "json",
+    });
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.equal(res.value.templateId, "weather-agent");
+      assert.equal(res.value.engine, "v4");
+      assert.deepEqual(res.value.answers, picks);
+    }
+  });
+
   it("WCS-01: copilot→add-action→mcp with DT on resolves the v4 da/mcp-server front door", async () => {
     const ui = new ScriptedUI(MCP_DA_PICKS);
 

--- a/packages/fx-core/tests/v4/surface/modifySelectorWalk.test.ts
+++ b/packages/fx-core/tests/v4/surface/modifySelectorWalk.test.ts
@@ -9,6 +9,7 @@ import {
   UserInteraction,
 } from "@microsoft/teamsfx-api";
 import AdmZip from "adm-zip";
+import fs from "fs-extra";
 import path from "path";
 import { Result, err, ok } from "neverthrow";
 import { runModifySelector } from "../../../src/v4/surface/modifySelectorWalk";
@@ -54,6 +55,23 @@ const MCP_ADD_ACTION_PICKS: Record<string, string> = {
 };
 
 describe("runModifySelector", () => {
+  it("WMS-00: selector-only Q1 can resolve from the selector's own v4 routes", async () => {
+    const selectorBytes = fs.readFileSync(path.join(TEMPLATES_V4_DIR, "modify", "selector.json"));
+    const ui = new ScriptedUI(MCP_ADD_ACTION_PICKS);
+
+    const res = await runModifySelector(selectorBytes, asUI(ui), "vscode", {
+      flagReader: flagsOn(DT),
+      selectorBytesKind: "json",
+    });
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.equal(res.value.templateId, "add-mcp-server");
+      assert.equal(res.value.engine, "v4");
+      assert.deepEqual(res.value.answers, MCP_ADD_ACTION_PICKS);
+    }
+  });
+
   it("WMS-01: add-action→mcp with DT on resolves the v4 add-mcp-server modify package", async () => {
     const ui = new ScriptedUI(MCP_ADD_ACTION_PICKS);
 

--- a/templates/scripts/generateV4Zip.js
+++ b/templates/scripts/generateV4Zip.js
@@ -33,7 +33,7 @@
  */
 
 const AdmZip = require("adm-zip");
-const { readdirSync, mkdirSync, writeFileSync, existsSync } = require("node:fs");
+const { readdirSync, mkdirSync, writeFileSync, existsSync, copyFileSync } = require("node:fs");
 const path = require("path");
 const semver = require("semver");
 
@@ -59,6 +59,25 @@ function computeV4PublishVersion(rawVersion) {
   return `${parsed.major}.${parsed.minor}.${parsed.patch}`;
 }
 
+function addV4MetadataFiles(zip, sourceRoot, zipRoot) {
+  for (const entry of readdirSync(sourceRoot, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceRoot, entry.name);
+    const zipPath = path.posix.join(zipRoot, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "content") {
+        continue;
+      }
+      addV4MetadataFiles(zip, sourcePath, zipPath);
+      continue;
+    }
+    if (
+      ["selector.json", "descriptor.json", "questions.json", "pipeline.json"].includes(entry.name)
+    ) {
+      zip.addLocalFile(sourcePath, path.posix.dirname(zipPath));
+    }
+  }
+}
+
 const LANGUAGES = ["common", "js", "ts", "python"];
 const BUILD_PATH = path.join(__dirname, "..", "build", "v4");
 const rawVersion = require(path.join(__dirname, "..", "package.json")).version;
@@ -82,6 +101,19 @@ LANGUAGES.forEach((lang) => {
 const v4SourcePath = path.join(__dirname, "..", "v4");
 if (existsSync(v4SourcePath)) {
   zip.addLocalFolder(v4SourcePath, "v4");
+
+  copyFileSync(
+    path.join(v4SourcePath, "create", "selector.json"),
+    path.join(BUILD_PATH, "create-selector.json")
+  );
+  copyFileSync(
+    path.join(v4SourcePath, "modify", "selector.json"),
+    path.join(BUILD_PATH, "modify-selector.json")
+  );
+
+  const metadataZip = new AdmZip();
+  addV4MetadataFiles(metadataZip, v4SourcePath, "v4");
+  metadataZip.writeZip(path.join(BUILD_PATH, "templates-metadata.zip"));
 }
 
 console.log(`Generating v4 templates.zip (version ${version})`);


### PR DESCRIPTION
## Summary

- Split v4 template distribution into staged artifacts: create selector, modify selector, metadata zip, and full templates zip.
- Add shared v4 artifact resolver/cache with pinned snapshot behavior across Q1, Q2, and scaffold.
- Wire create/modify front doors, metadata warming, bundled fallback, CD publishing, and docs/specs to the final staged artifact shape.
- Ignore generated `packages/fx-core/templates/v4` bundled artifacts so local build output does not enter source control.

## Validation

- `Push-Location templates; npm run generate:vsc; npm run distribute; Pop-Location`
- `Push-Location packages/fx-core; npm run build; Pop-Location`
- `Push-Location packages/fx-core; npx vitest run --config vitest.config.ts --maxWorkers=75% tests/v4/distribution/templateArtifacts.test.ts tests/v4/distribution/bundledFloor.test.ts tests/component/generator/v4MetadataSource.test.ts tests/component/generator/v4TemplateBridge.test.ts tests/core/createProjectFrontDoor.test.ts tests/core/modifyProjectFrontDoor.test.ts; Pop-Location`
- CLI smoke: `node packages/cli/cli.js new -c declarative-agent -n v4-cache-smoke-0102-124753 -f C:\Users\zhiyou\AgentsToolkitProjects -i false --telemetry false`, then verified cached latest online `templates-v4@6.11.2026070102` artifact digests matched `template-v4-tag-list`.

## Notes

Temporary smoke release markers and prerelease config changes used for validation have been reverted before this PR.