### PR TITLE
fix(fx-core): persist MCP add-action OAuth credentials to env files

### DIFF
--- a/packages/fx-core/src/component/generator/declarativeAgent/helper.ts
+++ b/packages/fx-core/src/component/generator/declarativeAgent/helper.ts
@@ -854,6 +854,7 @@ async function generateForMCPForDAWithAuth(
             endpoints,
             persistCredentialEnvRefs: dtOn,
             serverName,
+            scopes: inputs[QuestionNames.MCPForDAScopes],
           });
           if (injectResult.wellKnownUrlPlaceholderUsed) {
             warnings.push({

--- a/packages/fx-core/src/component/utils/mcpAuthScaffolder.ts
+++ b/packages/fx-core/src/component/utils/mcpAuthScaffolder.ts
@@ -104,7 +104,9 @@ export interface InjectMCPAuthActionResult {
  * When `persistCredentialEnvRefs` is set (DT mode), the OAuth injector
  * adds explicit `${{...}}` references to credential env vars derived from
  * `serverName` so that `oauth/register` resolves credentials from env files
- * persisted by the add-action flow instead of the in-process bridge.
+ * persisted by the add-action flow instead of the in-process bridge. The scope
+ * reference is emitted only when `scopes` is non-empty, matching the conditional
+ * env-var write so provision never sees a dangling `${{...}}` reference.
  *
  * `oauth-dynamic` is always injected even when `endpoints.wellKnownUrl` is
  * missing — a placeholder string is written instead so the action shows up in
@@ -120,6 +122,7 @@ export async function injectMCPAuthActionToYml(args: {
   endpoints: ResolvedMCPAuthEndpoints;
   persistCredentialEnvRefs?: boolean;
   serverName?: string;
+  scopes?: string;
 }): Promise<InjectMCPAuthActionResult> {
   if (args.authType === "none") return {};
   if (args.authType === "oauth-dynamic") {
@@ -142,7 +145,12 @@ export async function injectMCPAuthActionToYml(args: {
       credentialEnvNames = {
         clientIdEnvName: `MCP_DA_OAUTH_CLIENT_ID_${args.serverName}`,
         clientSecretEnvName: `SECRET_MCP_DA_OAUTH_CLIENT_SECRET_${args.serverName}`,
-        scopeEnvName: `MCP_DA_OAUTH_SCOPE_${args.serverName}`,
+        // Reference the scope env var only when a scope was actually provided.
+        // persistMCPAuthCredentialEnvVars writes MCP_DA_OAUTH_SCOPE_<NAME> only
+        // for a non-empty scope (scope is optional for OAuth); emitting the
+        // ${{...}} ref unconditionally leaves a dangling reference that fails to
+        // resolve and breaks provision.
+        ...(args.scopes ? { scopeEnvName: `MCP_DA_OAUTH_SCOPE_${args.serverName}` } : {}),
       };
     } else if (args.authType === "entra-sso") {
       credentialEnvNames = {

--- a/packages/fx-core/src/core/FxCore.declarativeAgent.ts
+++ b/packages/fx-core/src/core/FxCore.declarativeAgent.ts
@@ -53,6 +53,7 @@ import {
   ResolvedMCPAuthEndpoints,
   deriveMCPManifestOAuth,
   injectMCPAuthActionToYml,
+  persistMCPAuthCredentialEnvVars,
   resolveMCPAuthEndpoints,
 } from "../component/utils/mcpAuthScaffolder";
 import { pathUtils } from "../component/utils/pathUtils";
@@ -678,6 +679,10 @@ export class FxCoreDeclarativeAgentPart {
         };
 
         if (authType && authType !== "none") {
+          // Uppercased server name drives the credential env-var suffix
+          // (`MCP_DA_OAUTH_CLIENT_ID_<NAME>` ...). Shared with the create flow so
+          // a created project and a re-add of the same server reuse the same vars.
+          const serverName = deriveMCPServerNameFromUrl(mcpServerUrl).toUpperCase();
           // The add question tree does not collect the auth-server metadata /
           // well-known URL, so — mirroring the create flow — probe the MCP
           // server to discover it when the caller didn't pass one. The result
@@ -723,11 +728,34 @@ export class FxCoreDeclarativeAgentPart {
                 registrationId,
                 mcpServerUrl,
                 endpoints,
+                persistCredentialEnvRefs: true,
+                serverName,
               });
             }
           } catch (error: any) {
             mcpWarnings.push({
               type: "mcpAuthMetadataError",
+              content: getLocalizedString(
+                "core.MCPForDA.mcpAuthMetadataMissingError",
+                error.message
+              ),
+            });
+          }
+          // Persist the client id / secret / scopes the user entered into env
+          // files so the `${{...}}` refs stamped above resolve at provision time.
+          // No-op for oauth-dynamic / none. Mirrors the create flow.
+          try {
+            await persistMCPAuthCredentialEnvVars({
+              projectPath,
+              authType,
+              serverName,
+              clientId: inputs[QuestionNames.MCPForDAClientId],
+              clientSecret: inputs[QuestionNames.MCPForDAClientSecret],
+              scopes: inputs[QuestionNames.MCPForDAScopes],
+            });
+          } catch (error: any) {
+            mcpWarnings.push({
+              type: "mcpAuthEnvPersistError",
               content: getLocalizedString(
                 "core.MCPForDA.mcpAuthMetadataMissingError",
                 error.message

--- a/packages/fx-core/src/core/FxCore.declarativeAgent.ts
+++ b/packages/fx-core/src/core/FxCore.declarativeAgent.ts
@@ -730,6 +730,7 @@ export class FxCoreDeclarativeAgentPart {
                 endpoints,
                 persistCredentialEnvRefs: true,
                 serverName,
+                scopes: inputs[QuestionNames.MCPForDAScopes],
               });
             }
           } catch (error: any) {

--- a/packages/fx-core/tests/component/utils/mcpAuthScaffolder.test.ts
+++ b/packages/fx-core/tests/component/utils/mcpAuthScaffolder.test.ts
@@ -186,6 +186,7 @@ describe("mcpAuthScaffolder", () => {
         },
         persistCredentialEnvRefs: true,
         serverName: "SERVER1",
+        scopes: "scope1 scope2",
       });
       assert.deepEqual(result, {});
       assert.isTrue(oauthStub.mock.calls.length === 1);
@@ -193,6 +194,29 @@ describe("mcpAuthScaffolder", () => {
         clientIdEnvName: "MCP_DA_OAUTH_CLIENT_ID_SERVER1",
         clientSecretEnvName: "SECRET_MCP_DA_OAUTH_CLIENT_SECRET_SERVER1",
         scopeEnvName: "MCP_DA_OAUTH_SCOPE_SERVER1",
+      });
+    });
+
+    it("omits the scope env ref when no scope is provided (oauth)", async () => {
+      const oauthStub = vi
+        .spyOn(ActionInjector, "injectCreateOAuthActionForMCP")
+        .mockResolvedValue();
+      await injectMCPAuthActionToYml({
+        ...baseArgs,
+        authType: "oauth",
+        endpoints: {
+          authorizationUrl: "https://auth/authorize",
+          tokenUrl: "https://auth/token",
+        },
+        persistCredentialEnvRefs: true,
+        serverName: "SERVER1",
+      });
+      // No scope was entered, so persistMCPAuthCredentialEnvVars writes no
+      // MCP_DA_OAUTH_SCOPE_* var — the yaml must not reference one either, or
+      // provision fails resolving a dangling ${{...}}.
+      assert.deepEqual(oauthStub.mock.calls[0][8], {
+        clientIdEnvName: "MCP_DA_OAUTH_CLIENT_ID_SERVER1",
+        clientSecretEnvName: "SECRET_MCP_DA_OAUTH_CLIENT_SECRET_SERVER1",
       });
     });
 

--- a/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
+++ b/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
@@ -2850,6 +2850,99 @@ describe("addPlugin", async () => {
     }
   });
 
+  it("from MCP (DT flag on): omits the scope env ref and var when no scope is entered (oauth)", async () => {
+    const appName = await mockV3Project();
+    const projectPath = path.join(os.tmpdir(), appName);
+    const inputs: Inputs = {
+      platform: Platform.CLI,
+      [QuestionNames.Folder]: os.tmpdir(),
+      [QuestionNames.TeamsAppManifestFilePath]: "manifest.json",
+      [QuestionNames.ActionType]: ActionStartOptions.mcp().id,
+      [QuestionNames.MCPForDAServerUrl]: "https://example.com/mcp",
+      [QuestionNames.MCPToolsFilePath]: "",
+      [QuestionNames.MCPForDAAuthType]: "oauth",
+      [QuestionNames.MCPForDAClientId]: "client-id",
+      [QuestionNames.MCPForDAClientSecret]: "client-secret",
+      // Scope left blank (optional for OAuth).
+      [QuestionNames.MCPForDAScopes]: "",
+      [QuestionNames.MCPForDAAuthMetadataUrl]:
+        "https://example.com/.well-known/oauth-authorization-server",
+      projectPath,
+    };
+
+    const manifest = new TeamsAppManifest();
+    manifest.name = { short: "My MCP App", full: "My MCP App" };
+    manifest.copilotExtensions = {
+      declarativeCopilots: [{ file: "test1.json", id: "action_1" }],
+    };
+
+    vi.spyOn(featureFlagManager, "getBooleanValue").mockImplementation((flag) => {
+      return flag === FeatureFlags.MCPForDADT;
+    });
+    vi.spyOn(validationUtils, "validateInputs").mockResolvedValue(undefined);
+    vi.spyOn(manifestUtils, "_readAppManifest").mockResolvedValue(ok(manifest));
+    vi.spyOn(copilotGptManifestUtils, "getManifestPath").mockResolvedValue(ok("dcManifest.json"));
+    vi.spyOn(copilotGptManifestUtils, "readCopilotGptManifestFile").mockResolvedValue(
+      ok({} as DeclarativeCopilotManifestSchema)
+    );
+    vi.spyOn(
+      copilotGptManifestUtils,
+      "getDefaultNextAvailablePluginManifestPath"
+    ).mockResolvedValue("ai-plugin_1.json");
+    vi.spyOn(copilotGptManifestUtils, "addAction").mockResolvedValue(
+      ok({} as DeclarativeCopilotManifestSchema)
+    );
+
+    vi.spyOn(addPluginTools.ui, "showMessage").mockImplementation((level) => {
+      if (level === "warn") return Promise.resolve(ok("Add"));
+      return Promise.resolve(ok(""));
+    });
+
+    const mcpAuthScaffolderModule = await import("../../src/component/utils/mcpAuthScaffolder");
+    vi.spyOn(
+      mcpAuthScaffolderModule.mcpAuthScaffolderDeps,
+      "resolveMCPOAuthMetadata"
+    ).mockResolvedValue({
+      authorizationUrl: "https://example.com/oauth/authorize",
+      tokenUrl: "https://example.com/oauth/token",
+      refreshUrl: "https://example.com/oauth/token",
+      wellKnownUrl: "https://example.com/.well-known/oauth-authorization-server",
+    });
+
+    const actionInjectorModule = await import("../../src/component/configManager/actionInjector");
+    const injectStub = vi
+      .spyOn(actionInjectorModule.ActionInjector, "injectCreateOAuthActionForMCP")
+      .mockResolvedValue();
+
+    vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue("m365agents.yml");
+    vi.spyOn(fs, "ensureFile").mockResolvedValue();
+    vi.spyOn(fs, "writeJSON").mockResolvedValue();
+    vi.spyOn(envUtil, "listEnv").mockResolvedValue(ok(["dev"]));
+    const writeEnvStub = vi.spyOn(envUtil, "writeEnv").mockResolvedValue(ok(undefined));
+
+    const core = new FxCore(addPluginTools);
+    const result = await core.addPlugin(inputs);
+
+    assert.isTrue(result.isOk());
+    // No scope entered -> the injector receives no scopeEnvName, so the yaml
+    // oauth/register action carries no scope ${{...}} ref.
+    assert.deepEqual(injectStub.mock.calls[0][8], {
+      clientIdEnvName: "MCP_DA_OAUTH_CLIENT_ID_EXAMPLECOM",
+      clientSecretEnvName: "SECRET_MCP_DA_OAUTH_CLIENT_SECRET_EXAMPLECOM",
+    });
+    // ...and no MCP_DA_OAUTH_SCOPE_* var is written, keeping env and yaml
+    // consistent so provision never resolves a dangling reference.
+    assert.equal(writeEnvStub.mock.calls.length, 1);
+    assert.deepEqual(writeEnvStub.mock.calls[0][2], {
+      MCP_DA_OAUTH_CLIENT_ID_EXAMPLECOM: "client-id",
+      SECRET_MCP_DA_OAUTH_CLIENT_SECRET_EXAMPLECOM: "client-secret",
+    });
+
+    if (await fs.pathExists(projectPath)) {
+      await fs.remove(projectPath);
+    }
+  });
+
   it("from MCP (DT flag on): none auth writes None auth and skips oauth injection", async () => {
     const appName = await mockV3Project();
     const projectPath = path.join(os.tmpdir(), appName);

--- a/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
+++ b/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
@@ -28,6 +28,7 @@ import { copilotGptManifestUtils } from "../../src/component/driver/teamsApp/uti
 import { manifestUtils } from "../../src/component/driver/teamsApp/utils/ManifestUtils";
 import * as declarativeAgentHelper from "../../src/component/generator/declarativeAgent/helper";
 import * as openApiSpecHelper from "../../src/component/generator/openApiSpec/helper";
+import { envUtil } from "../../src/component/utils/envUtil";
 import { pathUtils } from "../../src/component/utils/pathUtils";
 import { NotImplementedError, UserCancelError } from "../../src/error/common";
 import { QuestionNames } from "../../src/question";
@@ -2796,6 +2797,8 @@ describe("addPlugin", async () => {
     vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue("m365agents.yml");
     vi.spyOn(fs, "ensureFile").mockResolvedValue();
     const writeJSONStub = vi.spyOn(fs, "writeJSON").mockResolvedValue();
+    vi.spyOn(envUtil, "listEnv").mockResolvedValue(ok(["dev"]));
+    const writeEnvStub = vi.spyOn(envUtil, "writeEnv").mockResolvedValue(ok(undefined));
 
     const core = new FxCore(addPluginTools);
     const result = await core.addPlugin(inputs);
@@ -2826,6 +2829,21 @@ describe("addPlugin", async () => {
     assert.equal(injectStub.mock.calls.length, 1);
     assert.equal(injectStub.mock.calls[0][2], "examplecom");
     assert.equal(injectStub.mock.calls[0][3], "MCP_DA_AUTH_ID_EXAMPLECOM");
+    // The client id / secret / scopes the user entered are persisted to env so
+    // the injected ${{...}} refs resolve at provision time. serverName is the
+    // uppercased URL-derived name, matching the registration id suffix.
+    assert.deepEqual(injectStub.mock.calls[0][8], {
+      clientIdEnvName: "MCP_DA_OAUTH_CLIENT_ID_EXAMPLECOM",
+      clientSecretEnvName: "SECRET_MCP_DA_OAUTH_CLIENT_SECRET_EXAMPLECOM",
+      scopeEnvName: "MCP_DA_OAUTH_SCOPE_EXAMPLECOM",
+    });
+    assert.equal(writeEnvStub.mock.calls.length, 1);
+    assert.equal(writeEnvStub.mock.calls[0][1], "dev");
+    assert.deepEqual(writeEnvStub.mock.calls[0][2], {
+      MCP_DA_OAUTH_CLIENT_ID_EXAMPLECOM: "client-id",
+      SECRET_MCP_DA_OAUTH_CLIENT_SECRET_EXAMPLECOM: "client-secret",
+      MCP_DA_OAUTH_SCOPE_EXAMPLECOM: "scope-a",
+    });
 
     if (await fs.pathExists(projectPath)) {
       await fs.remove(projectPath);
@@ -2964,6 +2982,8 @@ describe("addPlugin", async () => {
     vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue("m365agents.yml");
     vi.spyOn(fs, "ensureFile").mockResolvedValue();
     const writeJSONStub = vi.spyOn(fs, "writeJSON").mockResolvedValue();
+    vi.spyOn(envUtil, "listEnv").mockResolvedValue(ok(["dev"]));
+    const writeEnvStub = vi.spyOn(envUtil, "writeEnv").mockResolvedValue(ok(undefined));
 
     const core = new FxCore(addPluginTools);
     const result = await core.addPlugin(inputs);
@@ -2977,6 +2997,14 @@ describe("addPlugin", async () => {
     assert.equal(oauthInjectStub.mock.calls[0][1], "entra-sso");
     assert.equal(oauthInjectStub.mock.calls[0][2], "examplecom");
     assert.equal(dcrInjectStub.mock.calls.length, 0);
+    // entra-sso collects (and persists) only the client id — no secret / scopes.
+    assert.deepEqual(oauthInjectStub.mock.calls[0][8], {
+      clientIdEnvName: "MCP_DA_OAUTH_CLIENT_ID_EXAMPLECOM",
+    });
+    assert.equal(writeEnvStub.mock.calls.length, 1);
+    assert.deepEqual(writeEnvStub.mock.calls[0][2], {
+      MCP_DA_OAUTH_CLIENT_ID_EXAMPLECOM: "entra-client-id",
+    });
 
     const pluginCall = writeJSONStub.mock.calls.find((c) => String(c[0]).includes("ai-plugin"));
     assert.isDefined(pluginCall);


### PR DESCRIPTION
## Problem
When using **Add Action -> MCP server** (Dynamic Tool Discovery on, the default), the client id / secret / scopes entered during the flow were **not written to the env files**, so the injected `oauth/register` env-var references resolved to nothing at provision time.

## Root cause
`addPlugin`''s `useMCPDTModifyFlow` branch (`packages/fx-core/src/core/FxCore.declarativeAgent.ts`) collected the credentials via `MCPForDAAuthCredentialNodes()` but:
- called `injectMCPAuthActionToYml` **without** `persistCredentialEnvRefs` / `serverName`, and
- never called `persistMCPAuthCredentialEnvVars`.

The create flow (`component/generator/declarativeAgent/helper.ts`) already does this correctly; the add-action flow had drifted.

## Fix
Mirror the create flow in the add-action DT branch:
- derive `serverName = deriveMCPServerNameFromUrl(url).toUpperCase()`,
- pass `persistCredentialEnvRefs: true` + `serverName` to `injectMCPAuthActionToYml`,
- call `persistMCPAuthCredentialEnvVars(...)`.

Per auth type:
- **oauth** -> writes client id + secret (SECRET_ key) + scopes
- **entra-sso** -> writes only the client id
- **oauth-dynamic / none** -> no-op

## Tests
Updated the DT-on `oauth` and `entra-sso` `addPlugin` tests to assert the env writes and the injector credential env-ref args.
`npx vitest run tests/core/FxCore.declarativeAgent.test.ts` -> 66 passed, 6 skipped.