### PR TITLE
ci: fix vscuse per-case report link for single-plan runs

### DIFF
--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -364,12 +364,17 @@ jobs:
             echo "No run_result.txt found" > error.txt
           fi
 
+          # Copy to a uniquely named file so the report job can recover the test
+          # plan identity from the file name even when download-artifact flattens a
+          # single artifact into the download root (no per-artifact subdirectory).
+          cp error.txt "error-${{ matrix.test_plan }}-${{ github.run_id }}.txt"
+
       - name: Upload error file
         if: always()
         uses: actions/upload-artifact@v6
         with:
           name: error-file-${{ matrix.test_plan }}-${{ github.run_id }}
-          path: error.txt
+          path: error-${{ matrix.test_plan }}-${{ github.run_id }}.txt
           retention-days: 7
           if-no-files-found: ignore
 
@@ -436,7 +441,7 @@ jobs:
 
           Write-Host "🌐Here is the report: $storageUrl"
 
-          echo "$storageUrl" > storage_url.txt
+          echo "$storageUrl" > "storage_url-${{ matrix.test_plan }}-${{ github.run_id }}.txt"
 
           az storage blob upload-batch `
             --account-name $account `
@@ -452,7 +457,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: storage-url-${{ matrix.test_plan }}-${{ github.run_id }}
-          path: storage_url.txt
+          path: storage_url-${{ matrix.test_plan }}-${{ github.run_id }}.txt
           retention-days: 7
           if-no-files-found: ignore
 
@@ -523,12 +528,14 @@ jobs:
         with:
           pattern: storage-url-*
           path: /tmp/storage-urls
+          merge-multiple: true
 
       - name: Download error files
         uses: actions/download-artifact@v7
         with:
           pattern: error-file-*
           path: /tmp/error-files
+          merge-multiple: true
 
       - name: Process storage URLs
         shell: bash
@@ -540,13 +547,13 @@ jobs:
             echo "{" > /tmp/url_mapping.json
             first_entry=true
 
-            find /tmp/storage-urls -type f -name "storage_url.txt" | while read file; do
-              dir_name=$(basename $(dirname "$file"))
-              run_id=$(echo "$dir_name" | rev | cut -d'-' -f1 | rev)
-              test_plan=$(echo "$dir_name" | sed "s/^storage-url-//" | sed "s/-${run_id}$//")
-              case_run_id="${test_plan}-${run_id}"
+            find /tmp/storage-urls -type f -name "storage_url-*.txt" | while read file; do
+              # Identity is encoded in the file name (storage_url-<test_plan>-<run_id>.txt)
+              # rather than the parent directory, so this works whether download-artifact
+              # nests each artifact in its own folder or flattens a single one.
+              case_run_id=$(basename "$file" | sed "s/^storage_url-//" | sed "s/\.txt$//")
 
-              echo "Processing: dir_name=$dir_name, test_plan=$test_plan, run_id=$run_id, case_run_id=$case_run_id"
+              echo "Processing: file=$file, case_run_id=$case_run_id"
 
               content_json=$(cat "$file" | tr -d '\n' | tr -d '\r' | jq -Rs .)
 
@@ -565,7 +572,7 @@ jobs:
             echo "Generated JSON mapping:"
             cat /tmp/url_mapping.json
 
-            total_urls=$(find /tmp/storage-urls -type f -name "storage_url.txt" | wc -l)
+            total_urls=$(find /tmp/storage-urls -type f -name "storage_url-*.txt" | wc -l)
             echo "Total storage URL files processed: $total_urls"
           else
             echo "No storage URL artifacts found"
@@ -583,13 +590,12 @@ jobs:
             echo "{" > /tmp/error_mapping.json
             first_entry=true
 
-            find /tmp/error-files -type f -name "error.txt" | while read file; do
-              dir_name=$(basename $(dirname "$file"))
-              run_id=$(echo "$dir_name" | rev | cut -d'-' -f1 | rev)
-              test_plan=$(echo "$dir_name" | sed "s/^error-file-//" | sed "s/-${run_id}$//")
-              case_run_id="${test_plan}-${run_id}"
+            find /tmp/error-files -type f -name "error-*.txt" | while read file; do
+              # Identity is encoded in the file name (error-<test_plan>-<run_id>.txt),
+              # which survives both the nested and flattened download-artifact layouts.
+              case_run_id=$(basename "$file" | sed "s/^error-//" | sed "s/\.txt$//")
 
-              echo "Processing error: dir_name=$dir_name, test_plan=$test_plan, run_id=$run_id, case_run_id=$case_run_id"
+              echo "Processing error: file=$file, case_run_id=$case_run_id"
 
               content_json=$(cat "$file" | tr -d '\n' | tr -d '\r' | jq -Rs .)
 


### PR DESCRIPTION
## Problem

In the VscUse UI test pipeline, the aggregated summary table (the **📊 Detailed test report** linked from the PR comment) showed **N/A** in the per-case **REPORT** column whenever a PR ran a **single** test plan — e.g. #16263 (`Feature_UI_Layout__Create_Project_Questions`). The per-case HTML report was actually generated and uploaded to Azure fine; the summary just couldn't link to it.

## Root cause

The `report` job in `ui-test-vscuse-common.yml` maps each case to its report URL by parsing the **parent directory name** of each downloaded `storage-url-*` / `error-file-*` artifact:

```bash
dir_name=$(basename $(dirname "$file"))
test_plan=$(echo "$dir_name" | sed "s/^storage-url-//" | ...)
```

`actions/download-artifact` with `pattern` + `merge-multiple: false` only creates a per-artifact subdirectory when **multiple** artifacts match. When exactly **one** artifact matches (single test plan), the file is flattened into the download root (`/tmp/storage-urls/storage_url.txt`), so `basename(dirname)` becomes `storage-urls` and the derived lookup key is bogus (`storage-urls`). The row builder's lookup (`<case_id>-<run_id>`) then misses and falls back to `N/A`.

Multi-plan nightly runs (40+ artifacts, nested) were unaffected — which is why this only surfaced on PR smoke runs.

## Fix

Stop relying on directory nesting; encode the identity in the artifact **file name** and make the layout deterministic:

- **Producer (case job):** write the per-case files as `storage_url-<test_plan>-<run_id>.txt` and `error-<test_plan>-<run_id>.txt`, and upload those.
- **Consumer (report job):** set `merge-multiple: true` on both downloads (files are now uniquely named, so no collision), and derive `case_run_id` from the file name:
  ```bash
  case_run_id=$(basename "$file" | sed "s/^storage_url-//" | sed "s/\.txt$//")
  ```

This works identically whether `download-artifact` nests each artifact or flattens a single one. File-content reading (the URL / error text) is unchanged.

Relies on existing invariants: test-plan names contain no hyphens (verified) and `run_id` is numeric, so `<test_plan>-<run_id>` reconstructs the exact lookup key used by the summary row builder. Reruns use `rerun-failed-jobs`, which preserves `run_id`.

## Testing

- Validated the workflow YAML parses.
- Traced the failing run (`28576028409`) logs vs. a passing multi-plan run (`28499784564`) to confirm the flatten-vs-nest difference is the sole cause.
- No behavior change expected for multi-plan nightly runs; single-plan PR runs will now show a working per-case **Report** link instead of N/A.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>