### PR TITLE
fix(vscode-extension): improve .env snippet contrast on sample detail page (#16300) [cherry-pick to release/6.10]

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.scss
@@ -115,6 +115,33 @@ body.vscode-light {
     .upgrade-banner {
         background-color: #F0F0F0;
     }
+
+    /* TC-009: .env snippet syntax colors must keep >= 4.5:1 on light backgrounds.
+     * The default dark-theme GitHub token palette in github.scss uses low-contrast
+     * colors on white (for example #ff7b72 / #a5d6ff). Override key token colors
+     * in sample detail README rendering with light-theme accessible alternatives. */
+    .sample-detail-page {
+        .readme .pl-k {
+            color: #B42318;
+        }
+
+        .readme .pl-c1,
+        .readme .pl-s .pl-v,
+        .readme .pl-s,
+        .readme .pl-pds,
+        .readme .pl-s .pl-pse .pl-s1,
+        .readme .pl-sr,
+        .readme .pl-sr .pl-sre,
+        .readme .pl-sr .pl-sra,
+        .readme .pl-corl {
+            color: #0550AE;
+        }
+
+        .readme .pl-v,
+        .readme .pl-smw {
+            color: #953800;
+        }
+    }
 }
 
 body.vscode-dark {


### PR DESCRIPTION
Cherry-picks #16300 onto `release/6.10`.

**Original PR:** #16300 — fix(vscode-extension): improve .env snippet contrast on sample detail page

## What
Overrides the dark-palette GitHub syntax token colors (`pl-k`, `pl-s*`, `pl-v`/`pl-smw`, etc.) with light-theme accessible colors in the sample detail README so the `.env` example code meets WCAG AA 4.5:1 contrast against the white background (TC-009).

## Cherry-pick notes
- `release/6.10` did not contain the earlier `.sample-detail-page` block (TC-007 focus / TC-008 link overrides) that #16300's TC-009 rules were nested inside, so this port introduces a fresh `body.vscode-light .sample-detail-page` block containing **only** the TC-009 syntax-color overrides from #16300 — no unrelated changes are pulled in.
- Verified the component still renders `<div className="sample-detail-page"> ... <div className="readme">`, so the `.sample-detail-page .readme .pl-*` selectors match on this branch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>