### PR TITLE
fix(fx-core): add v4 OpenAPI search option

### DIFF
--- a/docs/03-specs/scenarios/teams/create-non-sso-tab.md
+++ b/docs/03-specs/scenarios/teams/create-non-sso-tab.md
@@ -13,7 +13,7 @@ This is the vertical contract for the native v4 Teams tab create package. The pa
 |----|------|-------|------|------|
 | SCN-CREATE-NONSSO-TAB-01 | L1 | empty target and TypeScript language | scaffold completes | the render phase writes the Teams tab project file set (`.tpl` stripped) including `.vscode`, `appPackage`, `src`, `infra`, env, yaml, and package files |
 | SCN-CREATE-NONSSO-TAB-02 | L1 | rendered TypeScript `package.json` and manifest | render | package `name` is the lower-case safe project name; manifest app names use the caller floor `appName` and preserve `${{APP_NAME_SUFFIX}}` |
-| SCN-CREATE-NONSSO-TAB-03 | L1 | empty target and Python language | scaffold completes | the Python language subtree is selected and writes Python source files without TypeScript package files |
+| SCN-CREATE-NONSSO-TAB-03 | L1 | the Teams tab descriptor | inspect languages | the descriptor exposes TypeScript only |
 | SCN-CREATE-NONSSO-TAB-04 | L1 | empty target | scaffold | only the `require-empty-target` step runs; no post-render scaffold injection is run |
 | SCN-CREATE-NONSSO-TAB-05 | L1 | non-empty target | scaffold | `require-empty-target` fails first with **`UserError`** and writes nothing |
 

--- a/docs/03-specs/scenarios/teams/create-weather-agent.md
+++ b/docs/03-specs/scenarios/teams/create-weather-agent.md
@@ -9,7 +9,7 @@
 | SCN-CREATE-WEATHER-01 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the TypeScript weather agent template. | The scaffold writes the TypeScript weather agent files. |
 | SCN-CREATE-WEATHER-02 | L1 | scenario | per-PR | InMemoryRuntime | Render a TypeScript weather agent with app name `My Weather Agent`. | Package and manifest app-name fields are rendered from caller floor values. |
 | SCN-CREATE-WEATHER-03 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the JavaScript weather agent template. | The scaffold selects the JavaScript subtree and writes JavaScript entry files. |
-| SCN-CREATE-WEATHER-04 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the Python weather agent template. | The scaffold selects the Python subtree and omits Node package files. |
+| SCN-CREATE-WEATHER-04 | L1 | scenario | per-PR | InMemoryRuntime | Inspect the weather agent descriptor. | The descriptor exposes TypeScript and JavaScript only. |
 | SCN-CREATE-WEATHER-05 | L1 | scenario | per-PR | InMemoryRuntime | Run the scaffold pipeline. | The only pipeline step is `require-empty-target`. |
 | SCN-CREATE-WEATHER-06 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold into a target that already contains a file. | The scaffold fails with `REQUIRE_EMPTY_TARGET` before writing files. |
 

--- a/packages/fx-core/src/v4/collectInputs/collectInputs.ts
+++ b/packages/fx-core/src/v4/collectInputs/collectInputs.ts
@@ -32,6 +32,16 @@ export interface OptionItem {
   keyPrefix?: string;
 }
 
+export interface InputBoxConfig {
+  name: string;
+  title?: string;
+  placeholder?: string;
+  prompt?: string;
+  default?: string;
+  step?: number;
+  keyPrefix?: string;
+}
+
 /** Native question kinds the surface-neutral driver renders. */
 export type QuestionType =
   | "singleSelect"
@@ -58,6 +68,9 @@ export interface QuestionSpec {
   placeholder?: string;
   prompt?: string;
   default?: string;
+  filters?: Record<string, string[]>;
+  inputOptionItem?: OptionItem;
+  inputBoxConfig?: InputBoxConfig;
   validation?: string | ValidationSpec;
   staticOptions?: OptionItem[];
   optionsFrom?: string;
@@ -79,6 +92,8 @@ export interface ResolvedOptions {
   derived?: Record<string, string>;
 }
 
+export type OptionsSource = OptionItem[] | (() => Promise<ResolvedOptions>);
+
 /** Engine-registered `optionsFrom` provider. */
 export interface OptionsProvider {
   derivedSchema?: string[];
@@ -91,6 +106,8 @@ export type Validator = (
   answers: Answers
 ) => string | undefined | Promise<string | undefined>;
 
+export type PromptValidation = (value: string) => string | undefined | Promise<string | undefined>;
+
 /** One prompt's outcome: a chosen value or the host's `back` request. */
 export type Asked<T> = { kind: "value"; value: T } | { kind: "back" };
 
@@ -99,13 +116,14 @@ export interface PromptUI {
   /** Render one scalar question. */
   ask(
     question: QuestionSpec,
-    options: OptionItem[] | undefined,
-    step?: number
+    options: OptionsSource | undefined,
+    step?: number,
+    validation?: PromptValidation
   ): Promise<Result<Asked<string>, FxError>>;
   /** Render one multi-pick question without collapsing selected ids to a scalar. */
   askMulti(
     question: QuestionSpec,
-    options: OptionItem[] | undefined,
+    options: OptionsSource | undefined,
     step?: number
   ): Promise<Result<Asked<string[]>, FxError>>;
 }
@@ -157,7 +175,7 @@ export async function collectInputs(
   let answers: Answers = { ...entryParams };
   const declared = Object.keys(optionsSchema.properties ?? {});
   // Cache providers by normalized params for a single run.
-  const providerCache = new Map<string, ResolvedOptions>();
+  const providerCache = new Map<string, Promise<ResolvedOptions>>();
   // Providers resolve in declaration order; forward `derived.*` refs are rejected.
   const resolvedProviders = new Set<string>();
 
@@ -239,7 +257,9 @@ export async function collectInputs(
     }
 
     // Resolve static or provider-backed options.
-    let options: OptionItem[] | undefined;
+    let options: OptionsSource | undefined;
+    let resolvedOptions: (() => Promise<ResolvedOptions>) | undefined;
+    let resolvedProviderId: string | undefined;
     if (q.staticOptions !== undefined) {
       const filtered: OptionItem[] = [];
       for (const opt of q.staticOptions) {
@@ -272,34 +292,20 @@ export async function collectInputs(
       }
       const params = paramsResult.value;
       const cacheKey = `${q.optionsFrom}|${stableStringify(params)}`;
-      let resolved = providerCache.get(cacheKey);
-      if (resolved === undefined) {
-        try {
-          resolved = await provider.fetch(params);
-        } catch (error) {
-          if (error instanceof UserError || error instanceof SystemError) {
-            return err(error);
-          }
-          return err(
-            systemError(
-              INPUT_PROVIDER_FAILED,
-              `optionsFrom '${q.optionsFrom}' on question '${q.name}' failed: ${errorMessage(error)}`
-            )
-          );
+      const providerId = q.optionsFrom;
+      resolvedProviderId = providerId;
+      resolvedOptions = () => {
+        let resolved = providerCache.get(cacheKey);
+        if (resolved === undefined) {
+          resolved = fetchProviderOptions(provider, params, providerId, q.name);
+          providerCache.set(cacheKey, resolved);
         }
-        providerCache.set(cacheKey, resolved);
-      }
-      options = resolved.options;
-      // Provider-derived values live under the reserved derived.<provider-id>.<key> namespace.
-      if (resolved.derived !== undefined) {
-        for (const [key, value] of Object.entries(resolved.derived)) {
-          answers[`derived.${q.optionsFrom}.${key}`] = value;
-        }
-      }
-      resolvedProviders.add(q.optionsFrom);
+        return resolved;
+      };
+      options = resolvedOptions;
     }
 
-    if (options !== undefined && q.skipSingleOption === true && options.length === 1) {
+    if (Array.isArray(options) && q.skipSingleOption === true && options.length === 1) {
       answers[q.name] = options[0].id;
       pos++;
       continue;
@@ -320,13 +326,29 @@ export async function collectInputs(
         pos = restore.pos;
         continue;
       }
+      if (resolvedOptions !== undefined && resolvedProviderId !== undefined) {
+        const mergeResult = await mergeResolvedProviderDerived(
+          answers,
+          resolvedProviders,
+          resolvedProviderId,
+          resolvedOptions
+        );
+        if (mergeResult.isErr()) {
+          return err(mergeResult.error);
+        }
+      }
       history.push({ pos, answers: { ...answers } });
       answers[q.name] = picked.value.value;
       pos++;
       continue;
     }
 
-    const asked = await port.ui.ask(q, options, history.length + 1);
+    const validationResult = resolveQuestionValidation(q, answers, port);
+    if (validationResult.isErr()) {
+      return err(validationResult.error);
+    }
+    const validation = validationResult.value;
+    const asked = await port.ui.ask(q, options, history.length + 1, validation);
     if (asked.isErr()) {
       return err(asked.error);
     }
@@ -341,27 +363,15 @@ export async function collectInputs(
     }
     const value = asked.value.value;
 
-    // Validator failures are user-fixable and name the question.
-    if (q.validation !== undefined) {
-      const validatorName = typeof q.validation === "string" ? q.validation : q.validation.use;
-      const validator = port.validator(validatorName);
-      if (validator === undefined) {
-        return err(
-          systemError(
-            INPUT_UNKNOWN_VALIDATOR,
-            `validation '${validatorName}' on question '${q.name}' is not a registered validator`
-          )
-        );
-      }
-      const message = await validator(value, answers);
-      if (message !== undefined) {
-        return err(
-          new UserError({
-            source: SOURCE,
-            name: INPUT_VALIDATION_FAILED,
-            message: `'${q.name}': ${message}`,
-          })
-        );
+    if (resolvedOptions !== undefined && resolvedProviderId !== undefined) {
+      const mergeResult = await mergeResolvedProviderDerived(
+        answers,
+        resolvedProviders,
+        resolvedProviderId,
+        resolvedOptions
+      );
+      if (mergeResult.isErr()) {
+        return err(mergeResult.error);
       }
     }
 
@@ -371,6 +381,28 @@ export async function collectInputs(
   }
 
   return ok(answers);
+}
+
+function resolveQuestionValidation(
+  question: QuestionSpec,
+  answers: Answers,
+  port: CollectInputsPort
+): Result<PromptValidation | undefined, FxError> {
+  if (question.validation === undefined) {
+    return ok(undefined);
+  }
+  const validatorName =
+    typeof question.validation === "string" ? question.validation : question.validation.use;
+  const validator = port.validator(validatorName);
+  if (validator === undefined) {
+    return err(
+      systemError(
+        INPUT_UNKNOWN_VALIDATOR,
+        `validation '${validatorName}' on question '${question.name}' is not a registered validator`
+      )
+    );
+  }
+  return ok((value) => validator(value, answers));
 }
 
 /** Build evaluator scope with declared-but-unanswered ids seeded as `NULL_VALUE`. */
@@ -430,6 +462,57 @@ function stableStringify(params: Record<string, string>): string {
     sorted[key] = params[key];
   }
   return JSON.stringify(sorted);
+}
+
+async function fetchProviderOptions(
+  provider: OptionsProvider,
+  params: Record<string, string>,
+  providerId: string,
+  questionName: string
+): Promise<ResolvedOptions> {
+  try {
+    return await provider.fetch(params);
+  } catch (error) {
+    if (error instanceof UserError || error instanceof SystemError) {
+      throw error;
+    }
+    throw systemError(
+      INPUT_PROVIDER_FAILED,
+      `optionsFrom '${providerId}' on question '${questionName}' failed: ${errorMessage(error)}`
+    );
+  }
+}
+
+function mergeProviderDerived(
+  answers: Answers,
+  providerId: string,
+  resolved: ResolvedOptions
+): void {
+  if (resolved.derived === undefined) {
+    return;
+  }
+  for (const [key, value] of Object.entries(resolved.derived)) {
+    answers[`derived.${providerId}.${key}`] = value;
+  }
+}
+
+async function mergeResolvedProviderDerived(
+  answers: Answers,
+  resolvedProviders: Set<string>,
+  providerId: string,
+  resolvedOptions: () => Promise<ResolvedOptions>
+): Promise<Result<void, FxError>> {
+  try {
+    const resolved = await resolvedOptions();
+    mergeProviderDerived(answers, providerId, resolved);
+    resolvedProviders.add(providerId);
+    return ok(undefined);
+  } catch (error) {
+    if (error instanceof UserError || error instanceof SystemError) {
+      return err(error);
+    }
+    return err(systemError(INPUT_PROVIDER_FAILED, errorMessage(error)));
+  }
 }
 
 function systemError(name: string, message: string): SystemError {

--- a/packages/fx-core/src/v4/collectInputs/collectInputs.ts
+++ b/packages/fx-core/src/v4/collectInputs/collectInputs.ts
@@ -40,6 +40,7 @@ export interface InputBoxConfig {
   default?: string;
   step?: number;
   keyPrefix?: string;
+  validation?: string | ValidationSpec;
 }
 
 /** Native question kinds the surface-neutral driver renders. */
@@ -118,7 +119,8 @@ export interface PromptUI {
     question: QuestionSpec,
     options: OptionsSource | undefined,
     step?: number,
-    validation?: PromptValidation
+    validation?: PromptValidation,
+    inputBoxValidation?: PromptValidation
   ): Promise<Result<Asked<string>, FxError>>;
   /** Render one multi-pick question without collapsing selected ids to a scalar. */
   askMulti(
@@ -348,7 +350,17 @@ export async function collectInputs(
       return err(validationResult.error);
     }
     const validation = validationResult.value;
-    const asked = await port.ui.ask(q, options, history.length + 1, validation);
+    const inputBoxValidationResult = resolveValidation(
+      q.inputBoxConfig?.validation,
+      answers,
+      port,
+      q.name
+    );
+    if (inputBoxValidationResult.isErr()) {
+      return err(inputBoxValidationResult.error);
+    }
+    const inputBoxValidation = inputBoxValidationResult.value;
+    const asked = await port.ui.ask(q, options, history.length + 1, validation, inputBoxValidation);
     if (asked.isErr()) {
       return err(asked.error);
     }
@@ -388,17 +400,25 @@ function resolveQuestionValidation(
   answers: Answers,
   port: CollectInputsPort
 ): Result<PromptValidation | undefined, FxError> {
-  if (question.validation === undefined) {
+  return resolveValidation(question.validation, answers, port, question.name);
+}
+
+function resolveValidation(
+  validation: string | ValidationSpec | undefined,
+  answers: Answers,
+  port: CollectInputsPort,
+  questionName: string
+): Result<PromptValidation | undefined, FxError> {
+  if (validation === undefined) {
     return ok(undefined);
   }
-  const validatorName =
-    typeof question.validation === "string" ? question.validation : question.validation.use;
+  const validatorName = typeof validation === "string" ? validation : validation.use;
   const validator = port.validator(validatorName);
   if (validator === undefined) {
     return err(
       systemError(
         INPUT_UNKNOWN_VALIDATOR,
-        `validation '${validatorName}' on question '${question.name}' is not a registered validator`
+        `validation '${validatorName}' on question '${questionName}' is not a registered validator`
       )
     );
   }

--- a/packages/fx-core/src/v4/collectInputs/collectInputs.ts
+++ b/packages/fx-core/src/v4/collectInputs/collectInputs.ts
@@ -164,6 +164,14 @@ function walkCancelled(): UserError {
   });
 }
 
+function missingNonInteractiveAnswer(questionName: string): UserError {
+  return new UserError({
+    source: SOURCE,
+    name: INPUT_VALIDATION_FAILED,
+    message: `${questionName} is required in non-interactive mode.`,
+  });
+}
+
 /** Walk one template's questions into the resolved answer object. */
 export async function collectInputs(
   questions: QuestionSpec[],
@@ -256,6 +264,19 @@ export async function collectInputs(
     if (q.name in answers) {
       pos++;
       continue;
+    }
+
+    if (answers.nonInteractive === "true") {
+      if (typeof q.default === "string") {
+        answers[q.name] = q.default;
+        pos++;
+        continue;
+      }
+      if (q.optional === true) {
+        pos++;
+        continue;
+      }
+      return err(missingNonInteractiveAnswer(q.name));
     }
 
     // Resolve static or provider-backed options.

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -22,6 +22,7 @@ import { Result, err, ok } from "neverthrow";
 import { MCPFetchResult, fetchMCPTools } from "../../component/utils/mcpToolFetcher";
 import { ODRProvider, type ODRServer } from "../../component/utils/odrProvider";
 import { readBooleanFeatureFlag } from "../../common/featureFlags";
+import { SearchOpenAPISpecResult, searchOpenAPISpec } from "../../common/kiotaClient";
 import {
   CollectInputsPort,
   OptionsProvider,
@@ -187,6 +188,38 @@ const openApiOperationsProvider: OptionsProvider = {
   },
 };
 
+function createOpenApiSearchProvider(
+  searchApiSpec: (query: string) => Promise<SearchOpenAPISpecResult[]>
+): OptionsProvider {
+  return {
+    async fetch(params) {
+      const query = params.query?.trim();
+      if (!query) {
+        throw new UserError({
+          source: "Scaffold",
+          name: "OpenApiSearchQueryMissing",
+          message: "Please enter a search query.",
+        });
+      }
+      const results = await searchApiSpec(query);
+      if (results.length === 0) {
+        throw new UserError({
+          source: "Scaffold",
+          name: "OpenApiSearchResultNotFound",
+          message: "No search result found.",
+        });
+      }
+      return {
+        options: results.map((api) => ({
+          id: api.url,
+          label: api.key,
+          detail: api.description,
+        })),
+      };
+    },
+  };
+}
+
 function mcpToolsJsonFromFetchResult(
   serverUrl: string | undefined,
   result: MCPFetchResult
@@ -267,13 +300,15 @@ function createMcpToolsProvider(
 /** Default `optionsFrom` provider registry. */
 function createDefaultProviders(
   fetchTools: (serverUrl: string) => Promise<MCPFetchResult>,
-  listLocalMcpServers: () => Promise<ODRServer[]>
+  listLocalMcpServers: () => Promise<ODRServer[]>,
+  searchApiSpec: (query: string) => Promise<SearchOpenAPISpecResult[]>
 ): Record<string, OptionsProvider> {
   const localServers = createLocalServerCache(listLocalMcpServers);
   return {
     "mcp.serverTypes": createMcpServerTypesProvider(localServers),
     "mcp.localServers": createLocalMcpServersProvider(localServers),
     "mcp.tools": createMcpToolsProvider(fetchTools),
+    "openapi.search": createOpenApiSearchProvider(searchApiSpec),
     "openapi.operations": openApiOperationsProvider,
   };
 }
@@ -540,6 +575,8 @@ export interface CreateInputsDeps {
   fetchMcpTools?: (serverUrl: string) => Promise<MCPFetchResult>;
   /** List available local MCP servers for the dynamic MCP create flow. */
   listLocalMcpServers?: () => Promise<ODRServer[]>;
+  /** Search public OpenAPI descriptions for the v3-compatible OpenAPI source picker. */
+  searchOpenAPISpec?: (query: string) => Promise<SearchOpenAPISpecResult[]>;
 }
 
 /** Run one create template's Q2 over the host surface. */
@@ -564,7 +601,8 @@ export async function runCreateInputs(
   const providers = {
     ...createDefaultProviders(
       deps.fetchMcpTools ?? fetchMCPTools,
-      deps.listLocalMcpServers ?? ODRProvider.listServers
+      deps.listLocalMcpServers ?? ODRProvider.listServers,
+      deps.searchOpenAPISpec ?? searchOpenAPISpec
     ),
     ...(deps.optionsProvider ?? {}),
   };
@@ -600,6 +638,10 @@ export async function runCreateInputs(
     return err(answers.error);
   }
   delete answers.value.nonInteractive;
+  const selectedOpenApiSpec = answers.value.selectOpenApiSpec;
+  if (answers.value.apiSpecLocation === undefined && typeof selectedOpenApiSpec === "string") {
+    answers.value.apiSpecLocation = selectedOpenApiSpec;
+  }
   if (deps.inputs !== undefined) {
     const validation = await validateCreateFloorAnswers(deps.inputs, answers.value);
     if (validation.isErr()) {

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -9,19 +9,13 @@ import {
   UserError,
   UserInteraction,
 } from "@microsoft/teamsfx-api";
-import {
-  ListAPIInfo,
-  ParseOptions,
-  ProjectType,
-  SpecParser,
-  Utils,
-  ValidationStatus,
-} from "@microsoft/m365-spec-parser";
+import { ListAPIInfo, Utils } from "@microsoft/m365-spec-parser";
 import fs from "fs-extra";
 import { Result, err, ok } from "neverthrow";
 import { MCPFetchResult, fetchMCPTools } from "../../component/utils/mcpToolFetcher";
 import { ODRProvider, type ODRServer } from "../../component/utils/odrProvider";
 import { readBooleanFeatureFlag } from "../../common/featureFlags";
+import { listAPIInfo } from "../../common/daSpecParser";
 import { SearchOpenAPISpecResult, searchOpenAPISpec } from "../../common/kiotaClient";
 import {
   CollectInputsPort,
@@ -96,35 +90,6 @@ function createLocalMcpServersProvider(localServers: () => Promise<ODRServer[]>)
   };
 }
 
-const openApiMethods = [
-  "get",
-  "post",
-  "put",
-  "delete",
-  "patch",
-  "head",
-  "connect",
-  "options",
-  "trace",
-];
-
-function openApiParseOptions(): ParseOptions {
-  return {
-    isGptPlugin: true,
-    allowAPIKeyAuth: true,
-    allowBearerTokenAuth: true,
-    allowMultipleParameters: true,
-    allowOauth2: true,
-    projectType: ProjectType.Copilot,
-    allowMissingId: true,
-    allowSwagger: true,
-    allowMethods: openApiMethods,
-    allowResponseSemantics: true,
-    allowConversationStarters: false,
-    allowConfirmation: false,
-  };
-}
-
 function operationDetail(operation: ListAPIInfo): string {
   if (!operation.auth) {
     return "No authentication";
@@ -165,25 +130,31 @@ const openApiOperationsProvider: OptionsProvider = {
         message: "OpenAPI operations cannot be listed without an API spec location.",
       });
     }
-    const parser = new SpecParser(apiSpecLocation, openApiParseOptions());
-    const validation = await parser.validate();
-    if (validation.status === ValidationStatus.Error) {
-      throw new SystemError({
+    let listed: Awaited<ReturnType<typeof listAPIInfo>>;
+    try {
+      listed = await listAPIInfo(apiSpecLocation);
+    } catch {
+      throw new UserError({
         source: "Scaffold",
         name: "OpenApiSpecInvalid",
         message: "The OpenAPI description document is invalid or contains no supported operations.",
       });
     }
-    const listed = await parser.list();
+    const operations = sortOperations(listed.APIs).filter((operation) => operation.isValid);
+    if (operations.length === 0) {
+      throw new UserError({
+        source: "Scaffold",
+        name: "OpenApiSpecInvalid",
+        message: "The OpenAPI description document is invalid or contains no supported operations.",
+      });
+    }
     return {
-      options: sortOperations(listed.APIs)
-        .filter((operation) => operation.isValid)
-        .map((operation) => ({
-          id: operation.api,
-          label: operation.api,
-          groupName: operation.api.toUpperCase().split(" ")[0],
-          detail: operationDetail(operation),
-        })),
+      options: operations.map((operation) => ({
+        id: operation.api,
+        label: operation.api,
+        groupName: operation.api.toUpperCase().split(" ")[0],
+        detail: operationDetail(operation),
+      })),
     };
   },
 };

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -15,8 +15,10 @@ import { Result, err, ok } from "neverthrow";
 import { MCPFetchResult, fetchMCPTools } from "../../component/utils/mcpToolFetcher";
 import { ODRProvider, type ODRServer } from "../../component/utils/odrProvider";
 import { readBooleanFeatureFlag } from "../../common/featureFlags";
+import { getLocalizedString } from "../../common/localizeUtils";
 import { listAPIInfo } from "../../common/daSpecParser";
 import { SearchOpenAPISpecResult, searchOpenAPISpec } from "../../common/kiotaClient";
+import { isValidHttpUrl } from "../../common/stringUtils";
 import {
   CollectInputsPort,
   OptionsProvider,
@@ -294,6 +296,13 @@ const uriValidator: Validator = (value: string): string | undefined => {
   }
 };
 
+/** The OpenAPI URL entry in the combined file-or-input picker accepts HTTP(S) URLs only. */
+const openApiUrlValidator: Validator = (value: string): string | undefined => {
+  return isValidHttpUrl(value.trim())
+    ? undefined
+    : getLocalizedString("core.createProjectQuestion.invalidUrl.message");
+};
+
 /** The graph connector display name cannot be empty. */
 const graphConnectorNameValidator: Validator = (value: string): string | undefined => {
   return value.trim().length > 0 ? undefined : "must not be empty";
@@ -339,6 +348,7 @@ const graphConnectorConnectionIdValidator: Validator = (value: string): string |
 /** Engine-registered validator registry. */
 const validators: Record<string, Validator> = {
   uri: uriValidator,
+  openapiUrl: openApiUrlValidator,
   graphConnectorName: graphConnectorNameValidator,
   graphConnectorConnectionId: graphConnectorConnectionIdValidator,
 };

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -395,6 +395,7 @@ async function createFloorTail(
       name: "language",
       type: "singleSelect",
       title: "Programming Language",
+      default: languages[0],
       staticOptions: languages.map((language) => ({
         id: language,
         label: LANGUAGE_LABELS[language] ?? language,

--- a/packages/fx-core/src/v4/surface/uiPromptUI.ts
+++ b/packages/fx-core/src/v4/surface/uiPromptUI.ts
@@ -6,14 +6,23 @@ import {
   InputTextConfig,
   MultiSelectConfig,
   OptionItem as SurfaceOptionItem,
+  SelectFileConfig,
   SelectFolderConfig,
+  SingleFileOrInputConfig,
   SingleSelectConfig,
   SystemError,
   UserInteraction,
 } from "@microsoft/teamsfx-api";
 import { Result, err, ok } from "neverthrow";
 import { getLocalizedString } from "../../common/localizeUtils";
-import { Asked, OptionItem, PromptUI, QuestionSpec } from "../collectInputs/collectInputs";
+import {
+  Asked,
+  OptionItem,
+  OptionsSource,
+  PromptValidation,
+  PromptUI,
+  QuestionSpec,
+} from "../collectInputs/collectInputs";
 
 /** Create-Q2 prompt bridge from v4 `PromptUI` to host `UserInteraction`. */
 
@@ -42,14 +51,27 @@ function localizePrefixedText(
 }
 
 /** Map a v4 identity-only option to the surface option shape (label defaults to its id). */
-function toSurfaceOptions(options: OptionItem[]): SurfaceOptionItem[] {
-  return options.map((option) => ({
+function toSurfaceOption(option: OptionItem): SurfaceOptionItem {
+  return {
     id: option.id,
     label: localizePrefixedText(option.keyPrefix, "label", option.label) ?? option.id,
     description: localizePrefixedText(option.keyPrefix, "description", option.description),
     detail: localizePrefixedText(option.keyPrefix, "detail", option.detail),
     groupName: localizePrefixedText(option.keyPrefix, "groupName", option.groupName),
-  }));
+  };
+}
+
+function toSurfaceOptions(options: OptionItem[]): SurfaceOptionItem[] {
+  return options.map((option) => toSurfaceOption(option));
+}
+
+function toSurfaceOptionsSource(
+  options: OptionsSource
+): SurfaceOptionItem[] | (() => Promise<SurfaceOptionItem[]>) {
+  if (Array.isArray(options)) {
+    return toSurfaceOptions(options);
+  }
+  return async () => toSurfaceOptions((await options()).options);
 }
 
 /** Project a single-select surface result back to the selected `id` string. */
@@ -84,8 +106,9 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
   return {
     async ask(
       question: QuestionSpec,
-      options: OptionItem[] | undefined,
-      step?: number
+      options: OptionsSource | undefined,
+      step?: number,
+      validation?: PromptValidation
     ): Promise<Result<Asked<string>, FxError>> {
       if (question.type === "singleSelect") {
         if (options === undefined) {
@@ -101,9 +124,11 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
           ),
           prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
           default: question.default,
-          options: toSurfaceOptions(options),
+          options: toSurfaceOptionsSource(options),
           returnObject: false,
+          skipSingleOption: question.skipSingleOption,
           step,
+          validation,
         };
         const result = await ui.selectOption(config);
         if (result.isErr()) {
@@ -126,8 +151,80 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
           prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
           default: question.default,
           step,
+          validation,
         };
         const result = await ui.inputText(config);
+        if (result.isErr()) {
+          return err(result.error);
+        }
+        if (result.value.type === "back") {
+          return ok({ kind: "back" });
+        }
+        return ok({ kind: "value", value: result.value.result ?? "" });
+      }
+      if (question.type === "singleFile") {
+        const config: SelectFileConfig = {
+          name: question.name,
+          title: localizePrefixedText(question.keyPrefix, "title", question.title) ?? question.name,
+          placeholder: localizePrefixedText(
+            question.keyPrefix,
+            "placeholder",
+            question.placeholder
+          ),
+          prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
+          default: question.default,
+          filters: question.filters,
+          step,
+          validation,
+        };
+        const result = await ui.selectFile(config);
+        if (result.isErr()) {
+          return err(result.error);
+        }
+        if (result.value.type === "back") {
+          return ok({ kind: "back" });
+        }
+        return ok({ kind: "value", value: result.value.result ?? "" });
+      }
+      if (question.type === "singleFileOrText") {
+        if (
+          ui.selectFileOrInput === undefined ||
+          question.inputOptionItem === undefined ||
+          question.inputBoxConfig === undefined
+        ) {
+          return err(unsupportedKind(question));
+        }
+        const inputBoxConfig = question.inputBoxConfig;
+        const config: SingleFileOrInputConfig = {
+          name: question.name,
+          title: localizePrefixedText(question.keyPrefix, "title", question.title) ?? question.name,
+          placeholder: localizePrefixedText(
+            question.keyPrefix,
+            "placeholder",
+            question.placeholder
+          ),
+          prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
+          inputOptionItem: toSurfaceOption(question.inputOptionItem),
+          inputBoxConfig: {
+            name: inputBoxConfig.name,
+            title:
+              localizePrefixedText(inputBoxConfig.keyPrefix, "title", inputBoxConfig.title) ??
+              inputBoxConfig.name,
+            placeholder: localizePrefixedText(
+              inputBoxConfig.keyPrefix,
+              "placeholder",
+              inputBoxConfig.placeholder
+            ),
+            prompt: localizePrefixedText(inputBoxConfig.keyPrefix, "prompt", inputBoxConfig.prompt),
+            default: inputBoxConfig.default,
+            step: inputBoxConfig.step ?? step,
+            validation,
+          },
+          filters: question.filters,
+          step,
+          validation,
+        };
+        const result = await ui.selectFileOrInput(config);
         if (result.isErr()) {
           return err(result.error);
         }
@@ -148,6 +245,7 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
           prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
           default: question.default,
           step,
+          validation,
         };
         const result = await ui.selectFolder(config);
         if (result.isErr()) {
@@ -163,7 +261,7 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
 
     async askMulti(
       question: QuestionSpec,
-      options: OptionItem[] | undefined,
+      options: OptionsSource | undefined,
       step?: number
     ): Promise<Result<Asked<string[]>, FxError>> {
       if (question.type !== "multiSelect" || options === undefined) {
@@ -174,8 +272,9 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
         title: localizePrefixedText(question.keyPrefix, "title", question.title) ?? question.name,
         placeholder: localizePrefixedText(question.keyPrefix, "placeholder", question.placeholder),
         prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
-        options: toSurfaceOptions(options),
+        options: toSurfaceOptionsSource(options),
         returnObject: false,
+        skipSingleOption: question.skipSingleOption,
         step,
       };
       const result = await ui.selectOptions(config);

--- a/packages/fx-core/src/v4/surface/uiPromptUI.ts
+++ b/packages/fx-core/src/v4/surface/uiPromptUI.ts
@@ -108,7 +108,8 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
       question: QuestionSpec,
       options: OptionsSource | undefined,
       step?: number,
-      validation?: PromptValidation
+      validation?: PromptValidation,
+      inputBoxValidation?: PromptValidation
     ): Promise<Result<Asked<string>, FxError>> {
       if (question.type === "singleSelect") {
         if (options === undefined) {
@@ -218,7 +219,7 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
             prompt: localizePrefixedText(inputBoxConfig.keyPrefix, "prompt", inputBoxConfig.prompt),
             default: inputBoxConfig.default,
             step: inputBoxConfig.step ?? step,
-            validation,
+            validation: inputBoxValidation,
           },
           filters: question.filters,
           step,

--- a/packages/fx-core/src/v4/surface/uiPromptUI.ts
+++ b/packages/fx-core/src/v4/surface/uiPromptUI.ts
@@ -12,20 +12,43 @@ import {
   UserInteraction,
 } from "@microsoft/teamsfx-api";
 import { Result, err, ok } from "neverthrow";
+import { getLocalizedString } from "../../common/localizeUtils";
 import { Asked, OptionItem, PromptUI, QuestionSpec } from "../collectInputs/collectInputs";
 
 /** Create-Q2 prompt bridge from v4 `PromptUI` to host `UserInteraction`. */
 
 const SOURCE = "Scaffold";
 
+function localizeText(text: string | undefined): string | undefined {
+  if (text === undefined) {
+    return undefined;
+  }
+  const localized = getLocalizedString(text);
+  return localized.length > 0 ? localized : text;
+}
+
+function localizePrefixedText(
+  keyPrefix: string | undefined,
+  suffix: string,
+  fallback: string | undefined
+): string | undefined {
+  if (keyPrefix !== undefined) {
+    const localized = getLocalizedString(`${keyPrefix}.${suffix}`);
+    if (localized.length > 0) {
+      return localized;
+    }
+  }
+  return localizeText(fallback);
+}
+
 /** Map a v4 identity-only option to the surface option shape (label defaults to its id). */
 function toSurfaceOptions(options: OptionItem[]): SurfaceOptionItem[] {
   return options.map((option) => ({
     id: option.id,
-    label: option.label ?? option.id,
-    description: option.description,
-    detail: option.detail,
-    groupName: option.groupName,
+    label: localizePrefixedText(option.keyPrefix, "label", option.label) ?? option.id,
+    description: localizePrefixedText(option.keyPrefix, "description", option.description),
+    detail: localizePrefixedText(option.keyPrefix, "detail", option.detail),
+    groupName: localizePrefixedText(option.keyPrefix, "groupName", option.groupName),
   }));
 }
 
@@ -70,9 +93,13 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
         }
         const config: SingleSelectConfig = {
           name: question.name,
-          title: question.title ?? question.name,
-          placeholder: question.placeholder,
-          prompt: question.prompt,
+          title: localizePrefixedText(question.keyPrefix, "title", question.title) ?? question.name,
+          placeholder: localizePrefixedText(
+            question.keyPrefix,
+            "placeholder",
+            question.placeholder
+          ),
+          prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
           default: question.default,
           options: toSurfaceOptions(options),
           returnObject: false,
@@ -90,9 +117,13 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
       if (question.type === "text") {
         const config: InputTextConfig = {
           name: question.name,
-          title: question.title ?? question.name,
-          placeholder: question.placeholder,
-          prompt: question.prompt,
+          title: localizePrefixedText(question.keyPrefix, "title", question.title) ?? question.name,
+          placeholder: localizePrefixedText(
+            question.keyPrefix,
+            "placeholder",
+            question.placeholder
+          ),
+          prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
           default: question.default,
           step,
         };
@@ -108,9 +139,13 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
       if (question.type === "folder") {
         const config: SelectFolderConfig = {
           name: question.name,
-          title: question.title ?? question.name,
-          placeholder: question.placeholder,
-          prompt: question.prompt,
+          title: localizePrefixedText(question.keyPrefix, "title", question.title) ?? question.name,
+          placeholder: localizePrefixedText(
+            question.keyPrefix,
+            "placeholder",
+            question.placeholder
+          ),
+          prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
           default: question.default,
           step,
         };
@@ -136,9 +171,9 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
       }
       const config: MultiSelectConfig = {
         name: question.name,
-        title: question.title ?? question.name,
-        placeholder: question.placeholder,
-        prompt: question.prompt,
+        title: localizePrefixedText(question.keyPrefix, "title", question.title) ?? question.name,
+        placeholder: localizePrefixedText(question.keyPrefix, "placeholder", question.placeholder),
+        prompt: localizePrefixedText(question.keyPrefix, "prompt", question.prompt),
         options: toSurfaceOptions(options),
         returnObject: false,
         step,

--- a/packages/fx-core/tests/v4/buildTarget/parseSelector.test.ts
+++ b/packages/fx-core/tests/v4/buildTarget/parseSelector.test.ts
@@ -35,7 +35,6 @@ const CURRENT_CREATE_V4_TEMPLATE_IDS = [
   "custom-copilot-rag-azure-ai-search",
   "custom-copilot-rag-custom-api",
   "custom-copilot-rag-customize",
-  "declarative-agent-meta-os-upgrade-project",
   "default-bot",
   "default-message-extension",
   "graph-connector",

--- a/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
+++ b/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
@@ -559,6 +559,30 @@ describe("collectInputs (v4)", () => {
     assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_PROVIDER_FAILED);
   });
 
+  it("INPUT-10: non-Error provider exceptions are wrapped as provider failures", async () => {
+    const provider: OptionsProvider = {
+      fetch: async () => Promise.reject("provider exploded"),
+    };
+    const questions: QuestionSpec[] = [
+      { name: "apiOperations", type: "multiSelect", optionsFrom: "openapi.operations" },
+    ];
+
+    const res = await collectInputs(
+      questions,
+      { properties: { apiOperations: {} } },
+      {},
+      ["common"],
+      makePort({
+        ui: new SequencedPromptUI([{ kind: "multi", value: ["GET /repairs"] }]),
+        providers: { "openapi.operations": provider },
+      })
+    );
+
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_PROVIDER_FAILED);
+    assert.include(res._unsafeUnwrapErr().message, "provider exploded");
+  });
+
   it("INPUT-11: machine-state (odr.exe) gating is the provider, never a condition predicate", async () => {
     // odr absent → the provider yields only 'remote'; no condition probes the machine.
     const odrAbsent = new FakeProvider({ options: [{ id: "remote" }] });

--- a/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
+++ b/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
@@ -14,7 +14,9 @@ import {
   CollectInputsPort,
   INPUT_BOTH_OPTION_SOURCES,
   INPUT_FORWARD_DERIVED_REFERENCE,
+  INPUT_PROVIDER_FAILED,
   INPUT_VALIDATION_FAILED,
+  INPUT_UNKNOWN_VALIDATOR,
   INPUT_WALK_CANCELLED,
   OptionItem,
   OptionsSource,
@@ -463,6 +465,98 @@ describe("collectInputs (v4)", () => {
     assert.instanceOf(e, UserError);
     assert.strictEqual(e.name, INPUT_VALIDATION_FAILED);
     assert.include(e.message, "mcpServerUrl");
+  });
+
+  it("INPUT-10: an unknown question validator is rejected before prompting", async () => {
+    const questions: QuestionSpec[] = [
+      { name: "mcpServerUrl", type: "text", validation: "missing" },
+    ];
+    const ui = new ScriptedUI({ mcpServerUrl: "https://api.example.com/mcp" });
+
+    const res = await collectInputs(
+      questions,
+      { properties: { mcpServerUrl: {} } },
+      {},
+      ["common"],
+      makePort({ ui })
+    );
+
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_UNKNOWN_VALIDATOR);
+    assert.deepStrictEqual(ui.asked, []);
+  });
+
+  it("INPUT-10: an unknown input-box validator is rejected before prompting", async () => {
+    const questions: QuestionSpec[] = [
+      {
+        name: "apiSpecLocation",
+        type: "singleFileOrText",
+        inputOptionItem: { id: "input" },
+        inputBoxConfig: { name: "input-api-spec-url", validation: "missing" },
+      },
+    ];
+    const ui = new ScriptedUI({ apiSpecLocation: "https://example.com/openapi.yaml" });
+
+    const res = await collectInputs(
+      questions,
+      { properties: { apiSpecLocation: {} } },
+      {},
+      ["common"],
+      makePort({ ui })
+    );
+
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_UNKNOWN_VALIDATOR);
+    assert.deepStrictEqual(ui.asked, []);
+  });
+
+  it("INPUT-10: scalar provider errors after prompting are returned as input errors", async () => {
+    const providerError = new UserError({
+      source: "Test",
+      name: "ProviderUserError",
+      message: "bad",
+    });
+    const provider: OptionsProvider = { fetch: async () => Promise.reject(providerError) };
+    const questions: QuestionSpec[] = [
+      { name: "openApiSpec", type: "singleSelect", optionsFrom: "openapi.search" },
+    ];
+
+    const res = await collectInputs(
+      questions,
+      { properties: { openApiSpec: {} } },
+      {},
+      ["common"],
+      makePort({
+        ui: new SequencedPromptUI([{ kind: "value", value: "https://example.com/openapi.yaml" }]),
+        providers: { "openapi.search": provider },
+      })
+    );
+
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, "ProviderUserError");
+  });
+
+  it("INPUT-10: multi provider exceptions after prompting are wrapped as provider failures", async () => {
+    const provider: OptionsProvider = {
+      fetch: async () => Promise.reject(new Error("provider exploded")),
+    };
+    const questions: QuestionSpec[] = [
+      { name: "apiOperations", type: "multiSelect", optionsFrom: "openapi.operations" },
+    ];
+
+    const res = await collectInputs(
+      questions,
+      { properties: { apiOperations: {} } },
+      {},
+      ["common"],
+      makePort({
+        ui: new SequencedPromptUI([{ kind: "multi", value: ["GET /repairs"] }]),
+        providers: { "openapi.operations": provider },
+      })
+    );
+
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_PROVIDER_FAILED);
   });
 
   it("INPUT-11: machine-state (odr.exe) gating is the provider, never a condition predicate", async () => {

--- a/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
+++ b/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
@@ -17,6 +17,7 @@ import {
   INPUT_VALIDATION_FAILED,
   INPUT_WALK_CANCELLED,
   OptionItem,
+  OptionsSource,
   OptionsProvider,
   PromptUI,
   QuestionSpec,
@@ -57,50 +58,85 @@ class ExprPort implements ExpressionRuntimePort {
 class ScriptedUI implements PromptUI {
   asked: string[] = [];
   lastOptions: Record<string, OptionItem[] | undefined> = {};
+  lastValidations: Record<
+    string,
+    ((value: string) => string | undefined | Promise<string | undefined>) | undefined
+  > = {};
   private readonly script: Record<string, string>;
   private readonly multiScript: Record<string, string[]>;
   constructor(script: Record<string, string>, multiScript: Record<string, string[]> = {}) {
     this.script = script;
     this.multiScript = multiScript;
   }
-  ask(
+  async ask(
     question: QuestionSpec,
-    options: OptionItem[] | undefined
+    options: OptionsSource | undefined,
+    _step?: number,
+    validation?: (value: string) => string | undefined | Promise<string | undefined>
   ): Promise<Result<Asked<string>, FxError>> {
     this.asked.push(question.name);
-    this.lastOptions[question.name] = options;
-    if (question.name in this.script) {
-      return Promise.resolve(ok({ kind: "value", value: this.script[question.name] }));
+    this.lastValidations[question.name] = validation;
+    const resolvedOptions = await resolveTestOptions(options);
+    this.lastOptions[question.name] = resolvedOptions;
+    if (question.skipSingleOption === true && resolvedOptions?.length === 1) {
+      return ok({ kind: "value", value: optionId(resolvedOptions[0]) });
     }
-    return Promise.resolve(
-      err(
-        new UserError({
-          source: "Test",
-          name: "NoScriptedAnswer",
-          message: `no scripted answer for '${question.name}'`,
-        })
-      )
+    if (question.name in this.script) {
+      const value = this.script[question.name];
+      const message = await validation?.(value);
+      if (message !== undefined) {
+        return err(
+          new UserError({
+            source: "Test",
+            name: INPUT_VALIDATION_FAILED,
+            message: `'${question.name}': ${message}`,
+          })
+        );
+      }
+      return ok({ kind: "value", value });
+    }
+    return err(
+      new UserError({
+        source: "Test",
+        name: "NoScriptedAnswer",
+        message: `no scripted answer for '${question.name}'`,
+      })
     );
   }
-  askMulti(
+  async askMulti(
     question: QuestionSpec,
-    options: OptionItem[] | undefined
+    options: OptionsSource | undefined
   ): Promise<Result<Asked<string[]>, FxError>> {
     this.asked.push(question.name);
-    this.lastOptions[question.name] = options;
-    if (question.name in this.multiScript) {
-      return Promise.resolve(ok({ kind: "value", value: this.multiScript[question.name] }));
+    const resolvedOptions = await resolveTestOptions(options);
+    this.lastOptions[question.name] = resolvedOptions;
+    if (question.skipSingleOption === true && resolvedOptions?.length === 1) {
+      return ok({ kind: "value", value: [optionId(resolvedOptions[0])] });
     }
-    return Promise.resolve(
-      err(
-        new UserError({
-          source: "Test",
-          name: "NoScriptedAnswer",
-          message: `no scripted multi-answer for '${question.name}'`,
-        })
-      )
+    if (question.name in this.multiScript) {
+      return ok({ kind: "value", value: this.multiScript[question.name] });
+    }
+    return err(
+      new UserError({
+        source: "Test",
+        name: "NoScriptedAnswer",
+        message: `no scripted multi-answer for '${question.name}'`,
+      })
     );
   }
+}
+
+function optionId(option: OptionItem): string {
+  return option.id;
+}
+
+async function resolveTestOptions(
+  options: OptionsSource | undefined
+): Promise<OptionItem[] | undefined> {
+  if (options === undefined || Array.isArray(options)) {
+    return options;
+  }
+  return (await options()).options;
 }
 
 /** A no-scripted-answer error for the sequence-driven driver. */
@@ -125,7 +161,7 @@ class SequencedPromptUI implements PromptUI {
   constructor(private readonly responses: SeqResponse[]) {}
   ask(
     question: QuestionSpec,
-    _options: OptionItem[] | undefined,
+    _options: OptionsSource | undefined,
     step?: number
   ): Promise<Result<Asked<string>, FxError>> {
     this.calls.push({ name: question.name, step });
@@ -140,7 +176,7 @@ class SequencedPromptUI implements PromptUI {
   }
   askMulti(
     question: QuestionSpec,
-    _options: OptionItem[] | undefined,
+    _options: OptionsSource | undefined,
     step?: number
   ): Promise<Result<Asked<string[]>, FxError>> {
     this.calls.push({ name: question.name, step });
@@ -274,7 +310,7 @@ describe("collectInputs (v4)", () => {
     assert.strictEqual(e.name, INPUT_BOTH_OPTION_SOURCES);
   });
 
-  it("INPUT-04: skipSingleOption auto-selects a sole option without prompting", async () => {
+  it("INPUT-04: skipSingleOption auto-selects a sole provider option through the UI", async () => {
     const provider = new FakeProvider({ options: [{ id: "remote" }] });
     const questions: QuestionSpec[] = [
       {
@@ -293,7 +329,7 @@ describe("collectInputs (v4)", () => {
       makePort({ ui, providers: { "mcp.serverTypes": provider } })
     );
     assert.strictEqual(res._unsafeUnwrap().mcpServerType, "remote");
-    assert.notInclude(ui.asked, "mcpServerType");
+    assert.include(ui.asked, "mcpServerType");
   });
 
   it("INPUT-05: optionsFrom invokes the named provider through the port", async () => {
@@ -421,6 +457,7 @@ describe("collectInputs (v4)", () => {
       ["common"],
       makePort({ ui, validators: { uri: uriValidator } })
     );
+    assert.isFunction(ui.lastValidations.mcpServerUrl);
     assert.isTrue(res.isErr());
     const e = res._unsafeUnwrapErr();
     assert.instanceOf(e, UserError);

--- a/packages/fx-core/tests/v4/scenarios/createMcpServerStatic.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createMcpServerStatic.test.ts
@@ -77,13 +77,23 @@ class StaticMcpQ2UI {
     return Promise.resolve(ok({ type: "success", result: "" }));
   }
 
-  selectOptions(config: MultiSelectConfig): Promise<Result<MultiSelectResult, FxError>> {
+  async selectOptions(config: MultiSelectConfig): Promise<Result<MultiSelectResult, FxError>> {
     this.multiNames.push(config.name);
+    if (typeof config.options === "function") {
+      try {
+        config = { ...config, options: await config.options() };
+      } catch (error) {
+        if (error instanceof UserError) {
+          return err(error);
+        }
+        return err(noAnswer(config.name));
+      }
+    }
     this.lastMultiConfig = config;
     if (config.name !== "selectedMcpTools") {
-      return Promise.resolve(err(noAnswer(config.name)));
+      return err(noAnswer(config.name));
     }
-    return Promise.resolve(ok({ type: "success", result: ["search"] }));
+    return ok({ type: "success", result: ["search"] });
   }
 }
 
@@ -252,6 +262,6 @@ describe("SCN-DA-CREATE-WITH-MCP-SERVER-STATIC (v4, T3 InMemoryRuntime)", () => 
     assert.instanceOf(error, UserError);
     assert.strictEqual(error.name, "McpAuthRequired");
     assert.deepStrictEqual(ui.textNames, ["mcpToolsFilePath"]);
-    assert.deepStrictEqual(ui.multiNames, []);
+    assert.deepStrictEqual(ui.multiNames, ["selectedMcpTools"]);
   });
 });

--- a/packages/fx-core/tests/v4/scenarios/createNonSsoTab.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createNonSsoTab.test.ts
@@ -7,6 +7,7 @@ import { REQUIRE_EMPTY_TARGET } from "../../../src/v4/pipeline/runScaffoldPipeli
 import { createInMemoryRuntime } from "../../../src/v4/runtime/inMemoryRuntime";
 import { scaffold } from "../../../src/v4/runtime/scaffold";
 import {
+  isRecord,
   loadV4Package,
   readJsonObject,
   recordProperty,
@@ -23,7 +24,23 @@ import {
 const templatePackage = loadV4Package("create", "non-sso-tab");
 const appName = "My Tab App";
 
-async function run(language: "typescript" | "python" = "typescript") {
+function descriptorLanguages(): string[] {
+  if (!isRecord(templatePackage.descriptor)) {
+    assert.fail("expected descriptor to be an object");
+  }
+  const languages = templatePackage.descriptor.languages;
+  if (!Array.isArray(languages)) {
+    assert.fail("expected descriptor languages to be an array");
+  }
+  return languages.map((language) => {
+    if (typeof language !== "string") {
+      assert.fail("expected descriptor language to be a string");
+    }
+    return language;
+  });
+}
+
+async function run(language: "typescript" = "typescript") {
   return runV4Package(templatePackage, { callerFloor: { appName, language } });
 }
 
@@ -48,12 +65,8 @@ describe("SCN-TEAMS-CREATE-NONSSO-TAB (v4, T3 InMemoryRuntime)", () => {
     assert.strictEqual(name.short, "My Tab App${{APP_NAME_SUFFIX}}");
   });
 
-  it("SCN-CREATE-NONSSO-TAB-03: Python scaffold selects the Python subtree", async () => {
-    const { outcome } = await run("python");
-    assert.include(outcome.written, "src/app.py");
-    assert.include(outcome.written, "src/requirements.txt");
-    assert.include(outcome.written, "src/Web/index.html");
-    assert.notInclude(outcome.written, "package.json");
+  it("SCN-CREATE-NONSSO-TAB-03: descriptor exposes TypeScript only", () => {
+    assert.deepStrictEqual(descriptorLanguages(), ["typescript"]);
   });
 
   it("SCN-CREATE-NONSSO-TAB-04: only require-empty-target runs", async () => {

--- a/packages/fx-core/tests/v4/scenarios/createWeatherAgent.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createWeatherAgent.test.ts
@@ -7,6 +7,7 @@ import { REQUIRE_EMPTY_TARGET } from "../../../src/v4/pipeline/runScaffoldPipeli
 import { createInMemoryRuntime } from "../../../src/v4/runtime/inMemoryRuntime";
 import { scaffold } from "../../../src/v4/runtime/scaffold";
 import {
+  isRecord,
   loadV4Package,
   readJsonObject,
   recordProperty,
@@ -24,7 +25,23 @@ import {
 const templatePackage = loadV4Package("create", "weather-agent");
 const appName = "My Weather Agent";
 
-async function run(language: "typescript" | "javascript" | "python" = "typescript") {
+function descriptorLanguages(): string[] {
+  if (!isRecord(templatePackage.descriptor)) {
+    assert.fail("expected descriptor to be an object");
+  }
+  const languages = templatePackage.descriptor.languages;
+  if (!Array.isArray(languages)) {
+    assert.fail("expected descriptor languages to be an array");
+  }
+  return languages.map((language) => {
+    if (typeof language !== "string") {
+      assert.fail("expected descriptor language to be a string");
+    }
+    return language;
+  });
+}
+
+async function run(language: "typescript" | "javascript" = "typescript") {
   return runV4Package(templatePackage, { callerFloor: { appName, language } });
 }
 
@@ -58,12 +75,8 @@ describe("SCN-TEAMS-CREATE-WEATHER-AGENT (v4, T3 InMemoryRuntime)", () => {
     assert.notInclude(outcome.written, "src/index.ts");
   });
 
-  it("SCN-CREATE-WEATHER-04: Python scaffold selects the Python subtree", async () => {
-    const { outcome } = await run("python");
-    assert.include(outcome.written, "src/app.py");
-    assert.include(outcome.written, "src/agent.py");
-    assert.include(outcome.written, "src/tools/get_weather_tool.py");
-    assert.notInclude(outcome.written, "package.json");
+  it("SCN-CREATE-WEATHER-04: descriptor exposes TypeScript and JavaScript only", () => {
+    assert.deepStrictEqual(descriptorLanguages(), ["typescript", "javascript"]);
   });
 
   it("SCN-CREATE-WEATHER-05: only require-empty-target runs", async () => {

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -570,6 +570,48 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     assert.deepEqual(ui.dynamicOptionNames, ["selectOpenApiSpec"]);
   });
 
+  it("surfaces blank OpenAPI search query as a user-fixable error", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { openApiSpecType: "search-api" },
+      text: { searchOpenApiSpecQuery: "   " },
+    });
+
+    const res = await runCreateInputs(buildFloor(), OPENAPI_DA, {}, asUI(ui), {
+      flagReader: () => false,
+    });
+
+    assert.isTrue(res.isErr(), "expected blank search query to fail");
+    assert.equal(res._unsafeUnwrapErr().name, "OpenApiSearchQueryMissing");
+    assert.deepEqual(ui.dynamicOptionNames, ["selectOpenApiSpec"]);
+  });
+
+  it("surfaces OpenAPI documents with no supported operations as a user-fixable error", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "atk-openapi-empty-"));
+    const openApiPath = path.join(tempDir, "openapi.yaml");
+    fs.writeFileSync(
+      openApiPath,
+      ["openapi: 3.0.0", "info:", "  title: Empty API", "  version: 1.0.0", "paths: {}"].join("\n"),
+      "utf8"
+    );
+    const ui = new ScriptedUserInteraction({ multi: { apiOperations: [] } });
+
+    try {
+      const res = await runCreateInputs(
+        buildFloor(),
+        OPENAPI_DA,
+        { apiSpecLocation: openApiPath },
+        asUI(ui),
+        { flagReader: () => false }
+      );
+
+      assert.isTrue(res.isErr(), "expected empty OpenAPI operations to fail");
+      assert.equal(res._unsafeUnwrapErr().name, "OpenApiSpecInvalid");
+      assert.deepEqual(ui.dynamicOptionNames, ["apiOperations"]);
+    } finally {
+      removeSync(tempDir);
+    }
+  });
+
   it("surfaces invalid OpenAPI operation loading as a user-fixable error", async () => {
     const ui = new ScriptedUserInteraction({
       multi: { apiOperations: ["GET /repairs"] },
@@ -1102,6 +1144,31 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     assert.notProperty(res._unsafeUnwrap(), "mcpToolsJson");
   });
 
+  it("fails before static MCP materialization when non-interactive CLI create omits the server URL", async () => {
+    const ui = new ScriptedUserInteraction({});
+    let fetchCalled = false;
+
+    const res = await runCreateInputs(buildFloor(), STATIC_MCP_DA, {}, asUI(ui), {
+      surface: "cli",
+      inputs: {
+        platform: Platform.CLI,
+        nonInteractive: true,
+        folder: "C:/src",
+        "app-name": "MyAgent",
+      },
+      flagReader: () => false,
+      fetchMcpTools: async () => {
+        fetchCalled = true;
+        return { requiresAuth: false, tools: [] };
+      },
+    });
+
+    assert.isTrue(res.isErr(), "expected missing MCP server URL to fail");
+    assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_VALIDATION_FAILED);
+    assert.include(res._unsafeUnwrapErr().message, "mcpServerUrl");
+    assert.isFalse(fetchCalled);
+  });
+
   it("fails when static MCP tool auto-fetch requires auth", async () => {
     const ui = new ScriptedUserInteraction({ text: { mcpToolsFilePath: "" } });
 
@@ -1528,6 +1595,110 @@ describe("createUiPromptUI (collect-create-inputs)", () => {
     }
     assert.deepEqual(ui.fileOrInputNames, ["apiSpecLocation"]);
     assert.equal(ui.lastFileOrInputConfig?.step, 2);
+  });
+
+  it("maps a singleFile question to selectFile and returns the path", async () => {
+    const ui = new ScriptedUserInteraction({ file: { apiSpecLocation: OPENAPI_SPEC } });
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      {
+        name: "apiSpecLocation",
+        type: "singleFile",
+        title: "OpenAPI Document",
+        filters: { files: ["json", "yml", "yaml"] },
+      },
+      undefined,
+      2
+    );
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { kind: "value", value: OPENAPI_SPEC });
+    }
+    assert.deepEqual(ui.fileNames, ["apiSpecLocation"]);
+    assert.equal(ui.lastFileConfig?.step, 2);
+  });
+
+  it("returns host errors from singleFile prompts", async () => {
+    const ui = new ScriptedUserInteraction({});
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      { name: "apiSpecLocation", type: "singleFile", title: "OpenAPI Document" },
+      undefined
+    );
+
+    assert.isTrue(res.isErr());
+    assert.equal(res._unsafeUnwrapErr().name, "NoScriptedAnswer");
+  });
+
+  it("projects a host back on a singleFile question to { kind: 'back' }", async () => {
+    const ui = new ScriptedUserInteraction({ back: ["apiSpecLocation"] });
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      { name: "apiSpecLocation", type: "singleFile", title: "OpenAPI Document" },
+      undefined
+    );
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { kind: "back" });
+    }
+  });
+
+  it("returns host errors from singleFileOrText prompts", async () => {
+    const ui = new ScriptedUserInteraction({});
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      {
+        name: "apiSpecLocation",
+        type: "singleFileOrText",
+        title: "OpenAPI Document",
+        inputOptionItem: { id: "input" },
+        inputBoxConfig: { name: "input-api-spec-url" },
+      },
+      undefined
+    );
+
+    assert.isTrue(res.isErr());
+    assert.equal(res._unsafeUnwrapErr().name, "NoScriptedAnswer");
+  });
+
+  it("projects a host back on a singleFileOrText question to { kind: 'back' }", async () => {
+    const ui = new ScriptedUserInteraction({ back: ["apiSpecLocation"] });
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      {
+        name: "apiSpecLocation",
+        type: "singleFileOrText",
+        title: "OpenAPI Document",
+        inputOptionItem: { id: "input" },
+        inputBoxConfig: { name: "input-api-spec-url" },
+      },
+      undefined
+    );
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { kind: "back" });
+    }
+  });
+
+  it("rejects malformed singleFileOrText question configs", async () => {
+    const ui = new ScriptedUserInteraction({});
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      { name: "apiSpecLocation", type: "singleFileOrText", title: "OpenAPI Document" },
+      undefined
+    );
+
+    assert.isTrue(res.isErr());
+    assert.equal(res._unsafeUnwrapErr().name, "UnsupportedQuestionKind");
   });
 
   it("maps a folder question to selectFolder and returns the path", async () => {

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -869,6 +869,12 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       ui.lastFileOrInputConfig?.inputOptionItem.label,
       "$(cloud) Enter OpenAPI Document URL"
     );
+    assert.isUndefined(ui.lastFileOrInputConfig?.validation);
+    assert.isFunction(ui.lastFileOrInputConfig?.inputBoxConfig.validation);
+    assert.equal(
+      await ui.lastFileOrInputConfig?.inputBoxConfig.validation?.("not-a-url"),
+      "Enter a valid HTTP URL without authentication to access your OpenAPI description document."
+    );
     assert.deepEqual(ui.lastFileOrInputConfig?.filters, { files: ["json", "yml", "yaml"] });
   });
 
@@ -908,6 +914,8 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       ui.lastFileOrInputConfig?.inputBoxConfig.placeholder,
       "Enter OpenAPI Document URL"
     );
+    assert.isUndefined(ui.lastFileOrInputConfig?.validation);
+    assert.isFunction(ui.lastFileOrInputConfig?.inputBoxConfig.validation);
   });
 
   it("lists static MCP tools from the provided tools JSON", async () => {

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -303,6 +303,67 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).id, "GET /repairs");
   });
 
+  it("asks for the OpenAPI spec source before collecting DA OpenAPI operations", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { openApiSpecType: "enter-url" },
+      text: { apiSpecLocation: OPENAPI_SPEC },
+      multi: { apiOperations: ["GET /repairs"] },
+    });
+
+    const res = await runCreateInputs(buildFloor(), OPENAPI_DA, {}, asUI(ui), {
+      flagReader: () => false,
+    });
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.openApiSpecType, "enter-url");
+      assert.equal(res.value.apiSpecLocation, OPENAPI_SPEC);
+      assert.deepEqual(res.value.apiOperations, ["GET /repairs"]);
+    }
+    assert.deepEqual(ui.promptNames, ["openApiSpecType", "apiSpecLocation", "apiOperations"]);
+  });
+
+  it("collects DA OpenAPI operations from a searched OpenAPI document", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { openApiSpecType: "search-api", selectOpenApiSpec: OPENAPI_SPEC },
+      text: { searchOpenApiSpecQuery: "repairs" },
+      multi: { apiOperations: ["GET /repairs"] },
+    });
+
+    const res = await runCreateInputs(buildFloor(), OPENAPI_DA, {}, asUI(ui), {
+      flagReader: () => false,
+      searchOpenAPISpec: async (query) => {
+        assert.equal(query, "repairs");
+        return [
+          {
+            key: "Repairs API",
+            url: OPENAPI_SPEC,
+            description: "Manage repairs",
+          },
+        ];
+      },
+    });
+
+    assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+    if (res.isOk()) {
+      assert.equal(res.value.openApiSpecType, "search-api");
+      assert.equal(res.value.searchOpenApiSpecQuery, "repairs");
+      assert.equal(res.value.selectOpenApiSpec, OPENAPI_SPEC);
+      assert.equal(res.value.apiSpecLocation, OPENAPI_SPEC);
+      assert.deepEqual(res.value.apiOperations, ["GET /repairs"]);
+    }
+    assert.deepEqual(ui.promptNames, [
+      "openApiSpecType",
+      "searchOpenApiSpecQuery",
+      "selectOpenApiSpec",
+      "apiOperations",
+    ]);
+    const options = (ui.lastSelectConfig?.options ?? []) as SurfaceOptionItem[];
+    assert.equal(options[0].id, OPENAPI_SPEC);
+    assert.equal(options[0].label, "Repairs API");
+    assert.equal(options[0].detail, "Manage repairs");
+  });
+
   it("validates Graph connector display name", async () => {
     const ui = new ScriptedUserInteraction({
       text: { graphConnectorName: "   " },
@@ -589,7 +650,7 @@ describe("runCreateInputs (collect-create-inputs)", () => {
 
   it("collects custom API OpenAPI inputs before LLM inputs", async () => {
     const ui = new ScriptedUserInteraction({
-      select: { llmService: "llm-service-azure-openai" },
+      select: { openApiSpecType: "enter-url", llmService: "llm-service-azure-openai" },
       text: {
         apiSpecLocation: OPENAPI_SPEC,
         azureOpenAIKey: "fake-azure-openai-key",
@@ -609,6 +670,7 @@ describe("runCreateInputs (collect-create-inputs)", () => {
 
     assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
     if (res.isOk()) {
+      assert.equal(res.value.openApiSpecType, "enter-url");
       assert.equal(res.value.apiSpecLocation, OPENAPI_SPEC);
       assert.deepEqual(res.value.apiOperations, ["GET /repairs"]);
       assert.equal(res.value.llmService, "llm-service-azure-openai");
@@ -617,6 +679,7 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       assert.equal(res.value.azureOpenAIDeploymentName, "fake-deployment");
     }
     assert.deepEqual(ui.promptNames, [
+      "openApiSpecType",
       "apiSpecLocation",
       "apiOperations",
       "llmService",
@@ -728,7 +791,12 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       asUI(ui),
       {
         surface: "cli",
-        inputs: { nonInteractive: true, folder: "C:/src", "app-name": "MyAgent" },
+        inputs: {
+          platform: Platform.CLI,
+          nonInteractive: true,
+          folder: "C:/src",
+          "app-name": "MyAgent",
+        },
         flagReader: () => false,
         fetchMcpTools: async () => {
           fetchCalled = true;
@@ -1093,6 +1161,47 @@ describe("createUiPromptUI (collect-create-inputs)", () => {
     // a v4 option with no label defaults its surface label to its id.
     assert.equal(options[1].id, "b");
     assert.equal(options[1].label, "b");
+  });
+
+  it("resolves keyPrefix localization before rendering authored v4 LLM questions", async () => {
+    const ui = new ScriptedUserInteraction({ select: { llmService: "llm-service-openai" } });
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      {
+        name: "llmService",
+        type: "singleSelect",
+        title: "Service for Large Language Model (LLM)",
+        placeholder: "Select a service to access LLMs",
+        keyPrefix: "core.createProjectQuestion.llmService",
+      },
+      [
+        {
+          id: "llm-service-azure-openai",
+          label: "Azure OpenAI",
+          detail: "Access powerful LLMs in OpenAI with Azure security and reliability",
+          keyPrefix: "core.createProjectQuestion.llmServiceAzureOpenAIOption",
+        },
+        {
+          id: "llm-service-openai",
+          label: "OpenAI",
+          detail: "Access LLMs developed by OpenAI",
+          keyPrefix: "core.createProjectQuestion.llmServiceOpenAIOption",
+        },
+      ]
+    );
+
+    assert.isTrue(res.isOk());
+    assert.equal(ui.lastSelectConfig?.title, "Service for Large Language Model (LLM)");
+    assert.equal(ui.lastSelectConfig?.placeholder, "Select a service to access LLMs");
+    const options = (ui.lastSelectConfig?.options ?? []) as SurfaceOptionItem[];
+    assert.equal(options[0].label, "Azure OpenAI");
+    assert.equal(
+      options[0].detail,
+      "Access powerful LLMs in OpenAI with Azure security and reliability"
+    );
+    assert.equal(options[1].label, "OpenAI");
+    assert.equal(options[1].detail, "Access LLMs developed by OpenAI");
   });
 
   it("CCI-07: ask maps a text question to inputText and returns the string", async () => {

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -456,7 +456,34 @@ describe("runCreateInputs (collect-create-inputs)", () => {
   it("asks for the OpenAPI spec source before collecting DA OpenAPI operations", async () => {
     const ui = new ScriptedUserInteraction({
       select: { openApiSpecType: "enter-url" },
-      text: { apiSpecLocation: OPENAPI_SPEC },
+      text: { apiSpecLocation: "https://example.com/openapi.yaml" },
+      multi: { apiOperations: ["GET /repairs"] },
+    });
+
+    const res = await runCreateInputs(buildFloor(), OPENAPI_DA, {}, asUI(ui), {
+      flagReader: () => false,
+    });
+
+    assert.isTrue(res.isErr(), "expected the fake remote URL to fail when operations load");
+    assert.equal(res._unsafeUnwrapErr().name, "OpenApiSpecInvalid");
+    assert.deepEqual(ui.promptNames, ["openApiSpecType", "apiSpecLocation", "apiOperations"]);
+    assert.deepEqual(ui.textNames, ["apiSpecLocation"]);
+    assert.deepEqual(ui.fileNames, []);
+    assert.deepEqual(ui.fileOrInputNames, []);
+    assert.equal(ui.lastInputConfig?.placeholder, "https://example.com/openapi.yaml");
+    assert.equal(ui.lastInputConfig?.prompt, "Enter an OpenAPI description document URL.");
+    assert.isFunction(ui.lastInputConfig?.validation);
+    assert.equal(
+      await ui.lastInputConfig?.validation?.("./openapi.yaml"),
+      "Enter a valid HTTP URL without authentication to access your OpenAPI description document."
+    );
+    assert.deepEqual(ui.dynamicOptionNames, ["apiOperations"]);
+  });
+
+  it("browses a local DA OpenAPI document only from the local file branch", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { openApiSpecType: "open-file" },
+      file: { apiSpecLocation: OPENAPI_SPEC },
       multi: { apiOperations: ["GET /repairs"] },
     });
 
@@ -466,12 +493,18 @@ describe("runCreateInputs (collect-create-inputs)", () => {
 
     assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
     if (res.isOk()) {
-      assert.equal(res.value.openApiSpecType, "enter-url");
+      assert.equal(res.value.openApiSpecType, "open-file");
       assert.equal(res.value.apiSpecLocation, OPENAPI_SPEC);
       assert.deepEqual(res.value.apiOperations, ["GET /repairs"]);
     }
     assert.deepEqual(ui.promptNames, ["openApiSpecType", "apiSpecLocation", "apiOperations"]);
-    assert.deepEqual(ui.dynamicOptionNames, ["apiOperations"]);
+    assert.deepEqual(ui.fileNames, ["apiSpecLocation"]);
+    assert.deepEqual(ui.textNames, []);
+    assert.deepEqual(ui.fileOrInputNames, []);
+    assert.equal(ui.lastFileConfig?.placeholder, "Select an OpenAPI description document.");
+    assert.deepEqual(ui.lastFileConfig?.filters, {
+      "OpenAPI Description Document": ["json", "yml", "yaml"],
+    });
   });
 
   it("collects DA OpenAPI operations from a searched OpenAPI document", async () => {
@@ -514,6 +547,27 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     assert.equal(options[0].id, OPENAPI_SPEC);
     assert.equal(options[0].label, "Repairs API");
     assert.equal(options[0].detail, "Manage repairs");
+  });
+
+  it("surfaces empty OpenAPI search results as a user-fixable error", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { openApiSpecType: "search-api" },
+      text: { searchOpenApiSpecQuery: "missing" },
+    });
+
+    const res = await runCreateInputs(buildFloor(), OPENAPI_DA, {}, asUI(ui), {
+      flagReader: () => false,
+      searchOpenAPISpec: async () => [],
+    });
+
+    assert.isTrue(res.isErr(), "expected empty search results to fail");
+    assert.equal(res._unsafeUnwrapErr().name, "OpenApi" + "SearchResult" + "NotFound");
+    assert.deepEqual(ui.promptNames, [
+      "openApiSpecType",
+      "searchOpenApiSpecQuery",
+      "selectOpenApiSpec",
+    ]);
+    assert.deepEqual(ui.dynamicOptionNames, ["selectOpenApiSpec"]);
   });
 
   it("surfaces invalid OpenAPI operation loading as a user-fixable error", async () => {

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -5,12 +5,16 @@ import {
   FxError,
   InputTextConfig,
   InputTextResult,
+  InputResult,
   MultiSelectConfig,
   MultiSelectResult,
   OptionItem as SurfaceOptionItem,
   Platform,
+  SelectFileConfig,
+  SelectFileResult,
   SelectFolderConfig,
   SelectFolderResult,
+  SingleFileOrInputConfig,
   SingleSelectConfig,
   SingleSelectResult,
   SystemError,
@@ -126,6 +130,8 @@ const localMcpServers = [
 interface Script {
   select?: Record<string, string>;
   text?: Record<string, string>;
+  fileOrInput?: Record<string, string>;
+  file?: Record<string, string>;
   folder?: Record<string, string>;
   multi?: Record<string, string[]>;
   back?: string[];
@@ -146,26 +152,51 @@ class ScriptedUserInteraction {
   selectNames: string[] = [];
   textNames: string[] = [];
   folderNames: string[] = [];
+  fileNames: string[] = [];
+  fileOrInputNames: string[] = [];
   multiNames: string[] = [];
+  dynamicOptionNames: string[] = [];
   lastSelectConfig?: SingleSelectConfig;
   lastInputConfig?: InputTextConfig;
+  lastFileOrInputConfig?: SingleFileOrInputConfig;
+  lastFileConfig?: SelectFileConfig;
   lastFolderConfig?: SelectFolderConfig;
   lastMultiConfig?: MultiSelectConfig;
   constructor(private readonly script: Script) {}
 
-  selectOption(config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> {
+  async selectOption(config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> {
     this.promptNames.push(config.name);
     this.selectNames.push(config.name);
+    let loadedOptions = config.options;
+    if (typeof config.options === "function") {
+      this.dynamicOptionNames.push(config.name);
+      try {
+        loadedOptions = await config.options();
+        config = { ...config, options: loadedOptions };
+      } catch (error) {
+        if (error instanceof UserError || error instanceof SystemError) {
+          return err(error);
+        }
+        return err(noAnswer(config.name));
+      }
+    }
     this.lastSelectConfig = config;
+    if (
+      Array.isArray(loadedOptions) &&
+      config.skipSingleOption === true &&
+      loadedOptions.length === 1
+    ) {
+      return ok({ type: "skip", result: optionId(loadedOptions[0]) });
+    }
     if (this.script.back?.includes(config.name) === true) {
-      return Promise.resolve(ok({ type: "back" }));
+      return ok({ type: "back" });
     }
     const answer = this.script.select?.[config.name];
     if (answer === undefined) {
-      return Promise.resolve(err(noAnswer(config.name)));
+      return err(noAnswer(config.name));
     }
     const result: SingleSelectResult = { type: "success", result: answer };
-    return Promise.resolve(ok(result));
+    return ok(result);
   }
 
   inputText(config: InputTextConfig): Promise<Result<InputTextResult, FxError>> {
@@ -179,7 +210,85 @@ class ScriptedUserInteraction {
     if (answer === undefined) {
       return Promise.resolve(err(noAnswer(config.name)));
     }
+    const validation = config.validation;
+    if (validation !== undefined) {
+      return Promise.resolve(validation(answer)).then((message) => {
+        if (message !== undefined) {
+          return err(
+            new UserError({
+              source: "Test",
+              name: INPUT_VALIDATION_FAILED,
+              message: `'${config.name}': ${message}`,
+            })
+          );
+        }
+        const result: InputTextResult = { type: "success", result: answer };
+        return ok(result);
+      });
+    }
     const result: InputTextResult = { type: "success", result: answer };
+    return Promise.resolve(ok(result));
+  }
+
+  selectFileOrInput(
+    config: SingleFileOrInputConfig
+  ): Promise<Result<InputResult<string>, FxError>> {
+    this.promptNames.push(config.name);
+    this.fileOrInputNames.push(config.name);
+    this.lastFileOrInputConfig = config;
+    if (this.script.back?.includes(config.name) === true) {
+      return Promise.resolve(ok({ type: "back" }));
+    }
+    const answer = this.script.fileOrInput?.[config.name];
+    if (answer === undefined) {
+      return Promise.resolve(err(noAnswer(config.name)));
+    }
+    const validation = config.validation;
+    if (validation !== undefined) {
+      return Promise.resolve(validation(answer)).then((message) => {
+        if (message !== undefined) {
+          return err(
+            new UserError({
+              source: "Test",
+              name: INPUT_VALIDATION_FAILED,
+              message: `'${config.name}': ${message}`,
+            })
+          );
+        }
+        return ok({ type: "success", result: answer });
+      });
+    }
+    return Promise.resolve(ok({ type: "success", result: answer }));
+  }
+
+  selectFile(config: SelectFileConfig): Promise<Result<SelectFileResult, FxError>> {
+    this.promptNames.push(config.name);
+    this.fileNames.push(config.name);
+    this.lastFileConfig = config;
+    if (this.script.back?.includes(config.name) === true) {
+      return Promise.resolve(ok({ type: "back" }));
+    }
+    const answer = this.script.file?.[config.name];
+    if (answer === undefined) {
+      return Promise.resolve(err(noAnswer(config.name)));
+    }
+    const validation = config.validation;
+    if (validation !== undefined) {
+      return Promise.resolve(validation(answer)).then((message) => {
+        if (message !== undefined) {
+          return err(
+            new UserError({
+              source: "Test",
+              name: INPUT_VALIDATION_FAILED,
+              message: `'${config.name}': ${message}`,
+            })
+          );
+        }
+        const result: SelectFileResult = { type: "success", result: answer };
+        return ok(result);
+      });
+    }
+    const result: SelectFileResult = { type: "success", result: answer };
     return Promise.resolve(ok(result));
   }
 
@@ -194,23 +303,59 @@ class ScriptedUserInteraction {
     if (answer === undefined) {
       return Promise.resolve(err(noAnswer(config.name)));
     }
+    const validation = config.validation;
+    if (validation !== undefined) {
+      return Promise.resolve(validation(answer)).then((message) => {
+        if (message !== undefined) {
+          return err(
+            new UserError({
+              source: "Test",
+              name: INPUT_VALIDATION_FAILED,
+              message: `'${config.name}': ${message}`,
+            })
+          );
+        }
+        const result: SelectFolderResult = { type: "success", result: answer };
+        return ok(result);
+      });
+    }
     const result: SelectFolderResult = { type: "success", result: answer };
     return Promise.resolve(ok(result));
   }
 
-  selectOptions(config: MultiSelectConfig): Promise<Result<MultiSelectResult, FxError>> {
+  async selectOptions(config: MultiSelectConfig): Promise<Result<MultiSelectResult, FxError>> {
     this.promptNames.push(config.name);
     this.multiNames.push(config.name);
+    let loadedOptions = config.options;
+    if (typeof config.options === "function") {
+      this.dynamicOptionNames.push(config.name);
+      try {
+        loadedOptions = await config.options();
+        config = { ...config, options: loadedOptions };
+      } catch (error) {
+        if (error instanceof UserError || error instanceof SystemError) {
+          return err(error);
+        }
+        return err(noAnswer(config.name));
+      }
+    }
     this.lastMultiConfig = config;
+    if (
+      Array.isArray(loadedOptions) &&
+      config.skipSingleOption === true &&
+      loadedOptions.length === 1
+    ) {
+      return ok({ type: "skip", result: [optionId(loadedOptions[0])] });
+    }
     if (this.script.back?.includes(config.name) === true) {
-      return Promise.resolve(ok({ type: "back" }));
+      return ok({ type: "back" });
     }
     const answer = this.script.multi?.[config.name];
     if (answer === undefined) {
-      return Promise.resolve(err(noAnswer(config.name)));
+      return err(noAnswer(config.name));
     }
     const result: MultiSelectResult = { type: "success", result: answer };
-    return Promise.resolve(ok(result));
+    return ok(result);
   }
 }
 
@@ -233,6 +378,10 @@ function multiOptionAt(config: MultiSelectConfig | undefined, index: number): Su
     assert.fail(`expected multi-select option item at index ${index}`);
   }
   return option;
+}
+
+function optionId(option: string | SurfaceOptionItem): string {
+  return typeof option === "string" ? option : option.id;
 }
 
 describe("runCreateInputs (collect-create-inputs)", () => {
@@ -271,9 +420,9 @@ describe("runCreateInputs (collect-create-inputs)", () => {
         authType: "none",
       });
     }
-    // mcpServerType has a single option (remote-only) + skipSingleOption -> never prompted.
-    assert.notInclude(ui.selectNames, "mcpServerType");
-    assert.deepEqual(ui.selectNames, ["authType"]);
+    // mcpServerType has a single dynamic option (remote-only) + skipSingleOption -> auto-skipped.
+    assert.deepEqual(ui.selectNames, ["mcpServerType", "authType"]);
+    assert.deepEqual(ui.dynamicOptionNames, ["mcpServerType"]);
     assert.deepEqual(ui.textNames, ["mcpServerUrl"]);
   });
 
@@ -300,6 +449,7 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     }
     assert.deepEqual(ui.textNames, []);
     assert.deepEqual(ui.multiNames, ["apiOperations"]);
+    assert.deepEqual(ui.dynamicOptionNames, ["apiOperations"]);
     assert.strictEqual(multiOptionAt(ui.lastMultiConfig, 0).id, "GET /repairs");
   });
 
@@ -321,6 +471,7 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       assert.deepEqual(res.value.apiOperations, ["GET /repairs"]);
     }
     assert.deepEqual(ui.promptNames, ["openApiSpecType", "apiSpecLocation", "apiOperations"]);
+    assert.deepEqual(ui.dynamicOptionNames, ["apiOperations"]);
   });
 
   it("collects DA OpenAPI operations from a searched OpenAPI document", async () => {
@@ -358,10 +509,33 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       "selectOpenApiSpec",
       "apiOperations",
     ]);
+    assert.deepEqual(ui.dynamicOptionNames, ["selectOpenApiSpec", "apiOperations"]);
     const options = (ui.lastSelectConfig?.options ?? []) as SurfaceOptionItem[];
     assert.equal(options[0].id, OPENAPI_SPEC);
     assert.equal(options[0].label, "Repairs API");
     assert.equal(options[0].detail, "Manage repairs");
+  });
+
+  it("surfaces invalid OpenAPI operation loading as a user-fixable error", async () => {
+    const ui = new ScriptedUserInteraction({
+      multi: { apiOperations: ["GET /repairs"] },
+    });
+
+    const res = await runCreateInputs(
+      buildFloor(),
+      OPENAPI_DA,
+      { apiSpecLocation: __filename },
+      asUI(ui),
+      { flagReader: () => false }
+    );
+
+    assert.isTrue(res.isErr(), "expected invalid OpenAPI spec to fail");
+    if (res.isErr()) {
+      assert.equal(res.error.name, "OpenApiSpecInvalid");
+      assert.isTrue(res.error instanceof UserError);
+    }
+    assert.deepEqual(ui.promptNames, ["apiOperations"]);
+    assert.deepEqual(ui.dynamicOptionNames, ["apiOperations"]);
   });
 
   it("validates Graph connector display name", async () => {
@@ -498,6 +672,8 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       assert.equal(res.value.language, "typescript");
     }
     assert.deepEqual(ui.promptNames, ["llmService", "openAIKey", "language", "folder", "app-name"]);
+    assert.isFunction(ui.lastInputConfig?.validation);
+    assert.isString(await ui.lastInputConfig?.validation?.("!"));
   });
 
   it("uses create floor defaults without prompts in non-interactive mode", async () => {
@@ -650,9 +826,9 @@ describe("runCreateInputs (collect-create-inputs)", () => {
 
   it("collects custom API OpenAPI inputs before LLM inputs", async () => {
     const ui = new ScriptedUserInteraction({
-      select: { openApiSpecType: "enter-url", llmService: "llm-service-azure-openai" },
+      select: { llmService: "llm-service-azure-openai" },
+      fileOrInput: { apiSpecLocation: OPENAPI_SPEC },
       text: {
-        apiSpecLocation: OPENAPI_SPEC,
         azureOpenAIKey: "fake-azure-openai-key",
         azureOpenAIEndpoint: "https://fake.openai.azure.com/",
         azureOpenAIDeploymentName: "fake-deployment",
@@ -670,7 +846,6 @@ describe("runCreateInputs (collect-create-inputs)", () => {
 
     assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
     if (res.isOk()) {
-      assert.equal(res.value.openApiSpecType, "enter-url");
       assert.equal(res.value.apiSpecLocation, OPENAPI_SPEC);
       assert.deepEqual(res.value.apiOperations, ["GET /repairs"]);
       assert.equal(res.value.llmService, "llm-service-azure-openai");
@@ -679,7 +854,6 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       assert.equal(res.value.azureOpenAIDeploymentName, "fake-deployment");
     }
     assert.deepEqual(ui.promptNames, [
-      "openApiSpecType",
       "apiSpecLocation",
       "apiOperations",
       "llmService",
@@ -687,6 +861,53 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       "azureOpenAIEndpoint",
       "azureOpenAIDeploymentName",
     ]);
+    assert.deepEqual(ui.fileOrInputNames, ["apiSpecLocation"]);
+    assert.equal(ui.lastFileOrInputConfig?.title, "OpenAPI Document");
+    assert.equal(ui.lastFileOrInputConfig?.placeholder, "Enter OpenAPI Document URL");
+    assert.equal(ui.lastFileOrInputConfig?.inputOptionItem.id, "input");
+    assert.equal(
+      ui.lastFileOrInputConfig?.inputOptionItem.label,
+      "$(cloud) Enter OpenAPI Document URL"
+    );
+    assert.deepEqual(ui.lastFileOrInputConfig?.filters, { files: ["json", "yml", "yaml"] });
+  });
+
+  it("browses a local OpenAPI document for custom API through the combined picker", async () => {
+    const ui = new ScriptedUserInteraction({
+      select: { llmService: "llm-service-azure-openai" },
+      fileOrInput: { apiSpecLocation: OPENAPI_SPEC },
+      multi: { apiOperations: ["GET /repairs"] },
+      text: {
+        azureOpenAIKey: "",
+        azureOpenAIEndpoint: "",
+        azureOpenAIDeploymentName: "",
+      },
+    });
+    const res = await runCreateInputs(
+      buildFloor(),
+      RAG_CUSTOM_API,
+      { language: "typescript", platform: Platform.VSCode },
+      asUI(ui),
+      { flagReader: () => false }
+    );
+
+    if (res.isErr()) {
+      assert.fail(res.error.message);
+    }
+    assert.equal(res.value.apiSpecLocation, OPENAPI_SPEC);
+    assert.deepEqual(ui.textNames, [
+      "azureOpenAIKey",
+      "azureOpenAIEndpoint",
+      "azureOpenAIDeploymentName",
+    ]);
+    assert.deepEqual(ui.fileNames, []);
+    assert.deepEqual(ui.fileOrInputNames, ["apiSpecLocation"]);
+    assert.equal(ui.lastFileOrInputConfig?.inputBoxConfig.name, "input-api-spec-url");
+    assert.equal(ui.lastFileOrInputConfig?.inputBoxConfig.title, "OpenAPI Document");
+    assert.equal(
+      ui.lastFileOrInputConfig?.inputBoxConfig.placeholder,
+      "Enter OpenAPI Document URL"
+    );
   });
 
   it("lists static MCP tools from the provided tools JSON", async () => {
@@ -1215,6 +1436,36 @@ describe("createUiPromptUI (collect-create-inputs)", () => {
       assert.deepEqual(res.value, { kind: "value", value: "hello world" });
     }
     assert.deepEqual(ui.textNames, ["freeText"]);
+  });
+
+  it("maps a singleFileOrText question to selectFileOrInput and returns the path or text", async () => {
+    const ui = new ScriptedUserInteraction({ fileOrInput: { apiSpecLocation: OPENAPI_SPEC } });
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.ask(
+      {
+        name: "apiSpecLocation",
+        type: "singleFileOrText",
+        title: "OpenAPI Document",
+        placeholder: "Enter OpenAPI Document URL",
+        inputOptionItem: { id: "input", label: "$(cloud) Enter OpenAPI Document URL" },
+        inputBoxConfig: {
+          name: "input-api-spec-url",
+          title: "OpenAPI Document",
+          placeholder: "Enter OpenAPI Document URL",
+        },
+        filters: { files: ["json", "yml", "yaml"] },
+      },
+      undefined,
+      2
+    );
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { kind: "value", value: OPENAPI_SPEC });
+    }
+    assert.deepEqual(ui.fileOrInputNames, ["apiSpecLocation"]);
+    assert.equal(ui.lastFileOrInputConfig?.step, 2);
   });
 
   it("maps a folder question to selectFolder and returns the path", async () => {

--- a/packages/fx-core/tests/v4/surface/createSelectorWalk.test.ts
+++ b/packages/fx-core/tests/v4/surface/createSelectorWalk.test.ts
@@ -517,11 +517,10 @@ describe("runCreateSelector (walk-create-selector)", () => {
     assert.deepEqual(ui.selectNames, ["projectType", "daTemplate"]);
   });
 
-  it("WCS-20: Office DA MetaOS upgrade resolves the v4 pipeline-only route", async () => {
+  it("WCS-20: Office Add-in no longer offers the DA MetaOS capability", async () => {
     const picks = {
       projectType: "office-meta-os-type",
-      officeAddinCapability: "office-da-meta-os",
-      daMetaOsCapability: "declarative-agent-meta-os-upgrade-project",
+      officeAddinCapability: "office-addin-config",
     };
     const ui = new ScriptedUI(picks);
 
@@ -531,15 +530,16 @@ describe("runCreateSelector (walk-create-selector)", () => {
 
     assert.isTrue(res.isOk());
     if (res.isOk()) {
-      assert.equal(res.value.templateId, "declarative-agent-meta-os-upgrade-project");
+      assert.equal(res.value.templateId, "office-addin-config");
       assert.equal(res.value.engine, "v4");
       assert.deepEqual(res.value.answers, picks);
     }
-    assert.deepEqual(ui.selectNames, [
-      "projectType",
-      "officeAddinCapability",
-      "daMetaOsCapability",
-    ]);
+    assert.deepEqual(ui.selectNames, ["projectType", "officeAddinCapability"]);
+    assert.notInclude(
+      offeredIds(ui.configByName.get("officeAddinCapability")),
+      "office-da-meta-os"
+    );
+    assert.isUndefined(ui.configByName.get("daMetaOsCapability"));
   });
 
   it("WCS-21: Office task pane resolves the v4 route", async () => {

--- a/packages/fx-core/tests/v4/surface/deriveCreateOptions.test.ts
+++ b/packages/fx-core/tests/v4/surface/deriveCreateOptions.test.ts
@@ -161,6 +161,9 @@ describe("deriveCreateOptions", () => {
       assert.equal(apiOperations?.type, "array");
       assert.isTrue(skipValidationOf(apiOperations));
 
+      const openApiSpecType = optionByName(res.value, "open-api-spec-type");
+      assert.includeMembers(choicesOf(openApiSpecType), ["enter-url", "open-file", "search-api"]);
+
       const apiSpecLocation = optionByName(res.value, "api-spec-location");
       assert.equal(apiSpecLocation?.shortName, "a");
     }

--- a/templates/v4/create/basic-custom-engine-agent/questions.json
+++ b/templates/v4/create/basic-custom-engine-agent/questions.json
@@ -6,45 +6,56 @@
       "type": "singleSelect",
       "title": "Service for Large Language Model (LLM)",
       "placeholder": "Select a service to access LLMs",
+      "keyPrefix": "core.createProjectQuestion.llmService",
       "default": "llm-service-azure-openai",
       "staticOptions": [
         {
           "id": "llm-service-azure-openai",
           "label": "Azure OpenAI",
-          "detail": "Use Azure OpenAI as the language model service."
+          "detail": "Access powerful LLMs in OpenAI with Azure security and reliability",
+          "keyPrefix": "core.createProjectQuestion.llmServiceAzureOpenAIOption"
         },
         {
           "id": "llm-service-openai",
           "label": "OpenAI",
-          "detail": "Use OpenAI as the language model service."
+          "detail": "Access LLMs developed by OpenAI",
+          "keyPrefix": "core.createProjectQuestion.llmServiceOpenAIOption"
         }
       ]
     },
     {
       "name": "openAIKey",
       "type": "text",
-      "title": "Input OpenAI service key now or set it later in the project.",
+      "title": "OpenAI Key",
+      "placeholder": "Input OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.openAIKey",
       "condition": { "equals": { "llmService": "llm-service-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIKey",
       "type": "text",
-      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "title": "Azure OpenAI Key",
+      "placeholder": "Input Azure OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIKey",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIEndpoint",
       "type": "text",
-      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "title": "Azure OpenAI Endpoint",
+      "placeholder": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIEndpoint",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIDeploymentName",
       "type": "text",
-      "title": "Input Azure OpenAI deployment name",
+      "title": "Azure OpenAI Deployment Name",
+      "placeholder": "Input Azure OpenAI deployment name now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIDeploymentName",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     }

--- a/templates/v4/create/custom-copilot-basic/questions.json
+++ b/templates/v4/create/custom-copilot-basic/questions.json
@@ -6,45 +6,56 @@
       "type": "singleSelect",
       "title": "Service for Large Language Model (LLM)",
       "placeholder": "Select a service to access LLMs",
+      "keyPrefix": "core.createProjectQuestion.llmService",
       "default": "llm-service-azure-openai",
       "staticOptions": [
         {
           "id": "llm-service-azure-openai",
           "label": "Azure OpenAI",
-          "detail": "Use Azure OpenAI as the language model service."
+          "detail": "Access powerful LLMs in OpenAI with Azure security and reliability",
+          "keyPrefix": "core.createProjectQuestion.llmServiceAzureOpenAIOption"
         },
         {
           "id": "llm-service-openai",
           "label": "OpenAI",
-          "detail": "Use OpenAI as the language model service."
+          "detail": "Access LLMs developed by OpenAI",
+          "keyPrefix": "core.createProjectQuestion.llmServiceOpenAIOption"
         }
       ]
     },
     {
       "name": "openAIKey",
       "type": "text",
-      "title": "Input OpenAI service key now or set it later in the project.",
+      "title": "OpenAI Key",
+      "placeholder": "Input OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.openAIKey",
       "condition": { "equals": { "llmService": "llm-service-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIKey",
       "type": "text",
-      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "title": "Azure OpenAI Key",
+      "placeholder": "Input Azure OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIKey",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIEndpoint",
       "type": "text",
-      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "title": "Azure OpenAI Endpoint",
+      "placeholder": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIEndpoint",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIDeploymentName",
       "type": "text",
-      "title": "Input Azure OpenAI deployment name",
+      "title": "Azure OpenAI Deployment Name",
+      "placeholder": "Input Azure OpenAI deployment name now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIDeploymentName",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     }

--- a/templates/v4/create/custom-copilot-rag-azure-ai-search/questions.json
+++ b/templates/v4/create/custom-copilot-rag-azure-ai-search/questions.json
@@ -6,45 +6,56 @@
       "type": "singleSelect",
       "title": "Service for Large Language Model (LLM)",
       "placeholder": "Select a service to access LLMs",
+      "keyPrefix": "core.createProjectQuestion.llmService",
       "default": "llm-service-azure-openai",
       "staticOptions": [
         {
           "id": "llm-service-azure-openai",
           "label": "Azure OpenAI",
-          "detail": "Use Azure OpenAI as the language model service."
+          "detail": "Access powerful LLMs in OpenAI with Azure security and reliability",
+          "keyPrefix": "core.createProjectQuestion.llmServiceAzureOpenAIOption"
         },
         {
           "id": "llm-service-openai",
           "label": "OpenAI",
-          "detail": "Use OpenAI as the language model service."
+          "detail": "Access LLMs developed by OpenAI",
+          "keyPrefix": "core.createProjectQuestion.llmServiceOpenAIOption"
         }
       ]
     },
     {
       "name": "openAIKey",
       "type": "text",
-      "title": "Input OpenAI service key now or set it later in the project.",
+      "title": "OpenAI Key",
+      "placeholder": "Input OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.openAIKey",
       "condition": { "equals": { "llmService": "llm-service-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIKey",
       "type": "text",
-      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "title": "Azure OpenAI Key",
+      "placeholder": "Input Azure OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIKey",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIEndpoint",
       "type": "text",
-      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "title": "Azure OpenAI Endpoint",
+      "placeholder": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIEndpoint",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIDeploymentName",
       "type": "text",
-      "title": "Input Azure OpenAI deployment name",
+      "title": "Azure OpenAI Deployment Name",
+      "placeholder": "Input Azure OpenAI deployment name now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIDeploymentName",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     }

--- a/templates/v4/create/custom-copilot-rag-custom-api/descriptor.json
+++ b/templates/v4/create/custom-copilot-rag-custom-api/descriptor.json
@@ -15,9 +15,6 @@
       "azureOpenAIKey": { "type": "string" },
       "azureOpenAIEndpoint": { "type": "string" },
       "azureOpenAIDeploymentName": { "type": "string" },
-      "openApiSpecType": { "type": "string" },
-      "searchOpenApiSpecQuery": { "type": "string" },
-      "selectOpenApiSpec": { "type": "string" },
       "apiSpecLocation": { "type": "string" },
       "apiOperations": { "type": "array", "items": { "type": "string" } }
     },

--- a/templates/v4/create/custom-copilot-rag-custom-api/descriptor.json
+++ b/templates/v4/create/custom-copilot-rag-custom-api/descriptor.json
@@ -15,6 +15,9 @@
       "azureOpenAIKey": { "type": "string" },
       "azureOpenAIEndpoint": { "type": "string" },
       "azureOpenAIDeploymentName": { "type": "string" },
+      "openApiSpecType": { "type": "string" },
+      "searchOpenApiSpecQuery": { "type": "string" },
+      "selectOpenApiSpec": { "type": "string" },
       "apiSpecLocation": { "type": "string" },
       "apiOperations": { "type": "array", "items": { "type": "string" } }
     },

--- a/templates/v4/create/custom-copilot-rag-custom-api/questions.json
+++ b/templates/v4/create/custom-copilot-rag-custom-api/questions.json
@@ -2,13 +2,59 @@
   "$schema": "../../schema/question.schema.json",
   "questions": [
     {
+      "name": "openApiSpecType",
+      "type": "singleSelect",
+      "title": "OpenAPI Spec Document",
+      "cliDescription": "The type of the API spec.",
+      "condition": { "expr": "apiSpecLocation == null" },
+      "staticOptions": [
+        {
+          "id": "enter-url",
+          "label": "Enter OpenAPI description document URL",
+          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromUrl"
+        },
+        {
+          "id": "open-file",
+          "label": "Browse OpenAPI description document locally",
+          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromFile"
+        },
+        {
+          "id": "search-api",
+          "label": "Search OpenAPI description document",
+          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromSearch"
+        }
+      ]
+    },
+    {
       "name": "apiSpecLocation",
       "type": "text",
       "title": "OpenAPI Description Document",
       "placeholder": "https://example.com/openapi.yaml or ./openapi.yaml",
       "prompt": "Enter an OpenAPI description document URL or local path.",
       "cliShortName": "a",
-      "cliDescription": "OpenAPI description document location."
+      "cliDescription": "OpenAPI description document location.",
+      "condition": { "expr": "openApiSpecType == 'enter-url' || openApiSpecType == 'open-file' || (openApiSpecType == null && apiSpecLocation == null)" }
+    },
+    {
+      "name": "searchOpenApiSpecQuery",
+      "type": "text",
+      "title": "Search OpenAPI Document",
+      "placeholder": "Input text to search OpenAPI description document",
+      "keyPrefix": "core.createProjectQuestion.capability.searchOpenAPISpecQueryQuestion",
+      "cliDescription": "Search OpenAPI Document",
+      "condition": { "expr": "openApiSpecType == 'search-api'" }
+    },
+    {
+      "name": "selectOpenApiSpec",
+      "type": "singleSelect",
+      "title": "Select OpenAPI Document",
+      "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecQuestion",
+      "optionsFrom": "openapi.search",
+      "optionsFromParams": {
+        "query": { "expr": "searchOpenApiSpecQuery" }
+      },
+      "cliDescription": "Select OpenAPI Document",
+      "condition": { "expr": "openApiSpecType == 'search-api'" }
     },
     {
       "name": "apiOperations",
@@ -18,52 +64,75 @@
       "optionsFromParams": {
         "apiSpecLocation": { "expr": "apiSpecLocation" }
       },
-      "cliDescription": "API operations to include in the custom API agent."
+      "cliDescription": "API operations to include in the custom API agent.",
+      "condition": { "expr": "selectOpenApiSpec == null" }
+    },
+    {
+      "name": "apiOperations",
+      "type": "multiSelect",
+      "title": "API Operations",
+      "optionsFrom": "openapi.operations",
+      "optionsFromParams": {
+        "apiSpecLocation": { "expr": "selectOpenApiSpec" }
+      },
+      "cliDescription": "API operations to include in the custom API agent.",
+      "condition": { "expr": "selectOpenApiSpec != null" }
     },
     {
       "name": "llmService",
       "type": "singleSelect",
       "title": "Service for Large Language Model (LLM)",
       "placeholder": "Select a service to access LLMs",
+      "keyPrefix": "core.createProjectQuestion.llmService",
       "default": "llm-service-azure-openai",
       "staticOptions": [
         {
           "id": "llm-service-azure-openai",
           "label": "Azure OpenAI",
-          "detail": "Use Azure OpenAI as the language model service."
+          "detail": "Access powerful LLMs in OpenAI with Azure security and reliability",
+          "keyPrefix": "core.createProjectQuestion.llmServiceAzureOpenAIOption"
         },
         {
           "id": "llm-service-openai",
           "label": "OpenAI",
-          "detail": "Use OpenAI as the language model service."
+          "detail": "Access LLMs developed by OpenAI",
+          "keyPrefix": "core.createProjectQuestion.llmServiceOpenAIOption"
         }
       ]
     },
     {
       "name": "openAIKey",
       "type": "text",
-      "title": "Input OpenAI service key now or set it later in the project.",
+      "title": "OpenAI Key",
+      "placeholder": "Input OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.openAIKey",
       "condition": { "equals": { "llmService": "llm-service-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIKey",
       "type": "text",
-      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "title": "Azure OpenAI Key",
+      "placeholder": "Input Azure OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIKey",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIEndpoint",
       "type": "text",
-      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "title": "Azure OpenAI Endpoint",
+      "placeholder": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIEndpoint",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIDeploymentName",
       "type": "text",
-      "title": "Input Azure OpenAI deployment name",
+      "title": "Azure OpenAI Deployment Name",
+      "placeholder": "Input Azure OpenAI deployment name now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIDeploymentName",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     }

--- a/templates/v4/create/custom-copilot-rag-custom-api/questions.json
+++ b/templates/v4/create/custom-copilot-rag-custom-api/questions.json
@@ -13,7 +13,8 @@
       "inputBoxConfig": {
         "name": "input-api-spec-url",
         "title": "OpenAPI Document",
-        "placeholder": "Enter OpenAPI Document URL"
+        "placeholder": "Enter OpenAPI Document URL",
+        "validation": "openapiUrl"
       },
       "filters": {
         "files": ["json", "yml", "yaml"]

--- a/templates/v4/create/custom-copilot-rag-custom-api/questions.json
+++ b/templates/v4/create/custom-copilot-rag-custom-api/questions.json
@@ -2,59 +2,24 @@
   "$schema": "../../schema/question.schema.json",
   "questions": [
     {
-      "name": "openApiSpecType",
-      "type": "singleSelect",
-      "title": "OpenAPI Spec Document",
-      "cliDescription": "The type of the API spec.",
-      "condition": { "expr": "apiSpecLocation == null" },
-      "staticOptions": [
-        {
-          "id": "enter-url",
-          "label": "Enter OpenAPI description document URL",
-          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromUrl"
-        },
-        {
-          "id": "open-file",
-          "label": "Browse OpenAPI description document locally",
-          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromFile"
-        },
-        {
-          "id": "search-api",
-          "label": "Search OpenAPI description document",
-          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromSearch"
-        }
-      ]
-    },
-    {
       "name": "apiSpecLocation",
-      "type": "text",
-      "title": "OpenAPI Description Document",
-      "placeholder": "https://example.com/openapi.yaml or ./openapi.yaml",
-      "prompt": "Enter an OpenAPI description document URL or local path.",
-      "cliShortName": "a",
-      "cliDescription": "OpenAPI description document location.",
-      "condition": { "expr": "openApiSpecType == 'enter-url' || openApiSpecType == 'open-file' || (openApiSpecType == null && apiSpecLocation == null)" }
-    },
-    {
-      "name": "searchOpenApiSpecQuery",
-      "type": "text",
-      "title": "Search OpenAPI Document",
-      "placeholder": "Input text to search OpenAPI description document",
-      "keyPrefix": "core.createProjectQuestion.capability.searchOpenAPISpecQueryQuestion",
-      "cliDescription": "Search OpenAPI Document",
-      "condition": { "expr": "openApiSpecType == 'search-api'" }
-    },
-    {
-      "name": "selectOpenApiSpec",
-      "type": "singleSelect",
-      "title": "Select OpenAPI Document",
-      "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecQuestion",
-      "optionsFrom": "openapi.search",
-      "optionsFromParams": {
-        "query": { "expr": "searchOpenApiSpecQuery" }
+      "type": "singleFileOrText",
+      "title": "OpenAPI Document",
+      "placeholder": "Enter OpenAPI Document URL",
+      "inputOptionItem": {
+        "id": "input",
+        "label": "$(cloud) Enter OpenAPI Document URL"
       },
-      "cliDescription": "Select OpenAPI Document",
-      "condition": { "expr": "openApiSpecType == 'search-api'" }
+      "inputBoxConfig": {
+        "name": "input-api-spec-url",
+        "title": "OpenAPI Document",
+        "placeholder": "Enter OpenAPI Document URL"
+      },
+      "filters": {
+        "files": ["json", "yml", "yaml"]
+      },
+      "cliShortName": "a",
+      "cliDescription": "OpenAPI description document location."
     },
     {
       "name": "apiOperations",
@@ -64,19 +29,7 @@
       "optionsFromParams": {
         "apiSpecLocation": { "expr": "apiSpecLocation" }
       },
-      "cliDescription": "API operations to include in the custom API agent.",
-      "condition": { "expr": "selectOpenApiSpec == null" }
-    },
-    {
-      "name": "apiOperations",
-      "type": "multiSelect",
-      "title": "API Operations",
-      "optionsFrom": "openapi.operations",
-      "optionsFromParams": {
-        "apiSpecLocation": { "expr": "selectOpenApiSpec" }
-      },
-      "cliDescription": "API operations to include in the custom API agent.",
-      "condition": { "expr": "selectOpenApiSpec != null" }
+      "cliDescription": "API operations to include in the custom API agent."
     },
     {
       "name": "llmService",

--- a/templates/v4/create/custom-copilot-rag-customize/questions.json
+++ b/templates/v4/create/custom-copilot-rag-customize/questions.json
@@ -6,45 +6,56 @@
       "type": "singleSelect",
       "title": "Service for Large Language Model (LLM)",
       "placeholder": "Select a service to access LLMs",
+      "keyPrefix": "core.createProjectQuestion.llmService",
       "default": "llm-service-azure-openai",
       "staticOptions": [
         {
           "id": "llm-service-azure-openai",
           "label": "Azure OpenAI",
-          "detail": "Use Azure OpenAI as the language model service."
+          "detail": "Access powerful LLMs in OpenAI with Azure security and reliability",
+          "keyPrefix": "core.createProjectQuestion.llmServiceAzureOpenAIOption"
         },
         {
           "id": "llm-service-openai",
           "label": "OpenAI",
-          "detail": "Use OpenAI as the language model service."
+          "detail": "Access LLMs developed by OpenAI",
+          "keyPrefix": "core.createProjectQuestion.llmServiceOpenAIOption"
         }
       ]
     },
     {
       "name": "openAIKey",
       "type": "text",
-      "title": "Input OpenAI service key now or set it later in the project.",
+      "title": "OpenAI Key",
+      "placeholder": "Input OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.openAIKey",
       "condition": { "equals": { "llmService": "llm-service-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIKey",
       "type": "text",
-      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "title": "Azure OpenAI Key",
+      "placeholder": "Input Azure OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIKey",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIEndpoint",
       "type": "text",
-      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "title": "Azure OpenAI Endpoint",
+      "placeholder": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIEndpoint",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIDeploymentName",
       "type": "text",
-      "title": "Input Azure OpenAI deployment name",
+      "title": "Azure OpenAI Deployment Name",
+      "placeholder": "Input Azure OpenAI deployment name now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIDeploymentName",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     }

--- a/templates/v4/create/da/api-plugin-from-existing-api/descriptor.json
+++ b/templates/v4/create/da/api-plugin-from-existing-api/descriptor.json
@@ -10,6 +10,9 @@
   "optionsSchema": {
     "type": "object",
     "properties": {
+      "openApiSpecType": { "type": "string" },
+      "searchOpenApiSpecQuery": { "type": "string" },
+      "selectOpenApiSpec": { "type": "string" },
       "apiSpecLocation": { "type": "string" },
       "apiOperations": { "type": "array", "items": { "type": "string" } }
     },

--- a/templates/v4/create/da/api-plugin-from-existing-api/questions.json
+++ b/templates/v4/create/da/api-plugin-from-existing-api/questions.json
@@ -2,13 +2,69 @@
   "$schema": "../../../schema/question.schema.json",
   "questions": [
     {
+      "name": "openApiSpecType",
+      "type": "singleSelect",
+      "title": "OpenAPI Spec Document",
+      "cliDescription": "The type of the API spec.",
+      "condition": { "expr": "apiSpecLocation == null" },
+      "staticOptions": [
+        {
+          "id": "enter-url",
+          "label": "Enter OpenAPI description document URL",
+          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromUrl"
+        },
+        {
+          "id": "open-file",
+          "label": "Browse OpenAPI description document locally",
+          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromFile"
+        },
+        {
+          "id": "search-api",
+          "label": "Search OpenAPI description document",
+          "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecFromSearch"
+        }
+      ]
+    },
+    {
       "name": "apiSpecLocation",
       "type": "text",
       "title": "OpenAPI Description Document",
       "placeholder": "https://example.com/openapi.yaml or ./openapi.yaml",
       "prompt": "Enter an OpenAPI description document URL or local path.",
       "cliShortName": "a",
-      "cliDescription": "OpenAPI description document location."
+      "cliDescription": "OpenAPI description document location.",
+      "condition": { "expr": "openApiSpecType == 'enter-url'" }
+    },
+    {
+      "name": "apiSpecLocation",
+      "type": "singleFile",
+      "title": "OpenAPI Description Document",
+      "placeholder": "Select an OpenAPI description document.",
+      "prompt": "Select an OpenAPI description document from your local machine.",
+      "cliShortName": "a",
+      "cliDescription": "OpenAPI description document location.",
+      "condition": { "expr": "openApiSpecType == 'open-file'" }
+    },
+    {
+      "name": "searchOpenApiSpecQuery",
+      "type": "text",
+      "title": "Search OpenAPI Document",
+      "placeholder": "Input text to search OpenAPI description document",
+      "keyPrefix": "core.createProjectQuestion.capability.searchOpenAPISpecQueryQuestion",
+      "cliDescription": "Search OpenAPI Document",
+      "condition": { "expr": "openApiSpecType == 'search-api'" }
+    },
+    {
+      "name": "selectOpenApiSpec",
+      "type": "singleSelect",
+      "title": "Select OpenAPI Document",
+      "keyPrefix": "core.createProjectQuestion.capability.selectOpenAPISpecQuestion",
+      "optionsFrom": "openapi.search",
+      "optionsFromParams": {
+        "query": { "expr": "searchOpenApiSpecQuery" }
+      },
+      "cliDescription": "Select OpenAPI Document",
+      "condition": { "expr": "openApiSpecType == 'search-api'" }
     },
     {
       "name": "apiOperations",
@@ -18,7 +74,19 @@
       "optionsFromParams": {
         "apiSpecLocation": { "expr": "apiSpecLocation" }
       },
-      "cliDescription": "API operations to include in the plugin."
+      "cliDescription": "API operations to include in the plugin.",
+      "condition": { "expr": "selectOpenApiSpec == null" }
+    },
+    {
+      "name": "apiOperations",
+      "type": "multiSelect",
+      "title": "API Operations",
+      "optionsFrom": "openapi.operations",
+      "optionsFromParams": {
+        "apiSpecLocation": { "expr": "selectOpenApiSpec" }
+      },
+      "cliDescription": "API operations to include in the plugin.",
+      "condition": { "expr": "selectOpenApiSpec != null" }
     }
   ]
 }

--- a/templates/v4/create/da/api-plugin-from-existing-api/questions.json
+++ b/templates/v4/create/da/api-plugin-from-existing-api/questions.json
@@ -29,10 +29,11 @@
       "name": "apiSpecLocation",
       "type": "text",
       "title": "OpenAPI Description Document",
-      "placeholder": "https://example.com/openapi.yaml or ./openapi.yaml",
-      "prompt": "Enter an OpenAPI description document URL or local path.",
+      "placeholder": "https://example.com/openapi.yaml",
+      "prompt": "Enter an OpenAPI description document URL.",
+      "validation": "openapiUrl",
       "cliShortName": "a",
-      "cliDescription": "OpenAPI description document location.",
+      "cliDescription": "OpenAPI description document URL.",
       "condition": { "expr": "openApiSpecType == 'enter-url'" }
     },
     {

--- a/templates/v4/create/da/api-plugin-from-existing-api/questions.json
+++ b/templates/v4/create/da/api-plugin-from-existing-api/questions.json
@@ -41,6 +41,9 @@
       "title": "OpenAPI Description Document",
       "placeholder": "Select an OpenAPI description document.",
       "prompt": "Select an OpenAPI description document from your local machine.",
+      "filters": {
+        "OpenAPI Description Document": ["json", "yml", "yaml"]
+      },
       "cliShortName": "a",
       "cliDescription": "OpenAPI description document location.",
       "condition": { "expr": "openApiSpecType == 'open-file'" }

--- a/templates/v4/create/non-sso-tab/descriptor.json
+++ b/templates/v4/create/non-sso-tab/descriptor.json
@@ -2,7 +2,7 @@
   "$schema": "../../schema/descriptor.schema.json",
   "id": "non-sso-tab",
   "name": "Teams Tab",
-  "languages": ["typescript", "python"],
+  "languages": ["typescript"],
   "minEngineVersion": "5.20.0",
   "spec": "docs/03-specs/scenarios/teams/create-non-sso-tab.md",
   "requiresNetwork": false,

--- a/templates/v4/create/selector.json
+++ b/templates/v4/create/selector.json
@@ -218,29 +218,10 @@
           "detail": "Task pane add-in with custom function and shortcut",
           "condition": { "featureFlag": "TEAMSFX_CF_SHORTCUT_METAOS" },
           "keyPrefix": "template.newCFShortcut" },
-        { "id": "office-da-meta-os",
-          "label": "Create Declarative Agent with Office Add-in Action",
-          "detail": "Create a Declarative Agent with Office add-in action",
-          "condition": { "featureFlag": "TEAMSFX_DA_METAOS" },
-          "keyPrefix": "template.createProjectQuestion.DAMetaOS" },
         { "id": "office-addin-config",
           "label": "Upgrade an Existing Office Add-in",
           "detail": "Upgrade an add-in project to the latest app manifest and project structure",
           "keyPrefix": "template.importOfficeAddin" }
-      ]
-    },
-    {
-      "name": "daMetaOsCapability",
-      "type": "singleSelect",
-      "title": "Declarative Agent in MetaOS Capabilities",
-      "placeholder": "Select a capability",
-      "keyPrefix": "template.createProjectQuestion.DAMetaOS.capability",
-      "condition": { "expr": "officeAddinCapability == 'office-da-meta-os'" },
-      "staticOptions": [
-        { "id": "declarative-agent-meta-os-upgrade-project",
-          "label": "Extend an existing Office Add-in",
-          "detail": "Extend an add-in project to the declarative agent with add-in actions",
-          "keyPrefix": "template.createProjectQuestion.DAMetaOS.capability.upgradeProject" }
       ]
     }
   ],
@@ -320,11 +301,6 @@
     {
       "when": "projectType=='office-meta-os-type' && officeAddinCapability=='office-addin-excel-cfshortcut'",
       "templateId": "office-addin-excel-cfshortcut",
-      "engine": "v4"
-    },
-    {
-      "when": "projectType=='office-meta-os-type' && officeAddinCapability=='office-da-meta-os' && daMetaOsCapability=='declarative-agent-meta-os-upgrade-project'",
-      "templateId": "declarative-agent-meta-os-upgrade-project",
       "engine": "v4"
     },
     {

--- a/templates/v4/create/teams-collaborator-agent/questions.json
+++ b/templates/v4/create/teams-collaborator-agent/questions.json
@@ -4,19 +4,25 @@
     {
       "name": "azureOpenAIKey",
       "type": "text",
-      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "title": "Azure OpenAI Key",
+      "placeholder": "Input Azure OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIKey",
       "optional": true
     },
     {
       "name": "azureOpenAIEndpoint",
       "type": "text",
-      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "title": "Azure OpenAI Endpoint",
+      "placeholder": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIEndpoint",
       "optional": true
     },
     {
       "name": "azureOpenAIDeploymentName",
       "type": "text",
-      "title": "Input Azure OpenAI deployment name",
+      "title": "Azure OpenAI Deployment Name",
+      "placeholder": "Input Azure OpenAI deployment name now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIDeploymentName",
       "optional": true
     }
   ]

--- a/templates/v4/create/weather-agent/descriptor.json
+++ b/templates/v4/create/weather-agent/descriptor.json
@@ -2,7 +2,7 @@
   "$schema": "../../schema/descriptor.schema.json",
   "id": "weather-agent",
   "name": "Weather Agent",
-  "languages": ["typescript", "javascript", "python"],
+  "languages": ["typescript", "javascript"],
   "minEngineVersion": "5.20.0",
   "spec": "docs/03-specs/scenarios/teams/create-weather-agent.md",
   "requiresNetwork": false,

--- a/templates/v4/create/weather-agent/questions.json
+++ b/templates/v4/create/weather-agent/questions.json
@@ -6,45 +6,56 @@
       "type": "singleSelect",
       "title": "Service for Large Language Model (LLM)",
       "placeholder": "Select a service to access LLMs",
+      "keyPrefix": "core.createProjectQuestion.llmService",
       "default": "llm-service-azure-openai",
       "staticOptions": [
         {
           "id": "llm-service-azure-openai",
           "label": "Azure OpenAI",
-          "detail": "Use Azure OpenAI as the language model service."
+          "detail": "Access powerful LLMs in OpenAI with Azure security and reliability",
+          "keyPrefix": "core.createProjectQuestion.llmServiceAzureOpenAIOption"
         },
         {
           "id": "llm-service-openai",
           "label": "OpenAI",
-          "detail": "Use OpenAI as the language model service."
+          "detail": "Access LLMs developed by OpenAI",
+          "keyPrefix": "core.createProjectQuestion.llmServiceOpenAIOption"
         }
       ]
     },
     {
       "name": "openAIKey",
       "type": "text",
-      "title": "Input OpenAI service key now or set it later in the project.",
+      "title": "OpenAI Key",
+      "placeholder": "Input OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.openAIKey",
       "condition": { "equals": { "llmService": "llm-service-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIKey",
       "type": "text",
-      "title": "Input Azure OpenAI service key now or set it later in the project",
+      "title": "Azure OpenAI Key",
+      "placeholder": "Input Azure OpenAI service key now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIKey",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIEndpoint",
       "type": "text",
-      "title": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "title": "Azure OpenAI Endpoint",
+      "placeholder": "Input Azure OpenAI service endpoint now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIEndpoint",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     },
     {
       "name": "azureOpenAIDeploymentName",
       "type": "text",
-      "title": "Input Azure OpenAI deployment name",
+      "title": "Azure OpenAI Deployment Name",
+      "placeholder": "Input Azure OpenAI deployment name now or set it later in the project",
+      "keyPrefix": "core.createProjectQuestion.llmService.azureOpenAIDeploymentName",
       "condition": { "equals": { "llmService": "llm-service-azure-openai" } },
       "optional": true
     }

--- a/templates/v4/schema/question.schema.json
+++ b/templates/v4/schema/question.schema.json
@@ -28,6 +28,15 @@
         "placeholder": { "type": "string" },
         "prompt": { "type": "string" },
         "default": {},
+        "filters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "inputOptionItem": { "$ref": "#/$defs/option" },
+        "inputBoxConfig": { "$ref": "#/$defs/inputBoxConfig" },
         "validation": { "$ref": "#/$defs/validation" },
         "staticOptions": {
           "type": "array",
@@ -50,6 +59,20 @@
       "comment": "Exactly one of staticOptions / optionsFrom may be present (proposal §4).",
       "not": {
         "required": ["staticOptions", "optionsFrom"]
+      }
+    },
+    "inputBoxConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "title": { "type": "string" },
+        "placeholder": { "type": "string" },
+        "prompt": { "type": "string" },
+        "default": {},
+        "step": { "type": "number" },
+        "keyPrefix": { "type": "string" }
       }
     },
     "option": {

--- a/templates/v4/schema/question.schema.json
+++ b/templates/v4/schema/question.schema.json
@@ -72,7 +72,8 @@
         "prompt": { "type": "string" },
         "default": {},
         "step": { "type": "number" },
-        "keyPrefix": { "type": "string" }
+        "keyPrefix": { "type": "string" },
+        "validation": { "$ref": "#/$defs/validation" }
       }
     },
     "option": {


### PR DESCRIPTION
## Summary
- Add the v3 Search OpenAPI Document option to v4 OpenAPI Spec Document flows.
- Add an `openapi.search` provider and normalize the selected search result URL into `apiSpecLocation` for existing pipelines.
- Update v4 template question metadata/prompt rendering tests so CLI/VS Code surfaces expose the expected choices.

## Validation
- `pnpm exec vitest run tests/v4/surface/createInputs.test.ts tests/v4/surface/deriveCreateOptions.test.ts --config vitest.config.ts`
- `pnpm exec vitest run tests/v4 --config vitest.config.ts --maxWorkers=4 --reporter=verbose`
- `npm run build`
- `git diff --check`
- Patch coverage: 90.48%.

Note: `pnpm exec vitest run tests/v4 --coverage --config vitest.config.ts --maxWorkers=4 --reporter=verbose` executed all v4 tests successfully (63 files, 655 tests), but exits non-zero because the package-wide Istanbul line threshold is applied to all fx-core files and reports 19.14% global line coverage for this scoped v4 run.