### PR TITLE
fix(vscuse): Auto-fix Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
@@ -5,7 +5,7 @@
     "execution_context": {
       "delay_between_steps": 1,
       "stop_on_error": true,
-      "precondition_wait_timeout": 30,
+      "precondition_wait_timeout": 120,
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
@@ -42,7 +42,7 @@
       "plan_r_1009_093215"
     ],
     "tags": [],
-    "updated_at": "2026-07-08T06:47:12.309000"
+    "updated_at": "2026-07-08T07:23:26.948000"
   },
   "steps": [
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 11,
+    "total_steps": 12,
     "created_at": "2026-05-11T06:38:05.296841",
     "name": "Basic Custom Engine Agent Azure OpenAI py Remote Debug",
     "description": {
@@ -38,10 +38,11 @@
       "step_2c1eae55",
       "step_743cf4e1",
       "plan_r_0930_063548",
+      "step_focus_teams_tab",
       "plan_r_1009_093215"
     ],
     "tags": [],
-    "updated_at": "2026-05-11T06:44:45.049169"
+    "updated_at": "2026-07-08T06:47:12.309000"
   },
   "steps": [
     {
@@ -300,6 +301,30 @@
       ],
       "screenshot": null,
       "created_at": "2026-05-11T06:44:25.861256",
+      "plan_id": "plan_b3437999"
+    },
+    {
+      "step_id": "step_focus_teams_tab",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 175,
+        "y": 19
+      },
+      "description": "Click the Microsoft Teams app browser tab (the \"vscuse_app...\" tab) at the top-left of the Google Chrome window to restore focus to the Teams chat. During the previous validation flow a documentation page can open in a new browser tab and steal focus; re-selecting the Teams tab ensures the Teams chat is the active tab before validating the bot response.",
+      "content_refs": [],
+      "timeout": 15,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "force_run:true"
+      ],
+      "screenshot": "",
+      "created_at": "2026-07-08T06:47:12.309000",
       "plan_id": "plan_b3437999"
     }
   ],

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 12,
+    "total_steps": 19,
     "created_at": "2026-05-11T06:38:05.296841",
     "name": "Basic Custom Engine Agent Azure OpenAI py Remote Debug",
     "description": {
@@ -39,10 +39,16 @@
       "step_743cf4e1",
       "plan_r_0930_063548",
       "step_focus_teams_tab",
-      "plan_r_1009_093215"
+      "step_ca70af4b",
+      "step_6524a9b0",
+      "step_fcd065be",
+      "step_3d8a9df6",
+      "step_18c4c16f",
+      "step_9b9ff263",
+      "step_2e6e5ac9"
     ],
     "tags": [],
-    "updated_at": "2026-07-08T07:23:26.948000"
+    "updated_at": "2026-07-08T08:10:40.608000"
   },
   "steps": [
     {
@@ -326,6 +332,168 @@
       "screenshot": "",
       "created_at": "2026-07-08T06:47:12.309000",
       "plan_id": "plan_b3437999"
+    },
+    {
+      "step_id": "step_ca70af4b",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 278,
+        "y": 721
+      },
+      "description": "Click the 'Type a message' input field in the Microsoft Teams app window at coordinates (278, 721).",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:278:721:16:5:8080c08000000000",
+        "dhash:278:721:96:5:002050b030400000",
+        "dhash:278:721:0:10:30b0b08e8e8c81a1"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_ca70af4b",
+      "created_at": "2026-03-12T05:21:37.607610",
+      "plan_id": "plan_r_1009_093215"
+    },
+    {
+      "step_id": "step_6524a9b0",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "How to develop agent for Teams?"
+      },
+      "description": "Type the text 'How to develop agent for Teams?' into the input field located at the bottom of the chat interface within the Teams application, under the section titled 'vscuse_app_QTSvnlocal'.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:30b0b08e8e8c80b9"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_6524a9b0",
+      "created_at": "2026-03-12T05:21:37.612758",
+      "plan_id": "plan_r_1009_093215"
+    },
+    {
+      "step_id": "step_fcd065be",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press the \"Enter\" key to submit the message typed in the input field at the bottom of the Microsoft Teams interface in the  conversation.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:30b0b08e8e8c80b9"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_fcd065be",
+      "created_at": "2026-03-12T05:21:37.618277",
+      "plan_id": "plan_r_1009_093215"
+    },
+    {
+      "step_id": "step_3d8a9df6",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 893,
+        "y": 484
+      },
+      "description": "Click the chat main panel at position (893, 484).",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "ocr:true"
+      ],
+      "screenshot": "step_3d8a9df6",
+      "created_at": "2026-03-12T05:21:37.622589",
+      "plan_id": "plan_r_1009_093215"
+    },
+    {
+      "step_id": "step_18c4c16f",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "home"
+      },
+      "description": "Press the \"Home\" key to navigate to the top of the chat in the Microsoft Teams chat interface.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:512:384:0:20:30f833bbaf3f3be1"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_18c4c16f",
+      "created_at": "2026-03-12T05:21:37.628093",
+      "plan_id": "plan_r_1009_093215"
+    },
+    {
+      "step_id": "step_9b9ff263",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion bot has responsed user's question.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 60"
+      ],
+      "screenshot": null,
+      "created_at": "2026-03-12T05:21:37.632619",
+      "plan_id": "plan_r_1009_093215"
+    },
+    {
+      "step_id": "step_2e6e5ac9",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 999,
+        "y": 18
+      },
+      "description": "Click the \"Close\" button (X) at the top-right corner of the Google Chrome window to exit the Microsoft Teams web app.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:999:18:16:5:0d19246691916624",
+        "dhash:999:18:96:5:c233333342006666",
+        "dhash:999:18:0:10:30b8b1b337bfbfa1"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "step_2e6e5ac9",
+      "created_at": "2026-03-12T05:21:37.636618",
+      "plan_id": "plan_r_1009_093215"
     }
   ],
   "screenshots": {


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug`
**Status:** :white_check_mark: FIXED (attempt 3/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/3a4ea99c-aedf-4251-9cda-d683505ee666/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/777f0def-3b26-4796-80b8-a227511acb1e/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Added a focus-recovery step (click the Teams chat browser tab at 175,19) before  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/3aadca25-bd6a-4a05-8972-e68224a8f372/test_report.html) |
| 2 | Increased the parent plan's `execution_context.precondition_wait_timeout` from 3 | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/cba58035-8d9b-41a0-8565-59df8cf34e50/test_report.html) |
| 3 | Inlined the validation_basic_ai_chat_bot group (plan_r_1009_093215) into the par | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/777f0def-3b26-4796-80b8-a227511acb1e/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
..._Engine_Agent_Azure_OpenAI_py_Remote_Debug.json | 201 ++++++++++++++++++++-
 1 file changed, 197 insertions(+), 4 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
index 5a91da2..0f1eb86 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Agent_Azure_OpenAI_py_Remote_Debug.json
@@ -5,11 +5,11 @@
     "execution_context": {
       "delay_between_steps": 1,
       "stop_on_error": true,
-      "precondition_wait_timeout": 30,
+      "precondition_wait_timeout": 120,
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 11,
+    "total_steps": 19,
     "created_at": "2026-05-11T06:38:05.296841",
     "name": "Basic Custom Engine Agent Azure OpenAI py Remote Debug",
     "description": {
@@ -38,10 +38,17 @@
       "step_2c1eae55",
       "step_743cf4e1",
       "plan_r_0930_063548",
-      "plan_r_1009_093215"
+      "step_focus_teams_tab",
+      "step_ca70af4b",
+      "step_6524a9b0",
+      "step_fcd065be",
+      "step_3d8a9df6",
+      "step_18c4c16f",
+      "step_9b9ff263",
+      "step_2e6e5ac9"
     ],
     "tags": [],
-    "updated_at": "2026-05-11T06:44:45.049169"
+    "updated_at": "2026-07-08T08:10:40.608000"
   },
   "steps": [
     {
@@ -301,6 +308,192 @@
       "screenshot": null,
       "created_at": "2026-05-11T06:44:25.861256",
       "plan_id": "plan_b3437999"
+    },
+    {
+      "step_id": "step_focus_teams_tab",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 175,
+        "y": 19
+      },
+      "description": "Click the Microsoft Teams app browser tab (the \"vscuse_app...\" tab) at the top-left of the Google Chrome window to restore focus to the Teams chat. During the previous validation flow a documentation page can open in a new browser tab and steal focus; re-selecting the Teams tab ensures the Teams chat is the active tab before validating the bot response.",
+      "content_refs": [],
+      "timeout": 15,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "force_run:true"
+      ],
+      "screenshot": "",
+      "created_at": "2026-07-08T06:47:12.309000",
+      "plan_id": "plan_b3437999"
+    },
+    {
+      "step_id": "step_ca70af4b",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 278,
+        "y": 721
+      },
+      "description": "Click the 'Type a message' input field in the Microsoft Teams app window at coordinates (278, 721).",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:278:7
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>