### PR TITLE
fix(vscode-extension): improve .env snippet contrast on sample detail page

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.scss
@@ -163,6 +163,31 @@ body.vscode-light {
                 color: #004480;
             }
         }
+
+        /* TC-009: .env snippet syntax colors must keep >= 4.5:1 on light backgrounds.
+         * The default dark-theme GitHub token palette in github.scss uses low-contrast
+         * colors on white (for example #ff7b72 / #a5d6ff). Override key token colors
+         * in sample detail README rendering with light-theme accessible alternatives. */
+        .readme .pl-k {
+            color: #B42318;
+        }
+
+        .readme .pl-c1,
+        .readme .pl-s .pl-v,
+        .readme .pl-s,
+        .readme .pl-pds,
+        .readme .pl-s .pl-pse .pl-s1,
+        .readme .pl-sr,
+        .readme .pl-sr .pl-sre,
+        .readme .pl-sr .pl-sra,
+        .readme .pl-corl {
+            color: #0550AE;
+        }
+
+        .readme .pl-v,
+        .readme .pl-smw {
+            color: #953800;
+        }
     }
 }
 


### PR DESCRIPTION
Similar to #16196, this addresses a WCAG AA color-contrast issue on the **sample detail (README) page**.

### Problem
On the sample detail page, the `.env` configuration example (rendered as a fenced code block by `github.scss`) uses the dark-theme GitHub syntax token palette. On the white Light-theme background, several token colors fall below the WCAG AA 4.5:1 text-contrast threshold — e.g. keys/keywords in `#ff7b72` and string values in `#a5d6ff`.

### Fix
Add a scoped `body.vscode-light` override in `sampleDetailPage.scss` for the syntax token classes used by the `.env` snippet, remapping them to accessible light-theme colors that all exceed 4.5:1 on white:

| Token | Old (on white) | New |
|-------|----------------|-----|
| `.pl-k` (keys/keywords) | `#ff7b72` | `#B42318` |
| `.pl-c1` / `.pl-s*` / `.pl-sr*` (strings, values) | `#a5d6ff` / `#79c0ff` | `#0550AE` |
| `.pl-v` / `.pl-smw` | `#ffa657` | `#953800` |

Only affects the sample detail README rendering in Light theme; Dark theme is unchanged.