### PR TITLE
fix(vscuse): Auto-fix Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 18,
+    "total_steps": 24,
     "created_at": "2025-11-14T05:50:41.381007",
     "name": "Basic Custom Engine Azure OpenAI ts Remote Debug",
     "description": {
@@ -43,10 +43,15 @@
       "step_06f77d3f",
       "step_d491dc74",
       "step_6df62c65",
-      "plan_r_1020_110153"
+      "step_8c6b26a7",
+      "step_6d3141f9",
+      "step_5793c327",
+      "step_5b2a3d32",
+      "step_d2127173",
+      "step_aef94205"
     ],
     "tags": [],
-    "updated_at": "2025-11-14T05:52:26.306047"
+    "updated_at": "2026-07-07T06:22:16.719423"
   },
   "steps": [
     {
@@ -493,6 +498,148 @@
       "screenshot": null,
       "created_at": "2026-06-05T07:17:55.334167",
       "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "agent": "interaction",
+      "description": "Click the \"How can you help me?\" dialog box within the vscuse_app_X1Cladev interface on Microsoft Teams at coordinates (558, 535) to activate or interact with its content.",
+      "step_id": "step_8c6b26a7",
+      "content_refs": [],
+      "retry_count": 0,
+      "depends_on": [],
+      "postconditions": [],
+      "screenshot": "step_8c6b26a7",
+      "tool": "click",
+      "plan_id": "plan_r_1020_110153",
+      "parameters": {
+        "x": 558,
+        "y": 535,
+        "button": "left"
+      },
+      "timeout": 30,
+      "continue_on_error": "false",
+      "preconditions": [
+        "dhash:558:535:16:5:2840000000000000",
+        "dhash:558:535:96:5:894d179a20000000",
+        "dhash:558:535:0:10:10b0b08e8c8e81a1"
+      ],
+      "tags": [],
+      "created_at": "2025-10-20T11:06:21.798378"
+    },
+    {
+      "agent": "interaction",
+      "description": "Click the \"Send\" button in the Microsoft Teams chat interface to submit the message \"How can you help me?\".",
+      "step_id": "step_6d3141f9",
+      "content_refs": [],
+      "retry_count": 0,
+      "depends_on": [],
+      "postconditions": [],
+      "screenshot": "step_6d3141f9",
+      "tool": "click",
+      "plan_id": "plan_r_1020_110153",
+      "parameters": {
+        "x": 936,
+        "y": 718,
+        "button": "left"
+      },
+      "timeout": 30,
+      "continue_on_error": "false",
+      "preconditions": [
+        "dhash:936:718:16:5:c070d8e8e8d028d0",
+        "dhash:936:718:96:5:b791649f146d1c00",
+        "dhash:936:718:0:10:10b0b08e8c8c80a9"
+      ],
+      "tags": [],
+      "created_at": "2025-10-20T11:06:21.817013"
+    },
+    {
+      "agent": "interaction",
+      "description": "Click the \"Send a message\" text box in Microsoft Teams to enable typing input.",
+      "step_id": "step_5793c327",
+      "content_refs": [],
+      "retry_count": 0,
+      "depends_on": [],
+      "postconditions": [],
+      "screenshot": "step_5793c327",
+      "tool": "click",
+      "plan_id": "plan_r_1020_110153",
+      "parameters": {
+        "x": 924,
+        "y": 446,
+        "button": "left"
+      },
+      "timeout": 30,
+      "continue_on_error": "false",
+      "preconditions": [],
+      "tags": [
+        "delay: 10"
+      ],
+      "created_at": "2025-10-20T11:06:21.835728"
+    },
+    {
+      "agent": "interaction",
+      "description": "Press 'Home' key to move the cursor to the beginning of the message input field in the Microsoft Teams web application chat interface.",
+      "step_id": "step_5b2a3d32",
+      "content_refs": [],
+      "retry_count": 0,
+      "depends_on": [],
+      "postconditions": [],
+      "screenshot": "step_5b2a3d32",
+      "tool": "key_press",
+      "plan_id": "plan_r_1020_110153",
+      "parameters": {
+        "key": "home"
+      },
+      "timeout": 30,
+      "continue_on_error": "false",
+      "preconditions": [
+        "dhash:512:384:0:20:10b0b93e333232e1"
+      ],
+      "tags": [],
+      "created_at": "2025-10-20T11:06:21.855222"
+    },
+    {
+      "agent": "assertion",
+      "description": "@assertion there's response message form ai agent.",
+      "step_id": "step_d2127173",
+      "content_refs": [],
+      "retry_count": 0,
+      "depends_on": [],
+      "postconditions": [],
+      "screenshot": null,
+      "tool": "",
+      "plan_id": "plan_r_1020_110153",
+      "parameters": {},
+      "timeout": 30,
+      "continue_on_error": "false",
+      "preconditions": [],
+      "tags": [],
+      "created_at": "2025-10-20T11:08:12.560330"
+    },
+    {
+      "agent": "interaction",
+      "description": "Click the \"Close (X)\" button located in the top-right corner of the Microsoft Teams chat application to close the window.",
+      "step_id": "step_aef94205",
+      "content_refs": [],
+      "retry_count": 0,
+      "depends_on": [],
+      "postconditions": [],
+      "screenshot": "step_aef94205",
+      "tool": "click",
+      "plan_id": "plan_r_1020_110153",
+      "parameters": {
+        "x": 1001,
+        "y": 20,
+        "button": "left"
+      },
+      "timeout": 30,
+      "continue_on_error": "false",
+      "preconditions": [
+        "dhash:1001:20:16:5:3748cd2323cd4823",
+        "dhash:1001:20:96:5:c233333342007666",
+        "dhash:1001:20:0:10:10b0a0a1363f3ba1"
+      ],
+      "tags": [],
+      "created_at": "2025-10-20T15:14:53.955086"
     }
   ],
   "screenshots": {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
@@ -56,11 +56,7 @@
       "retry_count": 0,
       "continue_on_error": "0",
       "depends_on": [],
-      "preconditions": [
-        "dhash:369:134:16:5:ca9629443bd8282a",
-        "dhash:369:134:96:5:6565293144c52723",
-        "dhash:369:134:0:10:c0c88094b2717075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_c3e4c33c",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 4,
+    "total_steps": 18,
     "created_at": "2025-11-14T05:50:41.381007",
     "name": "Basic Custom Engine Azure OpenAI ts Remote Debug",
     "description": {
@@ -29,7 +29,20 @@
       "plan_r_0929_040401",
       "plan_r_0928_073729",
       "plan_r_0928_075846",
-      "plan_r_0930_063548",
+      "step_64456d0d",
+      "step_3fb94c2c",
+      "step_0f0c12ce",
+      "step_710f99f7",
+      "step_edc27950",
+      "step_5721b490",
+      "step_b2737c0c",
+      "step_ea74996b",
+      "step_82f6ba51",
+      "step_56f3a504",
+      "step_25ce8a2f",
+      "step_06f77d3f",
+      "step_d491dc74",
+      "step_6df62c65",
       "plan_r_1020_110153"
     ],
     "tags": [],
@@ -155,6 +168,331 @@
       "screenshot": "step_fe64ffbd",
       "created_at": "2025-11-14T05:50:41.468718",
       "plan_id": "plan_5b32a1a1"
+    },
+    {
+      "step_id": "step_64456d0d",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f1"
+      },
+      "description": "Press the F1 key in Visual Studio Code to open the command palette.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:32832723b32c6c2b"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_64456d0d",
+      "created_at": "2026-06-05T07:17:55.236797",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_3fb94c2c",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Debug: Select and Start Debugging"
+      },
+      "description": "Type 'Debug: Select and Start Debugging' into the Visual Studio Code Command Palette input box at the top of the window.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:cce44463b32c6c2b"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_3fb94c2c",
+      "created_at": "2026-06-05T07:17:55.242212",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_0f0c12ce",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to select \"Debug: Select and Start Debugging\" from the command palette in Visual Studio Code.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:e4822323b32c6c2b"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_0f0c12ce",
+      "created_at": "2026-06-05T07:17:55.254924",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_710f99f7",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Launch Remote (Chrome)"
+      },
+      "description": "Type #text:'Launch Remote (Chrome)' into the debug configuration dropdown at the top of the Visual Studio Code interface, within the Microsoft 365 Agents project workspace.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:c4c44423b32c6c2b"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_710f99f7",
+      "created_at": "2026-06-05T07:17:55.261012",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_edc27950",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to select \"Launch Remote (Chrome)\" from the debug configuration dropdown in Visual Studio Code.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:c4832323b32c6c2b"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_edc27950",
+      "created_at": "2026-06-05T07:17:55.266797",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_5721b490",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 400,
+        "y": 410
+      },
+      "description": "Click the \"Password\" input field on the Microsoft login page to focus and enable password entry for the account test04@atktesting05.onmicrosoft.com.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:400:410:16:5:d85858d828585000",
+        "dhash:400:410:96:5:e7081258180124c5",
+        "dhash:400:410:0:10:1308f0d9d9e6e6e4"
+      ],
+      "postconditions": [],
+      "tags": [
+        "precondition_wait_timeout:60",
+        "delay:30"
+      ],
+      "screenshot": "step_5721b490",
+      "created_at": "2026-06-05T07:17:55.274621",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_b2737c0c",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "${{secret:M365_ACCOUNT_PASSWORD}}"
+      },
+      "description": "Type  ${{secret:M365_ACCOUNT_PASSWORD}} into the password input field on the Microsoft sign-in page for user  ${{env:M365_ACCOUNT_NAME}}.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_b2737c0c",
+      "created_at": "2026-06-05T07:17:55.282581",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_ea74996b",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 627,
+        "y": 534
+      },
+      "description": "Click the \"Sign in\" button on the Microsoft login password entry page to submit credentials and proceed with account authentication.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:627:534:16:5:4ab2425cd55559d4",
+        "dhash:627:534:96:5:00004b6474530000",
+        "dhash:627:534:0:10:1308f0d9d9e6e6e4"
+      ],
+      "postconditions": [],
+      "tags": [
+        "delay:3"
+      ],
+      "screenshot": "step_ea74996b",
+      "created_at": "2026-06-05T07:17:55.287023",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_82f6ba51",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 623,
+        "y": 533
+      },
+      "description": "Click the \"Yes\" button on the Microsoft sign-in prompt to confirm staying signed in for account  ${{env:M365_ACCOUNT_NAME}}.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:623:533:16:5:9626a6deb9a00805",
+        "dhash:623:533:96:5:0008525959460000",
+        "dhash:623:533:0:10:1c0cf0d9d9e6e6e4"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_82f6ba51",
+      "created_at": "2026-06-05T07:17:55.296447",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_56f3a504",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion there's \"Add\" or \"Open\" blue button exist.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 180"
+      ],
+      "screenshot": null,
+      "created_at": "2026-06-05T07:17:55.304234",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_25ce8a2f",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 265,
+        "y": 214
+      },
+      "description": "Click the blue \"Add\"/\"Open\" button within the app details in Microsoft Teams (web interface), located below the app name and publisher. The preceding assertion confirmed either an \"Add\" or \"Open\" button is present; click whichever is shown (the app may already be installed, in which case it reads \"Open\").",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_25ce8a2f",
+      "created_at": "2026-06-05T07:17:55.311011",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_06f77d3f",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion there's \"Open\" blue button exist.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 180"
+      ],
+      "screenshot": null,
+      "created_at": "2026-06-05T07:17:55.318381",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_d491dc74",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 529,
+        "y": 506
+      },
+      "description": "Click the \"Open\" button in the pop-up dialog for the  app on the Microsoft Teams web interface.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:529:506:16:5:0000a25da1929292",
+        "dhash:529:506:96:5:000058a4c4580040",
+        "dhash:529:506:0:10:3669696969697979"
+      ],
+      "postconditions": [],
+      "tags": [
+        "precondition_wait_timeout: 200"
+      ],
+      "screenshot": "step_d491dc74",
+      "created_at": "2026-06-05T07:17:55.320306",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_6df62c65",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion there's ${{var:app_name}}dev exist.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 60"
+      ],
+      "screenshot": null,
+      "created_at": "2026-06-05T07:17:55.334167",
+      "plan_id": "plan_r_0930_063548"
     }
   ],
   "screenshots": {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
@@ -74,7 +74,11 @@
       "retry_count": 0,
       "continue_on_error": "0",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:369:134:16:5:eccb9c6854dad828",
+        "dhash:369:134:96:5:6565a83144c82582",
+        "dhash:369:134:0:10:c0c8889692b17075"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_c3e4c33c",


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug`
**Status:** :white_check_mark: FIXED (attempt 3/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/9d031cd6-c7ab-437b-9285-dfbac24ee676/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/40f073d8-3709-400b-bd6b-78883c552cd4/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Removed stale dhash preconditions from step_c3e4c33c (New Project modal "Custom  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/32b06f23-b07d-4608-b41e-d611416d6f20/test_report.html) |
| 2 | Inlined the debug_in_teams_remote group (plan_r_0930_063548) into the main plan  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/abebac53-9e23-4584-8b26-df84558c3fb5/test_report.html) |
| 3 | Inlined the read-only validation_chat_data group (plan_r_1020_110153) into the m | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/40f073d8-3709-400b-bd6b-78883c552cd4/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
...Custom_Engine_Azure_OpenAI_ts_remote_debug.json | 499 ++++++++++++++++++++-
 1 file changed, 492 insertions(+), 7 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
index 1b3c69f..6aaec84 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_remote_debug.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 4,
+    "total_steps": 24,
     "created_at": "2025-11-14T05:50:41.381007",
     "name": "Basic Custom Engine Azure OpenAI ts Remote Debug",
     "description": {
@@ -29,11 +29,29 @@
       "plan_r_0929_040401",
       "plan_r_0928_073729",
       "plan_r_0928_075846",
-      "plan_r_0930_063548",
-      "plan_r_1020_110153"
+      "step_64456d0d",
+      "step_3fb94c2c",
+      "step_0f0c12ce",
+      "step_710f99f7",
+      "step_edc27950",
+      "step_5721b490",
+      "step_b2737c0c",
+      "step_ea74996b",
+      "step_82f6ba51",
+      "step_56f3a504",
+      "step_25ce8a2f",
+      "step_06f77d3f",
+      "step_d491dc74",
+      "step_6df62c65",
+      "step_8c6b26a7",
+      "step_6d3141f9",
+      "step_5793c327",
+      "step_5b2a3d32",
+      "step_d2127173",
+      "step_aef94205"
     ],
     "tags": [],
-    "updated_at": "2025-11-14T05:52:26.306047"
+    "updated_at": "2026-07-07T06:22:16.719423"
   },
   "steps": [
     {
@@ -57,9 +75,9 @@
       "continue_on_error": "0",
       "depends_on": [],
       "preconditions": [
-        "dhash:369:134:16:5:ca9629443bd8282a",
-        "dhash:369:134:96:5:6565293144c52723",
-        "dhash:369:134:0:10:c0c88094b2717075"
+        "dhash:369:134:16:5:eccb9c6854dad828",
+        "dhash:369:134:96:5:6565a83144c82582",
+        "dhash:369:134:0:10:c0c8889692b17075"
       ],
       "postconditions": [],
       "tags": [],
@@ -159,6 +177,473 @@
       "screenshot": "step_fe64ffbd",
       "created_at": "2025-11-14T05:50:41.468718",
       "plan_id": "plan_5b32a1a1"
+    },
+    {
+      "step_id": "step_64456d0d",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f1"
+      },
+      "description": "Press the F1 key in Visual Studio Code to open the command palette.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:32832723b32c6c2b"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_64456d0d",
+      "created_at": "2026-06-05T07:17:55.236797",
+      "plan_id": "plan_r_0930_063548"
+    },
+    {
+      "step_id": "step_3fb94c2c",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Debug: Select and Start Debugging"
+      },
+      "description": "Type 
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>