### PR TITLE
fix(vscuse): Auto-fix DA_MCP_Oauth_Remote

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -352,7 +352,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:317:38:16:5:0000000000000000",
+        "dhash:317:38:96:5:000000000024d390",
+        "dhash:317:38:0:10:e0c020202020223a"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_d0c53170",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 32,
+    "total_steps": 34,
     "created_at": "2026-06-29T03:21:51.231595",
     "name": "DA_with_MCP Server(Oauth)",
     "description": {
@@ -36,6 +36,8 @@
       "step_5120006b",
       "step_289ade9c",
       "step_d0c53170",
+      "step_d0c53171",
+      "step_d0c53172",
       "step_8ed7e3fe",
       "step_c83f7f58",
       "step_8db1832f",
@@ -341,10 +343,10 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 345,
-        "y": 94
+        "x": 317,
+        "y": 38
       },
-      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code. It is the second item because \"OAuth (with dynamic registration)\" now appears above it.",
+      "description": "Click the search input field in the \"Select Authentication Type\" dropdown dialog of Visual Studio Code to activate it for text entry.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -354,6 +356,48 @@
       "postconditions": [],
       "tags": [],
       "screenshot": "step_d0c53170",
+      "created_at": "2026-06-29T03:21:51.370262",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_d0c53171",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "static"
+      },
+      "description": "Type \"static\" into the \"Select Authentication Type\" filter box to uniquely narrow the list to \"OAuth (with static registration)\".",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-06-29T03:21:51.370262",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_d0c53172",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 296,
+        "y": 72
+      },
+      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code, after typing \"static\" in the filter box.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
       "created_at": "2026-06-29T03:21:51.370262",
       "plan_id": "plan_r_1024_023252"
     },

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -342,19 +342,15 @@
       "parameters": {
         "button": "left",
         "x": 345,
-        "y": 70
+        "y": 94
       },
-      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code.",
+      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code. It is the second item because \"OAuth (with dynamic registration)\" now appears above it.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:345:70:16:5:1040a8c10c336149",
-        "dhash:345:70:96:5:000090236cc42314",
-        "dhash:345:70:0:10:40b030216060623a"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_d0c53170",
@@ -648,7 +644,7 @@
       "parameters": {
         "text": "read:user"
       },
-      "description": "Type 'read:user' into the “Scope(s) for OAuth registration” input field at the top of the Visual Studio Code window.",
+      "description": "Type 'read:user' into the \u201cScope(s) for OAuth registration\u201d input field at the top of the Visual Studio Code window.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `DA_MCP_Oauth_Remote`
**Status:** :white_check_mark: FIXED (attempt 2/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/0b1363e9-b811-4b8f-97ae-b3a5aa2b9b2b/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/53053879-b85d-4af1-ac5a-21edcca8e0da/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | FALSE POSITIVE — step_d0c53170 clicked the wrong dropdown row: the DCR feature f | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/d38dc6be-57d0-4429-bcbf-3d5718fd287c/test_report.html) |
| 2 | Replaced fragile single-click auth-type selection (step_d0c53170, which hit the  | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/53053879-b85d-4af1-ac5a-21edcca8e0da/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/DA_MCP_Oauth_Remote.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../plans/DA_MCP_Oauth_Remote.json                 | 60 +++++++++++++++++++---
 1 file changed, 52 insertions(+), 8 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
index 5cf9b54..a657864 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 32,
+    "total_steps": 34,
     "created_at": "2026-06-29T03:21:51.231595",
     "name": "DA_with_MCP Server(Oauth)",
     "description": {
@@ -36,6 +36,8 @@
       "step_5120006b",
       "step_289ade9c",
       "step_d0c53170",
+      "step_d0c53171",
+      "step_d0c53172",
       "step_8ed7e3fe",
       "step_c83f7f58",
       "step_8db1832f",
@@ -341,19 +343,19 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 345,
-        "y": 70
+        "x": 317,
+        "y": 38
       },
-      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code.",
+      "description": "Click the search input field in the \"Select Authentication Type\" dropdown dialog of Visual Studio Code to activate it for text entry.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:345:70:16:5:1040a8c10c336149",
-        "dhash:345:70:96:5:000090236cc42314",
-        "dhash:345:70:0:10:40b030216060623a"
+        "dhash:317:38:16:5:0000000000000000",
+        "dhash:317:38:96:5:000000000024d390",
+        "dhash:317:38:0:10:e0c020202020223a"
       ],
       "postconditions": [],
       "tags": [],
@@ -361,6 +363,48 @@
       "created_at": "2026-06-29T03:21:51.370262",
       "plan_id": "plan_r_1024_023252"
     },
+    {
+      "step_id": "step_d0c53171",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "static"
+      },
+      "description": "Type \"static\" into the \"Select Authentication Type\" filter box to uniquely narrow the list to \"OAuth (with static registration)\".",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-06-29T03:21:51.370262",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_d0c53172",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 296,
+        "y": 72
+      },
+      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code, after typing \"static\" in the filter box.",
+      "content_refs": [],
+      "tim
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>