### PR TITLE
fix(vscuse): attempt 1 - In step_d0c53170, changed the click Y from 7…

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -342,7 +342,7 @@
       "parameters": {
         "button": "left",
         "x": 345,
-        "y": 70
+        "y": 125
       },
       "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code.",
       "content_refs": [],
@@ -648,7 +648,7 @@
       "parameters": {
         "text": "read:user"
       },
-      "description": "Type 'read:user' into the “Scope(s) for OAuth registration” input field at the top of the Visual Studio Code window.",
+      "description": "Type 'read:user' into the \u201cScope(s) for OAuth registration\u201d input field at the top of the Visual Studio Code window.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
…0 to 125 so it selects "OAuth (with static registration)" (2nd item) instead of "OAuth (with dynamic registration)" (1st item); dynamic registration caused provision to fail ("missing registration_endpoint") so the client-ID prompt never appeared and step_73df5e59 timed out.