### PR TITLE
fix(vscuse): Auto-fix Feature_UI_Layout__Create_Project_Questions

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
@@ -32,7 +32,7 @@
       "step_179ff717",
       "step_e5c7e8aa",
       "step_61ee9d59",
-      "plan_r_0624_024810",
+      "step_ta_fix01",
       "step_18eec105",
       "step_3b65d9b9",
       "step_91e5b84d",
@@ -268,7 +268,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion Verify that there are 5 options “Declarative Agent”, \"Custom Engine Agent\", \"Copilot Connectors\", \"Teams Agents and Apps\" and \"Office Add-in\"",
+      "description": "@assertion Verify that there are 5 options \u201cDeclarative Agent\u201d, \"Custom Engine Agent\", \"Copilot Connectors\", \"Teams Agents and Apps\" and \"Office Add-in\"",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -279,6 +279,28 @@
       "tags": [],
       "screenshot": null,
       "created_at": "2026-01-06T09:55:51.032498",
+      "plan_id": "plan_47e4bf4e"
+    },
+    {
+      "step_id": "step_ta_fix01",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 307,
+        "y": 232
+      },
+      "description": "Click the \"Teams Agents and Apps\" option in the \"New Project\" dropdown menu within the Microsoft 365 Agents Toolkit interface. Inline replacement for the read-only Teams Agents group: the earlier Ctrl+- zoom-out compressed the menu, so the group fixed y=266 was landing one row lower on \"Office Add-in\"; y is shifted up one row to hit \"Teams Agents and Apps\".",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-01-06T09:55:51.049000",
       "plan_id": "plan_47e4bf4e"
     },
     {
@@ -422,7 +444,7 @@
         "x": 278,
         "y": 17
       },
-      "description": "Click the \"Back (Ctrl+Alt+←)\" button in the Teams Capability quick selection popup at the top of the Visual Studio Code interface.",
+      "description": "Click the \"Back (Ctrl+Alt+\u2190)\" button in the Teams Capability quick selection popup at the top of the Visual Studio Code interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -632,7 +654,7 @@
         "x": 277,
         "y": 12
       },
-      "description": "Click the \"Back (Ctrl+Alt+←)\" button in the \"Create an Action\" modal at the top of the Visual Studio Code interface to return to the previous selection screen.",
+      "description": "Click the \"Back (Ctrl+Alt+\u2190)\" button in the \"Create an Action\" modal at the top of the Visual Studio Code interface to return to the previous selection screen.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
@@ -291,7 +291,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion Verify that there are 5 options \u201cDeclarative Agent\u201d, \"Custom Engine Agent\", \"Copilot Connectors\", \"Teams Agents and Apps\" and \"Office Add-in\"",
+      "description": "@assertion Verify that there are 6 options \u201cDeclarative Agent\u201d, \"Custom Engine Agent\", \"Copilot Connectors\", \"Blank App\", \"Teams Agents and Apps\" and \"Office Add-in\"",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
@@ -541,7 +541,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion verify options like : no action, add an action, add a copilot connector and start with typespec for microsoft 365 copilot",
+      "description": "@assertion verify options like : no action, create a declarative agent with an action, add a copilot connector and start with typespec for microsoft 365 copilot",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
@@ -585,7 +585,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion verify options like below:\n start with a new api\ncreate an action with a new api from azure functions, \nstart with an openapi description document\ncreate an action form your existing api, \nstart with an office add-in action\ncreate a declarative agent with office add in action, \nstart with an MCP server\ncreate actions from your existing mcp server.",
+      "description": "@assertion verify options like below:\n start with a new api\ncreate an action with a new api from azure functions, \nstart with an openapi description document\ncreate an action from your existing api, \nstart with an MCP server\ncreate actions from your existing mcp server.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_UI_Layout__Create_Project_Questions.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 29,
+    "total_steps": 30,
     "created_at": "2026-01-06T02:01:16.119023",
     "name": "Feature: UI Layout & Create Project Questions",
     "description": {
@@ -23,6 +23,7 @@
       "plan_r_0624_024810",
       "step_34be0072",
       "step_ae8b01b3",
+      "step_lang_fix01",
       "step_90d68e68",
       "plan_r_0928_014459",
       "step_add65aa6",
@@ -107,6 +108,28 @@
       "tags": [],
       "screenshot": "step_ae8b01b3",
       "created_at": "2026-01-06T09:55:50.955950",
+      "plan_id": "plan_47e4bf4e"
+    },
+    {
+      "step_id": "step_lang_fix01",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 400,
+        "y": 78
+      },
+      "description": "Select the \"TypeScript\" programming language option (top, highlighted) in the \"Programming Language\" dropdown that now appears after choosing the \"Tab\" Teams capability. The extension added this question between the Teams Capability selection and the Workspace Folder prompt, so selecting a language is required to advance the wizard to the \"Workspace Folder\" dialog expected by the next step.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-01-06T09:55:50.960000",
       "plan_id": "plan_47e4bf4e"
     },
     {


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Feature_UI_Layout__Create_Project_Questions`
**Status:** :white_check_mark: FIXED (attempt 5/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/e2edbd40-5fab-4b62-bd4c-f8b490c34dd3/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/0ff15e77-7b0d-4f58-9d71-c24ea74aadfe/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | False positive — the read-only Teams Agents group's fixed click (307,266) hit "O | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/fc5ea431-2993-4a2d-b828-9325d368db92/test_report.html) |
| 2 | Added missing step (step_lang_fix01) to select "TypeScript" in the new "Programm | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/303ccf73-51c9-4a27-a6cb-1e59580d3685/test_report.html) |
| 3 | Updated assertion step_61ee9d59 to expect 6 New Project options including the ne | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/5f4e83f5-d938-461f-8e11-f6ed0651ebe0/test_report.html) |
| 4 | Updated assertion step_878db414 to match the renamed dropdown option — replaced  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/c291da6a-6ccf-4fd6-91b5-c97b8ae67ceb/test_report.html) |
| 5 | Updated assertion step_62702597 to match the current 6 "Create an Action" option | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/0ff15e77-7b0d-4f58-9d71-c24ea74aadfe/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Feature_UI_Layout__Create_Project_Questions.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>