### PR TITLE
fix(vscuse): Auto-fix DA_MCP_Oauth_Remote

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -371,7 +371,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:345:70:16:5:00000064906a6e6c",
+        "dhash:345:70:96:5:0000041167468a85",
+        "dhash:345:70:0:10:c0b030282020223a"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_d0c53170",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 32,
+    "total_steps": 33,
     "created_at": "2026-06-29T03:21:51.231595",
     "name": "DA_with_MCP Server(Oauth)",
     "description": {
@@ -35,6 +35,7 @@
       "step_a712386e",
       "step_5120006b",
       "step_289ade9c",
+      "step_oauth_filter",
       "step_d0c53170",
       "step_8ed7e3fe",
       "step_c83f7f58",
@@ -336,6 +337,26 @@
       "plan_id": "plan_r_1024_023252"
     },
     {
+      "step_id": "step_oauth_filter",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "static"
+      },
+      "description": "Type 'static' into the search input box of the \"Select Authentication Type\" quick pick in Visual Studio Code to filter the list down to the \"OAuth (with static registration)\" option.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-06-29T03:21:51.370200",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
       "step_id": "step_d0c53170",
       "agent": "interaction",
       "tool": "click",
@@ -344,17 +365,13 @@
         "x": 345,
         "y": 70
       },
-      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code.",
+      "description": "Click the \"OAuth (with static registration)\" option (now the top filtered result) in the \"Select Authentication Type\" quick pick within Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:345:70:16:5:1040a8c10c336149",
-        "dhash:345:70:96:5:000090236cc42314",
-        "dhash:345:70:0:10:40b030216060623a"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_d0c53170",
@@ -648,7 +665,7 @@
       "parameters": {
         "text": "read:user"
       },
-      "description": "Type 'read:user' into the “Scope(s) for OAuth registration” input field at the top of the Visual Studio Code window.",
+      "description": "Type 'read:user' into the \u201cScope(s) for OAuth registration\u201d input field at the top of the Visual Studio Code window.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -5,7 +5,7 @@
     "execution_context": {
       "delay_between_steps": 0.5,
       "stop_on_error": true,
-      "precondition_wait_timeout": 60,
+      "precondition_wait_timeout": 120,
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
@@ -195,7 +195,7 @@
       },
       "description": "Click the \"Allow\" button in the GitHub authentication prompt for the MCP Server Definition within Visual Studio Code.",
       "content_refs": [],
-      "timeout": 30,
+      "timeout": 120,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `DA_MCP_Oauth_Remote`
**Status:** :white_check_mark: FIXED (attempt 2/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/0b1363e9-b811-4b8f-97ae-b3a5aa2b9b2b/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/78055eae-6509-47e7-b28e-2914916f6e66/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | False positive at step_d0c53170 ("OAuth (with static registration)") clicked the | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/71f8c3fc-2284-40c7-b562-8e9f9ceb1e24/test_report.html) |
| 2 | Increased precondition_wait_timeout 60→120 and step_5b9f6257 (GitHub "Allow" aut | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/78055eae-6509-47e7-b28e-2914916f6e66/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/DA_MCP_Oauth_Remote.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../plans/DA_MCP_Oauth_Remote.json                 | 37 +++++++++++++++++-----
 1 file changed, 29 insertions(+), 8 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
index 5cf9b54..6ad58fa 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -5,11 +5,11 @@
     "execution_context": {
       "delay_between_steps": 0.5,
       "stop_on_error": true,
-      "precondition_wait_timeout": 60,
+      "precondition_wait_timeout": 120,
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 32,
+    "total_steps": 33,
     "created_at": "2026-06-29T03:21:51.231595",
     "name": "DA_with_MCP Server(Oauth)",
     "description": {
@@ -35,6 +35,7 @@
       "step_a712386e",
       "step_5120006b",
       "step_289ade9c",
+      "step_oauth_filter",
       "step_d0c53170",
       "step_8ed7e3fe",
       "step_c83f7f58",
@@ -194,7 +195,7 @@
       },
       "description": "Click the \"Allow\" button in the GitHub authentication prompt for the MCP Server Definition within Visual Studio Code.",
       "content_refs": [],
-      "timeout": 30,
+      "timeout": 120,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
@@ -335,6 +336,26 @@
       "created_at": "2026-06-29T03:21:51.364260",
       "plan_id": "plan_r_1024_023252"
     },
+    {
+      "step_id": "step_oauth_filter",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "static"
+      },
+      "description": "Type 'static' into the search input box of the \"Select Authentication Type\" quick pick in Visual Studio Code to filter the list down to the \"OAuth (with static registration)\" option.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-06-29T03:21:51.370200",
+      "plan_id": "plan_r_1024_023252"
+    },
     {
       "step_id": "step_d0c53170",
       "agent": "interaction",
@@ -344,16 +365,16 @@
         "x": 345,
         "y": 70
       },
-      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code.",
+      "description": "Click the \"OAuth (with static registration)\" option (now the top filtered result) in the \"Select Authentication Type\" quick pick within Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:345:70:16:5:1040a8c10c336149",
-        "dhash:345:70:96:5:000090236cc42314",
-        "dhash:345:70:0:10:40b030216060623a"
+        "dhash:345:70:16:5:00000064906a6e6c",
+        "dhash:345:70:96:5:0000041167468a85",
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>