### PR TITLE
feat(cli): tag atk telemetry with caller-source from ATK_CALLER

### DIFF
--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -539,10 +539,27 @@ class CLIEngine {
       context.telemetryProperties[TelemetryProperty.Skill] = "true";
       CliTelemetry.reporter?.addSharedProperty(TelemetryProperty.Skill, "true");
     }
+    // Tag the invoking tool (e.g. wiqd) so wrapper-driven runs are distinguishable.
+    const caller = this.sanitizeCallerSource(process.env.ATK_CALLER);
+    if (caller) {
+      context.telemetryProperties[TelemetryProperty.CallerSource] = caller;
+      CliTelemetry.reporter?.addSharedProperty(TelemetryProperty.CallerSource, caller);
+    }
     // context.telemetryProperties[TelemetryProperty.CorrelationId] =
     //   context.optionValues.correlationId;
 
     return ok(undefined);
+  }
+
+  // ATK_CALLER is free-form env input; clamp to a short safe slug before it
+  // becomes a telemetry dimension to avoid PII leakage and high cardinality.
+  sanitizeCallerSource(raw?: string): string | undefined {
+    const slug = (raw ?? "")
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]/g, "")
+      .slice(0, 40);
+    return slug || undefined;
   }
 
   validateOptionsAndArguments(

--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -47,6 +47,12 @@ import UI from "../userInteraction";
 import { editDistance, getSystemInputs } from "../utils";
 import { helper } from "./helper";
 
+// Tools permitted to identify themselves as the atk caller via ATK_CALLER.
+// Any other value is mapped to "other" so the caller-source telemetry
+// dimension stays low-cardinality and cannot leak free-form input (e.g. PII).
+const KNOWN_CALLER_SOURCES = new Set(["wiqd"]);
+const OTHER_CALLER_SOURCE = "other";
+
 class CLIEngine {
   /**
    * @description cached debug logsd
@@ -540,7 +546,7 @@ class CLIEngine {
       CliTelemetry.reporter?.addSharedProperty(TelemetryProperty.Skill, "true");
     }
     // Tag the invoking tool (e.g. wiqd) so wrapper-driven runs are distinguishable.
-    const caller = this.sanitizeCallerSource(process.env.ATK_CALLER);
+    const caller = this.resolveCallerSource(process.env.ATK_CALLER);
     if (caller) {
       context.telemetryProperties[TelemetryProperty.CallerSource] = caller;
       CliTelemetry.reporter?.addSharedProperty(TelemetryProperty.CallerSource, caller);
@@ -551,15 +557,14 @@ class CLIEngine {
     return ok(undefined);
   }
 
-  // ATK_CALLER is free-form env input; clamp to a short safe slug before it
-  // becomes a telemetry dimension to avoid PII leakage and high cardinality.
-  sanitizeCallerSource(raw?: string): string | undefined {
-    const slug = (raw ?? "")
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9._-]/g, "")
-      .slice(0, 40);
-    return slug || undefined;
+  // ATK_CALLER is free-form env input, so normalize for matching and resolve
+  // against a known-caller allowlist; any recognized value maps to itself, any
+  // other declared value collapses to "other" to keep the telemetry dimension
+  // low-cardinality and free of PII. Blank/unset stays untagged.
+  private resolveCallerSource(raw?: string): string | undefined {
+    const value = (raw ?? "").trim().toLowerCase();
+    if (!value) return undefined;
+    return KNOWN_CALLER_SOURCES.has(value) ? value : OTHER_CALLER_SOURCE;
   }
 
   validateOptionsAndArguments(

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -180,6 +180,7 @@ export enum TelemetryProperty {
   CommandVerbose = "command-verbose",
   CommandInteractive = "command-interactive",
   BinName = "bin-name", // the input binary name: atk
+  CallerSource = "caller-source", // invoking tool/surface (e.g. "wiqd"), from ATK_CALLER
 }
 
 export enum TelemetrySuccess {

--- a/packages/cli/tests/unit/engine.tests.ts
+++ b/packages/cli/tests/unit/engine.tests.ts
@@ -792,7 +792,7 @@ describe("CLI Engine", () => {
       mockedEnvRestore();
     });
 
-    it("maps an unknown ATK_CALLER to \"other\"", async () => {
+    it('maps an unknown ATK_CALLER to "other"', async () => {
       const mockedEnvRestore = mockedEnv({
         ATK_CALLER: "johnsmith",
       });
@@ -814,7 +814,7 @@ describe("CLI Engine", () => {
       mockedEnvRestore();
     });
 
-    it("maps a near-miss of a known caller to \"other\" (no partial matching)", async () => {
+    it('maps a near-miss of a known caller to "other" (no partial matching)', async () => {
       const mockedEnvRestore = mockedEnv({
         ATK_CALLER: "wiqd-cli",
       });

--- a/packages/cli/tests/unit/engine.tests.ts
+++ b/packages/cli/tests/unit/engine.tests.ts
@@ -748,9 +748,9 @@ describe("CLI Engine", () => {
   });
 
   describe("ATK_CALLER env var", () => {
-    it("sets CallerSource telemetry property from ATK_CALLER", async () => {
+    it("sets CallerSource to a known caller from ATK_CALLER", async () => {
       const mockedEnvRestore = mockedEnv({
-        ATK_CALLER: "wiqd",
+        ATK_CALLER: "  WIQD  ",
       });
       const command: CLIFoundCommand = {
         name: "test",
@@ -792,9 +792,9 @@ describe("CLI Engine", () => {
       mockedEnvRestore();
     });
 
-    it("sanitizes ATK_CALLER to a lowercase slug capped at 40 chars", async () => {
+    it("maps an unknown ATK_CALLER to \"other\"", async () => {
       const mockedEnvRestore = mockedEnv({
-        ATK_CALLER: "  WIQD/CLI!! " + "x".repeat(40),
+        ATK_CALLER: "johnsmith",
       });
       const command: CLIFoundCommand = {
         name: "test",
@@ -810,14 +810,35 @@ describe("CLI Engine", () => {
       };
       const result = engine.parseArgs(ctx, rootCommand, []);
       assert.isTrue(result.isOk());
-      const value = ctx.telemetryProperties[TelemetryProperty.CallerSource];
-      assert.equal(value, ("wiqdcli" + "x".repeat(40)).slice(0, 40));
+      assert.equal(ctx.telemetryProperties[TelemetryProperty.CallerSource], "other");
       mockedEnvRestore();
     });
 
-    it("does not set CallerSource when ATK_CALLER has no safe characters", async () => {
+    it("maps a near-miss of a known caller to \"other\" (no partial matching)", async () => {
       const mockedEnvRestore = mockedEnv({
-        ATK_CALLER: "!!! @@@ ///",
+        ATK_CALLER: "wiqd-cli",
+      });
+      const command: CLIFoundCommand = {
+        name: "test",
+        fullName: "test",
+        description: "test command",
+      };
+      const ctx: CLIContext = {
+        command: command,
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      const result = engine.parseArgs(ctx, rootCommand, []);
+      assert.isTrue(result.isOk());
+      assert.equal(ctx.telemetryProperties[TelemetryProperty.CallerSource], "other");
+      mockedEnvRestore();
+    });
+
+    it("does not set CallerSource when ATK_CALLER is blank", async () => {
+      const mockedEnvRestore = mockedEnv({
+        ATK_CALLER: "   ",
       });
       const command: CLIFoundCommand = {
         name: "test",

--- a/packages/cli/tests/unit/engine.tests.ts
+++ b/packages/cli/tests/unit/engine.tests.ts
@@ -746,4 +746,95 @@ describe("CLI Engine", () => {
       mockedEnvRestore();
     });
   });
+
+  describe("ATK_CALLER env var", () => {
+    it("sets CallerSource telemetry property from ATK_CALLER", async () => {
+      const mockedEnvRestore = mockedEnv({
+        ATK_CALLER: "wiqd",
+      });
+      const command: CLIFoundCommand = {
+        name: "test",
+        fullName: "test",
+        description: "test command",
+      };
+      const ctx: CLIContext = {
+        command: command,
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      const result = engine.parseArgs(ctx, rootCommand, []);
+      assert.isTrue(result.isOk());
+      assert.equal(ctx.telemetryProperties[TelemetryProperty.CallerSource], "wiqd");
+      mockedEnvRestore();
+    });
+
+    it("does not set CallerSource when ATK_CALLER is not set", async () => {
+      const mockedEnvRestore = mockedEnv({
+        ATK_CALLER: undefined,
+      });
+      const command: CLIFoundCommand = {
+        name: "test",
+        fullName: "test",
+        description: "test command",
+      };
+      const ctx: CLIContext = {
+        command: command,
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      const result = engine.parseArgs(ctx, rootCommand, []);
+      assert.isTrue(result.isOk());
+      assert.notProperty(ctx.telemetryProperties, TelemetryProperty.CallerSource);
+      mockedEnvRestore();
+    });
+
+    it("sanitizes ATK_CALLER to a lowercase slug capped at 40 chars", async () => {
+      const mockedEnvRestore = mockedEnv({
+        ATK_CALLER: "  WIQD/CLI!! " + "x".repeat(40),
+      });
+      const command: CLIFoundCommand = {
+        name: "test",
+        fullName: "test",
+        description: "test command",
+      };
+      const ctx: CLIContext = {
+        command: command,
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      const result = engine.parseArgs(ctx, rootCommand, []);
+      assert.isTrue(result.isOk());
+      const value = ctx.telemetryProperties[TelemetryProperty.CallerSource];
+      assert.equal(value, ("wiqdcli" + "x".repeat(40)).slice(0, 40));
+      mockedEnvRestore();
+    });
+
+    it("does not set CallerSource when ATK_CALLER has no safe characters", async () => {
+      const mockedEnvRestore = mockedEnv({
+        ATK_CALLER: "!!! @@@ ///",
+      });
+      const command: CLIFoundCommand = {
+        name: "test",
+        fullName: "test",
+        description: "test command",
+      };
+      const ctx: CLIContext = {
+        command: command,
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      const result = engine.parseArgs(ctx, rootCommand, []);
+      assert.isTrue(result.isOk());
+      assert.notProperty(ctx.telemetryProperties, TelemetryProperty.CallerSource);
+      mockedEnvRestore();
+    });
+  });
 });


### PR DESCRIPTION
Add an optional `caller-source` telemetry property, populated from the `ATK_CALLER` environment variable, so runs driven by a wrapper tool (e.g. wiqd) are distinguishable from direct CLI usage in the `teamsfx_all_cli` data. Mirrors the existing `ATK_CLI_SKILL` -> `skill` pattern. The value is sanitized to a bounded lowercase slug to keep it low-cardinality and free of PII, since it comes from free-form process input.