### PR TITLE
ci(vscuse): stop pr-vscuse-test listening to labeled event

### DIFF
--- a/.github/workflows/pr-vscuse-test.yml
+++ b/.github/workflows/pr-vscuse-test.yml
@@ -1,7 +1,6 @@
 ﻿name: PR VscUse Test Plan Selector
 
 # Triggered automatically on every PR open/sync/reopen/ready_for_review,
-# when the 'atk-vsuse-test' label is added to a PR,
 # OR manually via workflow_dispatch with a pr_number input.
 #
 # IMPORTANT: this workflow is INFORMATIONAL ONLY — it must NEVER block merge.
@@ -11,7 +10,7 @@
 #   * Results are surfaced via PR comments; use them as guidance, not a gate.
 #
 # This workflow:
-#   1. Resolves PR context (works for label, auto, and manual triggers)
+#   1. Resolves PR context (works for both automatic and manual triggers)
 #   2. Gets the diff between the PR branch and the target branch
 #   3. Selects test plans — a changed test plan file is run as an "impacted" case;
 #      for product-code changes GitHub Copilot CLI (Claude Sonnet 4.6) picks relevant plans
@@ -21,7 +20,7 @@
 
 on:
   pull_request:
-    types: [labeled, opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -42,13 +41,10 @@ permissions:
 
 jobs:
   select-plans-and-run:
-    # Run for: label add (atk-vsuse-test), automatic PR events (skip drafts), or manual dispatch.
+    # Run for: automatic PR events (skip drafts) or manual dispatch.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && (
-        (github.event.action == 'labeled' && github.event.label.name == 'atk-vsuse-test') ||
-        (github.event.action != 'labeled' && github.event.pull_request.draft == false)
-      ))
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
 
     steps:
@@ -772,55 +768,4 @@ jobs:
             // The PR comment carries the result; merge gating must not depend on this run.
             if (!succeeded) {
               console.log(`VscUse tests concluded: ${conclusion}. See: ${smokeUrl}`);
-            }
-      # ── 9. Remove atk-vsuse-test label (signals completion) ───────────
-      - name: Remove atk-vsuse-test label
-        if: always()
-        uses: actions/github-script@v6
-        env:
-          PR_NUMBER: ${{ steps.pr-context.outputs.pr_number }}
-        with:
-          script: |
-            const prNumber = parseInt(process.env.PR_NUMBER);
-            if (!prNumber) { console.log('No PR number — skipping label removal'); return; }
-            try {
-              await github.rest.issues.removeLabel({
-                owner:        context.repo.owner,
-                repo:         context.repo.repo,
-                issue_number: prNumber,
-                name:         'atk-vsuse-test',
-              });
-              console.log(`Removed label 'atk-vsuse-test' from PR #${prNumber}`);
-            } catch (err) {
-              if (err.status === 404) {
-                console.log('Label not present, nothing to remove');
-              } else {
-                throw err;
-              }
-            }
-
-      # ── 9. Remove trigger label to indicate completion ────────────────
-      - name: Remove atk-vsuse-test label
-        if: always()
-        uses: actions/github-script@v6
-        env:
-          PR_NUMBER: ${{ steps.pr-context.outputs.pr_number }}
-        with:
-          script: |
-            const prNumber = parseInt(process.env.PR_NUMBER);
-            if (!prNumber) { console.log('No PR number — skipping label removal'); return; }
-            try {
-              await github.rest.issues.removeLabel({
-                owner:       context.repo.owner,
-                repo:        context.repo.repo,
-                issue_number: prNumber,
-                name:        'atk-vsuse-test',
-              });
-              console.log(`Removed label 'atk-vsuse-test' from PR #${prNumber}`);
-            } catch (err) {
-              if (err.status === 404) {
-                console.log('Label not present — nothing to remove');
-              } else {
-                throw err;
-              }
             }


### PR DESCRIPTION
## Problem

On PRs like #16253, the `PR VscUse Test Plan Selector / select-plans-and-run` check is reported as **skipped**.

Root cause: the workflow listened to the `pull_request: labeled` event. When a PR is opened together with non-`atk-vsuse-test` labels (e.g. `vscuse-auto-fix`, `ai-generated`), those near-simultaneous `labeled` events each start a run. Their job `if` evaluates to false (label ≠ `atk-vsuse-test`, and `action != 'labeled'` is also false), so the job **skips** — and because of the `cancel-in-progress` concurrency group, the surviving skipped run cancels the real `opened`-event run that would have actually executed.

## Change

- Remove `labeled` from `on.pull_request.types`.
- Simplify the job `if` to just `workflow_dispatch` or a non-draft `pull_request`.
- Remove the two now-dead `Remove atk-vsuse-test label` steps and update the header comments.

Manual re-triggering is unaffected: it goes through the `/atk-vsuse-test` PR comment, which dispatches via `workflow_dispatch` (label events performed with `GITHUB_TOKEN` never fire other workflows, which is why the comment path already avoids the label).

The workflow remains **informational-only** and is not a merge gate.

## Verification

- YAML parses (`yaml.safe_load`).
- No remaining `labeled` trigger / `removeLabel` / label-based `if` in the file.
- No other workflow adds the `atk-vsuse-test` label to trigger this one.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>