### PR TITLE
fix(scaffold): align v4 create question parity

### DIFF
--- a/docs/03-specs/scenarios/da/create-mcp-server-static.md
+++ b/docs/03-specs/scenarios/da/create-mcp-server-static.md
@@ -9,17 +9,26 @@ This is the DT-off v4 create contract for MCP-backed Declarative Agents. It
 keeps the legacy static-tools artifact shape inside the v4 scaffolding runtime:
 selected MCP tools are materialized into `appPackage/mcp-tools-1.json`, and
 `appPackage/ai-plugin.json` references that file through a `RemoteMCPServer`
-runtime. It is selected by `TEAMSFX_MCP_FOR_DA_DT == false`; the DT-on dynamic
-runtime shape remains owned by [`da/mcp-server`](create-mcp-server.md).
+runtime. The route is selected when `TEAMSFX_MCP_FOR_DA_DT == false`; the
+template's questions and post-render step then branch by surface. VS Code asks
+only for `mcpServerUrl` during create and leaves tool discovery to the follow-up
+MCP CodeLens flow. CLI asks for an optional static MCP tools file path; when the
+path is omitted, Q2 fetches tools from `mcpServerUrl`. If that fetch discovers an
+auth-required server, create fails instead of scaffolding incomplete static tool
+artifacts. The DT-on dynamic runtime shape
+remains owned by [`da/mcp-server`](create-mcp-server.md).
 
 ## Acceptance Criteria
 
 | ID | Tier | Given | When | Then |
 |----|------|-------|------|------|
-| SCN-CREATE-MCP-STATIC-01 | L1 | `mcpServerUrl`, `mcpToolsJson`, `selectedMcpTools=["search","calendar"]`, empty target | scaffold completes | render writes the base DA files and the static MCP step writes `appPackage/mcp-tools-1.json` |
-| SCN-CREATE-MCP-STATIC-02 | L1 | `selectedMcpTools=["search"]` and `mcpToolsJson` contains `search` + `calendar` | scaffold completes | `ai-plugin.json.functions` contains only `search`, and `mcp-tools-1.json.tools` contains only the full `search` tool definition |
+| SCN-CREATE-MCP-STATIC-01 | L1 | `surface="cli"`, `mcpServerUrl`, `mcpToolsFilePath`, `selectedMcpTools=["search","calendar"]`, empty target | scaffold completes | render writes the base DA files and the static MCP step writes `appPackage/mcp-tools-1.json` |
+| SCN-CREATE-MCP-STATIC-02 | L1 | `selectedMcpTools=["search"]` and `mcpToolsFilePath` points to tools containing `search` + `calendar` | scaffold completes | `ai-plugin.json.functions` contains only `search`, and `mcp-tools-1.json.tools` contains only the full `search` tool definition |
 | SCN-CREATE-MCP-STATIC-03 | L1 | static MCP scaffold output | inspect `ai-plugin.json` | `runtimes[0].spec.mcp_tool_description.file == "mcp-tools-1.json"`, `run_for_functions == ["search"]`, and `enable_dynamic_discovery` is absent |
 | SCN-CREATE-MCP-STATIC-04 | L1 | non-empty target | scaffold | `require-empty-target` fails first with **`UserError`** and writes nothing |
+| SCN-CREATE-MCP-STATIC-05 | L1 | `surface="vscode"`, `mcpServerUrl`, empty target | scaffold completes | render writes the base DA files, skips `mcp-static/materialize-tools`, and does not write `appPackage/mcp-tools-1.json` |
+| SCN-CREATE-MCP-STATIC-06 | L1 | `surface="cli"`, `mcpServerUrl`, no `mcpToolsFilePath` | Q2 reaches tool selection | tools are fetched from `mcpServerUrl` and listed for selection |
+| SCN-CREATE-MCP-STATIC-07 | L1 | `surface="cli"`, `mcpServerUrl`, no `mcpToolsFilePath`, and the server requires auth | Q2 fetches tools | create fails with **`UserError`** before scaffold writes files |
 
 ## Flow
 
@@ -29,7 +38,9 @@ flowchart TD
   Open --> Guard{require-empty-target}
   Guard -- non-empty --> Err[UserError — nothing written]
   Guard -- empty --> Render[render base DA files]
-  Render --> Static[mcp-static/materialize-tools]
+  Render --> Surface{surface == cli?}
+  Surface -- Yes --> Static[mcp-static/materialize-tools]
+  Surface -- No --> Done
   Static --> Plugin[ai-plugin.json functions + RemoteMCPServer runtime]
   Static --> Tools[mcp-tools-1.json full selected tool definitions]
   Plugin --> Done([scaffold output ready])
@@ -39,6 +50,7 @@ flowchart TD
 ## Boundary
 
 This scenario does not assert the DT-on dynamic discovery shape; that remains in
-[`create-mcp-server.md`](create-mcp-server.md). It also does not assert VS Code
-or CLI prompt mechanics; this is the scaffold-output contract over the v4
-runtime.
+[`create-mcp-server.md`](create-mcp-server.md). It also does not assert the VS
+Code follow-up CodeLens flow; this is the scaffold-output contract over the v4
+runtime after the CLI has supplied static MCP tools, plus the VS Code create
+contract that static tool materialization is skipped.

--- a/packages/cli/src/commands/models/create.ts
+++ b/packages/cli/src/commands/models/create.ts
@@ -35,6 +35,7 @@ const CREATE_INPUT_ALIASES: ReadonlyArray<readonly [string, string]> = [
   ["api-operation", "apiOperations"],
   ["addin-project-manifest", "officeAddinManifest"],
   ["mcp-da-server-url", "mcpServerUrl"],
+  ["mcp-tools-file-path", "mcpToolsFilePath"],
   ["mcp-da-auth-type", "authType"],
   ["azure-openai-key", "azureOpenAIKey"],
   ["azure-openai-endpoint", "azureOpenAIEndpoint"],

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -258,6 +258,7 @@ describe("CLI commands", () => {
         optionValues: {
           nonInteractive: true,
           "mcp-da-server-url": "https://example.com/mcp",
+          "mcp-tools-file-path": "C:/tools/mcp-tools.json",
           "mcp-da-auth-type": "none",
           "api-auth": "none",
           "api-operation": ["GET /repairs"],
@@ -276,6 +277,8 @@ describe("CLI commands", () => {
       const inputs = createProjectFrontDoorStub.mock.calls[0][0] as any;
       assert.equal(inputs.mcpServerUrl, "https://example.com/mcp");
       assert.equal(inputs["mcp-da-server-url"], "https://example.com/mcp");
+      assert.equal(inputs.mcpToolsFilePath, "C:/tools/mcp-tools.json");
+      assert.equal(inputs["mcp-tools-file-path"], "C:/tools/mcp-tools.json");
       assert.equal(inputs.authType, "none");
       assert.equal(inputs["mcp-da-auth-type"], "none");
       assert.equal(inputs.apiAuth, "none");

--- a/packages/fx-core/src/core/createProjectFrontDoor.ts
+++ b/packages/fx-core/src/core/createProjectFrontDoor.ts
@@ -40,9 +40,8 @@ import { QuestionNames } from "../question/questionNames";
  * Behind `TEAMSFX_V4_ENABLED`, the v4 create selector is the live Q1 front door
  * and the resolved `BuildTarget` is dispatched by its `engine` (INV-3):
  *   - `v4`             → run the template's own Q2 (`runCreateInputs`) over the
- *                        same floor, collect the create floor (`folder`/`app-name`,
- *                        the step the v3 `QuestionMW` owns), then `scaffoldV4` the
- *                        authored package;
+ *                        same floor, with the create floor appended to the same
+ *                        walk, then `scaffoldV4` the authored package;
  *   - `v3`             → translate the Q1 picks onto the v3 `QuestionNames.*`
  *                        (`applyV3PreFill`, INV-5) and hand off to `createV3`,
  *                        whose `QuestionMW` then skips Q1 and asks only Q2;
@@ -102,7 +101,7 @@ const NON_V4_INPUT_KEYS: ReadonlySet<string> = new Set([
  * The create front door's injected seams. `createV3` is required — it is both the
  * flag-off pass-through and the engine=v3 hand-off, and injecting it (rather than
  * importing `FxCore`) keeps this seam free of an import cycle. `scaffoldV4`,
- * `collectCreateFloor`, and `applyV3PreFill` are the flag-on hand-offs the
+ * `runInputs`, and `applyV3PreFill` are the flag-on hand-offs the
  * composition root (`FxCore`) supplies. The remaining members default to the real
  * wiring, so a production caller passes only the four handlers.
  */
@@ -117,13 +116,7 @@ export interface CreateFrontDoorDeps {
     flagReader: (name: string) => boolean,
     resolvedPackage?: ResolvedV4ChannelPackage
   ) => Promise<Result<CreateProjectResult, FxError>>;
-  /**
-   * The engine=v4 create-floor collection: ask `folder` + `app-name`. The v4 path
-   * carries no `QuestionMW`, so the front door collects the floor itself — the same
-   * step `createProject`'s `QuestionMW` runs (last) for v3. Interactive surfaces are
-   * prompted; a non-interactive surface (a CLI preset `template-name` / `-f` / `-n`)
-   * is skipped exactly as v3 is.
-   */
+  /** Legacy create-floor seam retained for existing composition wiring; v4 now appends floor questions inside `runInputs`. */
   collectCreateFloor: (inputs: Inputs, ui: UserInteraction) => Promise<Result<undefined, FxError>>;
   /** The engine=v3 adapter: translate the Q1 dimension picks onto the v3 `QuestionNames.*` (INV-5). */
   applyV3PreFill: (inputs: Inputs, target: BuildTarget) => void;
@@ -205,6 +198,17 @@ function selectorPrefillFromInputs(inputs: Inputs): Record<string, string> {
 
 function templateNameForV4(target: BuildTarget): string {
   return V4_TO_V3_TEMPLATE_ID[target.templateId] ?? target.templateId;
+}
+
+function applyV4CreateFloorAnswers(inputs: Inputs, answers: Answers): void {
+  const folder = answers[QuestionNames.Folder];
+  if (typeof folder === "string") {
+    inputs[QuestionNames.Folder] = folder;
+  }
+  const appName = answers[QuestionNames.AppName];
+  if (typeof appName === "string") {
+    inputs[QuestionNames.AppName] = appName;
+  }
 }
 
 /** Map the host `Platform` onto the selector's `surface` axis (drives option `condition`s). */
@@ -364,18 +368,12 @@ export async function createProjectFrontDoor(
       const answers = await runInputs(inputBytes, locator, entryParams, ui, {
         flagReader,
         surface,
+        inputs,
       });
       if (answers.isErr()) {
         return err(answers.error);
       }
-      // The v4 path carries no QuestionMW (createProject's, which asks the v3 tree's
-      // folder/app-name last), so collect the create floor here — interactive
-      // surfaces are prompted; a non-interactive surface fails through the same
-      // required-input validation without depending on the v3 question visitor.
-      const floorRes = await deps.collectCreateFloor(inputs, ui);
-      if (floorRes.isErr()) {
-        return err(floorRes.error);
-      }
+      applyV4CreateFloorAnswers(inputs, answers.value);
       if (snapshot !== undefined) {
         const fullBytes = await readSnapshotBytes(snapshot, "templates");
         if (fullBytes.isErr()) {

--- a/packages/fx-core/src/core/createProjectFrontDoor.ts
+++ b/packages/fx-core/src/core/createProjectFrontDoor.ts
@@ -7,7 +7,6 @@ import {
   Inputs,
   Platform,
   SystemError,
-  UserError,
   UserInteraction,
 } from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
@@ -25,13 +24,11 @@ import {
   runCreateSelector,
   templateSourceFromArtifactSnapshot,
 } from "../v4";
-import { parseMcpStaticToolsJson } from "../v4/mcp/mcpStaticTools";
 import { FeatureFlags, readBooleanFeatureFlag } from "../common/featureFlags";
 import { TOOLS } from "../common/globalVars";
 import { TemplateNames } from "../component/generator/templates/templateNames";
 import type { ResolvedV4ChannelPackage } from "../component/generator/v4TemplateBridge";
 import { QuestionNames } from "../question/questionNames";
-import { fetchMCPTools, MCPFetchResult } from "../component/utils/mcpToolFetcher";
 
 /**
  * Operation `dispatch-create-by-engine` — the create front door.
@@ -63,7 +60,6 @@ const SOURCE = "Scaffold";
 
 /** The only shipped create `surface-action`: open GitHub Copilot Chat (the v3 `startWithGithubCopilot` shape). */
 const OPEN_GITHUB_COPILOT_CHAT = "open-github-copilot-chat";
-const STATIC_MCP_TEMPLATE_ID = "da/mcp-server-static";
 const V4_TO_V3_TEMPLATE_ID: Readonly<Record<string, string>> = {
   "basic-custom-engine-agent": TemplateNames.BasicCustomEngineAgent,
   "weather-agent": TemplateNames.WeatherAgent,
@@ -151,8 +147,6 @@ export interface CreateFrontDoorDeps {
   resolveByTemplateId?: typeof resolveCreateTargetByTemplateId;
   /** The Q2 inputs walk (default: the real `runCreateInputs`). */
   runInputs?: typeof runCreateInputs;
-  /** Fetch MCP tools for the legacy static-MCP server-url-only CLI path. */
-  fetchMcpTools?: (serverUrl: string) => Promise<MCPFetchResult>;
 }
 
 /** The default `featureFlagManager`-backed reader (a flag is on per its env var / VS Code setting). */
@@ -197,59 +191,6 @@ function neutralAnswersFromInputs(inputs: Inputs): Answers {
     answers.officeAddinManifest = officeAddinManifest;
   }
   return answers;
-}
-
-async function addLegacyStaticMcpInputs(
-  target: BuildTarget,
-  inputs: Inputs,
-  entryParams: Answers,
-  fetchTools: (serverUrl: string) => Promise<MCPFetchResult>
-): Promise<Result<Answers, FxError>> {
-  if (target.templateId !== STATIC_MCP_TEMPLATE_ID) {
-    return ok(entryParams);
-  }
-
-  const toolsFilePath = inputs[QuestionNames.MCPToolsFilePath];
-  const mcpServerUrl = inputs[QuestionNames.MCPForDAServerUrl] ?? entryParams.mcpServerUrl;
-  let toolsJson: string | undefined;
-  if (typeof toolsFilePath === "string" && toolsFilePath.length > 0) {
-    try {
-      toolsJson = fs.readFileSync(toolsFilePath, "utf8");
-    } catch {
-      return err(
-        new UserError({
-          source: SOURCE,
-          name: "McpToolsFileReadFailed",
-          message: "Failed to read the MCP tools file.",
-        })
-      );
-    }
-  } else if (typeof mcpServerUrl === "string" && mcpServerUrl.length > 0) {
-    const fetchResult = await fetchTools(mcpServerUrl);
-    if (fetchResult.requiresAuth || fetchResult.tools.length === 0) {
-      return ok(entryParams);
-    }
-    toolsJson = JSON.stringify({ tools: fetchResult.tools });
-  }
-
-  if (toolsJson === undefined) {
-    return ok(entryParams);
-  }
-
-  const parsed = parseMcpStaticToolsJson(toolsJson);
-  if (!parsed.ok) {
-    return err(new UserError({ source: SOURCE, name: parsed.code, message: parsed.message }));
-  }
-
-  return ok({
-    ...entryParams,
-    ...(typeof mcpServerUrl === "string" ? { mcpServerUrl } : {}),
-    mcpToolsJson:
-      typeof entryParams.mcpToolsJson === "string" ? entryParams.mcpToolsJson : toolsJson,
-    selectedMcpTools: Array.isArray(entryParams.selectedMcpTools)
-      ? entryParams.selectedMcpTools
-      : parsed.tools.map((tool) => tool.name),
-  });
 }
 
 function selectorPrefillFromInputs(inputs: Inputs): Record<string, string> {
@@ -407,15 +348,6 @@ export async function createProjectFrontDoor(
         ...(target.value.answers ?? {}),
         ...neutralAnswersFromInputs(inputs),
       };
-      const bridgedEntryParams = await addLegacyStaticMcpInputs(
-        target.value,
-        inputs,
-        entryParams,
-        deps.fetchMcpTools ?? fetchMCPTools
-      );
-      if (bridgedEntryParams.isErr()) {
-        return err(bridgedEntryParams.error);
-      }
       let inputBytes: Buffer;
       if (snapshot === undefined) {
         if (floorBytes === undefined) {
@@ -429,7 +361,7 @@ export async function createProjectFrontDoor(
         }
         inputBytes = metadataBytes.value;
       }
-      const answers = await runInputs(inputBytes, locator, bridgedEntryParams.value, ui, {
+      const answers = await runInputs(inputBytes, locator, entryParams, ui, {
         flagReader,
         surface,
       });

--- a/packages/fx-core/src/v4/collectInputs/collectInputs.ts
+++ b/packages/fx-core/src/v4/collectInputs/collectInputs.ts
@@ -86,7 +86,10 @@ export interface OptionsProvider {
 }
 
 /** Engine-registered validator: an error message, or `undefined` when valid. */
-export type Validator = (value: string) => string | undefined;
+export type Validator = (
+  value: string,
+  answers: Answers
+) => string | undefined | Promise<string | undefined>;
 
 /** One prompt's outcome: a chosen value or the host's `back` request. */
 export type Asked<T> = { kind: "value"; value: T } | { kind: "back" };
@@ -113,6 +116,10 @@ export interface CollectInputsPort {
   optionsProvider(providerId: string): OptionsProvider | undefined;
   validator(name: string): Validator | undefined;
   evaluate(node: ConditionNode, scope: Scope): Result<EvalValue, FxError>;
+}
+
+export interface CollectInputsOptions {
+  appendLanguage?: boolean;
 }
 
 /** `SystemError` names for engine-side input collection breaks. */
@@ -143,7 +150,8 @@ export async function collectInputs(
   optionsSchema: OptionsSchema,
   entryParams: Answers,
   languages: string[],
-  port: CollectInputsPort
+  port: CollectInputsPort,
+  options: CollectInputsOptions = {}
 ): Promise<Result<Answers, FxError>> {
   // Pre-filled entry params must be visible to question conditions.
   let answers: Answers = { ...entryParams };
@@ -156,10 +164,11 @@ export async function collectInputs(
   // Back history snapshots only prompted steps; skipped and pre-filled steps are crossed over.
   const history: { pos: number; answers: Answers }[] = [];
 
-  // pos 0 is the language axis; later positions map to authored questions.
+  // Authored questions are asked first; the language axis is appended after Q2 by default.
+  const appendLanguage = options.appendLanguage ?? true;
   let pos = 0;
-  while (pos <= questions.length) {
-    if (pos === 0) {
+  while (pos < questions.length || (appendLanguage && pos === questions.length)) {
+    if (pos === questions.length) {
       // A non-singleton language list prompts; `["common"]` has no axis.
       if (languages.length > 1) {
         if (typeof answers.language === "string") {
@@ -197,7 +206,7 @@ export async function collectInputs(
       continue;
     }
 
-    const q = questions[pos - 1];
+    const q = questions[pos];
 
     // Keep the schema invariant guarded at runtime too.
     if (q.staticOptions !== undefined && q.optionsFrom !== undefined) {
@@ -344,7 +353,7 @@ export async function collectInputs(
           )
         );
       }
-      const message = validator(value);
+      const message = await validator(value, answers);
       if (message !== undefined) {
         return err(
           new UserError({

--- a/packages/fx-core/src/v4/runtime/steps/mcpLocal.ts
+++ b/packages/fx-core/src/v4/runtime/steps/mcpLocal.ts
@@ -3,11 +3,16 @@
 
 import { FxError, SystemError } from "@microsoft/teamsfx-api";
 import { Result, err, ok } from "neverthrow";
+import { ODRProvider, type ODRServer } from "../../../component/utils/odrProvider";
 import { RegisteredStep, StepContext, StepParams } from "../../pipeline/runScaffoldPipeline";
 
 /** Materialize local MCP stdio servers. See create-mcp-server scenario spec. */
 
 const SOURCE = "Scaffold";
+
+export const mcpLocalDeps = {
+  listServers: (): Promise<ODRServer[]> => ODRProvider.listServers(),
+};
 
 /** Engine step name `mcp-local/materialize-servers`. */
 export const STEP_MATERIALIZE_LOCAL_SERVERS = "mcp-local/materialize-servers";
@@ -20,6 +25,14 @@ function systemError(name: string, message: string): SystemError {
 function stringParam(params: StepParams, key: string): string | undefined {
   const value = params[key];
   return typeof value === "string" ? value : undefined;
+}
+
+function optionalStringParam(params: StepParams, key: string): string | undefined {
+  const value = stringParam(params, key);
+  if (value === undefined || /^\{\{[A-Za-z_][A-Za-z0-9_.]*\}\}$/.test(value)) {
+    return undefined;
+  }
+  return value;
 }
 
 /** Read a `with` value as the multiSelect `string[]`, or `undefined`. */
@@ -37,6 +50,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function catalogFromServers(servers: ODRServer[]): Record<string, unknown> {
+  const catalog: Record<string, unknown> = {};
+  for (const server of servers) {
+    catalog[server.name] = { command: server.command, args: server.args };
+  }
+  return catalog;
 }
 
 /** One materialized stdio server entry. */
@@ -80,30 +101,31 @@ export const mcpLocalMaterializeServers: RegisteredStep = {
     if (stringArrayParam(resolved, "selected") === undefined) {
       return "missing string[] parameter 'selected'";
     }
-    if (stringParam(resolved, "catalog") === undefined) {
-      return "missing string parameter 'catalog'";
-    }
     return undefined;
   },
-  apply(resolved: StepParams, ctx: StepContext): Result<void, FxError> {
+  async apply(resolved: StepParams, ctx: StepContext): Promise<Result<void, FxError>> {
     const target = stringParam(resolved, "target");
     const selected = stringArrayParam(resolved, "selected");
-    const catalogRaw = stringParam(resolved, "catalog");
-    if (target === undefined || selected === undefined || catalogRaw === undefined) {
+    const catalogRaw = optionalStringParam(resolved, "catalog");
+    if (target === undefined || selected === undefined) {
       return err(
         systemError("McpLocalParams", "resolved parameters are not all of the expected type")
       );
     }
     let parsed: unknown;
-    try {
-      parsed = JSON.parse(catalogRaw);
-    } catch (error) {
-      return err(
-        systemError(
-          "McpLocalCatalogParse",
-          `local server catalog is not valid JSON: ${errorMessage(error)}`
-        )
-      );
+    if (catalogRaw === undefined) {
+      parsed = catalogFromServers(await mcpLocalDeps.listServers());
+    } else {
+      try {
+        parsed = JSON.parse(catalogRaw);
+      } catch (error) {
+        return err(
+          systemError(
+            "McpLocalCatalogParse",
+            `local server catalog is not valid JSON: ${errorMessage(error)}`
+          )
+        );
+      }
     }
     if (!isRecord(parsed)) {
       return err(systemError("McpLocalCatalogShape", "local server catalog is not a JSON object"));

--- a/packages/fx-core/src/v4/runtime/steps/mcpStatic.ts
+++ b/packages/fx-core/src/v4/runtime/steps/mcpStatic.ts
@@ -1,14 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FxError, SystemError } from "@microsoft/teamsfx-api";
+import { FxError, SystemError, UserError } from "@microsoft/teamsfx-api";
+import fs from "fs-extra";
 import { Result, err, ok } from "neverthrow";
+import { MCPFetchResult, fetchMCPTools } from "../../../component/utils/mcpToolFetcher";
 import { parseMcpStaticToolsJson, selectMcpStaticTools } from "../../mcp/mcpStaticTools";
 import { RegisteredStep, StepContext, StepParams } from "../../pipeline/runScaffoldPipeline";
 
 /** Materialize static MCP tools and plugin runtime metadata. */
 
 const SOURCE = "Scaffold";
+
+export const mcpStaticDeps = {
+  fetchTools: (serverUrl: string): Promise<MCPFetchResult> => fetchMCPTools(serverUrl),
+};
 
 /** Engine step name `mcp-static/materialize-tools`. */
 export const STEP_MATERIALIZE_STATIC_MCP_TOOLS = "mcp-static/materialize-tools";
@@ -32,6 +38,71 @@ function stringArrayParam(params: StepParams, key: string): string[] | undefined
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mcpToolsJsonFromFetchResult(
+  serverUrl: string,
+  result: MCPFetchResult
+): Result<string, FxError> {
+  if (result.requiresAuth) {
+    return err(
+      new UserError({
+        source: SOURCE,
+        name: "McpAuthRequired",
+        message: `The MCP server at ${serverUrl} requires authentication.`,
+      })
+    );
+  }
+  if (result.tools.length === 0) {
+    return err(
+      new UserError({
+        source: SOURCE,
+        name: "McpToolsNotFound",
+        message: `No tools were discovered from the MCP server at ${serverUrl}.`,
+      })
+    );
+  }
+  return ok(JSON.stringify({ tools: result.tools }));
+}
+
+async function resolveToolsJson(
+  resolved: StepParams,
+  serverUrl: string
+): Promise<Result<string, FxError>> {
+  const toolsJson = stringParam(resolved, "toolsJson")?.trim();
+  if (toolsJson) {
+    return ok(toolsJson);
+  }
+
+  const toolsFilePath = stringParam(resolved, "toolsFilePath")?.trim();
+  if (toolsFilePath) {
+    try {
+      return ok(fs.readFileSync(toolsFilePath, "utf8"));
+    } catch {
+      return err(
+        new UserError({
+          source: SOURCE,
+          name: "McpToolsFileReadFailed",
+          message: "Failed to read the MCP tools file.",
+        })
+      );
+    }
+  }
+
+  try {
+    return mcpToolsJsonFromFetchResult(serverUrl, await mcpStaticDeps.fetchTools(serverUrl));
+  } catch (error) {
+    if (error instanceof UserError || error instanceof SystemError) {
+      return err(error);
+    }
+    return err(
+      new UserError({
+        source: SOURCE,
+        name: "McpToolsFetchFailed",
+        message: `Failed to fetch tools from the MCP server at ${serverUrl}.`,
+      })
+    );
+  }
 }
 
 function errorMessage(error: unknown): string {
@@ -85,25 +156,20 @@ export const mcpStaticMaterializeTools: RegisteredStep = {
     if (stringParam(resolved, "mcpServerUrl") === undefined) {
       return "missing string parameter 'mcpServerUrl'";
     }
-    if (stringParam(resolved, "toolsJson") === undefined) {
-      return "missing string parameter 'toolsJson'";
-    }
     if (stringArrayParam(resolved, "selected") === undefined) {
       return "missing string[] parameter 'selected'";
     }
     return undefined;
   },
-  apply(resolved: StepParams, ctx: StepContext): Result<void, FxError> {
+  async apply(resolved: StepParams, ctx: StepContext): Promise<Result<void, FxError>> {
     const pluginPath = stringParam(resolved, "pluginPath");
     const toolsPath = stringParam(resolved, "toolsPath");
     const mcpServerUrl = stringParam(resolved, "mcpServerUrl");
-    const toolsJson = stringParam(resolved, "toolsJson");
     const selected = stringArrayParam(resolved, "selected");
     if (
       pluginPath === undefined ||
       toolsPath === undefined ||
       mcpServerUrl === undefined ||
-      toolsJson === undefined ||
       selected === undefined
     ) {
       return err(
@@ -111,7 +177,12 @@ export const mcpStaticMaterializeTools: RegisteredStep = {
       );
     }
 
-    const parsedTools = parseMcpStaticToolsJson(toolsJson);
+    const toolsJson = await resolveToolsJson(resolved, mcpServerUrl);
+    if (toolsJson.isErr()) {
+      return err(toolsJson.error);
+    }
+
+    const parsedTools = parseMcpStaticToolsJson(toolsJson.value);
     if (!parsedTools.ok) {
       return err(systemError(parsedTools.code, parsedTools.message));
     }

--- a/packages/fx-core/src/v4/runtime/steps/mcpStatic.ts
+++ b/packages/fx-core/src/v4/runtime/steps/mcpStatic.ts
@@ -28,6 +28,18 @@ function stringParam(params: StepParams, key: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function isUnresolvedToken(value: string): boolean {
+  return /^\{\{[A-Za-z_][A-Za-z0-9_.]*\}\}$/.test(value);
+}
+
+function optionalStringParam(params: StepParams, key: string): string | undefined {
+  const value = stringParam(params, key);
+  if (value === undefined || value === "" || isUnresolvedToken(value)) {
+    return undefined;
+  }
+  return value;
+}
+
 function stringArrayParam(params: StepParams, key: string): string[] | undefined {
   const value = params[key];
   if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
@@ -38,10 +50,23 @@ function stringArrayParam(params: StepParams, key: string): string[] | undefined
 
 function optionalStringArrayParam(params: StepParams, key: string): string[] | undefined {
   const value = params[key];
-  if (value === undefined || value === "") {
+  if (
+    value === undefined ||
+    value === "" ||
+    (typeof value === "string" && isUnresolvedToken(value))
+  ) {
     return undefined;
   }
   return stringArrayParam(params, key);
+}
+
+function hasOptionalArrayParamValue(params: StepParams, key: string): boolean {
+  const value = params[key];
+  return !(
+    value === undefined ||
+    value === "" ||
+    (typeof value === "string" && isUnresolvedToken(value))
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -77,12 +102,12 @@ async function resolveToolsJson(
   resolved: StepParams,
   serverUrl: string
 ): Promise<Result<string, FxError>> {
-  const toolsJson = stringParam(resolved, "toolsJson")?.trim();
+  const toolsJson = optionalStringParam(resolved, "toolsJson")?.trim();
   if (toolsJson) {
     return ok(toolsJson);
   }
 
-  const toolsFilePath = stringParam(resolved, "toolsFilePath")?.trim();
+  const toolsFilePath = optionalStringParam(resolved, "toolsFilePath")?.trim();
   if (toolsFilePath) {
     try {
       return ok(fs.readFileSync(toolsFilePath, "utf8"));
@@ -165,8 +190,7 @@ export const mcpStaticMaterializeTools: RegisteredStep = {
       return "missing string parameter 'mcpServerUrl'";
     }
     if (
-      resolved.selected !== undefined &&
-      resolved.selected !== "" &&
+      hasOptionalArrayParamValue(resolved, "selected") &&
       stringArrayParam(resolved, "selected") === undefined
     ) {
       return "missing string[] parameter 'selected'";
@@ -178,7 +202,7 @@ export const mcpStaticMaterializeTools: RegisteredStep = {
     const toolsPath = stringParam(resolved, "toolsPath");
     const mcpServerUrl = stringParam(resolved, "mcpServerUrl");
     const selected = optionalStringArrayParam(resolved, "selected");
-    if (resolved.selected !== undefined && resolved.selected !== "" && selected === undefined) {
+    if (hasOptionalArrayParamValue(resolved, "selected") && selected === undefined) {
       return err(
         systemError("McpStaticParams", "resolved parameters are not all of the expected type")
       );

--- a/packages/fx-core/src/v4/runtime/steps/mcpStatic.ts
+++ b/packages/fx-core/src/v4/runtime/steps/mcpStatic.ts
@@ -36,6 +36,14 @@ function stringArrayParam(params: StepParams, key: string): string[] | undefined
   return value;
 }
 
+function optionalStringArrayParam(params: StepParams, key: string): string[] | undefined {
+  const value = params[key];
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  return stringArrayParam(params, key);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -156,7 +164,11 @@ export const mcpStaticMaterializeTools: RegisteredStep = {
     if (stringParam(resolved, "mcpServerUrl") === undefined) {
       return "missing string parameter 'mcpServerUrl'";
     }
-    if (stringArrayParam(resolved, "selected") === undefined) {
+    if (
+      resolved.selected !== undefined &&
+      resolved.selected !== "" &&
+      stringArrayParam(resolved, "selected") === undefined
+    ) {
       return "missing string[] parameter 'selected'";
     }
     return undefined;
@@ -165,13 +177,13 @@ export const mcpStaticMaterializeTools: RegisteredStep = {
     const pluginPath = stringParam(resolved, "pluginPath");
     const toolsPath = stringParam(resolved, "toolsPath");
     const mcpServerUrl = stringParam(resolved, "mcpServerUrl");
-    const selected = stringArrayParam(resolved, "selected");
-    if (
-      pluginPath === undefined ||
-      toolsPath === undefined ||
-      mcpServerUrl === undefined ||
-      selected === undefined
-    ) {
+    const selected = optionalStringArrayParam(resolved, "selected");
+    if (resolved.selected !== undefined && resolved.selected !== "" && selected === undefined) {
+      return err(
+        systemError("McpStaticParams", "resolved parameters are not all of the expected type")
+      );
+    }
+    if (pluginPath === undefined || toolsPath === undefined || mcpServerUrl === undefined) {
       return err(
         systemError("McpStaticParams", "resolved parameters are not all of the expected type")
       );
@@ -186,7 +198,10 @@ export const mcpStaticMaterializeTools: RegisteredStep = {
     if (!parsedTools.ok) {
       return err(systemError(parsedTools.code, parsedTools.message));
     }
-    const selectedTools = selectMcpStaticTools(parsedTools.tools, selected);
+    const selectedTools = selectMcpStaticTools(
+      parsedTools.tools,
+      selected ?? parsedTools.tools.map((tool) => tool.name)
+    );
     if (!selectedTools.ok) {
       return err(systemError(selectedTools.code, selectedTools.message));
     }

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -10,7 +10,11 @@ import {
   Utils,
   ValidationStatus,
 } from "@microsoft/m365-spec-parser";
+import fs from "fs-extra";
 import { Result, err } from "neverthrow";
+import { MCPFetchResult, fetchMCPTools } from "../../component/utils/mcpToolFetcher";
+import { ODRProvider, type ODRServer } from "../../component/utils/odrProvider";
+import { readBooleanFeatureFlag } from "../../common/featureFlags";
 import {
   CollectInputsPort,
   OptionsProvider,
@@ -26,16 +30,55 @@ import { Answers, DeclarativeLocator } from "../model/dataModel";
 import { parseDeclaredKeys } from "../runtime/packageParse";
 import { createExpressionPort } from "../runtime/whitelist";
 import { createUiPromptUI } from "./uiPromptUI";
-import { readBooleanFeatureFlag } from "../../common/featureFlags";
 
 /** Live create-path surface wiring for `collect-inputs`. See collect-create-inputs spec. */
 
-/** Default `mcp.serverTypes` provider; live local detection is injected later. */
-const remoteOnlyServerTypes: OptionsProvider = {
-  fetch() {
-    return { options: [{ id: "remote", label: "Remote" }] };
-  },
-};
+const remoteMcpServerType = { id: "remote", label: "Remote" };
+const localMcpServerType = { id: "local", label: "Local" };
+
+function createLocalServerCache(
+  listLocalMcpServers: () => Promise<ODRServer[]>
+): () => Promise<ODRServer[]> {
+  let cached: Promise<ODRServer[]> | undefined;
+  return () => {
+    if (cached === undefined) {
+      cached = listLocalMcpServers();
+    }
+    return cached;
+  };
+}
+
+function createMcpServerTypesProvider(localServers: () => Promise<ODRServer[]>): OptionsProvider {
+  return {
+    async fetch() {
+      const servers = await localServers();
+      return {
+        options:
+          servers.length > 0 ? [remoteMcpServerType, localMcpServerType] : [remoteMcpServerType],
+      };
+    },
+  };
+}
+
+function localServerDetail(server: ODRServer): string {
+  const toolsDetail = `${server.tools.length} tools available`;
+  return server.description ? `${server.description} (${toolsDetail})` : toolsDetail;
+}
+
+function createLocalMcpServersProvider(localServers: () => Promise<ODRServer[]>): OptionsProvider {
+  return {
+    async fetch() {
+      const servers = await localServers();
+      return {
+        options: servers.map((server) => ({
+          id: server.name,
+          label: server.display_name || server.name,
+          detail: localServerDetail(server),
+        })),
+      };
+    },
+  };
+}
 
 const openApiMethods = [
   "get",
@@ -129,36 +172,96 @@ const openApiOperationsProvider: OptionsProvider = {
   },
 };
 
-const mcpToolsProvider: OptionsProvider = {
-  fetch(params) {
-    const toolsJson = params.toolsJson?.trim();
-    if (!toolsJson) {
-      throw new UserError({
-        source: "Scaffold",
-        name: "McpToolsJsonMissing",
-        message: "MCP tools JSON is required before listing tools.",
-      });
-    }
-    const parsed = parseMcpStaticToolsJson(toolsJson);
-    if (!parsed.ok) {
-      throw new UserError({ source: "Scaffold", name: parsed.code, message: parsed.message });
-    }
-    return {
-      options: parsed.tools.map((tool) => ({
-        id: tool.name,
-        label: tool.name,
-        detail: tool.description,
-      })),
-    };
-  },
-};
+function mcpToolsJsonFromFetchResult(
+  serverUrl: string | undefined,
+  result: MCPFetchResult
+): string {
+  if (result.requiresAuth) {
+    throw new UserError({
+      source: "Scaffold",
+      name: "McpAuthRequired",
+      message: `The MCP server${serverUrl ? ` at ${serverUrl}` : ""} requires authentication.`,
+    });
+  }
+  if (result.tools.length === 0) {
+    throw new UserError({
+      source: "Scaffold",
+      name: "McpToolsNotFound",
+      message: `No tools were discovered from the MCP server${serverUrl ? ` at ${serverUrl}` : ""}.`,
+    });
+  }
+  return JSON.stringify({ tools: result.tools });
+}
+
+function createMcpToolsProvider(
+  fetchTools: (serverUrl: string) => Promise<MCPFetchResult>
+): OptionsProvider {
+  return {
+    async fetch(params) {
+      let toolsJson = params.toolsJson?.trim();
+      const toolsFilePath = params.toolsFilePath?.trim();
+      if (!toolsJson && toolsFilePath) {
+        try {
+          toolsJson = fs.readFileSync(toolsFilePath, "utf8");
+        } catch {
+          throw new UserError({
+            source: "Scaffold",
+            name: "McpToolsFileReadFailed",
+            message: "Failed to read the MCP tools file.",
+          });
+        }
+      }
+      const serverUrl = params.serverUrl?.trim();
+      if (!toolsJson && serverUrl) {
+        try {
+          toolsJson = mcpToolsJsonFromFetchResult(serverUrl, await fetchTools(serverUrl));
+        } catch (error) {
+          if (error instanceof UserError) {
+            throw error;
+          }
+          throw new UserError({
+            source: "Scaffold",
+            name: "McpToolsFetchFailed",
+            message: `Failed to fetch tools from the MCP server at ${serverUrl}.`,
+          });
+        }
+      }
+      if (!toolsJson) {
+        throw new UserError({
+          source: "Scaffold",
+          name: "McpToolsJsonMissing",
+          message: "MCP tools JSON is required before listing tools.",
+        });
+      }
+      const parsed = parseMcpStaticToolsJson(toolsJson);
+      if (!parsed.ok) {
+        throw new UserError({ source: "Scaffold", name: parsed.code, message: parsed.message });
+      }
+      return {
+        options: parsed.tools.map((tool) => ({
+          id: tool.name,
+          label: tool.name,
+          detail: tool.description,
+        })),
+        derived: { toolsJson },
+      };
+    },
+  };
+}
 
 /** Default `optionsFrom` provider registry. */
-const defaultProviders: Record<string, OptionsProvider> = {
-  "mcp.serverTypes": remoteOnlyServerTypes,
-  "mcp.tools": mcpToolsProvider,
-  "openapi.operations": openApiOperationsProvider,
-};
+function createDefaultProviders(
+  fetchTools: (serverUrl: string) => Promise<MCPFetchResult>,
+  listLocalMcpServers: () => Promise<ODRServer[]>
+): Record<string, OptionsProvider> {
+  const localServers = createLocalServerCache(listLocalMcpServers);
+  return {
+    "mcp.serverTypes": createMcpServerTypesProvider(localServers),
+    "mcp.localServers": createLocalMcpServersProvider(localServers),
+    "mcp.tools": createMcpToolsProvider(fetchTools),
+    "openapi.operations": openApiOperationsProvider,
+  };
+}
 
 /** The `"uri"` validator: a value that does not parse as a URL is user-fixable. */
 const uriValidator: Validator = (value: string): string | undefined => {
@@ -274,6 +377,10 @@ export interface CreateInputsDeps {
   flagReader?: (name: string) => boolean;
   /** The host surface (`vscode` / `cli` / `vs`) — gates the `csharp` language axis (default `vscode`). */
   surface?: string;
+  /** Fetch static MCP tools when CLI did not provide a tools file path. */
+  fetchMcpTools?: (serverUrl: string) => Promise<MCPFetchResult>;
+  /** List available local MCP servers for the dynamic MCP create flow. */
+  listLocalMcpServers?: () => Promise<ODRServer[]>;
 }
 
 /** Run one create template's Q2 over the host surface. */
@@ -295,8 +402,15 @@ export async function runCreateInputs(
     deps.flagReader ?? envFlagReader
   );
 
-  const providers = { ...defaultProviders, ...(deps.optionsProvider ?? {}) };
+  const providers = {
+    ...createDefaultProviders(
+      deps.fetchMcpTools ?? fetchMCPTools,
+      deps.listLocalMcpServers ?? ODRProvider.listServers
+    ),
+    ...(deps.optionsProvider ?? {}),
+  };
   const expressionPort = createExpressionPort(deps.flagReader);
+  const surface = deps.surface ?? "vscode";
   const port: CollectInputsPort = {
     ui: createUiPromptUI(ui),
     optionsProvider: (providerId) => providers[providerId],
@@ -307,7 +421,7 @@ export async function runCreateInputs(
   return collectInputs(
     opened.value.questions,
     declaredOptionsSchema(descriptor),
-    entryParams,
+    { ...entryParams, surface },
     languages,
     port
   );

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -581,11 +581,17 @@ export async function runCreateInputs(
     validator: (name) => validatorRegistry[name],
     evaluate: (node, scope) => evaluateExpression(node, scope, expressionPort),
   };
+  const initialAnswers = {
+    ...entryParams,
+    ...floorTail.value.answers,
+    surface,
+    nonInteractive: deps.inputs?.nonInteractive === true ? "true" : "false",
+  };
 
   const answers = await collectInputs(
     [...opened.value.questions, ...floorTail.value.questions],
     declaredOptionsSchema(descriptor),
-    { ...entryParams, ...floorTail.value.answers, surface },
+    initialAnswers,
     languages,
     port,
     { appendLanguage: false }
@@ -593,6 +599,7 @@ export async function runCreateInputs(
   if (answers.isErr()) {
     return err(answers.error);
   }
+  delete answers.value.nonInteractive;
   if (deps.inputs !== undefined) {
     const validation = await validateCreateFloorAnswers(deps.inputs, answers.value);
     if (validation.isErr()) {

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -1,7 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FxError, SystemError, UserError, UserInteraction } from "@microsoft/teamsfx-api";
+import {
+  FuncValidation,
+  FxError,
+  Inputs,
+  SystemError,
+  UserError,
+  UserInteraction,
+} from "@microsoft/teamsfx-api";
 import {
   ListAPIInfo,
   ParseOptions,
@@ -11,7 +18,7 @@ import {
   ValidationStatus,
 } from "@microsoft/m365-spec-parser";
 import fs from "fs-extra";
-import { Result, err } from "neverthrow";
+import { Result, err, ok } from "neverthrow";
 import { MCPFetchResult, fetchMCPTools } from "../../component/utils/mcpToolFetcher";
 import { ODRProvider, type ODRServer } from "../../component/utils/odrProvider";
 import { readBooleanFeatureFlag } from "../../common/featureFlags";
@@ -19,10 +26,12 @@ import {
   CollectInputsPort,
   OptionsProvider,
   OptionsSchema,
+  QuestionSpec,
   Validator,
   collectInputs,
 } from "../collectInputs/collectInputs";
-import { openCreateQuestions } from "../distribution/createQuestions";
+import { InputValidationError, MissingRequiredInputError } from "../../error/common";
+import { QuestionNames, appNameQuestion, folderQuestion } from "../../question";
 import { openDeclarativePackageMetadata } from "../distribution/declarativePackage";
 import { evaluateExpression } from "../expression/evaluateExpression";
 import { parseMcpStaticToolsJson } from "../mcp/mcpStaticTools";
@@ -35,6 +44,12 @@ import { createUiPromptUI } from "./uiPromptUI";
 
 const remoteMcpServerType = { id: "remote", label: "Remote" };
 const localMcpServerType = { id: "local", label: "Local" };
+const LANGUAGE_LABELS: Record<string, string> = {
+  javascript: "JavaScript",
+  typescript: "TypeScript",
+  csharp: "C#",
+  python: "Python",
+};
 
 function createLocalServerCache(
   listLocalMcpServers: () => Promise<ODRServer[]>
@@ -322,6 +337,148 @@ const validators: Record<string, Validator> = {
   graphConnectorConnectionId: graphConnectorConnectionIdValidator,
 };
 
+interface CreateFloorTail {
+  questions: QuestionSpec[];
+  answers: Answers;
+  validators: Record<string, Validator>;
+}
+
+function isFuncValidation(value: unknown): value is FuncValidation<string> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "validFunc") === "function"
+  );
+}
+
+function getStringValidationFunc(
+  validation: FuncValidation<string> | object | undefined
+): FuncValidation<string>["validFunc"] | undefined {
+  return isFuncValidation(validation) ? validation.validFunc : undefined;
+}
+
+async function resolveStringValue(
+  value:
+    | string
+    | ((inputs: Inputs) => string | undefined | Promise<string | undefined>)
+    | undefined,
+  inputs: Inputs
+): Promise<string | undefined> {
+  return typeof value === "function" ? await value(inputs) : value;
+}
+
+async function createFloorTail(
+  inputs: Inputs | undefined,
+  languages: string[]
+): Promise<Result<CreateFloorTail, FxError>> {
+  const questions: QuestionSpec[] = [];
+  const answers: Answers = {};
+
+  if (languages.length > 1) {
+    questions.push({
+      name: "language",
+      type: "singleSelect",
+      title: "Programming Language",
+      staticOptions: languages.map((language) => ({
+        id: language,
+        label: LANGUAGE_LABELS[language] ?? language,
+      })),
+    });
+  } else if (languages.length === 1 && languages[0] !== "common") {
+    answers.language = languages[0];
+  }
+
+  if (inputs === undefined) {
+    return ok({ questions, answers, validators: {} });
+  }
+
+  const folder = folderQuestion();
+  const appName = appNameQuestion();
+
+  const existingFolder = inputs[QuestionNames.Folder];
+  if (typeof existingFolder === "string") {
+    answers[QuestionNames.Folder] = existingFolder;
+  } else {
+    const defaultFolder = await resolveStringValue(folder.default, inputs);
+    if (inputs.nonInteractive) {
+      if (defaultFolder !== undefined) {
+        answers[QuestionNames.Folder] = defaultFolder;
+      }
+    } else {
+      questions.push({
+        name: folder.name,
+        type: "folder",
+        title: (await resolveStringValue(folder.title, inputs)) ?? folder.name,
+        placeholder: await resolveStringValue(folder.placeholder, inputs),
+        prompt: await resolveStringValue(folder.prompt, inputs),
+        default: defaultFolder,
+      });
+    }
+  }
+
+  const existingAppName = inputs[QuestionNames.AppName];
+  if (typeof existingAppName === "string") {
+    answers[QuestionNames.AppName] = existingAppName;
+  } else {
+    const defaultAppName = await resolveStringValue(appName.default, inputs);
+    if (inputs.nonInteractive) {
+      if (defaultAppName === undefined) {
+        return err(new MissingRequiredInputError(QuestionNames.AppName, "createFrontDoor"));
+      }
+      answers[QuestionNames.AppName] = defaultAppName;
+    } else {
+      questions.push({
+        name: appName.name,
+        type: "text",
+        title: (await resolveStringValue(appName.title, inputs)) ?? appName.name,
+        placeholder: await resolveStringValue(appName.placeholder, inputs),
+        prompt: await resolveStringValue(appName.prompt, inputs),
+        default: defaultAppName,
+        validation: "appName",
+      });
+    }
+  }
+
+  const validateAppName = getStringValidationFunc(appName.validation);
+  const floorValidators: Record<string, Validator> = {};
+  if (validateAppName !== undefined) {
+    floorValidators.appName = async (value, currentAnswers) => {
+      const validationInputs: Inputs = { ...inputs };
+      const folderAnswer = currentAnswers[QuestionNames.Folder];
+      if (typeof folderAnswer === "string") {
+        validationInputs[QuestionNames.Folder] = folderAnswer;
+      }
+      return validateAppName(value, validationInputs);
+    };
+  }
+
+  return ok({ questions, answers, validators: floorValidators });
+}
+
+async function validateCreateFloorAnswers(
+  inputs: Inputs,
+  answers: Answers
+): Promise<Result<undefined, FxError>> {
+  const appName = answers[QuestionNames.AppName];
+  if (typeof appName !== "string") {
+    return err(new MissingRequiredInputError(QuestionNames.AppName, "createFrontDoor"));
+  }
+  const validateAppName = getStringValidationFunc(appNameQuestion().validation);
+  if (validateAppName === undefined) {
+    return ok(undefined);
+  }
+  const validationInputs: Inputs = { ...inputs };
+  const folderAnswer = answers[QuestionNames.Folder];
+  if (typeof folderAnswer === "string") {
+    validationInputs[QuestionNames.Folder] = folderAnswer;
+  }
+  const message = await validateAppName(appName, validationInputs);
+  if (message !== undefined) {
+    return err(new InputValidationError(QuestionNames.AppName, message, "createFrontDoor"));
+  }
+  return ok(undefined);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -377,6 +534,8 @@ export interface CreateInputsDeps {
   flagReader?: (name: string) => boolean;
   /** The host surface (`vscode` / `cli` / `vs`) — gates the `csharp` language axis (default `vscode`). */
   surface?: string;
+  /** Full create inputs when the create floor (`folder` / `app-name`) should be appended after Q2. */
+  inputs?: Inputs;
   /** Fetch static MCP tools when CLI did not provide a tools file path. */
   fetchMcpTools?: (serverUrl: string) => Promise<MCPFetchResult>;
   /** List available local MCP servers for the dynamic MCP create flow. */
@@ -411,18 +570,34 @@ export async function runCreateInputs(
   };
   const expressionPort = createExpressionPort(deps.flagReader);
   const surface = deps.surface ?? "vscode";
+  const floorTail = await createFloorTail(deps.inputs, languages);
+  if (floorTail.isErr()) {
+    return err(floorTail.error);
+  }
+  const validatorRegistry = { ...validators, ...floorTail.value.validators };
   const port: CollectInputsPort = {
     ui: createUiPromptUI(ui),
     optionsProvider: (providerId) => providers[providerId],
-    validator: (name) => validators[name],
+    validator: (name) => validatorRegistry[name],
     evaluate: (node, scope) => evaluateExpression(node, scope, expressionPort),
   };
 
-  return collectInputs(
-    opened.value.questions,
+  const answers = await collectInputs(
+    [...opened.value.questions, ...floorTail.value.questions],
     declaredOptionsSchema(descriptor),
-    { ...entryParams, surface },
+    { ...entryParams, ...floorTail.value.answers, surface },
     languages,
-    port
+    port,
+    { appendLanguage: false }
   );
+  if (answers.isErr()) {
+    return err(answers.error);
+  }
+  if (deps.inputs !== undefined) {
+    const validation = await validateCreateFloorAnswers(deps.inputs, answers.value);
+    if (validation.isErr()) {
+      return err(validation.error);
+    }
+  }
+  return answers;
 }

--- a/packages/fx-core/src/v4/surface/uiPromptUI.ts
+++ b/packages/fx-core/src/v4/surface/uiPromptUI.ts
@@ -6,6 +6,7 @@ import {
   InputTextConfig,
   MultiSelectConfig,
   OptionItem as SurfaceOptionItem,
+  SelectFolderConfig,
   SingleSelectConfig,
   SystemError,
   UserInteraction,
@@ -72,6 +73,7 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
           title: question.title ?? question.name,
           placeholder: question.placeholder,
           prompt: question.prompt,
+          default: question.default,
           options: toSurfaceOptions(options),
           returnObject: false,
           step,
@@ -91,9 +93,28 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
           title: question.title ?? question.name,
           placeholder: question.placeholder,
           prompt: question.prompt,
+          default: question.default,
           step,
         };
         const result = await ui.inputText(config);
+        if (result.isErr()) {
+          return err(result.error);
+        }
+        if (result.value.type === "back") {
+          return ok({ kind: "back" });
+        }
+        return ok({ kind: "value", value: result.value.result ?? "" });
+      }
+      if (question.type === "folder") {
+        const config: SelectFolderConfig = {
+          name: question.name,
+          title: question.title ?? question.name,
+          placeholder: question.placeholder,
+          prompt: question.prompt,
+          default: question.default,
+          step,
+        };
+        const result = await ui.selectFolder(config);
         if (result.isErr()) {
           return err(result.error);
         }

--- a/packages/fx-core/tests/component/driver/add/AddWebpart.test.ts
+++ b/packages/fx-core/tests/component/driver/add/AddWebpart.test.ts
@@ -16,7 +16,19 @@ import { InstallSoftwareError } from "../../../../src/error/common";
 import { MockedM365Provider, MockTools } from "../../../core/utils";
 import { MockedLogProvider, MockedUserInteraction } from "../../../plugins/solution/util";
 
-vi.mock("fs-extra");
+vi.mock("fs-extra", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs-extra")>();
+  const pathExists = vi.fn();
+  return {
+    ...actual.default,
+    ...actual,
+    default: {
+      ...actual.default,
+      pathExists,
+    },
+    pathExists,
+  };
+});
 vi.mock("../../../../src/component/generator/spfx/spfxGenerator");
 vi.mock("../../../../src/component/driver/teamsApp/utils/ManifestUtils");
 describe("Add web part driver", async () => {

--- a/packages/fx-core/tests/component/generator/combinedGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/combinedGenerator.test.ts
@@ -13,8 +13,10 @@ import { developerPortalScaffoldUtils } from "../../../src/component/developerPo
 import { CombinedProjectGenerator } from "../../../src/component/generator/combinedProject/generator";
 import { TemplateNames } from "../../../src/component/generator/templates/templateNames";
 import { ApiAuthOptions, ProgrammingLanguage, QuestionNames } from "../../../src/question";
-import { DACapabilityOptions } from "../../../src/question/scaffold/vsc/CapabilityOptions";
-import { setTemplateNameAndGC } from "../../../src/question/scaffold/vsc/CapabilityOptions";
+import {
+  DACapabilityOptions,
+  setTemplateNameAndGC,
+} from "../../../src/question/scaffold/vsc/CapabilityOptions";
 import { MockTools } from "../../core/utils";
 import { assert, vi } from "vitest";
 

--- a/packages/fx-core/tests/component/util/fileOperations.test.ts
+++ b/packages/fx-core/tests/component/util/fileOperations.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import fs from "fs-extra";

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -10,10 +10,7 @@ import {
   UserError,
   UserInteraction,
 } from "@microsoft/teamsfx-api";
-import fs from "fs-extra";
 import { Result, err, ok } from "neverthrow";
-import os from "os";
-import path from "path";
 import { assert } from "vitest";
 import {
   Answers,
@@ -807,77 +804,19 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     assert.equal(runInputs.calls[0][2].officeAddinManifest, "manifest.json");
   });
 
-  it("DCE-18: legacy CLI MCP tools file is bridged into static v4 MCP Q2 params", async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-mcp-tools-"));
-    const toolsPath = path.join(tempDir, "mcp-tools.json");
-    fs.writeJsonSync(toolsPath, {
-      tools: [
-        {
-          name: "searchFlights",
-          description: "Search available flights",
-          inputSchema: { type: "object", properties: {} },
-        },
-      ],
-    });
+  it("DCE-18: CLI static MCP neutral params are passed through to Q2", async () => {
     const runInputs = inputsRecorder({});
+    const toolsJson = JSON.stringify({
+      tools: [{ name: "searchFlights", description: "Search available flights" }],
+    });
     const inputs: Inputs = {
       platform: Platform.CLI,
       nonInteractive: true,
       mcpServerUrl: "https://api.example/mcp",
       authType: "none",
-      [QuestionNames.MCPToolsFilePath]: toolsPath,
-    };
-
-    try {
-      const res = await createProjectFrontDoor(
-        inputs,
-        deps({
-          runSelector: selectorRecorder(STATIC_MCP_TARGET).fn,
-          runInputs: runInputs.fn,
-          collectCreateFloor: okFloor,
-          scaffoldV4: okScaffold,
-        })
-      );
-
-      assert.isTrue(res.isOk());
-      const mcpToolsJson = runInputs.calls[0][2].mcpToolsJson;
-      if (typeof mcpToolsJson !== "string") {
-        assert.fail("Expected mcpToolsJson to be bridged as a string.");
-      }
-      assert.deepEqual(JSON.parse(mcpToolsJson), {
-        tools: [
-          {
-            name: "searchFlights",
-            description: "Search available flights",
-            inputSchema: { type: "object", properties: {} },
-          },
-        ],
-      });
-      assert.deepEqual(runInputs.calls[0][2].selectedMcpTools, ["searchFlights"]);
-    } finally {
-      fs.removeSync(tempDir);
-    }
-  });
-
-  it("DCE-18b: legacy CLI MCP server URL is fetched into static v4 MCP Q2 params", async () => {
-    const runInputs = inputsRecorder({});
-    const fetchMcpTools = recorder((serverUrl: string) =>
-      Promise.resolve({
-        requiresAuth: false,
-        tools: [
-          {
-            name: "microsoft_docs_search",
-            description: `Search official docs from ${serverUrl}`,
-            inputSchema: { type: "object", properties: {} },
-          },
-        ],
-      })
-    );
-    const inputs: Inputs = {
-      platform: Platform.CLI,
-      nonInteractive: true,
-      [QuestionNames.MCPForDAServerUrl]: "https://learn.microsoft.com/api/mcp",
-      authType: "none",
+      mcpToolsFilePath: "C:/tools/mcp-tools.json",
+      mcpToolsJson: toolsJson,
+      selectedMcpTools: ["searchFlights"],
     };
 
     const res = await createProjectFrontDoor(
@@ -887,105 +826,15 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
         runInputs: runInputs.fn,
         collectCreateFloor: okFloor,
         scaffoldV4: okScaffold,
-        fetchMcpTools: fetchMcpTools.fn,
       })
     );
 
     assert.isTrue(res.isOk());
-    assert.deepEqual(fetchMcpTools.calls, [["https://learn.microsoft.com/api/mcp"]]);
-    const mcpToolsJson = runInputs.calls[0][2].mcpToolsJson;
-    if (typeof mcpToolsJson !== "string") {
-      assert.fail("Expected mcpToolsJson to be fetched and bridged as a string.");
-    }
-    assert.equal(runInputs.calls[0][2].mcpServerUrl, "https://learn.microsoft.com/api/mcp");
-    assert.deepEqual(JSON.parse(mcpToolsJson), {
-      tools: [
-        {
-          name: "microsoft_docs_search",
-          description: "Search official docs from https://learn.microsoft.com/api/mcp",
-          inputSchema: { type: "object", properties: {} },
-        },
-      ],
-    });
-    assert.deepEqual(runInputs.calls[0][2].selectedMcpTools, ["microsoft_docs_search"]);
-  });
-
-  it("DCE-18c: legacy CLI MCP tools file read failure is returned before Q2", async () => {
-    const runInputs = inputsRecorder({});
-    const inputs: Inputs = {
-      platform: Platform.CLI,
-      nonInteractive: true,
-      [QuestionNames.MCPToolsFilePath]: path.join(os.tmpdir(), "missing-mcp-tools.json"),
-    };
-
-    const res = await createProjectFrontDoor(
-      inputs,
-      deps({
-        runSelector: selectorRecorder(STATIC_MCP_TARGET).fn,
-        runInputs: runInputs.fn,
-        collectCreateFloor: okFloor,
-        scaffoldV4: okScaffold,
-      })
-    );
-
-    assert.isTrue(res.isErr());
-    if (res.isErr()) {
-      assert.equal(res.error.name, "McpToolsFileReadFailed");
-    }
-    assert.equal(runInputs.calls.length, 0);
-  });
-
-  it("returns an error before Q2 when a legacy static MCP tools file is invalid", async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-mcp-tools-"));
-    const toolsPath = path.join(tempDir, "mcp-tools.json");
-    fs.writeFileSync(toolsPath, "{ invalid json", "utf8");
-    const inputs: Inputs = {
-      platform: Platform.CLI,
-      nonInteractive: true,
-      [QuestionNames.MCPToolsFilePath]: toolsPath,
-    };
-
-    try {
-      const res = await createProjectFrontDoor(
-        inputs,
-        deps({
-          runSelector: selectorRecorder(STATIC_MCP_TARGET).fn,
-          runInputs: failRunInputs,
-        })
-      );
-
-      assert.isTrue(res.isErr());
-    } finally {
-      fs.removeSync(tempDir);
-    }
-  });
-
-  it("DCE-18d: legacy CLI MCP fetch requiring auth leaves entry params unchanged", async () => {
-    const runInputs = inputsRecorder({});
-    const fetchMcpTools = recorder((_serverUrl: string) =>
-      Promise.resolve({ requiresAuth: true, tools: [] })
-    );
-    const inputs: Inputs = {
-      platform: Platform.CLI,
-      nonInteractive: true,
-      [QuestionNames.MCPForDAServerUrl]: "https://secure.example.com/mcp",
-    };
-
-    const res = await createProjectFrontDoor(
-      inputs,
-      deps({
-        runSelector: selectorRecorder(STATIC_MCP_TARGET).fn,
-        runInputs: runInputs.fn,
-        collectCreateFloor: okFloor,
-        scaffoldV4: okScaffold,
-        fetchMcpTools: fetchMcpTools.fn,
-      })
-    );
-
-    assert.isTrue(res.isOk());
-    assert.deepEqual(fetchMcpTools.calls, [["https://secure.example.com/mcp"]]);
-    assert.notProperty(runInputs.calls[0][2], "mcpToolsJson");
-    assert.notProperty(runInputs.calls[0][2], "selectedMcpTools");
+    assert.equal(runInputs.calls[0][2].mcpServerUrl, "https://api.example/mcp");
+    assert.equal(runInputs.calls[0][2].authType, "none");
+    assert.equal(runInputs.calls[0][2].mcpToolsFilePath, "C:/tools/mcp-tools.json");
+    assert.equal(runInputs.calls[0][2].mcpToolsJson, toolsJson);
+    assert.deepEqual(runInputs.calls[0][2].selectedMcpTools, ["searchFlights"]);
   });
 
   it("DCE-17b: Office Add-in folder input is passed to the v4 input walk under its neutral key", async () => {

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -89,6 +89,14 @@ const okResult = (projectPath: string): Promise<Result<CreateProjectResult, FxEr
   Promise.resolve(ok({ projectPath }));
 const okAnswers = (answers: Answers): Promise<Result<Answers, FxError>> =>
   Promise.resolve(ok(answers));
+const okArtifactSnapshot = (
+  snapshot: TemplateArtifactSnapshot
+): Promise<Result<TemplateArtifactSnapshot, FxError>> => {
+  const result: Result<TemplateArtifactSnapshot, FxError> = ok<TemplateArtifactSnapshot, FxError>(
+    snapshot
+  );
+  return Promise.resolve(result);
+};
 const okTarget = (target: BuildTarget): Promise<Result<BuildTarget, FxError>> =>
   Promise.resolve(ok(target));
 const okFloor = (): Promise<Result<undefined, FxError>> => Promise.resolve(ok(undefined));
@@ -157,7 +165,8 @@ function artifactSnapshotRecorder(bytesByKind: Record<TemplateArtifactKind, Buff
       },
       bytes(kind: TemplateArtifactKind): Promise<Result<Buffer, FxError>> {
         calls.push(kind);
-        return Promise.resolve(ok(bytesByKind[kind]));
+        const result: Result<Buffer, FxError> = ok<Buffer, FxError>(bytesByKind[kind]);
+        return Promise.resolve(result);
       },
     },
   };
@@ -344,9 +353,13 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
       metadata: metadataBytes,
       templates: templatesBytes,
     });
-    const resolveArtifactSnapshot = recorder((_kind: TemplateArtifactKind) =>
-      Promise.resolve(ok(artifactSnapshot.snapshot))
-    );
+    const resolveArtifactSnapshotCalls: TemplateArtifactKind[] = [];
+    const resolveArtifactSnapshot = async (
+      kind: TemplateArtifactKind
+    ): Promise<Result<TemplateArtifactSnapshot, FxError>> => {
+      resolveArtifactSnapshotCalls.push(kind);
+      return await okArtifactSnapshot(artifactSnapshot.snapshot);
+    };
     const runSelector = selectorRecorder(V4_TARGET);
     const runInputs = inputsRecorder({ authType: "none" });
     const scaffoldV4 = recorder(
@@ -362,7 +375,7 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     const res = await createProjectFrontDoor(
       baseInputs(),
       deps({
-        resolveArtifactSnapshot: resolveArtifactSnapshot.fn,
+        resolveArtifactSnapshot,
         v4Registry: () => true,
         runSelector: runSelector.fn,
         runInputs: runInputs.fn,
@@ -372,7 +385,7 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     );
 
     assert.isTrue(res.isOk());
-    assert.deepEqual(resolveArtifactSnapshot.calls, [["create-selector"]]);
+    assert.deepEqual(resolveArtifactSnapshotCalls, ["create-selector"]);
     assert.deepEqual(artifactSnapshot.calls, ["create-selector", "metadata", "templates"]);
     assert.strictEqual(runSelector.calls[0][0], selectorBytes);
     assert.strictEqual(runInputs.calls[0][0], metadataBytes);
@@ -650,9 +663,13 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
       metadata: Buffer.from("metadata-zip"),
       templates: Buffer.from("templates-zip"),
     });
-    const resolveArtifactSnapshot = recorder((_kind: TemplateArtifactKind) =>
-      Promise.resolve(ok(artifactSnapshot.snapshot))
-    );
+    const resolveArtifactSnapshotCalls: TemplateArtifactKind[] = [];
+    const resolveArtifactSnapshot = async (
+      kind: TemplateArtifactKind
+    ): Promise<Result<TemplateArtifactSnapshot, FxError>> => {
+      resolveArtifactSnapshotCalls.push(kind);
+      return await okArtifactSnapshot(artifactSnapshot.snapshot);
+    };
     const resolveByTemplateId = resolveByTemplateIdRecorder({
       templateId: "da/mcp-server",
       engine: "v4",
@@ -663,7 +680,7 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     const res = await createProjectFrontDoor(
       presetInputs("da/mcp-server"),
       deps({
-        resolveArtifactSnapshot: resolveArtifactSnapshot.fn,
+        resolveArtifactSnapshot,
         resolveByTemplateId: resolveByTemplateId.fn,
         runInputs: runInputs.fn,
         collectCreateFloor: okFloor,
@@ -672,7 +689,7 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     );
 
     assert.isTrue(res.isOk());
-    assert.deepEqual(resolveArtifactSnapshot.calls, [["templates"]]);
+    assert.deepEqual(resolveArtifactSnapshotCalls, ["templates"]);
     assert.strictEqual(resolveByTemplateId.calls[0][0].toString(), "templates-zip");
     assert.deepEqual(artifactSnapshot.calls, ["templates", "metadata", "templates"]);
   });
@@ -872,25 +889,25 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     });
   });
 
-  it("DCE-14: engine v4 collects the create floor after Q2 and before scaffoldV4", async () => {
+  it("DCE-14: engine v4 collects Q2+Q3 in one input walk before scaffoldV4", async () => {
     const order: string[] = [];
+    const q2AndFloor: Answers = {
+      authType: "none",
+      [QuestionNames.Folder]: "C:/src",
+      [QuestionNames.AppName]: "MyAgent",
+    };
     const runInputs = recorder(
       (
         _floor: Buffer,
         _locator: DeclarativeLocator,
         _entry: Answers,
         _ui: UserInteraction,
-        _deps?: { flagReader?: (name: string) => boolean }
+        _deps?: { flagReader?: (name: string) => boolean; inputs?: Inputs }
       ): Promise<Result<Answers, FxError>> => {
-        order.push("q2");
-        return okAnswers({});
+        order.push("q2+q3");
+        return okAnswers(q2AndFloor);
       }
     );
-    const collectFloor = recorder((_i: Inputs, _ui: UserInteraction) => {
-      order.push("floor");
-      assert.equal(_i["template-name"], "declarative-agent-with-action-from-mcp");
-      return okFloor();
-    });
     const scaffoldV4 = recorder(
       (_i: Inputs, _t: BuildTarget, _a: Answers, _flagReader: (name: string) => boolean) => {
         order.push("scaffold");
@@ -904,19 +921,19 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
         scaffoldV4: scaffoldV4.fn,
         runSelector: () => okTarget(V4_TARGET),
         runInputs: runInputs.fn,
-        collectCreateFloor: collectFloor.fn,
       })
     );
 
     assert.isTrue(res.isOk());
-    assert.equal(collectFloor.calls.length, 1);
-    assert.deepEqual(order, ["q2", "floor", "scaffold"]); // floor sits between Q2 and the scaffold
-    // the floor mutates the same inputs bag scaffoldV4 then scaffolds from.
-    assert.strictEqual(collectFloor.calls[0][0], scaffoldV4.calls[0][0]);
+    assert.deepEqual(order, ["q2+q3", "scaffold"]);
+    assert.strictEqual(runInputs.calls[0][4]?.inputs, scaffoldV4.calls[0][0]);
+    assert.equal(scaffoldV4.calls[0][0][QuestionNames.Folder], "C:/src");
+    assert.equal(scaffoldV4.calls[0][0][QuestionNames.AppName], "MyAgent");
+    assert.deepEqual(scaffoldV4.calls[0][2], q2AndFloor);
     assert.equal(scaffoldV4.calls[0][0]["template-name"], "declarative-agent-with-action-from-mcp");
   });
 
-  it("DCE-15: a create-floor cancellation propagates and does not scaffold", async () => {
+  it("DCE-15: a Q2+Q3 input cancellation propagates and does not scaffold", async () => {
     const cancel = new UserError({ source: "Test", name: "UserCancelError", message: "cancel" });
     const scaffoldV4 = recorder(
       (_i: Inputs, _t: BuildTarget, _a: Answers, _flagReader: (name: string) => boolean) =>
@@ -928,8 +945,7 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
       deps({
         scaffoldV4: scaffoldV4.fn,
         runSelector: () => okTarget(V4_TARGET),
-        runInputs: () => okAnswers({}),
-        collectCreateFloor: () => Promise.resolve(err(cancel)),
+        runInputs: () => Promise.resolve(err(cancel)),
       })
     );
 

--- a/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
+++ b/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
@@ -487,19 +487,22 @@ describe("collectInputs (v4)", () => {
     assert.strictEqual(resAsk._unsafeUnwrap().mcpServerUrl, url);
   });
 
-  it("INPUT-13: a non-singleton languages list asks Q0 language; ['common'] auto-skips", async () => {
-    // multi-language → Q0 is asked
-    const uiMulti = new ScriptedUI({ language: "typescript" });
+  it("INPUT-13: a non-singleton languages list asks language after Q2; ['common'] auto-skips", async () => {
+    const questions: QuestionSpec[] = [
+      { name: "first", type: "singleSelect", staticOptions: [{ id: "a" }, { id: "b" }] },
+    ];
+    const uiMulti = new ScriptedUI({ first: "a", language: "typescript" });
     const resMulti = await collectInputs(
-      [],
-      {},
+      questions,
+      { properties: { first: {} } },
       {},
       ["typescript", "javascript", "python"],
       makePort({ ui: uiMulti })
     );
+    assert.strictEqual(resMulti._unsafeUnwrap().first, "a");
     assert.strictEqual(resMulti._unsafeUnwrap().language, "typescript");
-    assert.include(uiMulti.asked, "language");
-    // the Q0 options carry proper-cased display labels (mirroring v3's LanguageOptionMap),
+    assert.deepStrictEqual(uiMulti.asked, ["first", "language"]);
+    // the language options carry proper-cased display labels (mirroring v3's LanguageOptionMap),
     // not the raw lowercase ids
     assert.deepStrictEqual(uiMulti.lastOptions.language, [
       { id: "typescript", label: "TypeScript" },
@@ -513,7 +516,7 @@ describe("collectInputs (v4)", () => {
     assert.notProperty(resCommon._unsafeUnwrap(), "language");
   });
 
-  it("INPUT-13: a pre-filled language skips Q0 for a multi-language template", async () => {
+  it("INPUT-13: a pre-filled language skips the language axis for a multi-language template", async () => {
     const ui = new ScriptedUI({});
     const res = await collectInputs(
       [],
@@ -616,16 +619,16 @@ describe("collectInputs (v4)", () => {
     );
   });
 
-  it("INPUT-17: a back from the first question crosses into the Q0 language axis", async () => {
+  it("INPUT-17: a back from the language axis crosses into the previous Q2 question", async () => {
     const questions: QuestionSpec[] = [
       { name: "first", type: "singleSelect", staticOptions: [{ id: "a" }, { id: "b" }] },
     ];
-    // language→typescript, first→back (re-asks Q0), language→javascript, first→a
+    // first→a, language→back (re-asks Q2), first→b, language→javascript
     const ui = new SequencedPromptUI([
-      { kind: "value", value: "typescript" },
-      { kind: "back" },
-      { kind: "value", value: "javascript" },
       { kind: "value", value: "a" },
+      { kind: "back" },
+      { kind: "value", value: "b" },
+      { kind: "value", value: "javascript" },
     ]);
     const res = await collectInputs(
       questions,
@@ -635,11 +638,11 @@ describe("collectInputs (v4)", () => {
       makePort({ ui })
     );
     assert.isTrue(res.isOk());
-    // the back from the first question re-asks Q0; the re-picked language wins
-    assert.deepStrictEqual(res._unsafeUnwrap(), { language: "javascript", first: "a" });
+    // the stale first=a is discarded; the re-picked first=b wins
+    assert.deepStrictEqual(res._unsafeUnwrap(), { first: "b", language: "javascript" });
     assert.deepStrictEqual(
       ui.calls.map((c) => c.name),
-      ["language", "first", "language", "first"]
+      ["first", "language", "first", "language"]
     );
     assert.deepStrictEqual(
       ui.calls.map((c) => c.step),

--- a/packages/fx-core/tests/v4/runtime/steps/mcpLocal.test.ts
+++ b/packages/fx-core/tests/v4/runtime/steps/mcpLocal.test.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT license.
 
 import { SystemError } from "@microsoft/teamsfx-api";
-import { assert, afterEach } from "vitest";
+import { assert, afterEach, vi } from "vitest";
+import { ODRProvider } from "../../../../src/component/utils/odrProvider";
 import { StepContext } from "../../../../src/v4/pipeline/runScaffoldPipeline";
 import {
   STEP_MATERIALIZE_LOCAL_SERVERS,
@@ -26,7 +27,45 @@ function makeCtx(): { ctx: StepContext; files: Map<string, Buffer> } {
 
 describe(`${STEP_MATERIALIZE_LOCAL_SERVERS} (v4)`, () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     mcpLocalDeps.listServers = async () => [];
+  });
+
+  it("delegates the default local server catalog lookup to ODR", async () => {
+    vi.spyOn(ODRProvider, "listServers").mockResolvedValue([
+      {
+        name: "ghmcp",
+        display_name: "GitHub MCP",
+        description: "GitHub tools",
+        version: "1.0.0",
+        identifier: "github",
+        tools: [],
+        packageFamily: "GitHub.MCP",
+        command: "npx",
+        args: ["-y", "@github/github-mcp-server"],
+      },
+    ]);
+    const { ctx, files } = makeCtx();
+
+    const result = await mcpLocalMaterializeServers.apply(
+      { target: ".vscode/mcp.json", selected: ["ghmcp"] },
+      ctx
+    );
+
+    assert.isTrue(result.isOk(), result.isErr() ? result.error.message : "expected ok");
+    const mcpJson = files.get(".vscode/mcp.json");
+    if (mcpJson === undefined) {
+      assert.fail("expected .vscode/mcp.json to be written");
+    }
+    assert.deepStrictEqual(JSON.parse(mcpJson.toString("utf8")), {
+      servers: {
+        ghmcp: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@github/github-mcp-server"],
+        },
+      },
+    });
   });
 
   it("validateParams reports missing or invalid parameters", () => {

--- a/packages/fx-core/tests/v4/runtime/steps/mcpLocal.test.ts
+++ b/packages/fx-core/tests/v4/runtime/steps/mcpLocal.test.ts
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { SystemError } from "@microsoft/teamsfx-api";
+import { assert, afterEach } from "vitest";
+import { StepContext } from "../../../../src/v4/pipeline/runScaffoldPipeline";
+import {
+  STEP_MATERIALIZE_LOCAL_SERVERS,
+  mcpLocalDeps,
+  mcpLocalMaterializeServers,
+} from "../../../../src/v4/runtime/steps/mcpLocal";
+
+function makeCtx(): { ctx: StepContext; files: Map<string, Buffer> } {
+  const files = new Map<string, Buffer>();
+  return {
+    files,
+    ctx: {
+      read: (filePath) => files.get(filePath),
+      write: (filePath, data) => {
+        files.set(filePath, data);
+      },
+      manifestWrapper: () => ({ addAction: () => undefined }),
+    },
+  };
+}
+
+describe(`${STEP_MATERIALIZE_LOCAL_SERVERS} (v4)`, () => {
+  afterEach(() => {
+    mcpLocalDeps.listServers = async () => [];
+  });
+
+  it("validateParams reports missing or invalid parameters", () => {
+    assert.strictEqual(
+      mcpLocalMaterializeServers.validateParams({ selected: ["ghmcp"] }),
+      "missing string parameter 'target'"
+    );
+    assert.strictEqual(
+      mcpLocalMaterializeServers.validateParams({ target: ".vscode/mcp.json" }),
+      "missing string[] parameter 'selected'"
+    );
+    assert.isUndefined(
+      mcpLocalMaterializeServers.validateParams({
+        target: ".vscode/mcp.json",
+        selected: ["ghmcp"],
+      })
+    );
+  });
+
+  it("returns a parameter SystemError when apply receives invalid resolved params", async () => {
+    const result = await mcpLocalMaterializeServers.apply(
+      { target: ".vscode/mcp.json", selected: "ghmcp" },
+      makeCtx().ctx
+    );
+
+    assert.isTrue(result.isErr());
+    assert.instanceOf(result._unsafeUnwrapErr(), SystemError);
+    assert.strictEqual(result._unsafeUnwrapErr().name, "McpLocalParams");
+  });
+
+  it("materializes selected servers from ODR when catalog is not supplied", async () => {
+    mcpLocalDeps.listServers = async () => [
+      {
+        name: "ghmcp",
+        display_name: "GitHub MCP",
+        description: "GitHub tools",
+        version: "1.0.0",
+        identifier: "github",
+        tools: [],
+        packageFamily: "GitHub.MCP",
+        command: "npx",
+        args: ["-y", "@github/github-mcp-server"],
+      },
+    ];
+    const { ctx, files } = makeCtx();
+
+    const result = await mcpLocalMaterializeServers.apply(
+      { target: ".vscode/mcp.json", selected: ["ghmcp"] },
+      ctx
+    );
+
+    assert.isTrue(result.isOk(), result.isErr() ? result.error.message : "expected ok");
+    const mcpJson = files.get(".vscode/mcp.json");
+    if (mcpJson === undefined) {
+      assert.fail("expected .vscode/mcp.json to be written");
+    }
+    assert.deepStrictEqual(JSON.parse(mcpJson.toString("utf8")), {
+      servers: {
+        ghmcp: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@github/github-mcp-server"],
+        },
+      },
+    });
+  });
+
+  it("reports a missing selected local server when neither catalog nor ODR contains it", async () => {
+    const result = await mcpLocalMaterializeServers.apply(
+      { target: ".vscode/mcp.json", selected: ["missing"] },
+      makeCtx().ctx
+    );
+
+    assert.isTrue(result.isErr());
+    assert.instanceOf(result._unsafeUnwrapErr(), SystemError);
+    assert.strictEqual(result._unsafeUnwrapErr().name, "McpLocalCatalogEntry");
+  });
+
+  it("reports catalog parse and shape errors", async () => {
+    const invalidJson = await mcpLocalMaterializeServers.apply(
+      { target: ".vscode/mcp.json", selected: ["ghmcp"], catalog: "not json" },
+      makeCtx().ctx
+    );
+    assert.isTrue(invalidJson.isErr());
+    assert.strictEqual(invalidJson._unsafeUnwrapErr().name, "McpLocalCatalogParse");
+
+    const invalidShape = await mcpLocalMaterializeServers.apply(
+      { target: ".vscode/mcp.json", selected: ["ghmcp"], catalog: "[]" },
+      makeCtx().ctx
+    );
+    assert.isTrue(invalidShape.isErr());
+    assert.strictEqual(invalidShape._unsafeUnwrapErr().name, "McpLocalCatalogShape");
+  });
+
+  it("reports invalid catalog command and args entries", async () => {
+    const missingCommand = await mcpLocalMaterializeServers.apply(
+      {
+        target: ".vscode/mcp.json",
+        selected: ["ghmcp"],
+        catalog: JSON.stringify({ ghmcp: { args: [] } }),
+      },
+      makeCtx().ctx
+    );
+    assert.isTrue(missingCommand.isErr());
+    assert.strictEqual(missingCommand._unsafeUnwrapErr().name, "McpLocalCatalogCommand");
+
+    const invalidArgs = await mcpLocalMaterializeServers.apply(
+      {
+        target: ".vscode/mcp.json",
+        selected: ["ghmcp"],
+        catalog: JSON.stringify({ ghmcp: { command: "npx", args: [1] } }),
+      },
+      makeCtx().ctx
+    );
+    assert.isTrue(invalidArgs.isErr());
+    assert.strictEqual(invalidArgs._unsafeUnwrapErr().name, "McpLocalCatalogArgs");
+  });
+
+  it("materializes a catalog entry with omitted args as an empty args array", async () => {
+    const { ctx, files } = makeCtx();
+
+    const result = await mcpLocalMaterializeServers.apply(
+      {
+        target: ".vscode/mcp.json",
+        selected: ["ghmcp"],
+        catalog: JSON.stringify({ ghmcp: { command: "npx" } }),
+      },
+      ctx
+    );
+
+    assert.isTrue(result.isOk(), result.isErr() ? result.error.message : "expected ok");
+    const mcpJson = files.get(".vscode/mcp.json");
+    if (mcpJson === undefined) {
+      assert.fail("expected .vscode/mcp.json to be written");
+    }
+    assert.deepStrictEqual(JSON.parse(mcpJson.toString("utf8")), {
+      servers: { ghmcp: { type: "stdio", command: "npx", args: [] } },
+    });
+  });
+});

--- a/packages/fx-core/tests/v4/runtime/steps/mcpStatic.test.ts
+++ b/packages/fx-core/tests/v4/runtime/steps/mcpStatic.test.ts
@@ -7,8 +7,8 @@ import {
   mcpStaticDeps,
   mcpStaticMaterializeTools,
 } from "../../../../src/v4/runtime/steps/mcpStatic";
-import { StepContext } from "../../../../src/v4/pipeline/runScaffoldPipeline";
-import fs from "fs-extra";
+import { StepContext, StepParams } from "../../../../src/v4/pipeline/runScaffoldPipeline";
+import fs, { removeSync, writeJsonSync } from "fs-extra";
 import os from "os";
 import path from "path";
 import { assert, afterEach } from "vitest";
@@ -33,8 +33,8 @@ function makeCtx(initial: Record<string, string> = {}): {
   };
 }
 
-function validParams(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return {
+function validParams(overrides: Partial<StepParams> = {}, omitted: string[] = []): StepParams {
+  const params: StepParams = {
     pluginPath: "appPackage/ai-plugin.json",
     toolsPath: "appPackage/mcp-tools-1.json",
     mcpServerUrl: "https://api.example.com/mcp",
@@ -47,6 +47,10 @@ function validParams(overrides: Record<string, unknown> = {}): Record<string, un
     selected: ["searchFlights"],
     ...overrides,
   };
+  for (const key of omitted) {
+    delete params[key];
+  }
+  return params;
 }
 
 describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
@@ -58,22 +62,20 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
 
   it("validateParams reports missing or invalid parameters", () => {
     assert.strictEqual(
-      mcpStaticMaterializeTools.validateParams(validParams({ pluginPath: undefined })),
+      mcpStaticMaterializeTools.validateParams(validParams({}, ["pluginPath"])),
       "missing string parameter 'pluginPath'"
     );
     assert.strictEqual(
-      mcpStaticMaterializeTools.validateParams(validParams({ toolsPath: undefined })),
+      mcpStaticMaterializeTools.validateParams(validParams({}, ["toolsPath"])),
       "missing string parameter 'toolsPath'"
     );
     assert.strictEqual(
-      mcpStaticMaterializeTools.validateParams(validParams({ mcpServerUrl: undefined })),
+      mcpStaticMaterializeTools.validateParams(validParams({}, ["mcpServerUrl"])),
       "missing string parameter 'mcpServerUrl'"
     );
-    assert.isUndefined(
-      mcpStaticMaterializeTools.validateParams(validParams({ toolsJson: undefined }))
-    );
+    assert.isUndefined(mcpStaticMaterializeTools.validateParams(validParams({}, ["toolsJson"])));
     assert.strictEqual(
-      mcpStaticMaterializeTools.validateParams(validParams({ selected: ["ok", 1] })),
+      mcpStaticMaterializeTools.validateParams(validParams({ selected: true })),
       "missing string[] parameter 'selected'"
     );
   });
@@ -158,7 +160,7 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
   it("writes selected tools from a tools file path", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-mcp-tools-"));
     const toolsFilePath = path.join(tempDir, "mcp-tools.json");
-    fs.writeJsonSync(toolsFilePath, {
+    writeJsonSync(toolsFilePath, {
       tools: [
         { name: "searchFlights", description: "Search flights" },
         { name: "bookFlight", description: "Book flights" },
@@ -176,8 +178,32 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
       const tools = JSON.parse(files.get("appPackage/mcp-tools-1.json")?.toString("utf8") ?? "{}");
       assert.deepEqual(tools.tools, [{ name: "searchFlights", description: "Search flights" }]);
     } finally {
-      fs.removeSync(tempDir);
+      removeSync(tempDir);
     }
+  });
+
+  it("writes all fetched tools when no selection is provided", async () => {
+    const { ctx, files } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
+    mcpStaticDeps.fetchTools = async () => ({
+      requiresAuth: false,
+      tools: [
+        { name: "searchFlights", description: "Search flights", inputSchema: {} },
+        { name: "bookFlight", description: "Book flights", inputSchema: {} },
+      ],
+    });
+
+    const result = await mcpStaticMaterializeTools.apply(
+      validParams({ toolsJson: "", selected: "" }),
+      ctx
+    );
+
+    assert.isTrue(result.isOk(), result.isErr() ? result.error.message : "expected ok");
+    const plugin = JSON.parse(files.get("appPackage/ai-plugin.json")?.toString("utf8") ?? "{}");
+    assert.deepEqual(plugin.functions, [
+      { name: "searchFlights", description: "Search flights" },
+      { name: "bookFlight", description: "Book flights" },
+    ]);
+    assert.deepEqual(plugin.runtimes[0].run_for_functions, ["searchFlights", "bookFlight"]);
   });
 
   it("returns a UserError when the tools file path cannot be read", async () => {

--- a/packages/fx-core/tests/v4/runtime/steps/mcpStatic.test.ts
+++ b/packages/fx-core/tests/v4/runtime/steps/mcpStatic.test.ts
@@ -74,6 +74,9 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
       "missing string parameter 'mcpServerUrl'"
     );
     assert.isUndefined(mcpStaticMaterializeTools.validateParams(validParams({}, ["toolsJson"])));
+    assert.isUndefined(
+      mcpStaticMaterializeTools.validateParams(validParams({ selected: "{{selectedMcpTools}}" }))
+    );
     assert.strictEqual(
       mcpStaticMaterializeTools.validateParams(validParams({ selected: true })),
       "missing string[] parameter 'selected'"
@@ -194,6 +197,34 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
 
     const result = await mcpStaticMaterializeTools.apply(
       validParams({ toolsJson: "", selected: "" }),
+      ctx
+    );
+
+    assert.isTrue(result.isOk(), result.isErr() ? result.error.message : "expected ok");
+    const plugin = JSON.parse(files.get("appPackage/ai-plugin.json")?.toString("utf8") ?? "{}");
+    assert.deepEqual(plugin.functions, [
+      { name: "searchFlights", description: "Search flights" },
+      { name: "bookFlight", description: "Book flights" },
+    ]);
+    assert.deepEqual(plugin.runtimes[0].run_for_functions, ["searchFlights", "bookFlight"]);
+  });
+
+  it("writes all fetched tools when optional params resolve to unresolved tokens", async () => {
+    const { ctx, files } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
+    mcpStaticDeps.fetchTools = async () => ({
+      requiresAuth: false,
+      tools: [
+        { name: "searchFlights", description: "Search flights", inputSchema: {} },
+        { name: "bookFlight", description: "Book flights", inputSchema: {} },
+      ],
+    });
+
+    const result = await mcpStaticMaterializeTools.apply(
+      validParams({
+        toolsJson: "{{mcpToolsJson}}",
+        toolsFilePath: "{{mcpToolsFilePath}}",
+        selected: "{{selectedMcpTools}}",
+      }),
       ctx
     );
 

--- a/packages/fx-core/tests/v4/runtime/steps/mcpStatic.test.ts
+++ b/packages/fx-core/tests/v4/runtime/steps/mcpStatic.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SystemError } from "@microsoft/teamsfx-api";
+import { SystemError, UserError } from "@microsoft/teamsfx-api";
 import {
   STEP_MATERIALIZE_STATIC_MCP_TOOLS,
   mcpStaticDeps,
@@ -245,5 +245,17 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
 
     assert.isTrue(result.isErr());
     assert.strictEqual(result._unsafeUnwrapErr().name, "McpToolsFetchFailed");
+  });
+
+  it("returns FxError thrown while fetching tools", async () => {
+    const { ctx } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
+    mcpStaticDeps.fetchTools = async () => {
+      throw new UserError({ source: "Test", name: "McpFetchUserError", message: "failed" });
+    };
+
+    const result = await mcpStaticMaterializeTools.apply(validParams({ toolsJson: "" }), ctx);
+
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr().name, "McpFetchUserError");
   });
 });

--- a/packages/fx-core/tests/v4/runtime/steps/mcpStatic.test.ts
+++ b/packages/fx-core/tests/v4/runtime/steps/mcpStatic.test.ts
@@ -4,10 +4,14 @@
 import { SystemError } from "@microsoft/teamsfx-api";
 import {
   STEP_MATERIALIZE_STATIC_MCP_TOOLS,
+  mcpStaticDeps,
   mcpStaticMaterializeTools,
 } from "../../../../src/v4/runtime/steps/mcpStatic";
 import { StepContext } from "../../../../src/v4/pipeline/runScaffoldPipeline";
-import { assert } from "vitest";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { assert, afterEach } from "vitest";
 
 function makeCtx(initial: Record<string, string> = {}): {
   ctx: StepContext;
@@ -46,6 +50,12 @@ function validParams(overrides: Record<string, unknown> = {}): Record<string, un
 }
 
 describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
+  afterEach(() => {
+    mcpStaticDeps.fetchTools = async () => {
+      throw new Error("unexpected fetch");
+    };
+  });
+
   it("validateParams reports missing or invalid parameters", () => {
     assert.strictEqual(
       mcpStaticMaterializeTools.validateParams(validParams({ pluginPath: undefined })),
@@ -59,9 +69,8 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
       mcpStaticMaterializeTools.validateParams(validParams({ mcpServerUrl: undefined })),
       "missing string parameter 'mcpServerUrl'"
     );
-    assert.strictEqual(
-      mcpStaticMaterializeTools.validateParams(validParams({ toolsJson: undefined })),
-      "missing string parameter 'toolsJson'"
+    assert.isUndefined(
+      mcpStaticMaterializeTools.validateParams(validParams({ toolsJson: undefined }))
     );
     assert.strictEqual(
       mcpStaticMaterializeTools.validateParams(validParams({ selected: ["ok", 1] })),
@@ -69,26 +78,29 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
     );
   });
 
-  it("returns a parameter SystemError when apply receives invalid resolved params", () => {
+  it("returns a parameter SystemError when apply receives invalid resolved params", async () => {
     const { ctx } = makeCtx();
-    const result = mcpStaticMaterializeTools.apply(validParams({ selected: "searchFlights" }), ctx);
+    const result = await mcpStaticMaterializeTools.apply(
+      validParams({ selected: "searchFlights" }),
+      ctx
+    );
 
     assert.isTrue(result.isErr());
     assert.instanceOf(result._unsafeUnwrapErr(), SystemError);
     assert.strictEqual(result._unsafeUnwrapErr().name, "McpStaticParams");
   });
 
-  it("returns tool parser and selection errors as SystemError results", () => {
+  it("returns tool parser and selection errors as SystemError results", async () => {
     const { ctx } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
 
-    const parseResult = mcpStaticMaterializeTools.apply(
+    const parseResult = await mcpStaticMaterializeTools.apply(
       validParams({ toolsJson: "not json" }),
       ctx
     );
     assert.isTrue(parseResult.isErr());
     assert.strictEqual(parseResult._unsafeUnwrapErr().name, "McpStaticToolsParse");
 
-    const missingSelection = mcpStaticMaterializeTools.apply(
+    const missingSelection = await mcpStaticMaterializeTools.apply(
       validParams({ selected: ["missingTool"] }),
       ctx
     );
@@ -96,19 +108,19 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
     assert.strictEqual(missingSelection._unsafeUnwrapErr().name, "McpStaticToolMissing");
   });
 
-  it("returns plugin read and parse errors as SystemError results", () => {
-    const missing = mcpStaticMaterializeTools.apply(validParams(), makeCtx().ctx);
+  it("returns plugin read and parse errors as SystemError results", async () => {
+    const missing = await mcpStaticMaterializeTools.apply(validParams(), makeCtx().ctx);
     assert.isTrue(missing.isErr());
     assert.strictEqual(missing._unsafeUnwrapErr().name, "McpStaticPluginMissing");
 
-    const invalidJson = mcpStaticMaterializeTools.apply(
+    const invalidJson = await mcpStaticMaterializeTools.apply(
       validParams(),
       makeCtx({ "appPackage/ai-plugin.json": "not json" }).ctx
     );
     assert.isTrue(invalidJson.isErr());
     assert.strictEqual(invalidJson._unsafeUnwrapErr().name, "McpStaticPluginParse");
 
-    const invalidShape = mcpStaticMaterializeTools.apply(
+    const invalidShape = await mcpStaticMaterializeTools.apply(
       validParams(),
       makeCtx({ "appPackage/ai-plugin.json": "[]" }).ctx
     );
@@ -116,10 +128,10 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
     assert.strictEqual(invalidShape._unsafeUnwrapErr().name, "McpStaticPluginShape");
   });
 
-  it("writes selected tools and RemoteMCPServer runtime metadata", () => {
+  it("writes selected tools and RemoteMCPServer runtime metadata", async () => {
     const { ctx, files } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
 
-    const result = mcpStaticMaterializeTools.apply(
+    const result = await mcpStaticMaterializeTools.apply(
       validParams({ toolsPath: "nested/appPackage/mcp-tools-1.json" }),
       ctx
     );
@@ -141,5 +153,71 @@ describe(`${STEP_MATERIALIZE_STATIC_MCP_TOOLS} (v4)`, () => {
       files.get("nested/appPackage/mcp-tools-1.json")?.toString("utf8") ?? "{}"
     );
     assert.deepEqual(tools.tools, [{ name: "searchFlights", description: "Search flights" }]);
+  });
+
+  it("writes selected tools from a tools file path", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-mcp-tools-"));
+    const toolsFilePath = path.join(tempDir, "mcp-tools.json");
+    fs.writeJsonSync(toolsFilePath, {
+      tools: [
+        { name: "searchFlights", description: "Search flights" },
+        { name: "bookFlight", description: "Book flights" },
+      ],
+    });
+    const { ctx, files } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
+
+    try {
+      const result = await mcpStaticMaterializeTools.apply(
+        validParams({ toolsJson: "", toolsFilePath }),
+        ctx
+      );
+
+      assert.isTrue(result.isOk(), result.isErr() ? result.error.message : "expected ok");
+      const tools = JSON.parse(files.get("appPackage/mcp-tools-1.json")?.toString("utf8") ?? "{}");
+      assert.deepEqual(tools.tools, [{ name: "searchFlights", description: "Search flights" }]);
+    } finally {
+      fs.removeSync(tempDir);
+    }
+  });
+
+  it("returns a UserError when the tools file path cannot be read", async () => {
+    const { ctx } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
+
+    const result = await mcpStaticMaterializeTools.apply(
+      validParams({
+        toolsJson: "",
+        toolsFilePath: path.join(os.tmpdir(), "missing-mcp-tools.json"),
+      }),
+      ctx
+    );
+
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr().name, "McpToolsFileReadFailed");
+  });
+
+  it("returns a UserError when fetched tools require auth or are empty", async () => {
+    const { ctx } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
+    mcpStaticDeps.fetchTools = async () => ({ requiresAuth: true, tools: [] });
+
+    const authRequired = await mcpStaticMaterializeTools.apply(validParams({ toolsJson: "" }), ctx);
+    assert.isTrue(authRequired.isErr());
+    assert.strictEqual(authRequired._unsafeUnwrapErr().name, "McpAuthRequired");
+
+    mcpStaticDeps.fetchTools = async () => ({ requiresAuth: false, tools: [] });
+    const emptyTools = await mcpStaticMaterializeTools.apply(validParams({ toolsJson: "" }), ctx);
+    assert.isTrue(emptyTools.isErr());
+    assert.strictEqual(emptyTools._unsafeUnwrapErr().name, "McpToolsNotFound");
+  });
+
+  it("returns a UserError when fetching tools fails unexpectedly", async () => {
+    const { ctx } = makeCtx({ "appPackage/ai-plugin.json": "{}" });
+    mcpStaticDeps.fetchTools = async () => {
+      throw new Error("network down");
+    };
+
+    const result = await mcpStaticMaterializeTools.apply(validParams({ toolsJson: "" }), ctx);
+
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr().name, "McpToolsFetchFailed");
   });
 });

--- a/packages/fx-core/tests/v4/scenarios/createCustomCopilotBasic.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createCustomCopilotBasic.test.ts
@@ -11,6 +11,7 @@ import {
   readJsonObject,
   recordProperty,
   runV4Package,
+  text,
 } from "./helpers/scenarioHarness";
 
 /**
@@ -24,8 +25,11 @@ import {
 const templatePackage = loadV4Package("create", "custom-copilot-basic");
 const appName = "My Teams Agent";
 
-async function run(language: "typescript" | "javascript" | "python" = "typescript") {
-  return runV4Package(templatePackage, { callerFloor: { appName, language } });
+async function run(
+  language: "typescript" | "javascript" | "python" = "typescript",
+  answers: Record<string, string> = {}
+) {
+  return runV4Package(templatePackage, { answers, callerFloor: { appName, language } });
 }
 
 describe("SCN-TEAMS-CREATE-CUSTOM-COPILOT-BASIC (v4, T3 InMemoryRuntime)", () => {
@@ -48,6 +52,42 @@ describe("SCN-TEAMS-CREATE-CUSTOM-COPILOT-BASIC (v4, T3 InMemoryRuntime)", () =>
     const manifest = readJsonObject(files, "appPackage/manifest.json");
     const name = recordProperty(manifest, "name");
     assert.strictEqual(name.short, "My Teams Agent${{APP_NAME_SUFFIX}}");
+  });
+
+  it("OpenAI answers render the OpenAI branch", async () => {
+    const { files } = await run("typescript", {
+      llmService: "llm-service-openai",
+      openAIKey: "fake-openai-key",
+    });
+
+    const config = text(files, "src/config.ts");
+    assert.include(config, "openAIKey: process.env.OPENAI_API_KEY");
+    assert.notInclude(config, "azureOpenAIKey");
+
+    const app = text(files, "src/app/app.ts");
+    assert.include(app, "model: config.openAIModelName");
+    assert.include(app, "apiKey: config.openAIKey");
+    assert.notInclude(app, "endpoint: config.azureOpenAIEndpoint");
+  });
+
+  it("Azure OpenAI answers render the Azure OpenAI branch", async () => {
+    const { files } = await run("typescript", {
+      llmService: "llm-service-azure-openai",
+      azureOpenAIKey: "fake-azure-openai-key",
+      azureOpenAIEndpoint: "https://fake.openai.azure.com/",
+      azureOpenAIDeploymentName: "fake-deployment",
+    });
+
+    const config = text(files, "src/config.ts");
+    assert.include(config, "azureOpenAIKey: process.env.AZURE_OPENAI_API_KEY");
+    assert.include(config, "azureOpenAIEndpoint: process.env.AZURE_OPENAI_ENDPOINT");
+    assert.notInclude(config, "openAIKey");
+
+    const app = text(files, "src/app/app.ts");
+    assert.include(app, "model: config.azureOpenAIDeploymentName");
+    assert.include(app, "apiKey: config.azureOpenAIKey");
+    assert.include(app, "endpoint: config.azureOpenAIEndpoint");
+    assert.notInclude(app, "model: config.openAIModelName");
   });
 
   it("SCN-CREATE-CUSTOM-COPILOT-BASIC-03: JavaScript scaffold selects the JavaScript subtree", async () => {

--- a/packages/fx-core/tests/v4/scenarios/createCustomCopilotRagAzureAISearch.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createCustomCopilotRagAzureAISearch.test.ts
@@ -11,6 +11,7 @@ import {
   readJsonObject,
   recordProperty,
   runV4Package,
+  text,
 } from "./helpers/scenarioHarness";
 
 /**
@@ -24,8 +25,11 @@ import {
 const templatePackage = loadV4Package("create", "custom-copilot-rag-azure-ai-search");
 const appName = "My Search Agent";
 
-async function run(language: "typescript" | "javascript" | "python" = "typescript") {
-  return runV4Package(templatePackage, { callerFloor: { appName, language } });
+async function run(
+  language: "typescript" | "javascript" | "python" = "typescript",
+  answers: Record<string, string> = {}
+) {
+  return runV4Package(templatePackage, { answers, callerFloor: { appName, language } });
 }
 
 describe("SCN-TEAMS-CREATE-CUSTOM-COPILOT-RAG-AZURE-AI-SEARCH (v4, T3 InMemoryRuntime)", () => {
@@ -51,6 +55,36 @@ describe("SCN-TEAMS-CREATE-CUSTOM-COPILOT-RAG-AZURE-AI-SEARCH (v4, T3 InMemoryRu
     const manifest = readJsonObject(files, "appPackage/manifest.json");
     const name = recordProperty(manifest, "name");
     assert.strictEqual(name.short, "My Search Agent${{APP_NAME_SUFFIX}}");
+  });
+
+  it("OpenAI answers render the OpenAI data and chat branches", async () => {
+    const { files } = await run("typescript", {
+      llmService: "llm-service-openai",
+      openAIKey: "fake-openai-key",
+    });
+
+    const app = text(files, "src/app/app.ts");
+    assert.include(app, "apiKey: config.openAIKey!");
+    assert.include(app, "openAIEmbeddingModelName: config.openAIEmbeddingModelName!");
+    assert.include(app, "model: config.openAIModelName");
+    assert.notInclude(app, "azureOpenAIApiKey");
+    assert.notInclude(app, "endpoint: config.azureOpenAIEndpoint");
+  });
+
+  it("Azure OpenAI answers render the Azure OpenAI data and chat branches", async () => {
+    const { files } = await run("typescript", {
+      llmService: "llm-service-azure-openai",
+      azureOpenAIKey: "fake-azure-openai-key",
+      azureOpenAIEndpoint: "https://fake.openai.azure.com/",
+      azureOpenAIDeploymentName: "fake-deployment",
+    });
+
+    const app = text(files, "src/app/app.ts");
+    assert.include(app, "azureOpenAIApiKey: config.azureOpenAIKey!");
+    assert.include(app, "azureOpenAIEndpoint: config.azureOpenAIEndpoint!");
+    assert.include(app, "model: config.azureOpenAIDeploymentName");
+    assert.notInclude(app, "openAIEmbeddingModelName: config.openAIEmbeddingModelName!");
+    assert.notInclude(app, "model: config.openAIModelName");
   });
 
   it("SCN-CREATE-RAG-AZURE-SEARCH-03: JavaScript scaffold selects the JavaScript subtree", async () => {

--- a/packages/fx-core/tests/v4/scenarios/createMcpServerStatic.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createMcpServerStatic.test.ts
@@ -2,10 +2,23 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
-import { UserError } from "@microsoft/teamsfx-api";
+import {
+  FxError,
+  InputTextConfig,
+  InputTextResult,
+  MultiSelectConfig,
+  MultiSelectResult,
+  OptionItem as SurfaceOptionItem,
+  UserError,
+  UserInteraction,
+} from "@microsoft/teamsfx-api";
+import AdmZip from "adm-zip";
+import path from "path";
+import { Result, err, ok } from "neverthrow";
 import { REQUIRE_EMPTY_TARGET } from "../../../src/v4/pipeline/runScaffoldPipeline";
 import { createInMemoryRuntime } from "../../../src/v4/runtime/inMemoryRuntime";
 import { ScaffoldRequest, scaffold } from "../../../src/v4/runtime/scaffold";
+import { runCreateInputs } from "../../../src/v4/surface/createInputs";
 import {
   loadV4Package,
   readJsonObject,
@@ -23,6 +36,7 @@ import {
  */
 
 const MCP_SERVER_URL = "https://api.github.com/mcp";
+const TEMPLATES_V4_DIR = path.resolve(__dirname, "../../../../../templates/v4");
 const MCP_TOOLS_JSON = JSON.stringify({
   tools: [
     {
@@ -39,6 +53,57 @@ const MCP_TOOLS_JSON = JSON.stringify({
 });
 
 const templatePackage = loadV4Package("create", "da/mcp-server-static");
+
+function buildFloor(): Buffer {
+  const zip = new AdmZip();
+  zip.addLocalFolder(TEMPLATES_V4_DIR, "v4");
+  return zip.toBuffer();
+}
+
+function noAnswer(name: string): FxError {
+  return new UserError({ source: "Test", name: "NoScriptedAnswer", message: name });
+}
+
+class StaticMcpQ2UI {
+  textNames: string[] = [];
+  multiNames: string[] = [];
+  lastMultiConfig?: MultiSelectConfig;
+
+  inputText(config: InputTextConfig): Promise<Result<InputTextResult, FxError>> {
+    this.textNames.push(config.name);
+    if (config.name !== "mcpToolsFilePath") {
+      return Promise.resolve(err(noAnswer(config.name)));
+    }
+    return Promise.resolve(ok({ type: "success", result: "" }));
+  }
+
+  selectOptions(config: MultiSelectConfig): Promise<Result<MultiSelectResult, FxError>> {
+    this.multiNames.push(config.name);
+    this.lastMultiConfig = config;
+    if (config.name !== "selectedMcpTools") {
+      return Promise.resolve(err(noAnswer(config.name)));
+    }
+    return Promise.resolve(ok({ type: "success", result: ["search"] }));
+  }
+}
+
+function asUI(scripted: StaticMcpQ2UI): UserInteraction {
+  return scripted as unknown as UserInteraction;
+}
+
+function multiOptionAt(config: MultiSelectConfig | undefined, index: number): SurfaceOptionItem {
+  if (config === undefined) {
+    assert.fail("expected a multi-select config");
+  }
+  if (!Array.isArray(config.options)) {
+    assert.fail("expected static multi-select options");
+  }
+  const option = config.options[index];
+  if (option === undefined || typeof option === "string") {
+    assert.fail(`expected multi-select option item at index ${index}`);
+  }
+  return option;
+}
 
 async function run(
   selectedMcpTools: string[] = ["search"]
@@ -131,5 +196,62 @@ describe("SCN-DA-CREATE-WITH-MCP-SERVER-STATIC (v4, T3 InMemoryRuntime)", () => 
     const plugin = readJsonObject(files, "appPackage/ai-plugin.json");
     assert.deepStrictEqual(recordArrayProperty(plugin, "functions"), []);
     assert.deepStrictEqual(recordArrayProperty(plugin, "runtimes"), []);
+  });
+
+  it("SCN-CREATE-MCP-STATIC-06: CLI without tools path fetches tools from server URL for selection", async () => {
+    const ui = new StaticMcpQ2UI();
+    let fetchedUrl: string | undefined;
+
+    const result = await runCreateInputs(
+      buildFloor(),
+      { kind: "create", templateId: "da/mcp-server-static" },
+      { mcpServerUrl: MCP_SERVER_URL },
+      asUI(ui),
+      {
+        surface: "cli",
+        flagReader: () => false,
+        fetchMcpTools: async (serverUrl) => {
+          fetchedUrl = serverUrl;
+          return {
+            requiresAuth: false,
+            tools: [
+              { name: "search", description: "Search issues", inputSchema: {} },
+              { name: "calendar", description: "Read calendar", inputSchema: {} },
+            ],
+          };
+        },
+      }
+    );
+
+    assert.isTrue(result.isOk(), result.isErr() ? result.error.message : "expected ok");
+    assert.strictEqual(fetchedUrl, MCP_SERVER_URL);
+    assert.deepStrictEqual(ui.textNames, ["mcpToolsFilePath"]);
+    assert.deepStrictEqual(ui.multiNames, ["selectedMcpTools"]);
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).id, "search");
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 1).id, "calendar");
+    assert.deepStrictEqual(result._unsafeUnwrap().selectedMcpTools, ["search"]);
+  });
+
+  it("SCN-CREATE-MCP-STATIC-07: CLI auto-fetch requiring auth fails before scaffold", async () => {
+    const ui = new StaticMcpQ2UI();
+
+    const result = await runCreateInputs(
+      buildFloor(),
+      { kind: "create", templateId: "da/mcp-server-static" },
+      { mcpServerUrl: MCP_SERVER_URL },
+      asUI(ui),
+      {
+        surface: "cli",
+        flagReader: () => false,
+        fetchMcpTools: async () => ({ requiresAuth: true, tools: [] }),
+      }
+    );
+
+    assert.isTrue(result.isErr(), "expected auth-required fetch to fail");
+    const error = result._unsafeUnwrapErr();
+    assert.instanceOf(error, UserError);
+    assert.strictEqual(error.name, "McpAuthRequired");
+    assert.deepStrictEqual(ui.textNames, ["mcpToolsFilePath"]);
+    assert.deepStrictEqual(ui.multiNames, []);
   });
 });

--- a/packages/fx-core/tests/v4/scenarios/createMcpServerStatic.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createMcpServerStatic.test.ts
@@ -19,7 +19,7 @@ import {
  * T3 scenario tier for the DT-off v4 static MCP create package.
  *
  * Spec: docs/03-specs/scenarios/da/create-mcp-server-static.md
- * (SCN-CREATE-MCP-STATIC-01..04)
+ * (SCN-CREATE-MCP-STATIC-01..07)
  */
 
 const MCP_SERVER_URL = "https://api.github.com/mcp";
@@ -45,6 +45,7 @@ async function run(
 ): Promise<{ files: Map<string, Buffer>; outcome: V4ScenarioOutcome }> {
   return runV4Package(templatePackage, {
     answers: {
+      surface: "cli",
       mcpServerUrl: MCP_SERVER_URL,
       mcpToolsJson: MCP_TOOLS_JSON,
       selectedMcpTools,
@@ -99,6 +100,7 @@ describe("SCN-DA-CREATE-WITH-MCP-SERVER-STATIC (v4, T3 InMemoryRuntime)", () => 
       pipeline: templatePackage.pipeline,
       content: templatePackage.content,
       answers: {
+        surface: "cli",
         mcpServerUrl: MCP_SERVER_URL,
         mcpToolsJson: MCP_TOOLS_JSON,
         selectedMcpTools: ["search"],
@@ -112,5 +114,22 @@ describe("SCN-DA-CREATE-WITH-MCP-SERVER-STATIC (v4, T3 InMemoryRuntime)", () => 
     assert.instanceOf(error, UserError);
     assert.strictEqual(error.name, REQUIRE_EMPTY_TARGET);
     assert.strictEqual(runtime.files.size, 0);
+  });
+
+  it("SCN-CREATE-MCP-STATIC-05: VS Code create skips static MCP tool materialization", async () => {
+    const { files, outcome } = await runV4Package(templatePackage, {
+      answers: {
+        surface: "vscode",
+        mcpServerUrl: MCP_SERVER_URL,
+      },
+      callerFloor: { appName: "MyStaticMcpAgent", language: "common" },
+    });
+
+    assert.include(outcome.written, "appPackage/ai-plugin.json");
+    assert.notInclude(outcome.stepsRun, "mcp-static/materialize-tools");
+    assert.isFalse(files.has("appPackage/mcp-tools-1.json"));
+    const plugin = readJsonObject(files, "appPackage/ai-plugin.json");
+    assert.deepStrictEqual(recordArrayProperty(plugin, "functions"), []);
+    assert.deepStrictEqual(recordArrayProperty(plugin, "runtimes"), []);
   });
 });

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -8,6 +8,9 @@ import {
   MultiSelectConfig,
   MultiSelectResult,
   OptionItem as SurfaceOptionItem,
+  Platform,
+  SelectFolderConfig,
+  SelectFolderResult,
   SingleSelectConfig,
   SingleSelectResult,
   SystemError,
@@ -123,6 +126,7 @@ const localMcpServers = [
 interface Script {
   select?: Record<string, string>;
   text?: Record<string, string>;
+  folder?: Record<string, string>;
   multi?: Record<string, string[]>;
   back?: string[];
 }
@@ -141,9 +145,11 @@ class ScriptedUserInteraction {
   promptNames: string[] = [];
   selectNames: string[] = [];
   textNames: string[] = [];
+  folderNames: string[] = [];
   multiNames: string[] = [];
   lastSelectConfig?: SingleSelectConfig;
   lastInputConfig?: InputTextConfig;
+  lastFolderConfig?: SelectFolderConfig;
   lastMultiConfig?: MultiSelectConfig;
   constructor(private readonly script: Script) {}
 
@@ -174,6 +180,21 @@ class ScriptedUserInteraction {
       return Promise.resolve(err(noAnswer(config.name)));
     }
     const result: InputTextResult = { type: "success", result: answer };
+    return Promise.resolve(ok(result));
+  }
+
+  selectFolder(config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> {
+    this.promptNames.push(config.name);
+    this.folderNames.push(config.name);
+    this.lastFolderConfig = config;
+    if (this.script.back?.includes(config.name) === true) {
+      return Promise.resolve(ok({ type: "back" }));
+    }
+    const answer = this.script.folder?.[config.name];
+    if (answer === undefined) {
+      return Promise.resolve(err(noAnswer(config.name)));
+    }
+    const result: SelectFolderResult = { type: "success", result: answer };
     return Promise.resolve(ok(result));
   }
 
@@ -392,6 +413,30 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     }
     assert.deepEqual(ui.selectNames, ["llmService"]);
     assert.deepEqual(ui.textNames, ["openAIKey"]);
+  });
+
+  it("collects Basic Custom Engine Agent Q2 and create floor in one walk", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-openai", language: "typescript" },
+      text: { openAIKey: "fake-openai-key", "app-name": "MyAgent" },
+      folder: { folder: "C:/src" },
+    });
+
+    const res = await runCreateInputs(buildFloor(), BASIC_CUSTOM_ENGINE_AGENT, {}, asUI(ui), {
+      flagReader: () => false,
+      inputs: { platform: Platform.VSCode },
+      surface: "vscode",
+    });
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.llmService, "llm-service-openai");
+      assert.equal(res.value.openAIKey, "fake-openai-key");
+      assert.equal(res.value.folder, "C:/src");
+      assert.equal(res.value["app-name"], "MyAgent");
+      assert.equal(res.value.language, "typescript");
+    }
+    assert.deepEqual(ui.promptNames, ["llmService", "openAIKey", "language", "folder", "app-name"]);
   });
 
   it("collects Weather Agent Azure OpenAI service answers", async () => {

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -480,6 +480,45 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     assert.equal(res._unsafeUnwrapErr().name, "MissingRequiredInputError");
   });
 
+  it("surfaces create floor folder prompt errors", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-openai", language: "typescript" },
+      text: { openAIKey: "fake-openai-key", "app-name": "MyAgent" },
+    });
+
+    const res = await runCreateInputs(buildFloor(), BASIC_CUSTOM_ENGINE_AGENT, {}, asUI(ui), {
+      flagReader: () => false,
+      inputs: { platform: Platform.VSCode },
+      surface: "vscode",
+    });
+
+    assert.isTrue(res.isErr(), "expected missing scripted folder answer to fail");
+    assert.equal(res._unsafeUnwrapErr().name, "NoScriptedAnswer");
+    assert.deepEqual(ui.folderNames, ["folder"]);
+  });
+
+  it("validates preset create floor app name after collecting Q2", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-openai" },
+      text: { openAIKey: "fake-openai-key" },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      BASIC_CUSTOM_ENGINE_AGENT,
+      { language: "typescript" },
+      asUI(ui),
+      {
+        flagReader: () => false,
+        inputs: { platform: Platform.CLI, folder: "C:/src", "app-name": "!" },
+        surface: "cli",
+      }
+    );
+
+    assert.isTrue(res.isErr(), "expected invalid preset app name to fail");
+    assert.equal(res._unsafeUnwrapErr().name, "InputValidationError");
+  });
+
   it("collects Weather Agent Azure OpenAI service answers", async () => {
     const ui = new ScriptedUserInteraction({
       select: { llmService: "llm-service-azure-openai" },
@@ -729,6 +768,25 @@ describe("runCreateInputs (collect-create-inputs)", () => {
 
     assert.isTrue(res.isErr(), "expected auth-required fetch to fail");
     assert.strictEqual(res._unsafeUnwrapErr().name, "McpAuthRequired");
+  });
+
+  it("fails when static MCP tool auto-fetch returns no tools", async () => {
+    const ui = new ScriptedUserInteraction({ text: { mcpToolsFilePath: "" } });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      STATIC_MCP_DA,
+      { mcpServerUrl: "https://api.example.com/mcp" },
+      asUI(ui),
+      {
+        surface: "cli",
+        flagReader: () => false,
+        fetchMcpTools: async () => ({ requiresAuth: false, tools: [] }),
+      }
+    );
+
+    assert.isTrue(res.isErr(), "expected empty tool fetch to fail");
+    assert.strictEqual(res._unsafeUnwrapErr().name, "McpToolsNotFound");
   });
 
   it("surfaces a UserError when the static MCP tools file cannot be read", async () => {

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -439,6 +439,47 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     assert.deepEqual(ui.promptNames, ["llmService", "openAIKey", "language", "folder", "app-name"]);
   });
 
+  it("uses create floor defaults without prompts in non-interactive mode", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-openai", language: "typescript" },
+      text: { openAIKey: "fake-openai-key" },
+    });
+
+    const res = await runCreateInputs(buildFloor(), BASIC_CUSTOM_ENGINE_AGENT, {}, asUI(ui), {
+      surface: "cli",
+      flagReader: () => false,
+      inputs: {
+        platform: Platform.CLI,
+        nonInteractive: true,
+        teamsAppFromTdp: { appName: "My Agent" },
+      },
+    });
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.folder, "./");
+      assert.equal(res.value["app-name"], "MyAgent");
+    }
+    assert.notInclude(ui.promptNames, "folder");
+    assert.notInclude(ui.promptNames, "app-name");
+  });
+
+  it("fails non-interactive create floor when app name has no default", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-openai", language: "typescript" },
+      text: { openAIKey: "fake-openai-key" },
+    });
+
+    const res = await runCreateInputs(buildFloor(), BASIC_CUSTOM_ENGINE_AGENT, {}, asUI(ui), {
+      surface: "cli",
+      flagReader: () => false,
+      inputs: { platform: Platform.CLI, nonInteractive: true },
+    });
+
+    assert.isTrue(res.isErr(), "expected missing app-name default to fail");
+    assert.equal(res._unsafeUnwrapErr().name, "MissingRequiredInputError");
+  });
+
   it("collects Weather Agent Azure OpenAI service answers", async () => {
     const ui = new ScriptedUserInteraction({
       select: { llmService: "llm-service-azure-openai" },
@@ -635,6 +676,40 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     assert.deepEqual(ui.multiNames, ["selectedMcpTools"]);
     assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).id, "searchFlights");
     assert.deepEqual(res._unsafeUnwrap().selectedMcpTools, ["searchFlights"]);
+  });
+
+  it("skips static MCP tool prompts in non-interactive CLI create", async () => {
+    const ui = new ScriptedUserInteraction({});
+    let fetchCalled = false;
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      STATIC_MCP_DA,
+      { mcpServerUrl: "https://api.example.com/mcp" },
+      asUI(ui),
+      {
+        surface: "cli",
+        inputs: { nonInteractive: true, folder: "C:/src", "app-name": "MyAgent" },
+        flagReader: () => false,
+        fetchMcpTools: async () => {
+          fetchCalled = true;
+          return {
+            requiresAuth: false,
+            tools: [
+              { name: "searchFlights", description: "Search flights", inputSchema: {} },
+              { name: "bookFlight", description: "Book flights", inputSchema: {} },
+            ],
+          };
+        },
+      }
+    );
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    assert.deepEqual(ui.textNames, []);
+    assert.deepEqual(ui.multiNames, []);
+    assert.isFalse(fetchCalled);
+    assert.notProperty(res._unsafeUnwrap(), "selectedMcpTools");
+    assert.notProperty(res._unsafeUnwrap(), "mcpToolsJson");
   });
 
   it("fails when static MCP tool auto-fetch requires auth", async () => {
@@ -975,6 +1050,32 @@ describe("createUiPromptUI (collect-create-inputs)", () => {
     assert.deepEqual(ui.textNames, ["freeText"]);
   });
 
+  it("maps a folder question to selectFolder and returns the path", async () => {
+    const ui = new ScriptedUserInteraction({ folder: { folder: "C:/src" } });
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      {
+        name: "folder",
+        type: "folder",
+        title: "Workspace Folder",
+        placeholder: "Pick a folder",
+        prompt: "Choose where to create the project.",
+        default: "C:/default",
+      },
+      undefined,
+      3
+    );
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { kind: "value", value: "C:/src" });
+    }
+    assert.deepEqual(ui.folderNames, ["folder"]);
+    assert.equal(ui.lastFolderConfig?.default, "C:/default");
+    assert.equal(ui.lastFolderConfig?.step, 3);
+  });
+
   it("CCI-08: askMulti maps a multiSelect to selectOptions and returns the ids", async () => {
     const ui = new ScriptedUserInteraction({ multi: { servers: ["alpha", "beta"] } });
     const prompt = createUiPromptUI(asUI(ui));
@@ -1012,6 +1113,18 @@ describe("createUiPromptUI (collect-create-inputs)", () => {
     const prompt = createUiPromptUI(asUI(ui));
 
     const res = await prompt.ask({ name: "freeText", type: "text", title: "Enter" }, undefined);
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { kind: "back" });
+    }
+  });
+
+  it("ask projects a host back on a folder question to { kind: 'back' }", async () => {
+    const ui = new ScriptedUserInteraction({ back: ["folder"] });
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask({ name: "folder", type: "folder", title: "Folder" }, undefined);
 
     assert.isTrue(res.isOk());
     if (res.isOk()) {

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -15,12 +15,11 @@ import {
   UserInteraction,
 } from "@microsoft/teamsfx-api";
 import AdmZip from "adm-zip";
+import fs, { removeSync, writeJsonSync } from "fs-extra";
+import os from "os";
 import path from "path";
 import { Result, err, ok } from "neverthrow";
-import {
-  INPUT_VALIDATION_FAILED,
-  OptionsProvider,
-} from "../../../src/v4/collectInputs/collectInputs";
+import { INPUT_VALIDATION_FAILED } from "../../../src/v4/collectInputs/collectInputs";
 import { openCreateQuestions } from "../../../src/v4/distribution/createQuestions";
 import { openDeclarativePackageMetadata } from "../../../src/v4/distribution/declarativePackage";
 import { DeclarativeLocator } from "../../../src/v4/model/dataModel";
@@ -52,6 +51,30 @@ const OPENAPI_DA: DeclarativeLocator = {
   kind: "create",
   templateId: "da/api-plugin-from-existing-api",
 };
+const GRAPH_CONNECTOR: DeclarativeLocator = {
+  kind: "create",
+  templateId: "graph-connector",
+};
+const BASIC_CUSTOM_ENGINE_AGENT: DeclarativeLocator = {
+  kind: "create",
+  templateId: "basic-custom-engine-agent",
+};
+const WEATHER_AGENT: DeclarativeLocator = {
+  kind: "create",
+  templateId: "weather-agent",
+};
+const CUSTOM_COPILOT_BASIC: DeclarativeLocator = {
+  kind: "create",
+  templateId: "custom-copilot-basic",
+};
+const RAG_AZURE_AI_SEARCH: DeclarativeLocator = {
+  kind: "create",
+  templateId: "custom-copilot-rag-azure-ai-search",
+};
+const RAG_CUSTOM_API: DeclarativeLocator = {
+  kind: "create",
+  templateId: "custom-copilot-rag-custom-api",
+};
 const OPENAPI_SPEC = path.resolve(__dirname, "../scenarios/fixtures/repairs-openapi.yaml");
 
 function buildFloor(): Buffer {
@@ -72,17 +95,30 @@ function buildLanguageFloor(): Buffer {
   return zip.toBuffer();
 }
 
-/** A `mcp.serverTypes` provider yielding both server types (the local-available case). */
-const twoServerTypes: OptionsProvider = {
-  fetch() {
-    return {
-      options: [
-        { id: "remote", label: "Remote" },
-        { id: "local", label: "Local" },
-      ],
-    };
+const localMcpServers = [
+  {
+    name: "ghmcp",
+    display_name: "GitHub MCP",
+    description: "GitHub tools",
+    version: "1.0.0",
+    identifier: "github",
+    tools: [],
+    packageFamily: "GitHub.MCP",
+    command: "npx",
+    args: ["-y", "@github/github-mcp-server"],
   },
-};
+  {
+    name: "baremcp",
+    display_name: "",
+    description: "",
+    version: "1.0.0",
+    identifier: "bare",
+    tools: [{ name: "inspect", description: "Inspect", inputSchema: {} }],
+    packageFamily: "Bare.MCP",
+    command: "baremcp",
+    args: [],
+  },
+];
 
 interface Script {
   select?: Record<string, string>;
@@ -102,6 +138,7 @@ function noAnswer(name: string): FxError {
  * is test-only (the src no-`as` rule does not apply to tests).
  */
 class ScriptedUserInteraction {
+  promptNames: string[] = [];
   selectNames: string[] = [];
   textNames: string[] = [];
   multiNames: string[] = [];
@@ -111,6 +148,7 @@ class ScriptedUserInteraction {
   constructor(private readonly script: Script) {}
 
   selectOption(config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> {
+    this.promptNames.push(config.name);
     this.selectNames.push(config.name);
     this.lastSelectConfig = config;
     if (this.script.back?.includes(config.name) === true) {
@@ -125,6 +163,7 @@ class ScriptedUserInteraction {
   }
 
   inputText(config: InputTextConfig): Promise<Result<InputTextResult, FxError>> {
+    this.promptNames.push(config.name);
     this.textNames.push(config.name);
     this.lastInputConfig = config;
     if (this.script.back?.includes(config.name) === true) {
@@ -139,6 +178,7 @@ class ScriptedUserInteraction {
   }
 
   selectOptions(config: MultiSelectConfig): Promise<Result<MultiSelectResult, FxError>> {
+    this.promptNames.push(config.name);
     this.multiNames.push(config.name);
     this.lastMultiConfig = config;
     if (this.script.back?.includes(config.name) === true) {
@@ -157,6 +197,23 @@ function asUI(scripted: ScriptedUserInteraction): UserInteraction {
   return scripted as unknown as UserInteraction;
 }
 
+function multiOptionAt(config: MultiSelectConfig | undefined, index: number): SurfaceOptionItem {
+  if (config === undefined) {
+    assert.fail("expected a multi-select config");
+  }
+  if (!Array.isArray(config.options)) {
+    assert.fail("expected static multi-select options");
+  }
+  const option = config.options[index];
+  if (option === undefined) {
+    assert.fail(`expected multi-select option at index ${index}`);
+  }
+  if (typeof option === "string") {
+    assert.fail(`expected multi-select option item at index ${index}`);
+  }
+  return option;
+}
+
 describe("runCreateInputs (collect-create-inputs)", () => {
   it("CCI-00: metadata-only bytes drive Q2 language gating without content", async () => {
     const ui = new ScriptedUserInteraction({});
@@ -168,7 +225,7 @@ describe("runCreateInputs (collect-create-inputs)", () => {
 
     assert.isTrue(res.isOk(), res.isErr() ? `${res.error.name}: ${res.error.message}` : "ok");
     if (res.isOk()) {
-      assert.deepEqual(res.value, { language: "typescript" });
+      assert.deepEqual(res.value, { language: "typescript", surface: "vscode" });
     }
     assert.deepEqual(ui.selectNames, []);
   });
@@ -180,12 +237,14 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     });
 
     const res = await runCreateInputs(buildFloor(), MCP_DA, {}, asUI(ui), {
+      listLocalMcpServers: async () => [],
       flagReader: () => false,
     });
 
     assert.isTrue(res.isOk());
     if (res.isOk()) {
       assert.deepEqual(res.value, {
+        surface: "vscode",
         mcpServerType: "remote",
         mcpServerUrl: "https://api.example.com/mcp",
         authType: "none",
@@ -213,13 +272,233 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     assert.isTrue(res.isOk());
     if (res.isOk()) {
       assert.deepEqual(res.value, {
+        surface: "vscode",
         apiSpecLocation: OPENAPI_SPEC,
         apiOperations: ["GET /repairs"],
       });
     }
     assert.deepEqual(ui.textNames, []);
     assert.deepEqual(ui.multiNames, ["apiOperations"]);
-    assert.strictEqual(ui.lastMultiConfig?.options[0].id, "GET /repairs");
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).id, "GET /repairs");
+  });
+
+  it("validates Graph connector display name", async () => {
+    const ui = new ScriptedUserInteraction({
+      text: { graphConnectorName: "   " },
+    });
+
+    const res = await runCreateInputs(buildFloor(), GRAPH_CONNECTOR, {}, asUI(ui), {
+      flagReader: () => false,
+    });
+
+    assert.isTrue(res.isErr(), "expected empty graph connector name to fail");
+    assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_VALIDATION_FAILED);
+    assert.include(res._unsafeUnwrapErr().message, "must not be empty");
+  });
+
+  const invalidGraphConnectorConnectionIds = [
+    { value: "gh", message: "must be at least 3 characters" },
+    { value: "github-issues", message: "must contain only alphanumeric characters" },
+    { value: "githubissuesgithubissuesgithubissues1", message: "must be at most 32 characters" },
+    { value: "MicrosoftGraph", message: "must not begin with 'Microsoft'" },
+  ];
+
+  for (const invalid of invalidGraphConnectorConnectionIds) {
+    it(`validates Graph connector connection id '${invalid.value}'`, async () => {
+      const ui = new ScriptedUserInteraction({
+        text: {
+          graphConnectorName: "GitHub Issues",
+          graphConnectorConnectionId: invalid.value,
+        },
+      });
+
+      const res = await runCreateInputs(buildFloor(), GRAPH_CONNECTOR, {}, asUI(ui), {
+        flagReader: () => false,
+      });
+
+      assert.isTrue(res.isErr(), `expected '${invalid.value}' to fail`);
+      assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_VALIDATION_FAILED);
+      assert.include(res._unsafeUnwrapErr().message, invalid.message);
+    });
+  }
+
+  it("collects valid Graph connector inputs", async () => {
+    const ui = new ScriptedUserInteraction({
+      text: {
+        graphConnectorName: "GitHub Issues",
+        graphConnectorConnectionId: "githubissues",
+      },
+    });
+
+    const res = await runCreateInputs(buildFloor(), GRAPH_CONNECTOR, {}, asUI(ui), {
+      flagReader: () => false,
+    });
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.deepEqual(res.value, {
+        surface: "vscode",
+        language: "typescript",
+        graphConnectorName: "GitHub Issues",
+        graphConnectorConnectionId: "githubissues",
+      });
+    }
+    assert.deepEqual(ui.textNames, ["graphConnectorName", "graphConnectorConnectionId"]);
+  });
+
+  it("collects the General Teams Agent OpenAI service answers", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-openai" },
+      text: { openAIKey: "faked_openapi_key" },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      CUSTOM_COPILOT_BASIC,
+      { language: "typescript" },
+      asUI(ui),
+      { flagReader: () => false }
+    );
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.llmService, "llm-service-openai");
+      assert.equal(res.value.openAIKey, "faked_openapi_key");
+      assert.notProperty(res.value, "azureOpenAIKey");
+    }
+    assert.deepEqual(ui.selectNames, ["llmService"]);
+    assert.deepEqual(ui.textNames, ["openAIKey"]);
+  });
+
+  it("collects Basic Custom Engine Agent OpenAI service answers", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-openai" },
+      text: { openAIKey: "fake-openai-key" },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      BASIC_CUSTOM_ENGINE_AGENT,
+      { language: "typescript" },
+      asUI(ui),
+      { flagReader: () => false }
+    );
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.llmService, "llm-service-openai");
+      assert.equal(res.value.openAIKey, "fake-openai-key");
+      assert.notProperty(res.value, "azureOpenAIKey");
+    }
+    assert.deepEqual(ui.selectNames, ["llmService"]);
+    assert.deepEqual(ui.textNames, ["openAIKey"]);
+  });
+
+  it("collects Weather Agent Azure OpenAI service answers", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-azure-openai" },
+      text: {
+        azureOpenAIKey: "fake-azure-openai-key",
+        azureOpenAIEndpoint: "https://fake.openai.azure.com/",
+        azureOpenAIDeploymentName: "fake-deployment",
+      },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      WEATHER_AGENT,
+      { language: "typescript" },
+      asUI(ui),
+      { flagReader: () => false }
+    );
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.llmService, "llm-service-azure-openai");
+      assert.equal(res.value.azureOpenAIKey, "fake-azure-openai-key");
+      assert.equal(res.value.azureOpenAIEndpoint, "https://fake.openai.azure.com/");
+      assert.equal(res.value.azureOpenAIDeploymentName, "fake-deployment");
+      assert.notProperty(res.value, "openAIKey");
+    }
+    assert.deepEqual(ui.selectNames, ["llmService"]);
+    assert.deepEqual(ui.textNames, [
+      "azureOpenAIKey",
+      "azureOpenAIEndpoint",
+      "azureOpenAIDeploymentName",
+    ]);
+  });
+
+  it("collects Azure OpenAI service answers for the Azure AI Search RAG template", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-azure-openai" },
+      text: {
+        azureOpenAIKey: "fake-azure-openai-key",
+        azureOpenAIEndpoint: "https://fake.openai.azure.com/",
+        azureOpenAIDeploymentName: "fake-deployment",
+      },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      RAG_AZURE_AI_SEARCH,
+      { language: "typescript" },
+      asUI(ui),
+      { flagReader: () => false }
+    );
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.llmService, "llm-service-azure-openai");
+      assert.equal(res.value.azureOpenAIKey, "fake-azure-openai-key");
+      assert.equal(res.value.azureOpenAIEndpoint, "https://fake.openai.azure.com/");
+      assert.equal(res.value.azureOpenAIDeploymentName, "fake-deployment");
+      assert.notProperty(res.value, "openAIKey");
+    }
+    assert.deepEqual(ui.selectNames, ["llmService"]);
+    assert.deepEqual(ui.textNames, [
+      "azureOpenAIKey",
+      "azureOpenAIEndpoint",
+      "azureOpenAIDeploymentName",
+    ]);
+  });
+
+  it("collects custom API OpenAPI inputs before LLM inputs", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-azure-openai" },
+      text: {
+        apiSpecLocation: OPENAPI_SPEC,
+        azureOpenAIKey: "fake-azure-openai-key",
+        azureOpenAIEndpoint: "https://fake.openai.azure.com/",
+        azureOpenAIDeploymentName: "fake-deployment",
+      },
+      multi: { apiOperations: ["GET /repairs"] },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      RAG_CUSTOM_API,
+      { language: "typescript" },
+      asUI(ui),
+      { flagReader: () => false }
+    );
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.apiSpecLocation, OPENAPI_SPEC);
+      assert.deepEqual(res.value.apiOperations, ["GET /repairs"]);
+      assert.equal(res.value.llmService, "llm-service-azure-openai");
+      assert.equal(res.value.azureOpenAIKey, "fake-azure-openai-key");
+      assert.equal(res.value.azureOpenAIEndpoint, "https://fake.openai.azure.com/");
+      assert.equal(res.value.azureOpenAIDeploymentName, "fake-deployment");
+    }
+    assert.deepEqual(ui.promptNames, [
+      "apiSpecLocation",
+      "apiOperations",
+      "llmService",
+      "azureOpenAIKey",
+      "azureOpenAIEndpoint",
+      "azureOpenAIDeploymentName",
+    ]);
   });
 
   it("lists static MCP tools from the provided tools JSON", async () => {
@@ -238,30 +517,180 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       STATIC_MCP_DA,
       { mcpServerUrl: "https://api.example.com/mcp", mcpToolsJson: toolsJson },
       asUI(ui),
-      { flagReader: () => false }
+      { surface: "cli", flagReader: () => false }
     );
 
     assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
     assert.deepEqual(res._unsafeUnwrap().selectedMcpTools, ["searchFlights"]);
     assert.deepEqual(ui.multiNames, ["selectedMcpTools"]);
-    assert.strictEqual(ui.lastMultiConfig?.options[0].id, "searchFlights");
-    assert.strictEqual(ui.lastMultiConfig?.options[0].detail, "Search available flights");
-    assert.strictEqual(ui.lastMultiConfig?.options[1].id, "bookFlight");
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).id, "searchFlights");
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).detail, "Search available flights");
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 1).id, "bookFlight");
   });
 
-  it("surfaces a UserError when static MCP tools JSON is missing", async () => {
+  it("lists static MCP tools from the provided tools file path", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-mcp-tools-"));
+    const toolsPath = path.join(tempDir, "mcp-tools.json");
+    writeJsonSync(toolsPath, {
+      tools: [
+        { name: "searchFlights", description: "Search available flights" },
+        { name: "bookFlight" },
+      ],
+    });
+    const ui = new ScriptedUserInteraction({
+      multi: { selectedMcpTools: ["searchFlights"] },
+    });
+
+    try {
+      const res = await runCreateInputs(
+        buildFloor(),
+        STATIC_MCP_DA,
+        { mcpServerUrl: "https://api.example.com/mcp", mcpToolsFilePath: toolsPath },
+        asUI(ui),
+        { surface: "cli", flagReader: () => false }
+      );
+
+      assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+      assert.deepEqual(res._unsafeUnwrap().selectedMcpTools, ["searchFlights"]);
+      assert.deepEqual(ui.textNames, []);
+      assert.deepEqual(ui.multiNames, ["selectedMcpTools"]);
+      assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).id, "searchFlights");
+      assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 1).id, "bookFlight");
+    } finally {
+      removeSync(tempDir);
+    }
+  });
+
+  it("fetches static MCP tools from the server URL when the CLI tools path is blank", async () => {
+    const ui = new ScriptedUserInteraction({
+      text: { mcpToolsFilePath: "" },
+      multi: { selectedMcpTools: ["searchFlights"] },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      STATIC_MCP_DA,
+      { mcpServerUrl: "https://api.example.com/mcp" },
+      asUI(ui),
+      {
+        surface: "cli",
+        flagReader: () => false,
+        fetchMcpTools: async () => ({
+          requiresAuth: false,
+          tools: [
+            { name: "searchFlights", description: "Search flights", inputSchema: {} },
+            { name: "bookFlight", description: "Book flights", inputSchema: {} },
+          ],
+        }),
+      }
+    );
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    assert.deepEqual(ui.textNames, ["mcpToolsFilePath"]);
+    assert.deepEqual(ui.multiNames, ["selectedMcpTools"]);
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).id, "searchFlights");
+    assert.deepEqual(res._unsafeUnwrap().selectedMcpTools, ["searchFlights"]);
+  });
+
+  it("fails when static MCP tool auto-fetch requires auth", async () => {
+    const ui = new ScriptedUserInteraction({ text: { mcpToolsFilePath: "" } });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      STATIC_MCP_DA,
+      { mcpServerUrl: "https://api.example.com/mcp" },
+      asUI(ui),
+      {
+        surface: "cli",
+        flagReader: () => false,
+        fetchMcpTools: async () => ({ requiresAuth: true, tools: [] }),
+      }
+    );
+
+    assert.isTrue(res.isErr(), "expected auth-required fetch to fail");
+    assert.strictEqual(res._unsafeUnwrapErr().name, "McpAuthRequired");
+  });
+
+  it("surfaces a UserError when the static MCP tools file cannot be read", async () => {
     const ui = new ScriptedUserInteraction({});
 
     const res = await runCreateInputs(
       buildFloor(),
       STATIC_MCP_DA,
-      { mcpServerUrl: "https://api.example.com/mcp", mcpToolsJson: "   " },
+      {
+        mcpServerUrl: "https://api.example.com/mcp",
+        mcpToolsFilePath: path.join(os.tmpdir(), "missing-mcp-tools.json"),
+      },
       asUI(ui),
-      { flagReader: () => false }
+      { surface: "cli", flagReader: () => false }
     );
 
-    assert.isTrue(res.isErr(), "expected missing tools JSON to fail");
-    assert.strictEqual(res._unsafeUnwrapErr().name, "McpToolsJsonMissing");
+    assert.isTrue(res.isErr(), "expected missing tools file to fail");
+    assert.strictEqual(res._unsafeUnwrapErr().name, "McpToolsFileReadFailed");
+  });
+
+  it("surfaces parser errors from the static MCP tools file", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-mcp-tools-"));
+    const toolsPath = path.join(tempDir, "mcp-tools.json");
+    fs.writeFileSync(toolsPath, "not json", "utf8");
+    const ui = new ScriptedUserInteraction({});
+
+    try {
+      const res = await runCreateInputs(
+        buildFloor(),
+        STATIC_MCP_DA,
+        { mcpServerUrl: "https://api.example.com/mcp", mcpToolsFilePath: toolsPath },
+        asUI(ui),
+        { surface: "cli", flagReader: () => false }
+      );
+
+      assert.isTrue(res.isErr(), "expected invalid tools file to fail");
+      assert.strictEqual(res._unsafeUnwrapErr().name, "McpStaticToolsParse");
+    } finally {
+      removeSync(tempDir);
+    }
+  });
+
+  it("skips static MCP tools collection on VS Code", async () => {
+    const ui = new ScriptedUserInteraction({});
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      STATIC_MCP_DA,
+      { mcpServerUrl: "https://api.example.com/mcp" },
+      asUI(ui),
+      { surface: "vscode", flagReader: () => false }
+    );
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.surface, "vscode");
+      assert.notProperty(res.value, "mcpToolsJson");
+      assert.notProperty(res.value, "selectedMcpTools");
+    }
+    assert.deepEqual(ui.textNames, []);
+    assert.deepEqual(ui.multiNames, []);
+  });
+
+  it("surfaces fetch errors when static MCP tools JSON and file path are missing", async () => {
+    const ui = new ScriptedUserInteraction({ text: { mcpToolsFilePath: "" } });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      STATIC_MCP_DA,
+      { mcpServerUrl: "https://api.example.com/mcp" },
+      asUI(ui),
+      {
+        surface: "cli",
+        flagReader: () => false,
+        fetchMcpTools: async () => {
+          throw new Error("network down");
+        },
+      }
+    );
+
+    assert.isTrue(res.isErr(), "expected tools fetch to fail");
+    assert.strictEqual(res._unsafeUnwrapErr().name, "McpToolsFetchFailed");
   });
 
   it("surfaces parser errors from static MCP tools JSON", async () => {
@@ -272,20 +701,25 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       STATIC_MCP_DA,
       { mcpServerUrl: "https://api.example.com/mcp", mcpToolsJson: "not json" },
       asUI(ui),
-      { flagReader: () => false }
+      { surface: "cli", flagReader: () => false }
     );
 
     assert.isTrue(res.isErr(), "expected invalid tools JSON to fail");
     assert.strictEqual(res._unsafeUnwrapErr().name, "McpStaticToolsParse");
   });
 
-  it("CCI-02: provider [remote,local] prompts mcpServerType; local pick skips url, asks authType", async () => {
+  it("CCI-02: local MCP pick skips remote URL/auth and asks selected local servers", async () => {
+    let listCalls = 0;
     const ui = new ScriptedUserInteraction({
-      select: { mcpServerType: "local", authType: "none" },
+      select: { mcpServerType: "local" },
+      multi: { selectedLocalServers: ["baremcp"] },
     });
 
     const res = await runCreateInputs(buildFloor(), MCP_DA, {}, asUI(ui), {
-      optionsProvider: { "mcp.serverTypes": twoServerTypes },
+      listLocalMcpServers: async () => {
+        listCalls += 1;
+        return localMcpServers;
+      },
       flagReader: () => false,
     });
 
@@ -293,15 +727,32 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     if (res.isOk()) {
       assert.equal(res.value.mcpServerType, "local");
       assert.notProperty(res.value, "mcpServerUrl");
-      assert.equal(res.value.authType, "none");
+      assert.notProperty(res.value, "authType");
+      assert.deepEqual(res.value.selectedLocalServers, ["baremcp"]);
     }
-    // mcpServerType prompted (two options); mcpServerUrl's `== 'remote'` condition is false.
-    assert.deepEqual(ui.selectNames, ["mcpServerType", "authType"]);
+    // mcpServerType prompted (local is available); remote URL/auth questions are skipped.
+    assert.deepEqual(ui.selectNames, ["mcpServerType"]);
     assert.deepEqual(ui.textNames, []);
+    assert.deepEqual(ui.multiNames, ["selectedLocalServers"]);
+    assert.strictEqual(listCalls, 1);
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).label, "GitHub MCP");
+    assert.strictEqual(
+      multiOptionAt(ui.lastMultiConfig, 0).detail,
+      "GitHub tools (0 tools available)"
+    );
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 1).label, "baremcp");
+    assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 1).detail, "1 tools available");
   });
 
   it("CCI-03: an entryParams mcpServerUrl is used as-is (not prompted); authType=oauth", async () => {
-    const ui = new ScriptedUserInteraction({ select: { authType: "oauth" } });
+    const ui = new ScriptedUserInteraction({
+      select: { authType: "oauth" },
+      text: {
+        oauthClientId: "client-id",
+        oauthClientSecret: "client-secret",
+        oauthScopes: "scope.read",
+      },
+    });
 
     const res = await runCreateInputs(
       buildFloor(),
@@ -316,9 +767,36 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       assert.equal(res.value.mcpServerUrl, "https://seed.example.com/mcp");
       assert.equal(res.value.mcpServerType, "remote");
       assert.equal(res.value.authType, "oauth");
+      assert.equal(res.value.oauthClientId, "client-id");
+      assert.equal(res.value.oauthClientSecret, "client-secret");
+      assert.equal(res.value.oauthScopes, "scope.read");
     }
-    // The pre-filled url is used as-is (INPUT-12) -> the text prompt never runs.
-    assert.deepEqual(ui.textNames, []);
+    // The pre-filled url is used as-is (INPUT-12); only OAuth credential prompts run.
+    assert.deepEqual(ui.textNames, ["oauthClientId", "oauthClientSecret", "oauthScopes"]);
+  });
+
+  it("CCI-03b: authType=entra-sso asks only Entra client id", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { authType: "entra-sso" },
+      text: { entraClientId: "entra-client-id" },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      MCP_DA,
+      { mcpServerUrl: "https://seed.example.com/mcp" },
+      asUI(ui),
+      { flagReader: () => false }
+    );
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.equal(res.value.authType, "entra-sso");
+      assert.equal(res.value.entraClientId, "entra-client-id");
+      assert.notProperty(res.value, "oauthClientSecret");
+      assert.notProperty(res.value, "oauthScopes");
+    }
+    assert.deepEqual(ui.textNames, ["entraClientId"]);
   });
 
   it("CCI-04: an invalid uri for mcpServerUrl -> UserError INPUT_VALIDATION_FAILED", async () => {
@@ -540,14 +1018,23 @@ describe("openCreateQuestions (collect-create-inputs)", () => {
     }
   });
 
-  it("CCI-09: reads the three authored da/mcp-server questions from the floor", () => {
+  it("CCI-09: reads the authored da/mcp-server questions from the floor", () => {
     const res = openCreateQuestions(buildFloor(), MCP_DA);
 
     assert.isTrue(res.isOk());
     if (res.isOk()) {
       assert.deepEqual(
         res.value.map((q) => q.name),
-        ["mcpServerType", "mcpServerUrl", "authType"]
+        [
+          "mcpServerType",
+          "mcpServerUrl",
+          "selectedLocalServers",
+          "authType",
+          "oauthClientId",
+          "oauthClientSecret",
+          "oauthScopes",
+          "entraClientId",
+        ]
       );
     }
   });

--- a/packages/fx-core/tests/v4/surface/createSelectorWalk.test.ts
+++ b/packages/fx-core/tests/v4/surface/createSelectorWalk.test.ts
@@ -156,7 +156,21 @@ describe("runCreateSelector (walk-create-selector)", () => {
     assert.deepEqual(ui.selectNames, ["projectType", "daTemplate", "actionSource"]);
   });
 
-  it("WCS-02: the same picks with DT off resolve the v4 static MCP route", async () => {
+  it("WCS-02: CLI DA+MCP with DT off resolves the v4 static MCP route", async () => {
+    const ui = new ScriptedUI(MCP_DA_PICKS);
+
+    const res = await runCreateSelector(buildFloor(), asUI(ui), "cli", {
+      flagReader: () => false,
+    });
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.equal(res.value.templateId, "da/mcp-server-static");
+      assert.equal(res.value.engine, "v4");
+    }
+  });
+
+  it("WCS-02b: VS Code DA+MCP with DT off resolves the v4 static MCP route", async () => {
     const ui = new ScriptedUI(MCP_DA_PICKS);
 
     const res = await runCreateSelector(buildFloor(), asUI(ui), "vscode", {
@@ -170,7 +184,7 @@ describe("runCreateSelector (walk-create-selector)", () => {
     }
   });
 
-  it("WCS-02b: custom-engine→basic-custom-engine-agent resolves the v4 route", async () => {
+  it("WCS-02c: custom-engine→basic-custom-engine-agent resolves the v4 route", async () => {
     const picks = {
       projectType: "custom-engine-agent-type",
       customEngineAgent: "basic-custom-engine-agent",

--- a/packages/fx-core/tests/v4/validation/openAiQuestions.test.ts
+++ b/packages/fx-core/tests/v4/validation/openAiQuestions.test.ts
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as fs from "fs";
+import * as path from "path";
+import { assert } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+const CREATE_TEMPLATES_ROOT = path.join(REPO_ROOT, "templates/v4/create");
+const OPENAI_RENDER_VARS = new Set([
+  "openAIKey",
+  "azureOpenAIKey",
+  "azureOpenAIEndpoint",
+  "azureOpenAIDeploymentName",
+]);
+const OPENAI_OPTION_NAMES = new Set([...OPENAI_RENDER_VARS, "llmService"]);
+const OPENAI_REPLACE_MAP_VARS = new Set([
+  ...OPENAI_RENDER_VARS,
+  "originalOpenAIKey",
+  "originalAzureOpenAIKey",
+  "useOpenAI",
+  "useAzureOpenAI",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  if (!isRecord(parsed)) {
+    throw new Error(`${filePath} must contain a JSON object`);
+  }
+  return parsed;
+}
+
+function listFiles(root: string, matches: (name: string) => boolean): string[] {
+  const result: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of fs.readdirSync(dir)) {
+      const fullPath = path.join(dir, name);
+      if (fs.statSync(fullPath).isDirectory()) {
+        walk(fullPath);
+      } else if (matches(name)) {
+        result.push(fullPath);
+      }
+    }
+  };
+  walk(root);
+  return result.sort();
+}
+
+function questionNames(templateDir: string): Set<string> {
+  const questions = readJsonObject(path.join(templateDir, "questions.json"))["questions"];
+  const names = new Set<string>();
+  if (!Array.isArray(questions)) {
+    return names;
+  }
+  for (const question of questions) {
+    if (isRecord(question) && typeof question.name === "string") {
+      names.add(question.name);
+    }
+  }
+  return names;
+}
+
+function optionPropertyNames(templateDir: string): Set<string> {
+  const descriptor = readJsonObject(path.join(templateDir, "descriptor.json"));
+  const optionsSchema = descriptor.optionsSchema;
+  if (!isRecord(optionsSchema) || !isRecord(optionsSchema.properties)) {
+    return new Set<string>();
+  }
+  return new Set(Object.keys(optionsSchema.properties));
+}
+
+function replaceMapEntries(templateDir: string): Map<string, Record<string, unknown>> {
+  const descriptor = readJsonObject(path.join(templateDir, "descriptor.json"));
+  const replaceMap = descriptor.replaceMap;
+  const entries = new Map<string, Record<string, unknown>>();
+  if (!Array.isArray(replaceMap)) {
+    return entries;
+  }
+  for (const entry of replaceMap) {
+    if (isRecord(entry) && typeof entry.var === "string") {
+      entries.set(entry.var, entry);
+    }
+  }
+  return entries;
+}
+
+function openAiEnvPlaceholders(templateDir: string): Set<string> {
+  const vars = new Set<string>();
+  const contentDir = path.join(templateDir, "content");
+  if (!fs.existsSync(contentDir)) {
+    return vars;
+  }
+  const envFiles = listFiles(
+    contentDir,
+    (name) => name.startsWith(".env.") && name.endsWith(".tpl")
+  );
+  for (const envFile of envFiles) {
+    const text = fs.readFileSync(envFile, "utf8");
+    for (const match of text.matchAll(/\{\{\{([A-Za-z][A-Za-z0-9]*)\}\}\}/g)) {
+      const varName = match[1];
+      if (OPENAI_RENDER_VARS.has(varName)) {
+        vars.add(varName);
+      }
+    }
+  }
+  return vars;
+}
+
+function hasOpenAiContent(templateDir: string): boolean {
+  const contentDir = path.join(templateDir, "content");
+  if (!fs.existsSync(contentDir)) {
+    return false;
+  }
+  for (const contentFile of listFiles(contentDir, () => true)) {
+    const relative = path.relative(contentDir, contentFile).replace(/\\/g, "/");
+    if (relative.includes("/env/.env.")) {
+      continue;
+    }
+    const text = fs.readFileSync(contentFile, "utf8");
+    if (
+      /useOpenAI|useAzureOpenAI|openAIKey|azureOpenAIKey|azureOpenAIEndpoint|azureOpenAIDeploymentName|AZURE_OPENAI|OPENAI_API|@microsoft\/teams\.openai|OpenAI/.test(
+        text
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function relativePath(filePath: string): string {
+  return path.relative(REPO_ROOT, filePath).replace(/\\/g, "/");
+}
+
+describe("v4 OpenAI template questions", () => {
+  it("OpenAI inputs are asked only when non-env content uses OpenAI or Azure OpenAI", () => {
+    const failures: string[] = [];
+
+    for (const descriptorPath of listFiles(
+      CREATE_TEMPLATES_ROOT,
+      (name) => name === "descriptor.json"
+    )) {
+      const templateDir = path.dirname(descriptorPath);
+      const hasAiContent = hasOpenAiContent(templateDir);
+      const placeholders = openAiEnvPlaceholders(templateDir);
+      const questions = questionNames(templateDir);
+      const optionProperties = optionPropertyNames(templateDir);
+      const replaceMap = replaceMapEntries(templateDir);
+
+      if (!hasAiContent) {
+        for (const question of [...OPENAI_OPTION_NAMES].sort()) {
+          if (questions.has(question)) {
+            failures.push(
+              `${relativePath(templateDir)}/questions.json must not ask '${question}' without OpenAI content`
+            );
+          }
+          if (optionProperties.has(question)) {
+            failures.push(
+              `${relativePath(templateDir)}/descriptor.json optionsSchema must not allow '${question}' without OpenAI content`
+            );
+          }
+        }
+        for (const entry of [...OPENAI_REPLACE_MAP_VARS].sort()) {
+          if (replaceMap.has(entry)) {
+            failures.push(
+              `${relativePath(templateDir)}/descriptor.json replaceMap must not define '${entry}' without OpenAI content`
+            );
+          }
+        }
+        for (const placeholder of [...placeholders].sort()) {
+          failures.push(
+            `${relativePath(templateDir)}/content env files must not contain '${placeholder}' without OpenAI content`
+          );
+        }
+        continue;
+      }
+
+      if (placeholders.size === 0) {
+        failures.push(
+          `${relativePath(templateDir)}/content env files must contain OpenAI inputs used by OpenAI content`
+        );
+        continue;
+      }
+
+      for (const placeholder of [...placeholders].sort()) {
+        if (!questions.has(placeholder)) {
+          failures.push(`${relativePath(templateDir)}/questions.json must ask '${placeholder}'`);
+        }
+        if (!optionProperties.has(placeholder)) {
+          failures.push(
+            `${relativePath(templateDir)}/descriptor.json optionsSchema must allow '${placeholder}'`
+          );
+        }
+        if (replaceMap.get(placeholder)?.from !== placeholder) {
+          failures.push(
+            `${relativePath(templateDir)}/descriptor.json replaceMap '${placeholder}' must be sourced from '${placeholder}'`
+          );
+        }
+      }
+
+      if (placeholders.has("openAIKey") && placeholders.has("azureOpenAIKey")) {
+        if (!questions.has("llmService")) {
+          failures.push(
+            `${relativePath(templateDir)}/questions.json must ask 'llmService' to choose OpenAI vs Azure OpenAI`
+          );
+        }
+        if (!optionProperties.has("llmService")) {
+          failures.push(
+            `${relativePath(templateDir)}/descriptor.json optionsSchema must allow 'llmService'`
+          );
+        }
+        const useOpenAI = replaceMap.get("useOpenAI");
+        if (
+          useOpenAI?.when !== "llmService == 'llm-service-openai'" ||
+          useOpenAI.value !== "true"
+        ) {
+          failures.push(
+            `${relativePath(templateDir)}/descriptor.json replaceMap 'useOpenAI' must be conditional on llmService`
+          );
+        }
+        const useAzureOpenAI = replaceMap.get("useAzureOpenAI");
+        if (
+          useAzureOpenAI?.when !== "llmService != 'llm-service-openai'" ||
+          useAzureOpenAI.value !== "true"
+        ) {
+          failures.push(
+            `${relativePath(templateDir)}/descriptor.json replaceMap 'useAzureOpenAI' must be conditional on llmService`
+          );
+        }
+      }
+    }
+
+    assert.deepStrictEqual(failures, []);
+  });
+});

--- a/packages/fx-core/tests/v4/validation/schemaReferences.test.ts
+++ b/packages/fx-core/tests/v4/validation/schemaReferences.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as fs from "fs";
+import * as path from "path";
+import { assert } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+const TEMPLATES_V4_ROOT = path.join(REPO_ROOT, "templates/v4");
+
+function listFiles(root: string, matches: (name: string) => boolean): string[] {
+  const result: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of fs.readdirSync(dir)) {
+      const fullPath = path.join(dir, name);
+      if (fs.statSync(fullPath).isDirectory()) {
+        walk(fullPath);
+      } else if (matches(name)) {
+        result.push(fullPath);
+      }
+    }
+  };
+  walk(root);
+  return result.sort();
+}
+
+function localSchemaReferences(filePath: string): string[] {
+  const text = fs.readFileSync(filePath, "utf8");
+  const refs: string[] = [];
+  for (const match of text.matchAll(/"\$schema"\s*:\s*"([^"]+)"/g)) {
+    const ref = match[1];
+    if (ref.startsWith(".")) {
+      refs.push(ref);
+    }
+  }
+  return refs;
+}
+
+describe("v4 schema references", () => {
+  it("every local $schema reference resolves to an existing schema file", () => {
+    const schemaReferenceFiles = listFiles(
+      TEMPLATES_V4_ROOT,
+      (name) => name.endsWith(".json") || name.endsWith(".json.tpl") || name.endsWith(".tour")
+    );
+
+    for (const filePath of schemaReferenceFiles) {
+      for (const schemaRef of localSchemaReferences(filePath)) {
+        const schemaPath = schemaRef.split("#")[0];
+        const resolved = path.resolve(path.dirname(filePath), schemaPath);
+        assert.isTrue(
+          fs.existsSync(resolved),
+          `${path.relative(REPO_ROOT, filePath).replace(/\\/g, "/")} $schema '${schemaRef}' must resolve to an existing file`
+        );
+      }
+    }
+  });
+});

--- a/packages/tests/src/e2e/teamsAgent/teamsCollaboratorAgent.tests.ts
+++ b/packages/tests/src/e2e/teamsAgent/teamsCollaboratorAgent.tests.ts
@@ -88,7 +88,7 @@ describe("Teams Collaborator Agent", function () {
         testFolder,
         Capability.TeamsCollaboratorAgent,
         process.env,
-        options
+        options,
       );
 
       // Validate Scaffold
@@ -126,7 +126,7 @@ describe("Teams Collaborator Agent", function () {
       assert.equal(bot?.botId, context.BOT_ID);
       assert.equal(
         bot?.messagingEndpoint,
-        "https://test.ngrok.io/api/messages"
+        "https://test.ngrok.io/api/messages",
       );
 
       // Local Debug (Deploy)
@@ -139,14 +139,14 @@ describe("Teams Collaborator Agent", function () {
       // validate .localConfigs
       assert.isTrue(
         await fs.pathExists(path.join(projectPath, ".localConfigs")),
-        ".localConfigs should exist"
+        ".localConfigs should exist",
       );
 
       // Remote Provision
       const result = await createResourceGroup(resourceGroupName, "westus");
       assert.isTrue(
         result,
-        `failed to create resource group: ${resourceGroupName}`
+        `failed to create resource group: ${resourceGroupName}`,
       );
 
       await CliHelper.provisionProject(projectPath, "", "dev", {
@@ -166,7 +166,7 @@ describe("Teams Collaborator Agent", function () {
         context[EnvConstants.BOT_AZURE_APP_SERVICE_RESOURCE_ID];
       assert.exists(
         appServiceResourceId,
-        "Azure App Service resource ID should exist"
+        "Azure App Service resource ID should exist",
       );
 
       const tokenProvider = MockAzureAccountProvider;
@@ -178,23 +178,23 @@ describe("Teams Collaborator Agent", function () {
         subscription,
         getResourceGroupNameFromResourceId(appServiceResourceId),
         getSiteNameFromResourceId(appServiceResourceId),
-        token as string
+        token as string,
       );
       assert.exists(response, "Web app settings should exist");
       assert.equal(
         response["WEBSITE_NODE_DEFAULT_VERSION"],
-        "~20",
-        "Node version should be 20"
+        "~22",
+        "Node version should be 22",
       );
       assert.equal(
         response["WEBSITE_RUN_FROM_PACKAGE"],
         "1",
-        "Run from package should be 1"
+        "Run from package should be 1",
       );
       assert.equal(
         response["RUNNING_ON_AZURE"],
         "1",
-        "Running on azure should be 1"
+        "Running on azure should be 1",
       );
 
       // Remote Deploy
@@ -203,6 +203,6 @@ describe("Teams Collaborator Agent", function () {
       // Validate Deploy
       context = await readContextMultiEnvV3(projectPath, envName);
       assert.exists(context, "env file should exist");
-    }
+    },
   );
 });

--- a/templates/v4/create/basic-custom-engine-agent/descriptor.json
+++ b/templates/v4/create/basic-custom-engine-agent/descriptor.json
@@ -9,7 +9,13 @@
 
   "optionsSchema": {
     "type": "object",
-    "properties": {},
+    "properties": {
+      "llmService": { "type": "string" },
+      "openAIKey": { "type": "string" },
+      "azureOpenAIKey": { "type": "string" },
+      "azureOpenAIEndpoint": { "type": "string" },
+      "azureOpenAIDeploymentName": { "type": "string" }
+    },
     "additionalProperties": false
   },
 
@@ -18,11 +24,11 @@
     { "var": "SandBoxedTeam", "when": "featureFlag('TEAMSFX_SANDBOXED_TEAM')", "value": "true" },
     { "var": "CEAEnabled", "when": "featureFlag('TEAMSFX_CEA_ENABLED')", "value": "true" },
     { "var": "pathDelimiter", "expr": "pathDelimiter()" },
-    { "var": "useOpenAI", "const": "" },
-    { "var": "useAzureOpenAI", "const": "true" },
-    { "var": "openAIKey", "const": "" },
-    { "var": "azureOpenAIKey", "const": "" },
-    { "var": "azureOpenAIEndpoint", "const": "" },
-    { "var": "azureOpenAIDeploymentName", "const": "" }
+    { "var": "useOpenAI", "when": "llmService == 'llm-service-openai'", "value": "true" },
+    { "var": "useAzureOpenAI", "when": "llmService != 'llm-service-openai'", "value": "true" },
+    { "var": "openAIKey", "from": "openAIKey" },
+    { "var": "azureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "azureOpenAIEndpoint", "from": "azureOpenAIEndpoint" },
+    { "var": "azureOpenAIDeploymentName", "from": "azureOpenAIDeploymentName" }
   ]
 }

--- a/templates/v4/create/basic-custom-engine-agent/questions.json
+++ b/templates/v4/create/basic-custom-engine-agent/questions.json
@@ -1,4 +1,52 @@
 {
-  "$schema": "../../schema/questions.schema.json",
-  "questions": []
+  "$schema": "../../schema/question.schema.json",
+  "questions": [
+    {
+      "name": "llmService",
+      "type": "singleSelect",
+      "title": "Service for Large Language Model (LLM)",
+      "placeholder": "Select a service to access LLMs",
+      "default": "llm-service-azure-openai",
+      "staticOptions": [
+        {
+          "id": "llm-service-azure-openai",
+          "label": "Azure OpenAI",
+          "detail": "Use Azure OpenAI as the language model service."
+        },
+        {
+          "id": "llm-service-openai",
+          "label": "OpenAI",
+          "detail": "Use OpenAI as the language model service."
+        }
+      ]
+    },
+    {
+      "name": "openAIKey",
+      "type": "text",
+      "title": "Input OpenAI service key now or set it later in the project.",
+      "condition": { "equals": { "llmService": "llm-service-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIKey",
+      "type": "text",
+      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIEndpoint",
+      "type": "text",
+      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIDeploymentName",
+      "type": "text",
+      "title": "Input Azure OpenAI deployment name",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    }
+  ]
 }

--- a/templates/v4/create/custom-copilot-basic/descriptor.json
+++ b/templates/v4/create/custom-copilot-basic/descriptor.json
@@ -9,7 +9,13 @@
 
   "optionsSchema": {
     "type": "object",
-    "properties": {},
+    "properties": {
+      "llmService": { "type": "string" },
+      "openAIKey": { "type": "string" },
+      "azureOpenAIKey": { "type": "string" },
+      "azureOpenAIEndpoint": { "type": "string" },
+      "azureOpenAIDeploymentName": { "type": "string" }
+    },
     "additionalProperties": false
   },
 
@@ -18,13 +24,13 @@
     { "var": "SandBoxedTeam", "when": "featureFlag('TEAMSFX_SANDBOXED_TEAM')", "value": "true" },
     { "var": "CEAEnabled", "when": "featureFlag('TEAMSFX_CEA_ENABLED')", "value": "true" },
     { "var": "pathDelimiter", "expr": "pathDelimiter()" },
-    { "var": "useOpenAI", "const": "" },
-    { "var": "useAzureOpenAI", "const": "true" },
-    { "var": "openAIKey", "const": "" },
-    { "var": "originalOpenAIKey", "const": "" },
-    { "var": "azureOpenAIKey", "const": "" },
-    { "var": "originalAzureOpenAIKey", "const": "" },
-    { "var": "azureOpenAIEndpoint", "const": "" },
-    { "var": "azureOpenAIDeploymentName", "const": "" }
+    { "var": "useOpenAI", "when": "llmService == 'llm-service-openai'", "value": "true" },
+    { "var": "useAzureOpenAI", "when": "llmService != 'llm-service-openai'", "value": "true" },
+    { "var": "openAIKey", "from": "openAIKey" },
+    { "var": "originalOpenAIKey", "from": "openAIKey" },
+    { "var": "azureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "originalAzureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "azureOpenAIEndpoint", "from": "azureOpenAIEndpoint" },
+    { "var": "azureOpenAIDeploymentName", "from": "azureOpenAIDeploymentName" }
   ]
 }

--- a/templates/v4/create/custom-copilot-basic/questions.json
+++ b/templates/v4/create/custom-copilot-basic/questions.json
@@ -1,4 +1,52 @@
 {
-  "$schema": "../../schema/questions.schema.json",
-  "questions": []
+  "$schema": "../../schema/question.schema.json",
+  "questions": [
+    {
+      "name": "llmService",
+      "type": "singleSelect",
+      "title": "Service for Large Language Model (LLM)",
+      "placeholder": "Select a service to access LLMs",
+      "default": "llm-service-azure-openai",
+      "staticOptions": [
+        {
+          "id": "llm-service-azure-openai",
+          "label": "Azure OpenAI",
+          "detail": "Use Azure OpenAI as the language model service."
+        },
+        {
+          "id": "llm-service-openai",
+          "label": "OpenAI",
+          "detail": "Use OpenAI as the language model service."
+        }
+      ]
+    },
+    {
+      "name": "openAIKey",
+      "type": "text",
+      "title": "Input OpenAI service key now or set it later in the project.",
+      "condition": { "equals": { "llmService": "llm-service-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIKey",
+      "type": "text",
+      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIEndpoint",
+      "type": "text",
+      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIDeploymentName",
+      "type": "text",
+      "title": "Input Azure OpenAI deployment name",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    }
+  ]
 }

--- a/templates/v4/create/custom-copilot-rag-azure-ai-search/descriptor.json
+++ b/templates/v4/create/custom-copilot-rag-azure-ai-search/descriptor.json
@@ -9,7 +9,13 @@
 
   "optionsSchema": {
     "type": "object",
-    "properties": {},
+    "properties": {
+      "llmService": { "type": "string" },
+      "openAIKey": { "type": "string" },
+      "azureOpenAIKey": { "type": "string" },
+      "azureOpenAIEndpoint": { "type": "string" },
+      "azureOpenAIDeploymentName": { "type": "string" }
+    },
     "additionalProperties": false
   },
 
@@ -18,14 +24,14 @@
     { "var": "SandBoxedTeam", "when": "featureFlag('TEAMSFX_SANDBOXED_TEAM')", "value": "true" },
     { "var": "CEAEnabled", "when": "featureFlag('TEAMSFX_CEA_ENABLED')", "value": "true" },
     { "var": "pathDelimiter", "expr": "pathDelimiter()" },
-    { "var": "useOpenAI", "const": "" },
-    { "var": "useAzureOpenAI", "const": "true" },
-    { "var": "openAIKey", "const": "" },
-    { "var": "originalOpenAIKey", "const": "" },
-    { "var": "azureOpenAIKey", "const": "" },
-    { "var": "originalAzureOpenAIKey", "const": "" },
-    { "var": "azureOpenAIEndpoint", "const": "" },
-    { "var": "azureOpenAIDeploymentName", "const": "" },
+    { "var": "useOpenAI", "when": "llmService == 'llm-service-openai'", "value": "true" },
+    { "var": "useAzureOpenAI", "when": "llmService != 'llm-service-openai'", "value": "true" },
+    { "var": "openAIKey", "from": "openAIKey" },
+    { "var": "originalOpenAIKey", "from": "openAIKey" },
+    { "var": "azureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "originalAzureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "azureOpenAIEndpoint", "from": "azureOpenAIEndpoint" },
+    { "var": "azureOpenAIDeploymentName", "from": "azureOpenAIDeploymentName" },
     { "var": "azureOpenAIEmbeddingDeploymentName", "const": "" },
     { "var": "azureSearchEndpoint", "const": "" },
     { "var": "secretAzureSearchKey", "const": "" }

--- a/templates/v4/create/custom-copilot-rag-azure-ai-search/questions.json
+++ b/templates/v4/create/custom-copilot-rag-azure-ai-search/questions.json
@@ -1,4 +1,52 @@
 {
-  "$schema": "../../schema/questions.schema.json",
-  "questions": []
+  "$schema": "../../schema/question.schema.json",
+  "questions": [
+    {
+      "name": "llmService",
+      "type": "singleSelect",
+      "title": "Service for Large Language Model (LLM)",
+      "placeholder": "Select a service to access LLMs",
+      "default": "llm-service-azure-openai",
+      "staticOptions": [
+        {
+          "id": "llm-service-azure-openai",
+          "label": "Azure OpenAI",
+          "detail": "Use Azure OpenAI as the language model service."
+        },
+        {
+          "id": "llm-service-openai",
+          "label": "OpenAI",
+          "detail": "Use OpenAI as the language model service."
+        }
+      ]
+    },
+    {
+      "name": "openAIKey",
+      "type": "text",
+      "title": "Input OpenAI service key now or set it later in the project.",
+      "condition": { "equals": { "llmService": "llm-service-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIKey",
+      "type": "text",
+      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIEndpoint",
+      "type": "text",
+      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIDeploymentName",
+      "type": "text",
+      "title": "Input Azure OpenAI deployment name",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    }
+  ]
 }

--- a/templates/v4/create/custom-copilot-rag-custom-api/descriptor.json
+++ b/templates/v4/create/custom-copilot-rag-custom-api/descriptor.json
@@ -10,6 +10,11 @@
   "optionsSchema": {
     "type": "object",
     "properties": {
+      "llmService": { "type": "string" },
+      "openAIKey": { "type": "string" },
+      "azureOpenAIKey": { "type": "string" },
+      "azureOpenAIEndpoint": { "type": "string" },
+      "azureOpenAIDeploymentName": { "type": "string" },
       "apiSpecLocation": { "type": "string" },
       "apiOperations": { "type": "array", "items": { "type": "string" } }
     },
@@ -21,13 +26,13 @@
     { "var": "SandBoxedTeam", "when": "featureFlag('TEAMSFX_SANDBOXED_TEAM')", "value": "true" },
     { "var": "CEAEnabled", "when": "featureFlag('TEAMSFX_CEA_ENABLED')", "value": "true" },
     { "var": "pathDelimiter", "expr": "pathDelimiter()" },
-    { "var": "useOpenAI", "const": "" },
-    { "var": "useAzureOpenAI", "const": "true" },
-    { "var": "openAIKey", "const": "" },
-    { "var": "originalOpenAIKey", "const": "" },
-    { "var": "azureOpenAIKey", "const": "" },
-    { "var": "originalAzureOpenAIKey", "const": "" },
-    { "var": "azureOpenAIEndpoint", "const": "" },
-    { "var": "azureOpenAIDeploymentName", "const": "" }
+    { "var": "useOpenAI", "when": "llmService == 'llm-service-openai'", "value": "true" },
+    { "var": "useAzureOpenAI", "when": "llmService != 'llm-service-openai'", "value": "true" },
+    { "var": "openAIKey", "from": "openAIKey" },
+    { "var": "originalOpenAIKey", "from": "openAIKey" },
+    { "var": "azureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "originalAzureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "azureOpenAIEndpoint", "from": "azureOpenAIEndpoint" },
+    { "var": "azureOpenAIDeploymentName", "from": "azureOpenAIDeploymentName" }
   ]
 }

--- a/templates/v4/create/custom-copilot-rag-custom-api/questions.json
+++ b/templates/v4/create/custom-copilot-rag-custom-api/questions.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../schema/questions.schema.json",
+  "$schema": "../../schema/question.schema.json",
   "questions": [
     {
       "name": "apiSpecLocation",
@@ -19,6 +19,53 @@
         "apiSpecLocation": { "expr": "apiSpecLocation" }
       },
       "cliDescription": "API operations to include in the custom API agent."
+    },
+    {
+      "name": "llmService",
+      "type": "singleSelect",
+      "title": "Service for Large Language Model (LLM)",
+      "placeholder": "Select a service to access LLMs",
+      "default": "llm-service-azure-openai",
+      "staticOptions": [
+        {
+          "id": "llm-service-azure-openai",
+          "label": "Azure OpenAI",
+          "detail": "Use Azure OpenAI as the language model service."
+        },
+        {
+          "id": "llm-service-openai",
+          "label": "OpenAI",
+          "detail": "Use OpenAI as the language model service."
+        }
+      ]
+    },
+    {
+      "name": "openAIKey",
+      "type": "text",
+      "title": "Input OpenAI service key now or set it later in the project.",
+      "condition": { "equals": { "llmService": "llm-service-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIKey",
+      "type": "text",
+      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIEndpoint",
+      "type": "text",
+      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIDeploymentName",
+      "type": "text",
+      "title": "Input Azure OpenAI deployment name",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
     }
   ]
 }

--- a/templates/v4/create/custom-copilot-rag-customize/descriptor.json
+++ b/templates/v4/create/custom-copilot-rag-customize/descriptor.json
@@ -9,7 +9,13 @@
 
   "optionsSchema": {
     "type": "object",
-    "properties": {},
+    "properties": {
+      "llmService": { "type": "string" },
+      "openAIKey": { "type": "string" },
+      "azureOpenAIKey": { "type": "string" },
+      "azureOpenAIEndpoint": { "type": "string" },
+      "azureOpenAIDeploymentName": { "type": "string" }
+    },
     "additionalProperties": false
   },
 
@@ -18,13 +24,13 @@
     { "var": "SandBoxedTeam", "when": "featureFlag('TEAMSFX_SANDBOXED_TEAM')", "value": "true" },
     { "var": "CEAEnabled", "when": "featureFlag('TEAMSFX_CEA_ENABLED')", "value": "true" },
     { "var": "pathDelimiter", "expr": "pathDelimiter()" },
-    { "var": "useOpenAI", "const": "" },
-    { "var": "useAzureOpenAI", "const": "true" },
-    { "var": "openAIKey", "const": "" },
-    { "var": "originalOpenAIKey", "const": "" },
-    { "var": "azureOpenAIKey", "const": "" },
-    { "var": "originalAzureOpenAIKey", "const": "" },
-    { "var": "azureOpenAIEndpoint", "const": "" },
-    { "var": "azureOpenAIDeploymentName", "const": "" }
+    { "var": "useOpenAI", "when": "llmService == 'llm-service-openai'", "value": "true" },
+    { "var": "useAzureOpenAI", "when": "llmService != 'llm-service-openai'", "value": "true" },
+    { "var": "openAIKey", "from": "openAIKey" },
+    { "var": "originalOpenAIKey", "from": "openAIKey" },
+    { "var": "azureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "originalAzureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "azureOpenAIEndpoint", "from": "azureOpenAIEndpoint" },
+    { "var": "azureOpenAIDeploymentName", "from": "azureOpenAIDeploymentName" }
   ]
 }

--- a/templates/v4/create/custom-copilot-rag-customize/questions.json
+++ b/templates/v4/create/custom-copilot-rag-customize/questions.json
@@ -1,4 +1,52 @@
 {
-  "$schema": "../../schema/questions.schema.json",
-  "questions": []
+  "$schema": "../../schema/question.schema.json",
+  "questions": [
+    {
+      "name": "llmService",
+      "type": "singleSelect",
+      "title": "Service for Large Language Model (LLM)",
+      "placeholder": "Select a service to access LLMs",
+      "default": "llm-service-azure-openai",
+      "staticOptions": [
+        {
+          "id": "llm-service-azure-openai",
+          "label": "Azure OpenAI",
+          "detail": "Use Azure OpenAI as the language model service."
+        },
+        {
+          "id": "llm-service-openai",
+          "label": "OpenAI",
+          "detail": "Use OpenAI as the language model service."
+        }
+      ]
+    },
+    {
+      "name": "openAIKey",
+      "type": "text",
+      "title": "Input OpenAI service key now or set it later in the project.",
+      "condition": { "equals": { "llmService": "llm-service-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIKey",
+      "type": "text",
+      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIEndpoint",
+      "type": "text",
+      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIDeploymentName",
+      "type": "text",
+      "title": "Input Azure OpenAI deployment name",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    }
+  ]
 }

--- a/templates/v4/create/da/mcp-server-static/descriptor.json
+++ b/templates/v4/create/da/mcp-server-static/descriptor.json
@@ -9,9 +9,10 @@
 
   "optionsSchema": {
     "type": "object",
-    "required": ["mcpServerUrl", "mcpToolsJson", "selectedMcpTools"],
+    "required": ["mcpServerUrl"],
     "properties": {
       "mcpServerUrl": { "type": "string", "format": "uri" },
+      "mcpToolsFilePath": { "type": "string" },
       "mcpToolsJson": { "type": "string" },
       "selectedMcpTools": { "type": "array", "items": { "type": "string" } }
     },

--- a/templates/v4/create/da/mcp-server-static/pipeline.json
+++ b/templates/v4/create/da/mcp-server-static/pipeline.json
@@ -1,6 +1,6 @@
 {
   "pipeline": "default",
-  "comment": "Render produces the base DA project files. The static MCP step then materializes selected tools into appPackage/mcp-tools-1.json and rewrites appPackage/ai-plugin.json to the legacy static RemoteMCPServer runtime shape. This route is selected when TEAMSFX_MCP_FOR_DA_DT is off, so it must not fall back to the v3 generator.",
+  "comment": "Render produces the base DA project files. On CLI, the static MCP step materializes selected tools into appPackage/mcp-tools-1.json and rewrites appPackage/ai-plugin.json to the legacy static RemoteMCPServer runtime shape. VS Code create skips static tool materialization and leaves tool fetch/update to the MCP CodeLens flow.",
   "steps": [
     {
       "step": "require-empty-target",
@@ -8,10 +8,12 @@
     },
     {
       "step": "mcp-static/materialize-tools",
+      "when": "surface == 'cli'",
       "with": {
         "pluginPath": "appPackage/ai-plugin.json",
         "toolsPath": "appPackage/mcp-tools-1.json",
         "mcpServerUrl": "{{MCPForDAServerUrl}}",
+        "toolsFilePath": "{{mcpToolsFilePath}}",
         "toolsJson": "{{mcpToolsJson}}",
         "selected": "{{selectedMcpTools}}"
       }

--- a/templates/v4/create/da/mcp-server-static/questions.json
+++ b/templates/v4/create/da/mcp-server-static/questions.json
@@ -15,7 +15,7 @@
       "prompt": "Enter the path to a JSON file containing MCP tool definitions.",
       "cliDescription": "Path to a JSON file containing MCP tool definitions.",
       "optional": true,
-      "condition": { "expr": "surface == 'cli' && mcpToolsJson == null" }
+      "condition": { "expr": "surface == 'cli' && nonInteractive != 'true' && mcpToolsJson == null" }
     },
     {
       "name": "selectedMcpTools",
@@ -28,7 +28,7 @@
         "serverUrl": { "expr": "mcpServerUrl" }
       },
       "cliDescription": "MCP tools to include in the action.",
-      "condition": { "expr": "surface == 'cli'" }
+      "condition": { "expr": "surface == 'cli' && nonInteractive != 'true'" }
     }
   ]
 }

--- a/templates/v4/create/da/mcp-server-static/questions.json
+++ b/templates/v4/create/da/mcp-server-static/questions.json
@@ -9,11 +9,13 @@
       "validation": "uri"
     },
     {
-      "name": "mcpToolsJson",
+      "name": "mcpToolsFilePath",
       "type": "text",
-      "title": "MCP Tools JSON",
-      "prompt": "Paste the MCP tools JSON returned by the server tools/list response.",
-      "cliDescription": "MCP tools JSON returned by the server tools/list response."
+      "title": "MCP Tools File Path",
+      "prompt": "Enter the path to a JSON file containing MCP tool definitions.",
+      "cliDescription": "Path to a JSON file containing MCP tool definitions.",
+      "optional": true,
+      "condition": { "expr": "surface == 'cli' && mcpToolsJson == null" }
     },
     {
       "name": "selectedMcpTools",
@@ -21,9 +23,12 @@
       "title": "MCP Tools",
       "optionsFrom": "mcp.tools",
       "optionsFromParams": {
-        "toolsJson": { "expr": "mcpToolsJson" }
+        "toolsJson": { "expr": "mcpToolsJson" },
+        "toolsFilePath": { "expr": "mcpToolsFilePath" },
+        "serverUrl": { "expr": "mcpServerUrl" }
       },
-      "cliDescription": "MCP tools to include in the action."
+      "cliDescription": "MCP tools to include in the action.",
+      "condition": { "expr": "surface == 'cli'" }
     }
   ]
 }

--- a/templates/v4/create/da/mcp-server/descriptor.json
+++ b/templates/v4/create/da/mcp-server/descriptor.json
@@ -9,7 +9,7 @@
 
   "optionsSchema": {
     "type": "object",
-    "required": ["mcpServerType", "authType"],
+    "required": ["mcpServerType"],
     "properties": {
       "mcpServerType": { "enum": ["local", "remote"], "default": "remote" },
       "mcpServerUrl": { "type": "string", "format": "uri" },
@@ -18,13 +18,12 @@
       "oauthClientSecret": { "type": "string" },
       "oauthScopes": { "type": "string" },
       "entraClientId": { "type": "string" },
-      "selectedLocalServers": { "type": "array", "items": { "type": "string" } },
-      "localServerCatalog": { "type": "string" }
+      "selectedLocalServers": { "type": "array", "items": { "type": "string" } }
     },
     "allOf": [
       {
         "if": { "properties": { "mcpServerType": { "const": "remote" } } },
-        "then": { "required": ["mcpServerUrl"] }
+        "then": { "required": ["mcpServerUrl", "authType"] }
       },
       {
         "if": { "properties": { "mcpServerType": { "const": "local" } } },

--- a/templates/v4/create/da/mcp-server/pipeline.json
+++ b/templates/v4/create/da/mcp-server/pipeline.json
@@ -8,7 +8,7 @@
     },
     {
       "step": "mcp-auth/inject-yml-action",
-      "when": "authType != 'none'",
+      "when": "mcpServerType == 'remote' && authType != 'none'",
       "with": {
         "ymlPath": "m365agents.yml",
         "authType": "{{authType}}",
@@ -18,7 +18,7 @@
     },
     {
       "step": "mcp-auth/persist-credential-env",
-      "when": "authType == 'oauth' || authType == 'entra-sso'",
+      "when": "mcpServerType == 'remote' && (authType == 'oauth' || authType == 'entra-sso')",
       "with": {
         "authType": "{{authType}}",
         "mcpServerUrl": "{{MCPForDAServerUrl}}"

--- a/templates/v4/create/da/mcp-server/questions.json
+++ b/templates/v4/create/da/mcp-server/questions.json
@@ -19,10 +19,19 @@
       "validation": "uri"
     },
     {
+      "name": "selectedLocalServers",
+      "type": "multiSelect",
+      "title": "Local MCP Servers",
+      "keyPrefix": "template.daMcpServer.localServers",
+      "optionsFrom": "mcp.localServers",
+      "condition": { "expr": "mcpServerType == 'local'" }
+    },
+    {
       "name": "authType",
       "type": "singleSelect",
       "title": "Authentication",
       "keyPrefix": "template.daMcpServer.authType",
+      "condition": { "expr": "mcpServerType == 'remote'" },
       "staticOptions": [
         { "id": "oauth", "label": "OAuth (with static registration)" },
         { "id": "oauth-dynamic", "label": "OAuth (with dynamic registration)",
@@ -31,6 +40,35 @@
         { "id": "none", "label": "None" }
       ],
       "default": "none"
+    },
+    {
+      "name": "oauthClientId",
+      "type": "text",
+      "title": "OAuth Client ID",
+      "keyPrefix": "template.daMcpServer.oauthClientId",
+      "condition": { "expr": "authType == 'oauth'" }
+    },
+    {
+      "name": "oauthClientSecret",
+      "type": "text",
+      "title": "OAuth Client Secret",
+      "keyPrefix": "template.daMcpServer.oauthClientSecret",
+      "condition": { "expr": "authType == 'oauth'" }
+    },
+    {
+      "name": "oauthScopes",
+      "type": "text",
+      "title": "OAuth Scopes",
+      "keyPrefix": "template.daMcpServer.oauthScopes",
+      "condition": { "expr": "authType == 'oauth'" },
+      "optional": true
+    },
+    {
+      "name": "entraClientId",
+      "type": "text",
+      "title": "Entra Client ID",
+      "keyPrefix": "template.daMcpServer.entraClientId",
+      "condition": { "expr": "authType == 'entra-sso'" }
     }
   ]
 }

--- a/templates/v4/create/default-bot/content/python/env/.env.dev.user.tpl
+++ b/templates/v4/create/default-bot/content/python/env/.env.dev.user.tpl
@@ -1,11 +1,3 @@
 # This file includes environment variables that will not be committed to git by default. You can set these environment variables in your CI/CD system for your project.
 
 # Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
-{{#useOpenAI}}
-SECRET_OPENAI_API_KEY={{{openAIKey}}}
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
-AZURE_OPENAI_ENDPOINT='{{{azureOpenAIEndpoint}}}'
-AZURE_OPENAI_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'
-{{/useAzureOpenAI}}

--- a/templates/v4/create/default-bot/content/python/env/.env.local.user.tpl
+++ b/templates/v4/create/default-bot/content/python/env/.env.local.user.tpl
@@ -3,11 +3,3 @@
 # If you're adding a secret value, add SECRET_ prefix to the name so Microsoft 365 Agents Toolkit can handle them properly
 # Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
 SECRET_BOT_PASSWORD=
-{{#useOpenAI}}
-SECRET_OPENAI_API_KEY={{{openAIKey}}}
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
-AZURE_OPENAI_ENDPOINT='{{{azureOpenAIEndpoint}}}'
-AZURE_OPENAI_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'
-{{/useAzureOpenAI}}

--- a/templates/v4/create/default-bot/content/python/env/.env.playground.user.tpl
+++ b/templates/v4/create/default-bot/content/python/env/.env.playground.user.tpl
@@ -2,11 +2,3 @@
 
 # If you're adding a secret value, add SECRET_ prefix to the name so Microsoft 365 Agents Toolkit can handle them properly
 # Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
-{{#useOpenAI}}
-SECRET_OPENAI_API_KEY={{{openAIKey}}}
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
-AZURE_OPENAI_ENDPOINT='{{{azureOpenAIEndpoint}}}'
-AZURE_OPENAI_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'
-{{/useAzureOpenAI}}

--- a/templates/v4/create/default-bot/content/python/env/.env.sandbox.user.tpl
+++ b/templates/v4/create/default-bot/content/python/env/.env.sandbox.user.tpl
@@ -3,11 +3,3 @@
 # If you're adding a secret value, add SECRET_ prefix to the name so Microsoft 365 Agents Toolkit can handle them properly
 # Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
 SECRET_BOT_PASSWORD=
-{{#useOpenAI}}
-SECRET_OPENAI_API_KEY={{{openAIKey}}}
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
-AZURE_OPENAI_ENDPOINT='{{{azureOpenAIEndpoint}}}'
-AZURE_OPENAI_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'
-{{/useAzureOpenAI}}

--- a/templates/v4/create/default-bot/descriptor.json
+++ b/templates/v4/create/default-bot/descriptor.json
@@ -16,12 +16,6 @@
   "replaceMap": [
     { "var": "SafeProjectNameLowerCase", "expr": "safeProjectNameLowerCase(appName)" },
     { "var": "SandBoxedTeam", "when": "featureFlag('TEAMSFX_SANDBOXED_TEAM')", "value": "true" },
-    { "var": "pathDelimiter", "expr": "pathDelimiter()" },
-    { "var": "useOpenAI", "const": "" },
-    { "var": "useAzureOpenAI", "const": "true" },
-    { "var": "openAIKey", "const": "" },
-    { "var": "azureOpenAIKey", "const": "" },
-    { "var": "azureOpenAIEndpoint", "const": "" },
-    { "var": "azureOpenAIDeploymentName", "const": "" }
+    { "var": "pathDelimiter", "expr": "pathDelimiter()" }
   ]
 }

--- a/templates/v4/create/default-bot/questions.json
+++ b/templates/v4/create/default-bot/questions.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "../../schema/questions.schema.json",
+  "$schema": "../../schema/question.schema.json",
   "questions": []
 }

--- a/templates/v4/create/default-message-extension/content/python/env/.env.dev.user.tpl
+++ b/templates/v4/create/default-message-extension/content/python/env/.env.dev.user.tpl
@@ -1,11 +1,3 @@
 # This file includes environment variables that will not be committed to git by default. You can set these environment variables in your CI/CD system for your project.
 
 # Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
-{{#useOpenAI}}
-SECRET_OPENAI_API_KEY={{{openAIKey}}}
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
-AZURE_OPENAI_ENDPOINT='{{{azureOpenAIEndpoint}}}'
-AZURE_OPENAI_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'
-{{/useAzureOpenAI}}

--- a/templates/v4/create/default-message-extension/content/python/env/.env.local.user.tpl
+++ b/templates/v4/create/default-message-extension/content/python/env/.env.local.user.tpl
@@ -3,11 +3,3 @@
 # If you're adding a secret value, add SECRET_ prefix to the name so Microsoft 365 Agents Toolkit can handle them properly
 # Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
 SECRET_BOT_PASSWORD=
-{{#useOpenAI}}
-SECRET_OPENAI_API_KEY={{{openAIKey}}}
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
-AZURE_OPENAI_ENDPOINT='{{{azureOpenAIEndpoint}}}'
-AZURE_OPENAI_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'
-{{/useAzureOpenAI}}

--- a/templates/v4/create/default-message-extension/content/python/env/.env.playground.user.tpl
+++ b/templates/v4/create/default-message-extension/content/python/env/.env.playground.user.tpl
@@ -2,11 +2,3 @@
 
 # If you're adding a secret value, add SECRET_ prefix to the name so Microsoft 365 Agents Toolkit can handle them properly
 # Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
-{{#useOpenAI}}
-SECRET_OPENAI_API_KEY={{{openAIKey}}}
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
-AZURE_OPENAI_ENDPOINT='{{{azureOpenAIEndpoint}}}'
-AZURE_OPENAI_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'
-{{/useAzureOpenAI}}

--- a/templates/v4/create/default-message-extension/content/python/env/.env.sandbox.user.tpl
+++ b/templates/v4/create/default-message-extension/content/python/env/.env.sandbox.user.tpl
@@ -3,11 +3,3 @@
 # If you're adding a secret value, add SECRET_ prefix to the name so Microsoft 365 Agents Toolkit can handle them properly
 # Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
 SECRET_BOT_PASSWORD=
-{{#useOpenAI}}
-SECRET_OPENAI_API_KEY={{{openAIKey}}}
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
-AZURE_OPENAI_ENDPOINT='{{{azureOpenAIEndpoint}}}'
-AZURE_OPENAI_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'
-{{/useAzureOpenAI}}

--- a/templates/v4/create/default-message-extension/descriptor.json
+++ b/templates/v4/create/default-message-extension/descriptor.json
@@ -16,12 +16,6 @@
   "replaceMap": [
     { "var": "SafeProjectNameLowerCase", "expr": "safeProjectNameLowerCase(appName)" },
     { "var": "SandBoxedTeam", "when": "featureFlag('TEAMSFX_SANDBOXED_TEAM')", "value": "true" },
-    { "var": "pathDelimiter", "expr": "pathDelimiter()" },
-    { "var": "useOpenAI", "const": "" },
-    { "var": "useAzureOpenAI", "const": "true" },
-    { "var": "openAIKey", "const": "" },
-    { "var": "azureOpenAIKey", "const": "" },
-    { "var": "azureOpenAIEndpoint", "const": "" },
-    { "var": "azureOpenAIDeploymentName", "const": "" }
+    { "var": "pathDelimiter", "expr": "pathDelimiter()" }
   ]
 }

--- a/templates/v4/create/default-message-extension/questions.json
+++ b/templates/v4/create/default-message-extension/questions.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "../../schema/questions.schema.json",
+  "$schema": "../../schema/question.schema.json",
   "questions": []
 }

--- a/templates/v4/create/office-addin-config/questions.json
+++ b/templates/v4/create/office-addin-config/questions.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../schema/questions.schema.json",
+  "$schema": "../../schema/question.schema.json",
   "questions": [
     {
       "name": "officeAddinFolder",

--- a/templates/v4/create/teams-collaborator-agent/questions.json
+++ b/templates/v4/create/teams-collaborator-agent/questions.json
@@ -1,4 +1,23 @@
 {
-  "$schema": "../../schema/questions.schema.json",
-  "questions": []
+  "$schema": "../../schema/question.schema.json",
+  "questions": [
+    {
+      "name": "azureOpenAIKey",
+      "type": "text",
+      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIEndpoint",
+      "type": "text",
+      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIDeploymentName",
+      "type": "text",
+      "title": "Input Azure OpenAI deployment name",
+      "optional": true
+    }
+  ]
 }

--- a/templates/v4/create/weather-agent/descriptor.json
+++ b/templates/v4/create/weather-agent/descriptor.json
@@ -9,7 +9,13 @@
 
   "optionsSchema": {
     "type": "object",
-    "properties": {},
+    "properties": {
+      "llmService": { "type": "string" },
+      "openAIKey": { "type": "string" },
+      "azureOpenAIKey": { "type": "string" },
+      "azureOpenAIEndpoint": { "type": "string" },
+      "azureOpenAIDeploymentName": { "type": "string" }
+    },
     "additionalProperties": false
   },
 
@@ -18,13 +24,13 @@
     { "var": "SandBoxedTeam", "when": "featureFlag('TEAMSFX_SANDBOXED_TEAM')", "value": "true" },
     { "var": "CEAEnabled", "when": "featureFlag('TEAMSFX_CEA_ENABLED')", "value": "true" },
     { "var": "pathDelimiter", "expr": "pathDelimiter()" },
-    { "var": "useOpenAI", "const": "" },
-    { "var": "useAzureOpenAI", "const": "true" },
-    { "var": "openAIKey", "const": "" },
-    { "var": "originalOpenAIKey", "const": "" },
-    { "var": "azureOpenAIKey", "const": "" },
-    { "var": "originalAzureOpenAIKey", "const": "" },
-    { "var": "azureOpenAIEndpoint", "const": "" },
-    { "var": "azureOpenAIDeploymentName", "const": "" }
+    { "var": "useOpenAI", "when": "llmService == 'llm-service-openai'", "value": "true" },
+    { "var": "useAzureOpenAI", "when": "llmService != 'llm-service-openai'", "value": "true" },
+    { "var": "openAIKey", "from": "openAIKey" },
+    { "var": "originalOpenAIKey", "from": "openAIKey" },
+    { "var": "azureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "originalAzureOpenAIKey", "from": "azureOpenAIKey" },
+    { "var": "azureOpenAIEndpoint", "from": "azureOpenAIEndpoint" },
+    { "var": "azureOpenAIDeploymentName", "from": "azureOpenAIDeploymentName" }
   ]
 }

--- a/templates/v4/create/weather-agent/questions.json
+++ b/templates/v4/create/weather-agent/questions.json
@@ -1,4 +1,52 @@
 {
-  "$schema": "../../schema/questions.schema.json",
-  "questions": []
+  "$schema": "../../schema/question.schema.json",
+  "questions": [
+    {
+      "name": "llmService",
+      "type": "singleSelect",
+      "title": "Service for Large Language Model (LLM)",
+      "placeholder": "Select a service to access LLMs",
+      "default": "llm-service-azure-openai",
+      "staticOptions": [
+        {
+          "id": "llm-service-azure-openai",
+          "label": "Azure OpenAI",
+          "detail": "Use Azure OpenAI as the language model service."
+        },
+        {
+          "id": "llm-service-openai",
+          "label": "OpenAI",
+          "detail": "Use OpenAI as the language model service."
+        }
+      ]
+    },
+    {
+      "name": "openAIKey",
+      "type": "text",
+      "title": "Input OpenAI service key now or set it later in the project.",
+      "condition": { "equals": { "llmService": "llm-service-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIKey",
+      "type": "text",
+      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIEndpoint",
+      "type": "text",
+      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    },
+    {
+      "name": "azureOpenAIDeploymentName",
+      "type": "text",
+      "title": "Input Azure OpenAI deployment name",
+      "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
+      "optional": true
+    }
+  ]
 }

--- a/templates/v4/schema/pipeline.schema.json
+++ b/templates/v4/schema/pipeline.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aka.ms/m365atk/v4/pipeline.schema.json",
+  "title": "v4 pipeline.json",
+  "description": "Authoring-time schema for a v4 template scaffold pipeline: a named orchestration plus an ordered list of whitelisted runtime steps.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["pipeline", "steps"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "pipeline": { "type": "string" },
+    "comment": { "type": "string" },
+    "steps": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/pipelineStep" }
+    }
+  },
+  "$defs": {
+    "pipelineStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step"],
+      "properties": {
+        "step": { "type": "string" },
+        "comment": { "type": "string" },
+        "when": { "type": "string" },
+        "with": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "boolean" },
+              { "type": "array", "items": { "type": "string" } }
+            ]
+          }
+        },
+        "produces": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Align v4 create template Q2 coverage with migrated v3 template behavior, including LLM/OpenAI prompts, custom API ordering, and MCP static/dynamic behavior.
- Keep MCP tool/local-server business logic in Q2 providers and runtime pipeline steps instead of the create front door.
- Add v4 template validation and focused scenario/runtime tests for MCP and OpenAI question coverage.

## Validation
- npm run build from repo root: passed
- npm run lint:fix in packages/fx-core: completed with existing warnings, no errors
- npx vitest run tests/core/createProjectFrontDoor.test.ts tests/v4/surface/createInputs.test.ts: 64 passed
- npx vitest run tests/v4/surface/createInputs.test.ts: 40 passed
- Focused coverage command over touched fx-core source files: 105 passed

## Patch coverage
- Focused touched-source coverage: lines 92.75%, statements 92.85%, branches 84.81%, functions 94.73%.
- Note: npm run test:coverage:changed currently reports No changed source files found against origin/dev because the script filters for paths starting with src/, while this repo diff returns paths like packages/fx-core/src/....