### PR TITLE
refactor: move manifest template resolver into @microsoft/app-manifest

### DIFF
--- a/packages/fx-core/src/component/utils/common.ts
+++ b/packages/fx-core/src/component/utils/common.ts
@@ -18,8 +18,6 @@ import { getLocalizedString } from "../../common/localizeUtils";
 import { SummaryConstant } from "../configManager/constant";
 import { EOL } from "os";
 
-const placeholderRegex = /\${{ *[a-zA-Z_][a-zA-Z0-9_]* *}}/g;
-
 /**
  * check parameter, throw error if value is null or undefined
  * @param name parameter name
@@ -128,44 +126,10 @@ export async function wrapSummary(
   }
 }
 
-// Expand environment variables in content. The format of referencing environment variable is: ${{ENV_NAME}}
-export function expandEnvironmentVariable(
-  content: string,
-  envs?: { [key in string]: string }
-): string {
-  const placeholders = content.match(placeholderRegex);
-  if (placeholders) {
-    for (const placeholder of placeholders) {
-      const envName = placeholder.slice(3, -2).trim(); // removes `${{` and `}}`
-      const envValue = envs ? envs[envName] : process.env[envName];
-      if (envName === "APP_NAME_SUFFIX") {
-        if (envValue !== undefined && envValue !== null) {
-          content = content.replace(placeholder, envValue);
-        }
-      } else {
-        if (envValue) {
-          content = content.replace(placeholder, envValue);
-        }
-      }
-    }
-  }
-
-  return content;
-}
-
-/**
- * Expand environment variables in content. The format of referencing environment variable is: ${{ENV_NAME}}
- * @return An array of environment variables
- */
-export function getEnvironmentVariables(content: string): string[] {
-  const placeholders = content.match(placeholderRegex);
-  if (placeholders) {
-    const variables = placeholders.map((placeholder) => placeholder.slice(3, -2).trim()); // removes `${{` and `}}`)
-    // remove duplicates
-    return [...new Set(variables)];
-  }
-  return [];
-}
+// Manifest env-variable (`${{ENV_NAME}}`) expansion lives in @microsoft/app-manifest
+// (re-exported via @microsoft/teamsfx-api) so hosts can resolve manifests without
+// fx-core. Re-exported here to keep the existing import path for fx-core call sites.
+export { expandEnvironmentVariable, getEnvironmentVariables } from "@microsoft/teamsfx-api";
 
 export function getAbsolutePath(relativeOrAbsolutePath: string, projectPath: string): string {
   relativeOrAbsolutePath = relativeOrAbsolutePath || "";

--- a/packages/fx-core/src/component/utils/envFunctionUtils.ts
+++ b/packages/fx-core/src/component/utils/envFunctionUtils.ts
@@ -8,12 +8,18 @@ import {
   Result,
   UserError,
   UserErrorOptions,
+  // Host-agnostic manifest-template resolution lives in @microsoft/app-manifest and
+  // is re-exported by @microsoft/teamsfx-api. fx-core stays the home for telemetry,
+  // localized messages, and FxError mapping; the resolution logic lives one layer down.
+  ManifestType,
+  expandFileFunctionMacros,
+  UnsupportedFileFormatError as ManifestUnsupportedFileFormatError,
+  InvalidFunctionError as ManifestInvalidFunctionError,
+  InvalidFunctionParameterError as ManifestInvalidFunctionParameterError,
+  ReadFileError as ManifestReadFileError,
+  FileNotFoundError as ManifestFileNotFoundError,
 } from "@microsoft/teamsfx-api";
-import path from "path";
-import fs from "fs-extra";
-import stripBom from "strip-bom";
 import { FileNotFoundError } from "../../error";
-import { expandEnvironmentVariable } from "./common";
 import { getLocalizedString } from "../../common/localizeUtils";
 import { DriverContext } from "../driver/interface/commonArgs";
 
@@ -26,12 +32,40 @@ enum TelemetryPropertyKey {
   functionCount = "function-count",
 }
 
-export enum ManifestType {
-  TeamsManifest = "teams-manifest",
-  PluginManifest = "plugin-manifest",
-  DeclarativeCopilotManifest = "declarative-copilot-manifest",
-  ApiSpec = "api-spec",
-  EmbeddedKnowledgeFile = "embedded-knowledge-file",
+// Re-exported for existing importers (ManifestUtils, PluginManifestUtils, utils, createAppPackage).
+export { ManifestType };
+
+// Map a plain error thrown by @microsoft/app-manifest's resolver to the localized
+// FxError surface fx-core drivers expect, emitting the same diagnostic logs as before.
+function toFxError(e: unknown, ctx: DriverContext): FxError {
+  if (e instanceof ManifestUnsupportedFileFormatError) {
+    ctx.logProvider.error(
+      getLocalizedString("core.envFunc.unsupportedFile.errorLog", e.filePath, "txt")
+    );
+    return new UnsupportedFileFormatError(ctx.platform);
+  }
+  if (e instanceof ManifestInvalidFunctionError) {
+    ctx.logProvider.error(
+      getLocalizedString("core.envFunc.unsupportedFunction.errorLog", e.token, "file")
+    );
+    return new InvalidFunctionError(ctx.platform);
+  }
+  if (e instanceof ManifestInvalidFunctionParameterError) {
+    ctx.logProvider.error(
+      getLocalizedString("core.envFunc.invalidFunctionParameter.errorLog", e.token, "file")
+    );
+    return new InvalidFunctionParameter(ctx.platform);
+  }
+  if (e instanceof ManifestReadFileError) {
+    ctx.logProvider.error(
+      getLocalizedString("core.envFunc.readFile.errorLog", e.filePath, e.cause?.toString())
+    );
+    return new ReadFileError(ctx.platform, e.filePath);
+  }
+  if (e instanceof ManifestFileNotFoundError) {
+    return new FileNotFoundError(source, e.filePath);
+  }
+  throw e;
 }
 
 export async function expandVariableWithFunction(
@@ -42,129 +76,20 @@ export async function expandVariableWithFunction(
   manifestType: ManifestType,
   fromPath: string
 ): Promise<Result<string, FxError>> {
-  const regex = /\$\[ *[a-zA-Z][a-zA-Z]*\([^\]]*\) *\]/g;
-  const matches = content.match(regex);
-
-  if (!matches) {
-    return ok(content); // no function
-  }
-  let count = 0;
-  for (const placeholder of matches) {
-    const processedRes = await processFunction(
-      placeholder.slice(2, -1).trim(),
-      ctx,
-      envs,
-      fromPath
-    );
-    if (processedRes.isErr()) {
-      return err(processedRes.error);
-    }
-    let value = processedRes.value;
-    if (isJson && value) {
-      value = JSON.stringify(value).slice(1, -1);
-    }
-    if (value) {
-      count += 1;
-      content = content.replace(placeholder, value);
-    }
+  let resolved: { content: string; functionCount: number };
+  try {
+    resolved = await expandFileFunctionMacros(content, isJson, { envs, fromPath });
+  } catch (e) {
+    return err(toFxError(e, ctx));
   }
 
-  if (count > 0) {
+  if (resolved.functionCount > 0) {
     ctx.telemetryReporter.sendTelemetryEvent(telemetryEvent, {
       [TelemetryPropertyKey.manifestType]: manifestType.toString(),
-      [TelemetryPropertyKey.functionCount]: count.toString(),
+      [TelemetryPropertyKey.functionCount]: resolved.functionCount.toString(),
     });
   }
-  return ok(content);
-}
-
-async function processFunction(
-  content: string,
-  ctx: DriverContext,
-  envs: { [key in string]: string } | undefined,
-  path: string
-): Promise<Result<string, FxError>> {
-  const firstTrimmedContent = content.trim();
-  if (!firstTrimmedContent.startsWith("file(") || !firstTrimmedContent.endsWith(")")) {
-    ctx.logProvider.error(
-      getLocalizedString("core.envFunc.unsupportedFunction.errorLog", firstTrimmedContent, "file")
-    );
-    return err(new InvalidFunctionError(ctx.platform));
-  }
-
-  // file()
-  const trimmedParameter = content.slice(5, -1).trim();
-  if (trimmedParameter[0] === "'" && trimmedParameter[trimmedParameter.length - 1] === "'") {
-    // static string as function parameter
-    const res = await readFileContent(
-      trimmedParameter.substring(1, trimmedParameter.length - 1),
-      ctx,
-      envs,
-      path
-    );
-    return res;
-  } else if (trimmedParameter.startsWith("${{") && trimmedParameter.endsWith("}}")) {
-    // env variable inside
-    const resolvedParameter = expandEnvironmentVariable(trimmedParameter, envs);
-
-    const res = readFileContent(resolvedParameter, ctx, envs, path);
-    return res;
-  } else if (trimmedParameter.startsWith("file(") && trimmedParameter.endsWith(")")) {
-    // nested function inside
-    const processsedRes = await processFunction(trimmedParameter, ctx, envs, path);
-
-    if (processsedRes.isErr()) {
-      return err(processsedRes.error);
-    }
-
-    const readFileRes = await readFileContent(processsedRes.value, ctx, envs, path);
-    return readFileRes;
-  } else {
-    // invalid content inside function
-    ctx.logProvider.error(
-      getLocalizedString("core.envFunc.invalidFunctionParameter.errorLog", trimmedParameter, "file")
-    );
-    return err(new InvalidFunctionParameter(ctx.platform));
-  }
-}
-
-async function readFileContent(
-  filePath: string,
-  ctx: DriverContext,
-  envs: { [key in string]: string } | undefined,
-  fromPath: string
-): Promise<Result<string, FxError>> {
-  const ext = path.extname(filePath);
-  if (ext.toLowerCase() !== ".txt" && ext.toLowerCase() !== ".md") {
-    ctx.logProvider.error(
-      getLocalizedString("core.envFunc.unsupportedFile.errorLog", filePath, "txt")
-    );
-    return err(new UnsupportedFileFormatError(ctx.platform));
-  }
-
-  const absolutePath = getAbsolutePath(filePath, fromPath);
-  if (await fs.pathExists(absolutePath)) {
-    try {
-      let fileContent = await fs.readFile(absolutePath, "utf8");
-      fileContent = stripBom(fileContent);
-      let processedFileContent = expandEnvironmentVariable(fileContent, envs);
-      processedFileContent = processedFileContent.replace(/\r\n/g, "\n");
-      return ok(processedFileContent);
-    } catch (e) {
-      ctx.logProvider.error(
-        getLocalizedString("core.envFunc.readFile.errorLog", absolutePath, e?.toString())
-      );
-      return err(new ReadFileError(ctx.platform, absolutePath));
-    }
-  } else {
-    return err(new FileNotFoundError(source, filePath));
-  }
-}
-
-function getAbsolutePath(relativeOrAbsolutePath: string, fromPath: string): string {
-  return path.isAbsolute(relativeOrAbsolutePath)
-    ? relativeOrAbsolutePath
-    : path.join(path.dirname(fromPath), relativeOrAbsolutePath);
+  return ok(resolved.content);
 }
 
 class UnsupportedFileFormatError extends UserError {

--- a/packages/fx-core/tests/component/driver/teamsApp/manifestUtils.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/manifestUtils.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
 import mockedEnv, { RestoreFn } from "mocked-env";
+import os from "os";
 import path from "path";
 import { assert, vi } from "vitest";
 import {
@@ -527,13 +528,18 @@ describe("trimManifestShortName", () => {
 describe("resolveLocFile", () => {
   const sandbox = vi;
   let mockedEnvRestore: RestoreFn;
+  let tmpDir: string | undefined;
 
-  afterEach(() => {
+  afterEach(async () => {
     if (mockedEnvRestore) {
       mockedEnvRestore();
     }
     vi.restoreAllMocks();
     vi.restoreAllMocks();
+    if (tmpDir) {
+      await fs.remove(tmpDir);
+      tmpDir = undefined;
+    }
   });
 
   it("returns error when loc file doesn't exist", async () => {
@@ -582,21 +588,17 @@ describe("resolveLocFile", () => {
   });
 
   it("resolves $[file(...)] when context is provided", async () => {
-    vi.spyOn(fs, "pathExists").mockImplementation(async (filePath) => {
-      return filePath === "loc_file_path" || filePath === "instruction.txt";
-    });
-    vi.spyOn(fs, "readFile").mockImplementation(((filePath: number | fs.PathLike) => {
-      if (filePath === "loc_file_path") {
-        return Promise.resolve(
-          JSON.stringify({
-            name: {
-              short: "$[file('instruction.txt')]",
-            },
-          })
-        );
-      }
-      return Promise.resolve("localized short name");
-    }) as any);
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "resolveloc-"));
+    const locFilePath = path.join(tmpDir, "loc_file.json");
+    await fs.writeFile(
+      locFilePath,
+      JSON.stringify({
+        name: {
+          short: "$[file('instruction.txt')]",
+        },
+      })
+    );
+    await fs.writeFile(path.join(tmpDir, "instruction.txt"), "localized short name");
 
     const context: any = {
       platform: Platform.VSCode,
@@ -608,7 +610,7 @@ describe("resolveLocFile", () => {
       },
     };
 
-    const locFile = await manifestUtils.resolveLocFile("loc_file_path", context);
+    const locFile = await manifestUtils.resolveLocFile(locFilePath, context);
 
     assert.isTrue(locFile.isOk());
     if (locFile.isOk()) {

--- a/packages/fx-core/tests/component/util/envFunctionUtils.test.ts
+++ b/packages/fx-core/tests/component/util/envFunctionUtils.test.ts
@@ -1,4 +1,6 @@
 import fs from "fs-extra";
+import os from "os";
+import path from "path";
 import mockedEnv, { RestoreFn } from "mocked-env";
 import { setTools } from "../../../src/common/globalVars";
 import { MockTools } from "../../core/utils";
@@ -24,10 +26,15 @@ describe("expandVariableWithFunction", async () => {
   };
 
   let mockedEnvRestore: RestoreFn | undefined;
-  afterEach(() => {
+  let tmpDir: string | undefined;
+  afterEach(async () => {
     vi.restoreAllMocks();
     if (mockedEnvRestore) {
       mockedEnvRestore();
+    }
+    if (tmpDir) {
+      await fs.remove(tmpDir);
+      tmpDir = undefined;
     }
   });
 
@@ -48,23 +55,16 @@ describe("expandVariableWithFunction", async () => {
   it("happy path with placeholders", async () => {
     mockedEnvRestore = mockedEnv({
       TEST_ENV: "test",
-      FILE_PATH: "testfile1.txt",
+      FILE_PATH: "byEnv.txt",
     });
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "envfunc-"));
+    await fs.writeFile(path.join(tmpDir, "simple.md"), "description in ${{TEST_ENV}}");
+    await fs.writeFile(path.join(tmpDir, "outer.txt"), "inner.txt");
+    await fs.writeFile(path.join(tmpDir, "inner.txt"), "description in ${{TEST_ENV}}");
+    await fs.writeFile(path.join(tmpDir, "byEnv.txt"), "description in ${{TEST_ENV}}");
+
     const content =
-      "description:\"$[file('testfile1.md')]\",description2:\"$[file( file( 'C://testfile2.txt' ))] $[file(${{FILE_PATH}})]\"";
-    vi.spyOn(fs, "pathExists").mockResolvedValue(true);
-    vi.spyOn(fs, "readFile").mockImplementation((file: number | fs.PathLike) => {
-      if (file.toString().endsWith("testfile1.txt")) {
-        return Promise.resolve("description in ${{TEST_ENV}}" as any);
-      } else if (file.toString().endsWith("testfile2.txt")) {
-        return Promise.resolve("test/testfile1.txt" as any);
-      }
-      if (file.toString().endsWith("testfile1.md")) {
-        return Promise.resolve("description in ${{TEST_ENV}}" as any);
-      } else {
-        throw new Error("not support " + file);
-      }
-    });
+      "description:\"$[file('simple.md')]\",description2:\"$[file( file( 'outer.txt' ))] $[file(${{FILE_PATH}})]\"";
 
     const res = await expandVariableWithFunction(
       content,
@@ -72,7 +72,7 @@ describe("expandVariableWithFunction", async () => {
       undefined,
       true,
       ManifestType.DeclarativeCopilotManifest,
-      "C://test.json"
+      path.join(tmpDir, "manifest.json")
     );
     if (res.isErr()) {
       console.log(res.error);
@@ -155,12 +155,10 @@ describe("expandVariableWithFunction", async () => {
       TEST_ENV: "test",
       FILE_PATH: "testfile1.txt",
     });
-    const content = "description:\"$[ file('testfile1.txt')]\"C://test";
-
-    vi.spyOn(fs, "pathExists").mockResolvedValue(true);
-    vi.spyOn(fs, "readFile").mockImplementation((file: number | fs.PathLike) => {
-      throw new Error("not support " + file);
-    });
+    // Make the target path a directory so the real readFile throws (EISDIR).
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "envfunc-"));
+    await fs.mkdirp(path.join(tmpDir, "testfile1.txt"));
+    const content = "description:\"$[ file('testfile1.txt')]\"";
 
     let res = await expandVariableWithFunction(
       content,
@@ -168,7 +166,7 @@ describe("expandVariableWithFunction", async () => {
       undefined,
       true,
       ManifestType.DeclarativeCopilotManifest,
-      "C://test"
+      path.join(tmpDir, "manifest.json")
     );
     assert.isTrue(
       res.isErr() &&
@@ -182,7 +180,7 @@ describe("expandVariableWithFunction", async () => {
       undefined,
       true,
       ManifestType.DeclarativeCopilotManifest,
-      "C://test"
+      path.join(tmpDir, "manifest.json")
     );
     assert.isTrue(res.isErr() && res.error.name === "ReadFileError");
   });
@@ -192,12 +190,12 @@ describe("expandVariableWithFunction", async () => {
       TEST_ENV: "test",
       FILE_PATH: "testfile1.txt",
     });
-    const content = "description:\"$[ file(file('testfile1.txt'))]\"C://test";
-
-    vi.spyOn(fs, "pathExists").mockResolvedValue(true);
-    vi.spyOn(fs, "readFile").mockImplementation((file: number | fs.PathLike) => {
-      throw new Error("not support " + file);
-    });
+    // Inner file() resolves to a path whose target is a directory, so the
+    // outer read throws (EISDIR).
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "envfunc-"));
+    await fs.writeFile(path.join(tmpDir, "testfile1.txt"), "erroring.txt");
+    await fs.mkdirp(path.join(tmpDir, "erroring.txt"));
+    const content = "description:\"$[ file(file('testfile1.txt'))]\"";
 
     let res = await expandVariableWithFunction(
       content,
@@ -205,7 +203,7 @@ describe("expandVariableWithFunction", async () => {
       undefined,
       true,
       ManifestType.DeclarativeCopilotManifest,
-      "C://test"
+      path.join(tmpDir, "manifest.json")
     );
 
     assert.isTrue(
@@ -220,7 +218,7 @@ describe("expandVariableWithFunction", async () => {
       undefined,
       true,
       ManifestType.DeclarativeCopilotManifest,
-      "C://test"
+      path.join(tmpDir, "manifest.json")
     );
     assert.isTrue(res.isErr() && res.error.name === "ReadFileError");
   });
@@ -230,9 +228,8 @@ describe("expandVariableWithFunction", async () => {
       TEST_ENV: "test",
       FILE_PATH: "testfile1.txt",
     });
-    const content = "description:\"$[ file('testfile1.txt')]\"C://test";
-
-    vi.spyOn(fs, "pathExists").mockResolvedValue(false);
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "envfunc-"));
+    const content = "description:\"$[ file('testfile1.txt')]\"";
 
     const res = await expandVariableWithFunction(
       content,
@@ -240,7 +237,7 @@ describe("expandVariableWithFunction", async () => {
       undefined,
       true,
       ManifestType.DeclarativeCopilotManifest,
-      "C://test"
+      path.join(tmpDir, "manifest.json")
     );
     assert.isTrue(res.isErr() && res.error instanceof FileNotFoundError);
   });

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -21,6 +21,7 @@ import { PluginManifestSchema } from "./pluginManifest";
 export * from "./declarativeCopilotManifest";
 export * from "./generated-types";
 export * from "./manifest";
+export * from "./manifestTemplate";
 export * from "./pluginManifest";
 export * from "./wrappers";
 

--- a/packages/manifest/src/manifestTemplate.ts
+++ b/packages/manifest/src/manifestTemplate.ts
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Host-agnostic resolution of manifest templating: the `${{ENV}}` environment
+// variable syntax and the `$[file('<path>')]` function syntax. This logic was
+// previously entangled with fx-core's DriverContext (telemetry, logging, i18n,
+// FxError). It is relocated here so consumers such as the SPFx build pipeline can
+// resolve declarative-agent manifests without depending on @microsoft/teamsfx-core
+// or a DriverContext. fx-core keeps telemetry and localized-error mapping and
+// delegates the resolution itself to the functions below.
+
+import path from "path";
+import fs from "fs-extra";
+import stripBom from "strip-bom";
+
+const placeholderRegex = /\${{ *[a-zA-Z_][a-zA-Z0-9_]* *}}/g;
+const functionRegex = /\$\[ *[a-zA-Z][a-zA-Z]*\([^\]]*\) *\]/g;
+
+export enum ManifestType {
+  TeamsManifest = "teams-manifest",
+  PluginManifest = "plugin-manifest",
+  DeclarativeCopilotManifest = "declarative-copilot-manifest",
+  ApiSpec = "api-spec",
+  EmbeddedKnowledgeFile = "embedded-knowledge-file",
+}
+
+export interface ResolveManifestOptions {
+  // Explicit environment map. When omitted, process.env is used.
+  envs?: { [key in string]: string };
+  // Absolute path of the manifest file being resolved. `file()` paths are
+  // resolved relative to this file's directory.
+  fromPath: string;
+  manifestType: ManifestType;
+  // Optional diagnostic sink, replacing DriverContext.logProvider.
+  logger?: { error: (message: string) => void };
+}
+
+// Base error for all template-resolution failures. Consumers can catch this to
+// distinguish resolution errors from unexpected exceptions. Subclasses carry the
+// offending path/token so a host (e.g. fx-core) can remap them to its own errors.
+export class ManifestTemplateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ManifestTemplateError";
+  }
+}
+
+export class UnsupportedFileFormatError extends ManifestTemplateError {
+  constructor(public readonly filePath: string) {
+    super("The file to be embedded must be a .txt or .md file.");
+    this.name = "UnsupportedFileFormatError";
+  }
+}
+
+export class InvalidFunctionError extends ManifestTemplateError {
+  constructor(public readonly token: string) {
+    super("Unsupported function. Only the 'file' function is supported.");
+    this.name = "InvalidFunctionError";
+  }
+}
+
+export class InvalidFunctionParameterError extends ManifestTemplateError {
+  constructor(public readonly token: string) {
+    super("Invalid parameter for the 'file' function.");
+    this.name = "InvalidFunctionParameterError";
+  }
+}
+
+export class ReadFileError extends ManifestTemplateError {
+  constructor(
+    public readonly filePath: string,
+    public readonly cause?: unknown
+  ) {
+    super(`Failed to read file '${filePath}'.`);
+    this.name = "ReadFileError";
+  }
+}
+
+export class FileNotFoundError extends ManifestTemplateError {
+  constructor(public readonly filePath: string) {
+    super(`File not found: '${filePath}'.`);
+    this.name = "FileNotFoundError";
+  }
+}
+
+export class MissingEnvironmentVariablesError extends ManifestTemplateError {
+  constructor(public readonly names: string) {
+    super(`The following environment variables are not defined: ${names}.`);
+    this.name = "MissingEnvironmentVariablesError";
+  }
+}
+
+// Expand `${{ENV_NAME}}` references in content. A value not present in
+// `envs`/process.env leaves the placeholder untouched, except APP_NAME_SUFFIX
+// which is substituted whenever it is explicitly set (including empty string).
+export function expandEnvironmentVariable(
+  content: string,
+  envs?: { [key in string]: string }
+): string {
+  const placeholders = content.match(placeholderRegex);
+  if (placeholders) {
+    for (const placeholder of placeholders) {
+      const envName = placeholder.slice(3, -2).trim(); // removes `${{` and `}}`
+      const envValue = envs ? envs[envName] : process.env[envName];
+      if (envName === "APP_NAME_SUFFIX") {
+        if (envValue !== undefined && envValue !== null) {
+          content = content.replace(placeholder, envValue);
+        }
+      } else {
+        if (envValue) {
+          content = content.replace(placeholder, envValue);
+        }
+      }
+    }
+  }
+  return content;
+}
+
+// Return the de-duplicated list of `${{ENV_NAME}}` variables referenced in content.
+export function getEnvironmentVariables(content: string): string[] {
+  const placeholders = content.match(placeholderRegex);
+  if (placeholders) {
+    const variables = placeholders.map((placeholder) => placeholder.slice(3, -2).trim());
+    return [...new Set(variables)];
+  }
+  return [];
+}
+
+function getAbsolutePath(relativeOrAbsolutePath: string, fromPath: string): string {
+  return path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.join(path.dirname(fromPath), relativeOrAbsolutePath);
+}
+
+async function readFileContent(
+  filePath: string,
+  envs: { [key in string]: string } | undefined,
+  fromPath: string,
+  logger?: { error: (message: string) => void }
+): Promise<string> {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext !== ".txt" && ext !== ".md") {
+    logger?.error(`Unsupported file '${filePath}'. Only .txt and .md files are supported.`);
+    throw new UnsupportedFileFormatError(filePath);
+  }
+
+  const absolutePath = getAbsolutePath(filePath, fromPath);
+  if (await fs.pathExists(absolutePath)) {
+    try {
+      let fileContent = await fs.readFile(absolutePath, "utf8");
+      fileContent = stripBom(fileContent);
+      let processedFileContent = expandEnvironmentVariable(fileContent, envs);
+      processedFileContent = processedFileContent.replace(/\r\n/g, "\n");
+      return processedFileContent;
+    } catch (e) {
+      logger?.error(`Failed to read file '${absolutePath}': ${(e as Error)?.toString()}`);
+      throw new ReadFileError(absolutePath, e);
+    }
+  }
+  throw new FileNotFoundError(filePath);
+}
+
+// Resolve a single `file(...)` call (the text inside `$[ ... ]`) to its embedded,
+// env-expanded file content. Supports a single-quoted static path, a `${{env}}`
+// parameter, and a nested `file(file(...))` call.
+export async function processManifestFunction(
+  content: string,
+  envs: { [key in string]: string } | undefined,
+  fromPath: string,
+  logger?: { error: (message: string) => void }
+): Promise<string> {
+  const firstTrimmedContent = content.trim();
+  if (!firstTrimmedContent.startsWith("file(") || !firstTrimmedContent.endsWith(")")) {
+    logger?.error(`Unsupported function '${firstTrimmedContent}'. Only 'file' is supported.`);
+    throw new InvalidFunctionError(firstTrimmedContent);
+  }
+
+  const trimmedParameter = content.slice(5, -1).trim();
+  if (trimmedParameter[0] === "'" && trimmedParameter[trimmedParameter.length - 1] === "'") {
+    // static string as function parameter
+    return readFileContent(
+      trimmedParameter.substring(1, trimmedParameter.length - 1),
+      envs,
+      fromPath,
+      logger
+    );
+  } else if (trimmedParameter.startsWith("${{") && trimmedParameter.endsWith("}}")) {
+    // env variable inside
+    const resolvedParameter = expandEnvironmentVariable(trimmedParameter, envs);
+    return readFileContent(resolvedParameter, envs, fromPath, logger);
+  } else if (trimmedParameter.startsWith("file(") && trimmedParameter.endsWith(")")) {
+    // nested function inside
+    const nested = await processManifestFunction(trimmedParameter, envs, fromPath, logger);
+    return readFileContent(nested, envs, fromPath, logger);
+  } else {
+    logger?.error(`Invalid parameter '${trimmedParameter}' for the 'file' function.`);
+    throw new InvalidFunctionParameterError(trimmedParameter);
+  }
+}
+
+// Expand every `$[file('<path>')]` call in content. When `isJson` is true the
+// embedded content is JSON-string escaped so it can be inlined into a JSON string.
+// Returns the resolved content along with the number of calls that produced a
+// value, so a host can report telemetry.
+export async function expandFileFunctionMacros(
+  content: string,
+  isJson: boolean,
+  options: Pick<ResolveManifestOptions, "envs" | "fromPath" | "logger">
+): Promise<{ content: string; functionCount: number }> {
+  const matches = content.match(functionRegex);
+  if (!matches) {
+    return { content, functionCount: 0 };
+  }
+  let functionCount = 0;
+  for (const placeholder of matches) {
+    let value = await processManifestFunction(
+      placeholder.slice(2, -1).trim(),
+      options.envs,
+      options.fromPath,
+      options.logger
+    );
+    if (isJson && value) {
+      value = JSON.stringify(value).slice(1, -1);
+    }
+    if (value) {
+      functionCount += 1;
+      content = content.replace(placeholder, value);
+    }
+  }
+  return { content, functionCount };
+}
+
+// Fully resolve a manifest template string: expand `$[file()]` calls (except for
+// ApiSpec) then `${{ENV}}` variables, failing if any variable is left unresolved.
+// This is the host-agnostic counterpart of fx-core's getResolvedManifest.
+export async function resolveManifest(
+  content: string,
+  options: ResolveManifestOptions
+): Promise<string> {
+  let value = content;
+  if (options.manifestType !== ManifestType.ApiSpec) {
+    value = (await expandFileFunctionMacros(content, true, options)).content;
+    value = expandEnvironmentVariable(value, options.envs);
+  } else {
+    value = expandEnvironmentVariable(value, options.envs);
+  }
+
+  const notExpandedVars = getEnvironmentVariables(value);
+  if (notExpandedVars.length > 0) {
+    throw new MissingEnvironmentVariablesError(notExpandedVars.join(","));
+  }
+  return value;
+}

--- a/packages/manifest/test/manifestTemplate.test.ts
+++ b/packages/manifest/test/manifestTemplate.test.ts
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { assert } from "chai";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import {
+  expandEnvironmentVariable,
+  getEnvironmentVariables,
+  expandFileFunctionMacros,
+  processManifestFunction,
+  resolveManifest,
+  ManifestType,
+  UnsupportedFileFormatError,
+  InvalidFunctionError,
+  InvalidFunctionParameterError,
+  ReadFileError,
+  FileNotFoundError,
+  MissingEnvironmentVariablesError,
+} from "../src/manifestTemplate";
+
+describe("manifestTemplate", () => {
+  let tmpDir: string;
+  let fromPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "manifest-template-"));
+    fromPath = path.join(tmpDir, "declarativeAgent.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFixture(name: string, content: string): void {
+    fs.writeFileSync(path.join(tmpDir, name), content);
+  }
+
+  describe("expandEnvironmentVariable", () => {
+    it("replaces a defined variable", () => {
+      assert.strictEqual(expandEnvironmentVariable("a ${{FOO}} b", { FOO: "x" }), "a x b");
+    });
+
+    it("leaves an undefined variable untouched", () => {
+      assert.strictEqual(expandEnvironmentVariable("a ${{FOO}} b", {}), "a ${{FOO}} b");
+    });
+
+    it("substitutes APP_NAME_SUFFIX even when empty", () => {
+      assert.strictEqual(
+        expandEnvironmentVariable("name${{APP_NAME_SUFFIX}}", { APP_NAME_SUFFIX: "" }),
+        "name"
+      );
+    });
+  });
+
+  describe("getEnvironmentVariables", () => {
+    it("returns de-duplicated variable names", () => {
+      assert.deepStrictEqual(getEnvironmentVariables("${{A}} ${{B}} ${{A}}"), ["A", "B"]);
+    });
+
+    it("returns an empty array when there are none", () => {
+      assert.deepStrictEqual(getEnvironmentVariables("no placeholders"), []);
+    });
+  });
+
+  describe("expandFileFunctionMacros", () => {
+    it("inlines a .txt file", async () => {
+      writeFixture("instruction.txt", "hello");
+      const out = await expandFileFunctionMacros("$[file('instruction.txt')]", false, {
+        fromPath,
+      });
+      assert.strictEqual(out.content, "hello");
+      assert.strictEqual(out.functionCount, 1);
+    });
+
+    it("JSON-escapes inlined content when isJson is true", async () => {
+      writeFixture("instruction.txt", 'a "quote"\r\nsecond');
+      const out = await expandFileFunctionMacros(`{"i":"$[file('instruction.txt')]"}`, true, {
+        fromPath,
+      });
+      assert.strictEqual(JSON.parse(out.content).i, 'a "quote"\nsecond');
+    });
+
+    it("strips a leading BOM and normalizes CRLF", async () => {
+      writeFixture("bom.md", "\uFEFFline1\r\nline2");
+      const out = await expandFileFunctionMacros("$[file('bom.md')]", false, { fromPath });
+      assert.strictEqual(out.content, "line1\nline2");
+    });
+
+    it("expands ${{env}} inside the embedded file", async () => {
+      writeFixture("instruction.txt", "value is ${{FOO}}");
+      const out = await expandFileFunctionMacros("$[file('instruction.txt')]", false, {
+        fromPath,
+        envs: { FOO: "bar" },
+      });
+      assert.strictEqual(out.content, "value is bar");
+    });
+
+    it("resolves an env variable used as the file() parameter", async () => {
+      writeFixture("byEnv.txt", "content");
+      const out = await expandFileFunctionMacros("$[file(${{FILE_PATH}})]", false, {
+        fromPath,
+        envs: { FILE_PATH: "byEnv.txt" },
+      });
+      assert.strictEqual(out.content, "content");
+    });
+
+    it("resolves a nested file(file(...)) call", async () => {
+      writeFixture("outer.txt", "inner.txt");
+      writeFixture("inner.txt", "nested content");
+      const out = await expandFileFunctionMacros("$[file( file( 'outer.txt' ))]", false, {
+        fromPath,
+      });
+      assert.strictEqual(out.content, "nested content");
+    });
+
+    it("leaves content without a function untouched", async () => {
+      const out = await expandFileFunctionMacros("no macros here", false, { fromPath });
+      assert.strictEqual(out.content, "no macros here");
+      assert.strictEqual(out.functionCount, 0);
+    });
+  });
+
+  describe("processManifestFunction errors", () => {
+    it("throws InvalidFunctionError for a non-file function", async () => {
+      try {
+        await processManifestFunction("env('X')", undefined, fromPath);
+        assert.fail("should have thrown");
+      } catch (e) {
+        assert.instanceOf(e, InvalidFunctionError);
+        assert.strictEqual((e as InvalidFunctionError).token, "env('X')");
+      }
+    });
+
+    it("throws InvalidFunctionParameterError for an unquoted parameter", async () => {
+      try {
+        await processManifestFunction("file(instruction.md)", undefined, fromPath);
+        assert.fail("should have thrown");
+      } catch (e) {
+        assert.instanceOf(e, InvalidFunctionParameterError);
+      }
+    });
+
+    it("throws UnsupportedFileFormatError for a disallowed extension", async () => {
+      try {
+        await processManifestFunction("file('logo.png')", undefined, fromPath);
+        assert.fail("should have thrown");
+      } catch (e) {
+        assert.instanceOf(e, UnsupportedFileFormatError);
+        assert.strictEqual((e as UnsupportedFileFormatError).filePath, "logo.png");
+      }
+    });
+
+    it("throws FileNotFoundError when the file is absent", async () => {
+      try {
+        await processManifestFunction("file('missing.txt')", undefined, fromPath);
+        assert.fail("should have thrown");
+      } catch (e) {
+        assert.instanceOf(e, FileNotFoundError);
+      }
+    });
+
+    it("throws ReadFileError when the target cannot be read", async () => {
+      // A directory at the target path makes readFile fail (EISDIR).
+      fs.mkdirSync(path.join(tmpDir, "instruction.txt"));
+      try {
+        await processManifestFunction("file('instruction.txt')", undefined, fromPath);
+        assert.fail("should have thrown");
+      } catch (e) {
+        assert.instanceOf(e, ReadFileError);
+        assert.isDefined((e as ReadFileError).cause);
+      }
+    });
+  });
+
+  describe("resolveManifest", () => {
+    it("expands file() then env for a declarative-agent manifest", async () => {
+      writeFixture("instruction.txt", "do ${{TASK}}");
+      const out = await resolveManifest(`{"i":"$[file('instruction.txt')]"}`, {
+        fromPath,
+        manifestType: ManifestType.DeclarativeCopilotManifest,
+        envs: { TASK: "things" },
+      });
+      assert.strictEqual(JSON.parse(out).i, "do things");
+    });
+
+    it("skips file() expansion for an ApiSpec", async () => {
+      const input = "$[file('instruction.txt')]";
+      const out = await resolveManifest(input, {
+        fromPath,
+        manifestType: ManifestType.ApiSpec,
+      });
+      assert.strictEqual(out, input);
+    });
+
+    it("throws MissingEnvironmentVariablesError for an unresolved variable", async () => {
+      try {
+        await resolveManifest("${{NOPE}}", {
+          fromPath,
+          manifestType: ManifestType.DeclarativeCopilotManifest,
+          envs: {},
+        });
+        assert.fail("should have thrown");
+      } catch (e) {
+        assert.instanceOf(e, MissingEnvironmentVariablesError);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Moves the `DriverContext`-free parts of fx-core's manifest templating
(`$[file('...')]` function expansion and `${{ENV}}` variable expansion) down into
`@microsoft/app-manifest`, so the logic can be consumed directly from the manifest
package without depending on `@microsoft/teamsfx-core`, a `DriverContext`,
localization, or `UserError`.

This is a behavior-preserving refactor. fx-core now delegates to the moved logic
and keeps only its host concerns (telemetry + localized error mapping).

## What moves where

**Relocated into `@microsoft/app-manifest`** (single source of truth):
- `expandEnvironmentVariable` / `getEnvironmentVariables` — moved verbatim from
  `fx-core/src/component/utils/common.ts`.
- The `file()` function resolver and file reader — moved from
  `fx-core/src/component/utils/envFunctionUtils.ts`, decoupled from `DriverContext`
  and raising plain typed errors that carry the offending path/token.
- The `ManifestType` enum.
- Also exposes `expandFileFunctionMacros` (the resolution loop, returning the
  expanded content plus a function count for host telemetry) and `resolveManifest`,
  the host-agnostic counterpart of fx-core's `getResolvedManifest`.
- Reuses the package's existing `strip-bom` and `fs-extra` usage — no new deps.

**Left in fx-core** (host concerns only):
- `common.ts` re-exports `expandEnvironmentVariable` / `getEnvironmentVariables`
  from `@microsoft/teamsfx-api`, so all existing call sites are unchanged.
- `expandVariableWithFunction` delegates its loop to `expandFileFunctionMacros`,
  keeping the telemetry event and mapping the resolver's plain errors to localized
  `UserError` / fx-core `FileNotFoundError` via `toFxError`.
- `getResolvedManifest` is unchanged and keeps composing these primitives (its
  telemetry is preserved exactly).

## Testing

- `@microsoft/app-manifest` unit suite: 184 passing (`manifestTemplate.ts` at
  100% statements / 95% branch / 100% functions).
- `@microsoft/teamsfx-core`: the affected suites plus every consumer of the
  re-exported env functions (aad manifest builder, common utils, scenarios,
  declarative-agent generator) pass — no regressions.
- Affected tests were updated to drive resolution through real temp files instead
  of `fs` mocks, since file reads now happen inside `@microsoft/app-manifest`.
- Lint / `lint-staged` clean on all changed files.

## Notes / follow-ups

- **Public API naming** — `resolveManifest`, `expandFileFunctionMacros`, and
  `processManifestFunction` are new public exports on `@microsoft/app-manifest`.
  Happy to adjust the names/shape if the team prefers a different surface.
- **Schema-validation packaging** — separate from this PR, but noting it here:
  `AppManifestUtils.fetchSchema` is local-first (maps the manifest `$schema` URL to
  a bundled `build/json-schemas/...` file, with the network only as a fallback).
  The source bundles the schemas (`src/json-schemas/`, `prebuild: copy-json-schema`,
  `files: ["build/**/*"]`), but the published tarball does not include
  `build/json-schemas/`, so offline validation silently falls back to a network
  fetch. Fixing the publish so the schemas ship would make schema validation fully
  hermetic with no code change. Can file/fix separately if useful.
- **CI** — I validated the affected suites and all consumers of the re-exported
  functions locally; a full `@microsoft/teamsfx-core` suite run in CI is worth a
  glance (the 3 unrelated pre-existing failures need bundled template artifacts that
  a plain bootstrap doesn't produce).

Opened as a draft to gather feedback on the API surface before finalizing.
