### PR TITLE
feat(fx-core): v4 cross-phase back navigation

### DIFF
--- a/docs/02-architecture/adr/ADR-0014-dispatcher-buildtarget-resolution.md
+++ b/docs/02-architecture/adr/ADR-0014-dispatcher-buildtarget-resolution.md
@@ -1,8 +1,8 @@
 # ADR-0014 — Dispatcher + BuildTarget resolution as the scaffolding front stage
 
-- **Status:** Accepted (Amended 2026-07-02 — see Amendments 1–3)
+- **Status:** Accepted (Amended 2026-07-08 — see Amendments 1–4)
 - **Date:** 2026-05-28 (Accepted 2026-06-05; Amended 2026-06-15;
-  Amended 2026-07-02)
+  Amended 2026-07-02; Amended 2026-07-08)
 - **Source:** [`scaffolding.create.proposal.md` §14](../scaffolding.create.proposal.md#14-adrs-this-proposal-will-be-decomposed-into)
   (decomposes §§5, 5.1, 5.3, 9, 9.1, 10; invariants 12, 17). Validated against
   the on-disk `templates/v4/create/selector.json` and
@@ -294,3 +294,78 @@ rejects legacy `engine:"v3"` routes as malformed selector JSON. Create dispatch
 withdraws the v3-generator rejection AC rows because such `BuildTarget`s are no
 longer representable; `engine:"v3-core-method"` remains an unsupported create
 target.
+
+## Amendment 4 — Cross-phase back navigation as a front-door re-entry loop (2026-07-08)
+
+- **Status:** Accepted (in-place amendment; additive — no prior decision is
+  superseded).
+- **Scope:** How back navigation composes across the Q1 → dispatch → Q2 phase
+  boundary. The single `walk` source, the closed `engine` set, descriptor-bound
+  `language`, and `templateId`-only dispatch are all unchanged.
+
+### Why
+
+Q1 (`walk-create-selector`) and Q2+common-floor (`collect-create-inputs`) are
+two separate runs of the one shared question-walk engine, glued by this
+dispatcher: Q1 resolves a `BuildTarget`, then dispatch runs Q2 for the resolved
+template. Each phase already has *internal* back (collect-inputs INV-8), but a
+`back` at Q2's **first** prompt had nowhere to go — the first prompt showed no
+Back button (step 1) and a forced back cancelled the whole create. Users expect
+one continuous wizard: from Q2's first question, `back` should return to Q1's
+last dimension and let them re-pick, potentially selecting a **different**
+template whose Q2+Q3 differ.
+
+The original deferral cited the shared v3 `traverse`; that reason is now moot —
+the create selector routes are all `engine:"v4"` (Amendment 3), so every create
+Q2 is the v4 engine this project owns. The only real question is how a changed
+Q1 pick loads a different template's Q2+Q3 without a stale-state hazard.
+
+### Decision
+
+1. **A front-door re-entry loop.** With `TEAMSFX_V4_ENABLED` on, the
+   `engine:"v4"` path is a loop: run Q1 (retaining its `history` +
+   `promptCount`), dispatch, run Q2+floor with `baseStep = promptCount` (so Q2's
+   first prompt continues Q1's numbering and shows a Back button) and
+   `backable`, and on a Q2-first `back` re-enter Q1 at its last dimension via its
+   retained history. `back` past Q1's first dimension cancels the whole create
+   (`BuildTargetWalkCancelled`).
+
+2. **Q1 history is retained; Q2+Q3 are stateless-rebuilt per forward crossing.**
+   The loop retains only the **Q1** walk history (so Q1 back is multi-level and
+   continuous across re-entry). Q2+Q3 are re-derived from the resolved
+   `BuildTarget` on every forward crossing — a different `templateId` re-opens
+   that template's `questions.json` + `descriptor` (its `optionsSchema`,
+   `languages`) and rebuilds the question set from scratch. The loop keeps **no**
+   Q2 answer cache, so "different Q1 pick → different Q2+Q3" needs no
+   invalidation logic: the stale template's answers are simply not carried.
+
+3. **All back logic stays in the one shared engine.** The engine
+   (`collect-inputs`) gains a `baseStep` offset, a `backable` typed
+   `{ kind:"back" }` outcome, and a resumable `history` (in/out) — no surface or
+   this dispatcher owns a parallel back-stack. The front door only ferries the
+   opaque Q1 `history` between phases (v4-scaffolding "one walk engine").
+
+### Consequences
+
+- **New constraint:** the re-entry loop is scoped **below** the
+  preset-`template-name` short-circuit (Amendment 1 / INV-8), so a prior
+  iteration's `inputs["template-name"]` never re-triggers the preset path and
+  skips Q1. Preset resolution stays a one-shot, non-looping front-door entry.
+- The legacy `collectInputs(...)` entry stays a thin wrapper over the resumable
+  engine, so the existing collect-inputs contract (INPUT-01..19, INV-8) is
+  byte-for-byte unchanged; only new callers opt into `baseStep` / `backable` /
+  `resume`.
+- Whole behavior is behind `TEAMSFX_V4_ENABLED` (default off); flag-off is the
+  unchanged v3 pass-through.
+
+### Derived-spec impact
+
+[`collect-inputs`](../../03-specs/operations/scaffolding/collect-inputs.md)
+(INPUT-20..22, INV-9 — the resumable walk primitive),
+[`collect-create-inputs`](../../03-specs/operations/scaffolding/collect-create-inputs.md)
+(CCI-25/26, INV-11 — threading + stateless Q2+Q3 rebuild),
+[`walk-create-selector`](../../03-specs/operations/scaffolding/walk-create-selector.md)
+(WCS-24/25, INV-6 — Q1 resume + `history`/`promptCount` output), and
+[`dispatch-create-by-engine`](../../03-specs/operations/scaffolding/dispatch-create-by-engine.md)
+(DCE-22..25, INV-10 — the re-entry loop) realize this amendment. No other
+ADR-0014 consequence changes.

--- a/docs/03-specs/operations/scaffolding/collect-create-inputs.md
+++ b/docs/03-specs/operations/scaffolding/collect-create-inputs.md
@@ -128,6 +128,10 @@ in-memory provider while production uses the default registry.
 | CCI-22 | L1 | the same route, a scripted UI that cancels on `folder` or `app-name` | `runCreateInputs` | `err` is the cancellation `UserError` propagated unchanged; the front door does not scaffold |
 | CCI-23 | L1 | `entryParams` already contains `folder`, `app-name`, or `language` | `runCreateInputs` | those common floor values are used as pre-filled answers and are not prompted again; validation/bounds checking still happens in the shared walk |
 | CCI-24 | L1 | an interactive text question with a registered validator (`mcpServerUrl` or common-floor `app-name`) and earlier answers that the validator depends on | `runCreateInputs` | the prompt bridge passes a validation callback to `inputText`, bound to the current answers, so invalid text can be rejected during collection rather than only later at scaffold runtime |
+| CCI-25 | L1 | the DA+MCP v4 route, a caller-supplied `baseStep` (Q1's `promptCount`) and `backable: true` | `runCreateInputs` | the values are threaded onto the shared walk, so the **first** Q2/floor prompt shows a Back button (`step > 1`, collect-inputs INPUT-20) and a `back` at it returns a typed `{ kind:"back" }` outcome to the front door instead of cancelling the create (INPUT-21); the operation adds no back logic of its own |
+| CCI-26 | L1 | two `runCreateInputs` calls under **different** `locator.templateId`s (a Q1 re-pick from `da/mcp-server` to `da/no-action`) | `runCreateInputs` | each call re-opens `questions.json` + `descriptor` for its own `templateId` and rebuilds Q2 + the descriptor-bound `language` axis + common floor from scratch, holding no state from the other call — the Q2+Q3 set is a pure function of the current `locator`, so a Q1 re-pick that changes the template yields the new template's questions and discards the prior template's answers with no invalidation logic |
+| CCI-27 | L1 | a `skipSingleOption` singleSelect with a single option, a fake `UserInteraction` whose `selectOption` returns `{ type: "skip" }` | `createUiPromptUI(ui).ask(q, options)` | the host skip is projected to `ok({ kind: "skip", value })` so the shared walk records the answer without a back-stop (collect-inputs INPUT-24) |
+| CCI-28 | L1 | the real `da/mcp-server` (remote-only `mcp.serverTypes`, so `mcpServerType` auto-skips), a caller `baseStep` + `backable`, and a `back` at the first *visible* prompt (`mcpServerUrl`) | `runCreateInputsWalk` | the auto-skipped `mcpServerType` leaves no history, so the `back` returns `{ kind:"back" }` to the front door (re-enters Q1) instead of re-asking the skipped question, and `mcpServerUrl` is shown at `baseStep + 1` |
 
 ## Flow
 
@@ -169,9 +173,11 @@ flowchart TD
   from an in-memory floor built from the loose `templates/v4` source — no built
   `templates.zip` artifact required.
 - **INV-6** — The bridge threads the caller's 1-based `step` onto each host config
-  (the Back-button gate) and projects a host `back` result to `{ kind: "back" }`,
-  so [`collect-inputs`](collect-inputs.md) drives back navigation
-  surface-neutrally (CCI-10..13 / INPUT-16..19).
+  (the Back-button gate), projects a host `back` result to `{ kind: "back" }`, and
+  projects a host `skip` (an auto-selected `skipSingleOption`) to `{ kind: "skip" }`,
+  so [`collect-inputs`](collect-inputs.md) drives back navigation and
+  skip-transparency surface-neutrally (CCI-10..13, CCI-27..28 / INPUT-16..19,
+  INPUT-24).
 - **INV-7** — The `csharp` language axis is gated by `surface` + the injected
   `TEAMSFX_CLI_DOTNET` reader **before** the create floor composer builds the language question
   (CCI-14..16): the VS Code extension never offers C#, the CLI / VS surfaces offer
@@ -196,6 +202,15 @@ flowchart TD
   for focused integration checks such as descriptor/question loading and the
   default registry wiring, and may be shared across tests in that file because
   package bytes are immutable input.
+- **INV-11** — Q2+Q3 are stateless-rebuilt per call; back navigation is threaded,
+  not owned. `runCreateInputs` derives the entire Q2 + `language` + common-floor
+  question set from `locator` + the loaded descriptor on every call, holding no
+  cross-call state, so the front door's re-entry loop (dispatch-create-by-engine
+  INV-10) produces the correct new Q2+Q3 for a changed `BuildTarget` with no
+  invalidation logic (CCI-26). The operation only threads the caller's `baseStep`
+  / `backable` / typed `{ kind:"back" }` outcome through to the shared
+  [`collect-inputs`](collect-inputs.md) engine (collect-inputs INV-9); it
+  implements no back-stack of its own.
 
 ## Notes
 

--- a/docs/03-specs/operations/scaffolding/collect-inputs.md
+++ b/docs/03-specs/operations/scaffolding/collect-inputs.md
@@ -106,6 +106,10 @@ On `err`:
 | INPUT-17 | L1 | a caller-provided `language` question after one earlier prompted question, and the host returns `back` at `language` | collect | `back` crosses into the previous prompted question; the re-picked previous answer wins, then `language` is asked again |
 | INPUT-18 | L1 | a single prompted question, the host returns `back` at it (the first prompt) | collect | the walk is cancelled with a **`UserError`** named `InputWalkCancelled` (a `back` past the first prompt — unreachable via UI, where step 1 shows no Back button) |
 | INPUT-19 | L1 | a `singleSelect` then a `multiSelect`, the host returns `back` at the multiSelect | collect | the previous question is re-asked and the staged multi-select is discarded; the re-walk records the new `string[]` (the multi-pick face honours `back` too) |
+| INPUT-20 | L1 | a `baseStep` offset of `N` and two prompted questions | walkInputs | the shown `step` for the k-th prompted question is `N + (prompts shown so far) + 1`, so with `N ≥ 1` the **first** prompted question is `step ≥ 2` and the host shows a Back button on it — the create funnel's Q2 continues Q1's step numbering instead of restarting at 1 |
+| INPUT-21 | L1 | `backable: true`, a single prompted question, the host returns `back` at it (the first prompt) | walkInputs | the walk does **not** cancel; it returns a typed `{ kind: "back" }` outcome carrying the walk `history`, so the caller can hand control to the previous phase. With `backable: false` (the default) the same `back` still cancels with `InputWalkCancelled` (INPUT-18 unchanged) |
+| INPUT-22 | L1 | a `resume` of a prior walk's returned `history` (a re-entered phase) | walkInputs | the walk restores that history and re-asks its **last** prompted question; a subsequent `back` pops the retained history exactly as if it had been built in-process (a resumed phase's back reaches every prompt the previous run recorded), and a `back` past the retained history's first entry follows the `backable` rule (typed `back` or `InputWalkCancelled`) |
+| INPUT-24 | L1 | a question the surface auto-skips (the prompt driver returns `{ kind: "skip" }`, e.g. a `skipSingleOption` provider question resolved to a single option), then a `back` at the next prompt | walkInputs | the skipped question's answer is **recorded** but pushes **no** history, so the `back` crosses straight over it (matching the engine's static `skipSingleOption` skip) — it re-asks the previous *prompted* question, or crosses into the previous phase / cancels when none remain; the skipped step consumes no `step` number |
 
 ## Flow
 
@@ -243,4 +247,22 @@ This operation does **not**:
   `step` = prompts shown so far + 1 (the host shows a Back button only when
   `step > 1`), so the first prompt is step 1 and a `back` there cancels the walk
   (`InputWalkCancelled`). A caller-provided `language` question participates in
-  that same history like any other prompted question (INPUT-16..19).
+  that same history like any other prompted question (INPUT-16..19). A **surface**
+  auto-skip (the prompt driver returns `{ kind: "skip" }` — e.g. `skipSingleOption`
+  resolved to a single option) is one such auto-selected step: it records its
+  answer but pushes no history (INPUT-24), so `back` crosses over it identically
+  to the engine's static single-option skip (the two skip paths are symmetric).
+- **INV-9 — Resumable walk with step offset (the cross-phase back primitive).**
+  The walk exposes an optional `baseStep` (added to the 1-based shown step so a
+  later phase continues an earlier phase's numbering, INPUT-20), an optional
+  `backable` flag (a `back` past the first prompt returns a typed
+  `{ kind:"back" }` outcome instead of cancelling, INPUT-21), and an optional
+  `resume` of a prior walk's `history` (re-enter a completed phase at its last
+  prompt with the retained history intact, INPUT-22). The engine returns
+  `{ kind, answers?, history, promptCount }` (`promptCount` = prompts actually
+  shown; skipped / pre-filled / auto-selected steps excluded). The legacy
+  `collectInputs(...)` entry is a thin wrapper (`baseStep:0`, `backable:false`,
+  no `resume`) mapping `{kind:"done"}` → `ok(answers)` and back-past-first →
+  `InputWalkCancelled`, so INPUT-01..19 and INV-8 are byte-for-byte unchanged.
+  All back logic lives in this one engine — no surface or front door owns a
+  parallel back-stack (v4-scaffolding "one walk engine").

--- a/docs/03-specs/operations/scaffolding/dispatch-create-by-engine.md
+++ b/docs/03-specs/operations/scaffolding/dispatch-create-by-engine.md
@@ -112,6 +112,10 @@ production path does not split selector and content resolution.
 | DCE-19 | L1 | flag **on**, a v4 target whose id has a known v3 template equivalent | `createProjectFrontDoor` resolves the target | the front door stores the mapped v3 template id on `inputs["template-name"]` before the create-input walk runs, so v4 scaffold-level `generate-template` telemetry can report a v3-compatible `template-name` and continue joining with command-level `create-project`; common floor collection inside `runCreateInputs` is not short-circuited by the resolved template name |
 | DCE-20 | L1 | flag **on**, a v4 target whose id has no mapping entry | `createProjectFrontDoor` resolves the target | `inputs["template-name"]` falls back to the v4 target id itself, preserving a stable match key for `generate-template` telemetry |
 | DCE-21 | L1 | flag **on**, the v4 scaffold succeeds or fails after target resolution | `scaffoldV4` | emits `generate-template` success/error telemetry with `template-name = <mapped-or-fallback-template-id>-<language-key>` and the resolved v4 package source/version/digest properties, so existing OKR queries can continue to join `generate-template` with `create-project` by correlation id |
+| DCE-22 | L1 | flag **on**, the DA+MCP v4 route, a scripted UI answering Q1, reaching Q2, then returning `back` at Q2's **first** prompt | `createProjectFrontDoor` | the front door does **not** cancel the create; it re-enters Q1 (resuming at its last dimension — walk-create-selector WCS-24, collect-create-inputs CCI-25) so the user can re-pick a Q1 dimension — Q1 and Q2 form one continuous back-navigable wizard across the phase boundary |
+| DCE-23 | L1 | flag **on**, after re-entering Q1 the user picks a **different** dimension that resolves a **different** `templateId` (e.g. `daTemplate` `add-action`→`no-action`) | `createProjectFrontDoor` | the loop resolves the new `BuildTarget` and runs `runCreateInputs` fresh under the new `locator`, loading that template's Q2+Q3 (CCI-26); the prior template's Q2 answers are discarded and no stale question is asked — the Q2+Q3 set always matches the currently resolved template |
+| DCE-24 | L1 | flag **on**, the user backs through Q2 into Q1 and then `back` at Q1's **first** dimension | `createProjectFrontDoor` | the whole create is cancelled with the propagated `BuildTargetWalkCancelled` `UserError` (the true top of the wizard); no scaffold occurs |
+| DCE-25 | L1 | flag **on**, a re-entry loop iteration whose prior iteration wrote `inputs["template-name"]` | `createProjectFrontDoor` | the loop re-walks Q1 and does **not** mistake the prior iteration's `inputs["template-name"]` for a preset short-circuit; the preset-`template-name` fast path (INV-8) is evaluated once, before the loop, so re-entry never skips Q1 |
 
 ## Flow
 
@@ -120,10 +124,12 @@ flowchart TD
   start(["createProjectFrontDoor(inputs)"]) --> flag{"TEAMSFX_V4_ENABLED?"}
   flag -- off --> v3pass["createV3(inputs)\n(unmodified createProject — pass-through)"] --> done(["CreateProjectResult"])
   flag -- on --> src["resolve TemplateArtifactSnapshot\n(or injected floor bytes in tests)"]
-  src --> sel["runCreateSelector(create-selector bytes, ui, surface) → BuildTarget"]
+  src --> sel["runCreateSelector(create-selector bytes, ui, surface,\nresume=retained Q1 history) → BuildTarget + history + promptCount"]
   sel --> eng{"engine"}
   eng -- "surface-action" --> act["return {projectPath:'', shouldInvokeTeamsAgent:true}\n(no Q2, no scaffold)"] --> done
-  eng -- "v4" --> q2v4["runCreateInputs(metadata bytes, locator, answers, ui)\n→ Answers + floor write-back"] --> sc["scaffoldDeclarativeFromV4Channel(locator, answers, templates bytes)"] --> done
+  eng -- "v4" --> q2v4["runCreateInputs(metadata bytes, locator, answers, ui,\nbaseStep=Q1 promptCount, backable)\n→ Answers + floor write-back | back"]
+  q2v4 -- "back at Q2 first prompt" --> sel
+  q2v4 -- "done" --> sc["scaffoldDeclarativeFromV4Channel(locator, answers, templates bytes)"] --> done
   eng -- "v3-core-method" --> unsupported(["err(UnsupportedCreateEngine)\nno v3 hand-off"])
   sel -. cancel .-> e(["err(UserError)"])
   q2v4 -. cancel/invalid .-> e
@@ -187,6 +193,20 @@ flowchart TD
   `collectCreateFloor` prompt engine and no v3 question-tree visitor. Preset
   `folder` / `app-name` values are reused and never re-prompted; a floor
   cancellation propagates unchanged with no scaffold (DCE-15).
+- **INV-10** — Cross-phase back is a front-door re-entry loop; Q1 history
+  retained, Q2+Q3 stateless-rebuilt. With `TEAMSFX_V4_ENABLED` on, the
+  `engine:"v4"` path is a loop: run Q1 (retaining its `history` + `promptCount`),
+  dispatch, run Q2+floor with `baseStep = promptCount` and `backable`, and on a
+  Q2-first `back` re-enter Q1 via its retained history (DCE-22..24). Q2+Q3 are
+  rebuilt fresh from the resolved `BuildTarget` on every forward crossing
+  (collect-create-inputs CCI-26 / INV-11) — the loop keeps **no** Q2 answer
+  cache, so a changed `templateId` yields the new template's questions with no
+  invalidation logic. The loop is scoped **below** the preset-`template-name`
+  check so a prior iteration's `inputs["template-name"]` never short-circuits Q1
+  (DCE-25). All back logic lives in the shared engine (collect-inputs INV-9); the
+  front door only ferries the opaque `history` between phases. The whole loop is
+  behind the flag (default off); flag-off is the unchanged v3 pass-through
+  (INV-1).
 
 ## Notes
 
@@ -216,3 +236,16 @@ flowchart TD
   design folds those common floor questions into `runCreateInputs`: template Q2,
   descriptor-bound `language`, and `folder` / `app-name` are one shared
   question-walk pass, while the front door remains a dispatch-only seam.
+- **Resolved (cross-phase back, 2026-07-08) — a surface auto-skip is
+ back-transparent.** The re-entry loop (INV-10) crosses back into Q1 when a
+  `back` reaches Q2's walk with an **empty** history. A provider-backed question
+  with `skipSingleOption` (e.g. `mcpServerType` when only `remote` is available)
+  is auto-selected by the **surface** (`{ type: "skip" }`); the prompt bridge now
+  projects that to `{ kind: "skip" }`, and the shared walk records the answer but
+  pushes **no** history (collect-inputs INPUT-24 / collect-create-inputs
+  CCI-27..28) — identically to a `staticOptions` single-option skip. So when such
+  a question is Q2's first, a `back` at the next visible prompt (`mcpServerUrl`)
+  now re-enters Q1 rather than re-asking the skipped provider question. (Earlier
+  this pushed history and shadowed the Q1 re-entry; it also affected Q2's own
+  internal back. Both are fixed by the symmetric skip handling.)
+

--- a/docs/03-specs/operations/scaffolding/walk-create-selector.md
+++ b/docs/03-specs/operations/scaffolding/walk-create-selector.md
@@ -139,6 +139,8 @@ localization mechanism.
 | WCS-15 | L1 | the floor (flag on), a scripted UI picking `projectType=copilot-agent-type` → `daTemplate=add-action`, returning `back` at `actionSource`, then re-picking `daTemplate=no-action` | `runCreateSelector` | `back` re-asks the previous prompted dimension (`daTemplate`) and discards the stale `add-action` pick before re-routing; `answers={ projectType:"copilot-agent-type", daTemplate:"no-action" }` (no `actionSource` left behind); prompt order is `projectType, daTemplate, actionSource, daTemplate` |
 | WCS-16 | L1 | the floor, a scripted UI picking `projectType=copilot-agent-type`, returning `back` at `daTemplate`, then re-picking `projectType` → `daTemplate=no-action` | `runCreateSelector` | `back` at the second prompt re-asks the first dimension (`projectType`) at `step` 1 (no Back button there); prompt order is `projectType(1), daTemplate(2), projectType(1), daTemplate(2)` |
 | WCS-17 | L1 | the floor, a scripted UI returning `back` at the very first prompt (`projectType`) | `runCreateSelector` | `err` — a `UserError` named `BuildTargetWalkCancelled` (a `back` past the first prompt cancels the walk; unreachable via UI, where step 1 shows no Back button) |
+| WCS-24 | L1 | a completed Q1 walk whose `history` the caller retained, then a `resume` of that history (the front door re-entering Q1 after a Q2 `back`) | `runCreateSelector` | the walk re-asks Q1's **last** prompted dimension with its history intact, and a further `back` multi-hops through the earlier Q1 dimensions (each still `step > 1`) until the first dimension, where `back` cancels with `BuildTargetWalkCancelled` — resuming preserves continuous Q1 back navigation across the phase boundary (collect-inputs INPUT-22) |
+| WCS-25 | L1 | any Q1 walk | `runCreateSelector` | the `ok` result exposes the walk `history` and `promptCount` (the number of dimensions actually prompted) so the front door can retain the history for `resume` and use `promptCount` as Q2's `baseStep`; a `surface-action` / fully-pre-filled walk reports `promptCount` accordingly (0 when nothing was prompted) |
 
 > **Withdrawn by ADR-0014 Amendment 2:** WCS-08 (the single-language no-prompt
 > check). `language` is no longer resolved in this Q1 walk; that behavior is now
@@ -183,6 +185,10 @@ flowchart TD
 - **INV-5** — The selector bytes are injectable, so the operation is CI-testable
   from an in-memory floor built from the loose `templates/v4` source — no built
   `templates.zip` artifact required.
+- **INV-6** — Resume preserves one back-stack. Q1 exposes the shared engine's
+  resumable `history` + `promptCount` (collect-inputs INV-9) so the front door
+  can re-enter it after a downstream Q2 `back` (WCS-24/25); the multi-level Q1
+  back on resume is the engine's history, not a Q1-specific re-implementation.
 
 ## Notes
 

--- a/packages/fx-core/src/core/createProjectFrontDoor.ts
+++ b/packages/fx-core/src/core/createProjectFrontDoor.ts
@@ -296,10 +296,7 @@ export async function createProjectFrontDoor(
         };
         let inputBytes: Buffer;
         if (snapshot === undefined) {
-          if (floorBytes === undefined) {
-            floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
-          }
-          inputBytes = floorBytes;
+          inputBytes = floorBytes ?? (deps.readFloorBytes ?? readBundledFloorBytes)();
         } else {
           const metadataBytes = await readSnapshotBytes(snapshot, "metadata");
           if (metadataBytes.isErr()) {
@@ -380,11 +377,10 @@ export async function createProjectFrontDoor(
     if (dispatched.isErr()) {
       return err(dispatched.error);
     }
-    /* istanbul ignore next -- the preset path is not backable (baseStep 0, backable false) */
-    if (dispatched.value.kind === "back") {
-      return err(unsupportedCreateTarget(target.value));
-    }
-    return ok(dispatched.value.result);
+    // The preset path is not backable (baseStep 0, backable false), so `done` is the live branch.
+    return dispatched.value.kind === "back"
+      ? err(unsupportedCreateTarget(target.value))
+      : ok(dispatched.value.result);
   }
 
   // Otherwise walk Q1 (INV-2). The selector bytes are stable across the cross-phase

--- a/packages/fx-core/src/core/createProjectFrontDoor.ts
+++ b/packages/fx-core/src/core/createProjectFrontDoor.ts
@@ -15,12 +15,14 @@ import { Result, err, ok } from "neverthrow";
 import {
   Answers,
   BuildTarget,
+  CreateSelectorDeps,
   DeclarativeLocator,
   TemplateArtifactKind,
   TemplateArtifactSnapshot,
+  WalkHistoryEntry,
   bundledFloorDir,
   resolveCreateTargetByTemplateId,
-  runCreateInputs,
+  runCreateInputsWalk,
   runCreateSelector,
   templateSourceFromArtifactSnapshot,
 } from "../v4";
@@ -134,8 +136,8 @@ export interface CreateFrontDoorDeps {
   runSelector?: typeof runCreateSelector;
   /** Resolve a target directly from a preset `template-name`, bypassing Q1 (default: the real `resolveCreateTargetByTemplateId`). */
   resolveByTemplateId?: typeof resolveCreateTargetByTemplateId;
-  /** The Q2 inputs walk (default: the real `runCreateInputs`). */
-  runInputs?: typeof runCreateInputs;
+  /** The Q2 inputs walk (default: the real `runCreateInputsWalk`, returning a resumable outcome). */
+  runInputs?: typeof runCreateInputsWalk;
 }
 
 /** The default `featureFlagManager`-backed reader (a flag is on per its env var / VS Code setting). */
@@ -268,14 +270,90 @@ export async function createProjectFrontDoor(
   let floorBytes: Buffer | undefined;
   const interactive = !inputs.nonInteractive;
 
+  // Dispatch one resolved BuildTarget by its engine (INV-3). Returns a scaffolded
+  // result, or `{ kind: "back" }` when a backable Q2 was exited at its first prompt
+  // (the caller re-enters Q1). `snapshot` / `floorBytes` are read lazily and shared.
+  async function dispatchByEngine(
+    target: BuildTarget,
+    baseStep: number,
+    backable: boolean
+  ): Promise<Result<{ kind: "result"; result: CreateProjectResult } | { kind: "back" }, FxError>> {
+    switch (target.engine) {
+      case "surface-action": {
+        const action = dispatchSurfaceAction(target);
+        return action.isErr() ? err(action.error) : ok({ kind: "result", result: action.value });
+      }
+      case "v3-core-method":
+        return err(unsupportedCreateTarget(target));
+      case "v4": {
+        inputs[QuestionNames.TemplateName] = templateNameForV4(target);
+        const runInputs = deps.runInputs ?? runCreateInputsWalk;
+        const locator: DeclarativeLocator = { kind: "create", templateId: target.templateId };
+        // Q2 + common floor, over the same floor, continuing Q1's step numbering.
+        const entryParams: Answers = {
+          ...(target.answers ?? {}),
+          ...neutralAnswersFromInputs(inputs),
+        };
+        let inputBytes: Buffer;
+        if (snapshot === undefined) {
+          if (floorBytes === undefined) {
+            floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
+          }
+          inputBytes = floorBytes;
+        } else {
+          const metadataBytes = await readSnapshotBytes(snapshot, "metadata");
+          if (metadataBytes.isErr()) {
+            return err(metadataBytes.error);
+          }
+          inputBytes = metadataBytes.value;
+        }
+        const outcome = await runInputs(inputBytes, locator, entryParams, ui, {
+          flagReader,
+          surface,
+          inputs,
+          baseStep,
+          backable,
+        });
+        if (outcome.isErr()) {
+          return err(outcome.error);
+        }
+        if (outcome.value.kind === "back") {
+          return ok({ kind: "back" });
+        }
+        const answers = outcome.value.answers;
+        applyV4CreateFloorAnswers(inputs, answers);
+        // The scaffold contract is a plain BuildTarget; do not leak Q1 walk metadata.
+        const scaffoldTarget: BuildTarget = {
+          templateId: target.templateId,
+          engine: target.engine,
+          answers: target.answers,
+        };
+        if (snapshot !== undefined) {
+          const fullBytes = await readSnapshotBytes(snapshot, "templates");
+          if (fullBytes.isErr()) {
+            return err(fullBytes.error);
+          }
+          const scaffolded = await deps.scaffoldV4(inputs, scaffoldTarget, answers, flagReader, {
+            source: templateSourceFromArtifactSnapshot(snapshot),
+            bytes: fullBytes.value,
+          });
+          return scaffolded.isErr()
+            ? err(scaffolded.error)
+            : ok({ kind: "result", result: scaffolded.value });
+        }
+        const scaffolded = await deps.scaffoldV4(inputs, scaffoldTarget, answers, flagReader);
+        return scaffolded.isErr()
+          ? err(scaffolded.error)
+          : ok({ kind: "result", result: scaffolded.value });
+      }
+    }
+  }
+
   // A surface that already resolved the leaf template — the CLI in non-interactive
   // mode presets `template-name` from its `-c` capability — pins the BuildTarget by
-  // id: the Q1 selector is a *router*, so re-walking it would re-prompt, or (non-
-  // interactive) fail on a missing dimension, for a target already chosen. Resolve
-  // the engine from the template's route. Otherwise walk Q1 (INV-2), threading
-  // `interactive` so a non-interactive surface never silently prompts.
+  // id: the Q1 selector is a *router*, so re-walking it would re-prompt. Resolve the
+  // engine from the template's route and dispatch once (no cross-phase back; INV-8).
   const presetTemplateId = inputs[QuestionNames.TemplateName];
-  let target: Result<BuildTarget, FxError>;
   if (presetTemplateId) {
     if (snapshot === undefined && deps.resolveArtifactSnapshot !== undefined) {
       const resolved = await deps.resolveArtifactSnapshot("templates");
@@ -294,33 +372,54 @@ export async function createProjectFrontDoor(
       floorBytes = fullBytes.value;
     }
     const resolveByTemplateId = deps.resolveByTemplateId ?? resolveCreateTargetByTemplateId;
-    target = resolveByTemplateId(floorBytes, presetTemplateId);
+    const target = resolveByTemplateId(floorBytes, presetTemplateId);
+    if (target.isErr()) {
+      return err(target.error);
+    }
+    const dispatched = await dispatchByEngine(target.value, 0, false);
+    if (dispatched.isErr()) {
+      return err(dispatched.error);
+    }
+    /* istanbul ignore next -- the preset path is not backable (baseStep 0, backable false) */
+    if (dispatched.value.kind === "back") {
+      return err(unsupportedCreateTarget(target.value));
+    }
+    return ok(dispatched.value.result);
+  }
+
+  // Otherwise walk Q1 (INV-2). The selector bytes are stable across the cross-phase
+  // back re-entry loop, so resolve them once; each iteration re-walks Q1 (retaining
+  // its history for `resume`) and dispatches, re-entering Q1 on a Q2-first back so
+  // Q1 and Q2 form one continuous back-navigable wizard (INV-10). The loop is scoped
+  // below the preset check, so a prior iteration's `template-name` never short-circuits Q1.
+  if (snapshot === undefined && deps.resolveArtifactSnapshot !== undefined) {
+    const resolved = await deps.resolveArtifactSnapshot("create-selector");
+    if (resolved.isErr()) {
+      return err(resolved.error);
+    }
+    snapshot = resolved.value;
+  }
+  let selectorBytes: Buffer;
+  if (snapshot === undefined) {
+    floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
+    selectorBytes = floorBytes;
   } else {
-    if (snapshot === undefined && deps.resolveArtifactSnapshot !== undefined) {
-      const resolved = await deps.resolveArtifactSnapshot("create-selector");
-      if (resolved.isErr()) {
-        return err(resolved.error);
-      }
-      snapshot = resolved.value;
+    const selector = await readSnapshotBytes(snapshot, "create-selector");
+    if (selector.isErr()) {
+      return err(selector.error);
     }
-    let selectorBytes: Buffer;
-    if (snapshot === undefined) {
-      floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
-      selectorBytes = floorBytes;
-    } else {
-      const selector = await readSnapshotBytes(snapshot, "create-selector");
-      if (selector.isErr()) {
-        return err(selector.error);
-      }
-      selectorBytes = selector.value;
-    }
-    const runSelector = deps.runSelector ?? runCreateSelector;
-    const selectorDeps = {
+    selectorBytes = selector.value;
+  }
+  const runSelector: typeof runCreateSelector = deps.runSelector ?? runCreateSelector;
+  let resumeHistory: WalkHistoryEntry[] | undefined = undefined;
+  for (;;) {
+    const selectorDeps: CreateSelectorDeps = {
       flagReader,
       interactive,
       prefilled: selectorPrefillFromInputs(inputs),
+      resume: resumeHistory === undefined ? undefined : { history: resumeHistory },
     };
-    target =
+    const target =
       snapshot === undefined
         ? await runSelector(selectorBytes, ui, surface, selectorDeps)
         : await runSelector(selectorBytes, ui, surface, {
@@ -328,59 +427,19 @@ export async function createProjectFrontDoor(
             selectorBytesKind: "json",
             v4Registry: deps.v4Registry,
           });
-  }
-  if (target.isErr()) {
-    return err(target.error);
-  }
-
-  // INV-3: exactly one resolved BuildTarget, dispatched by its engine.
-  switch (target.value.engine) {
-    case "surface-action":
-      return dispatchSurfaceAction(target.value);
-    case "v4": {
-      inputs[QuestionNames.TemplateName] = templateNameForV4(target.value);
-      const runInputs = deps.runInputs ?? runCreateInputs;
-      const locator: DeclarativeLocator = { kind: "create", templateId: target.value.templateId };
-      // Q2: the template's own inputs, over the same floor.
-      const entryParams: Answers = {
-        ...(target.value.answers ?? {}),
-        ...neutralAnswersFromInputs(inputs),
-      };
-      let inputBytes: Buffer;
-      if (snapshot === undefined) {
-        if (floorBytes === undefined) {
-          floorBytes = (deps.readFloorBytes ?? readBundledFloorBytes)();
-        }
-        inputBytes = floorBytes;
-      } else {
-        const metadataBytes = await readSnapshotBytes(snapshot, "metadata");
-        if (metadataBytes.isErr()) {
-          return err(metadataBytes.error);
-        }
-        inputBytes = metadataBytes.value;
-      }
-      const answers = await runInputs(inputBytes, locator, entryParams, ui, {
-        flagReader,
-        surface,
-        inputs,
-      });
-      if (answers.isErr()) {
-        return err(answers.error);
-      }
-      applyV4CreateFloorAnswers(inputs, answers.value);
-      if (snapshot !== undefined) {
-        const fullBytes = await readSnapshotBytes(snapshot, "templates");
-        if (fullBytes.isErr()) {
-          return err(fullBytes.error);
-        }
-        return deps.scaffoldV4(inputs, target.value, answers.value, flagReader, {
-          source: templateSourceFromArtifactSnapshot(snapshot),
-          bytes: fullBytes.value,
-        });
-      }
-      return deps.scaffoldV4(inputs, target.value, answers.value, flagReader);
+    if (target.isErr()) {
+      return err(target.error);
     }
-    case "v3-core-method":
-      return err(unsupportedCreateTarget(target.value));
+    // Q2 continues Q1's step numbering (baseStep = promptCount) and is backable: a
+    // back at its first prompt re-enters Q1 with the retained history (INV-10).
+    const dispatched = await dispatchByEngine(target.value, target.value.promptCount, true);
+    if (dispatched.isErr()) {
+      return err(dispatched.error);
+    }
+    if (dispatched.value.kind === "back") {
+      resumeHistory = target.value.history;
+      continue;
+    }
+    return ok(dispatched.value.result);
   }
 }

--- a/packages/fx-core/src/v4/buildTarget/resolveBuildTarget.ts
+++ b/packages/fx-core/src/v4/buildTarget/resolveBuildTarget.ts
@@ -8,7 +8,8 @@ import {
   OptionItem,
   PromptUI,
   QuestionSpec,
-  collectInputs,
+  WalkHistoryEntry,
+  walkInputs,
 } from "../collectInputs/collectInputs";
 import {
   ExpressionNode,
@@ -81,6 +82,17 @@ export interface BuildTarget {
   engine: DispatchEngine;
   /** The Q1 dimension picks that produced this target. */
   answers?: Record<string, string>;
+}
+
+/**
+ * A `BuildTarget` plus the Q1 walk state the front door retains for cross-phase
+ * back (a superset, so existing `BuildTarget` reads are unaffected). `history` is
+ * opaque to the front door — it is only handed back via `resume`; `promptCount`
+ * is the number of Q1 dimensions actually prompted (Q2's `baseStep`).
+ */
+export interface SelectorWalkResult extends BuildTarget {
+  history: WalkHistoryEntry[];
+  promptCount: number;
 }
 
 /** `UserError` name: a resolved/supplied `templateId` belongs to no world. */
@@ -277,18 +289,34 @@ async function collectSelectorAnswers(
   selector: SelectorSpec,
   prefilled: Record<string, string>,
   interactive: boolean,
-  port: RouteResolverPort
-): Promise<Result<Record<string, string>, FxError>> {
-  const collected = await collectInputs(
+  port: RouteResolverPort,
+  resume: { history: WalkHistoryEntry[] } | undefined
+): Promise<
+  Result<
+    { answers: Record<string, string>; history: WalkHistoryEntry[]; promptCount: number },
+    FxError
+  >
+> {
+  const collected = await walkInputs(
     selectorQuestions(selector),
     selectorOptionsSchema(selector),
     prefilled,
-    buildCollectPort(interactive, port)
+    buildCollectPort(interactive, port),
+    { resume }
   );
   if (collected.isErr()) {
     return err(collected.error);
   }
-  return scalarAnswers(selector, collected.value, port);
+  const outcome = collected.value;
+  /* istanbul ignore next -- Q1 is not backable; a back past the first prompt errors in the prompt face (WCS-17) */
+  if (outcome.kind === "back") {
+    return err(userError(BUILD_TARGET_WALK_CANCELLED, "the create selector was cancelled"));
+  }
+  const scalar = scalarAnswers(selector, outcome.answers, port);
+  if (scalar.isErr()) {
+    return err(scalar.error);
+  }
+  return ok({ answers: scalar.value, history: outcome.history, promptCount: outcome.promptCount });
 }
 
 /** Match the first route whose `when` predicate is true against the collected answers. */
@@ -359,8 +387,9 @@ export async function resolveBuildTarget(
   selector: SelectorSpec,
   prefilled: Record<string, string>,
   interactive: boolean,
-  port: RouteResolverPort
-): Promise<Result<BuildTarget, FxError>> {
+  port: RouteResolverPort,
+  options: { resume?: { history: WalkHistoryEntry[] } } = {}
+): Promise<Result<SelectorWalkResult, FxError>> {
   // Validate the whole routing table before any route match.
   const routesOk = validateRoutes(selector.routes, port);
   if (routesOk.isErr()) {
@@ -368,11 +397,17 @@ export async function resolveBuildTarget(
   }
 
   // One prefill-aware walk covers interactive and non-interactive resolution.
-  const walked = await collectSelectorAnswers(selector, prefilled, interactive, port);
+  const walked = await collectSelectorAnswers(
+    selector,
+    prefilled,
+    interactive,
+    port,
+    options.resume
+  );
   if (walked.isErr()) {
     return err(walked.error);
   }
-  const answers = walked.value;
+  const { answers, history, promptCount } = walked.value;
 
   const matched = matchRoute(selector, answers, port);
   if (matched.isErr()) {
@@ -383,5 +418,5 @@ export async function resolveBuildTarget(
     return err(dispatched.error);
   }
 
-  return ok({ ...dispatched.value, answers });
+  return ok({ ...dispatched.value, answers, history, promptCount });
 }

--- a/packages/fx-core/src/v4/buildTarget/resolveBuildTarget.ts
+++ b/packages/fx-core/src/v4/buildTarget/resolveBuildTarget.ts
@@ -308,15 +308,15 @@ async function collectSelectorAnswers(
     return err(collected.error);
   }
   const outcome = collected.value;
-  /* istanbul ignore next -- Q1 is not backable; a back past the first prompt errors in the prompt face (WCS-17) */
-  if (outcome.kind === "back") {
-    return err(userError(BUILD_TARGET_WALK_CANCELLED, "the create selector was cancelled"));
-  }
-  const scalar = scalarAnswers(selector, outcome.answers, port);
-  if (scalar.isErr()) {
-    return err(scalar.error);
-  }
-  return ok({ answers: scalar.value, history: outcome.history, promptCount: outcome.promptCount });
+  // `backable` is off for Q1, so a back past the first prompt errors in the prompt face (WCS-17)
+  // rather than returning a top-level back; the `done` branch is the live path.
+  return outcome.kind === "done"
+    ? scalarAnswers(selector, outcome.answers, port).map((answers) => ({
+        answers,
+        history: outcome.history,
+        promptCount: outcome.promptCount,
+      }))
+    : err(userError(BUILD_TARGET_WALK_CANCELLED, "the create selector was cancelled"));
 }
 
 /** Match the first route whose `when` predicate is true against the collected answers. */

--- a/packages/fx-core/src/v4/collectInputs/collectInputs.ts
+++ b/packages/fx-core/src/v4/collectInputs/collectInputs.ts
@@ -441,11 +441,8 @@ export async function collectInputs(
   if (outcome.isErr()) {
     return err(outcome.error);
   }
-  /* istanbul ignore next -- backable is off here, so the walk cancels before returning a top-level back */
-  if (outcome.value.kind === "back") {
-    return err(walkCancelled());
-  }
-  return ok(outcome.value.answers);
+  // `backable` is off here, so the walk cancels rather than returning a top-level back.
+  return outcome.value.kind === "back" ? err(walkCancelled()) : ok(outcome.value.answers);
 }
 
 function resolveQuestionValidation(

--- a/packages/fx-core/src/v4/collectInputs/collectInputs.ts
+++ b/packages/fx-core/src/v4/collectInputs/collectInputs.ts
@@ -100,8 +100,29 @@ export type Validator = (
 
 export type PromptValidation = (value: string) => string | undefined | Promise<string | undefined>;
 
-/** One prompt's outcome: a chosen value or the host's `back` request. */
-export type Asked<T> = { kind: "value"; value: T } | { kind: "back" };
+/** One prompt's outcome: a chosen value, a surface auto-skip, or the host's `back` request. */
+export type Asked<T> = { kind: "value"; value: T } | { kind: "skip"; value: T } | { kind: "back" };
+
+/** One resumable walk's history entry (opaque to cross-phase callers). */
+export interface WalkHistoryEntry {
+  pos: number;
+  answers: Answers;
+}
+
+/** The resumable walk's outcome: a completed answer set, or a `back` handed to the caller. */
+export type WalkOutcome =
+  | { kind: "done"; answers: Answers; history: WalkHistoryEntry[]; promptCount: number }
+  | { kind: "back"; history: WalkHistoryEntry[]; promptCount: number };
+
+/** Options for the resumable walk (the cross-phase back primitive; see collect-inputs INV-9). */
+export interface WalkOptions {
+  /** Added to the 1-based shown step so a later phase continues an earlier phase's numbering. */
+  baseStep?: number;
+  /** Resume a prior walk by re-entering its last prompted question via `back`. */
+  resume?: { history: WalkHistoryEntry[] };
+  /** When true, a `back` past the first prompt returns `{ kind: "back" }` instead of cancelling. */
+  backable?: boolean;
+}
 
 /** Surface-neutral prompt driver. */
 export interface PromptUI {
@@ -159,15 +180,21 @@ function missingNonInteractiveAnswer(questionName: string): UserError {
   });
 }
 
-/** Walk one template's questions into the resolved answer object. */
-export async function collectInputs(
+/**
+ * Walk one phase's questions into a resumable outcome — the shared cross-phase
+ * back primitive (collect-inputs INV-9). `baseStep` offsets the shown step so a
+ * later phase continues an earlier phase's numbering; `backable` turns a `back`
+ * past the first prompt into a `{ kind: "back" }` outcome instead of cancelling;
+ * `resume` re-enters a prior walk's history at its last prompted question.
+ */
+export async function walkInputs(
   questions: QuestionSpec[],
   optionsSchema: OptionsSchema,
   entryParams: Answers,
-  port: CollectInputsPort
-): Promise<Result<Answers, FxError>> {
-  // Pre-filled entry params must be visible to question conditions.
-  let answers: Answers = { ...entryParams };
+  port: CollectInputsPort,
+  walkOptions: WalkOptions = {}
+): Promise<Result<WalkOutcome, FxError>> {
+  const baseStep = walkOptions.baseStep ?? 0;
   const declared = Object.keys(optionsSchema.properties ?? {});
   // Cache providers by normalized params for a single run.
   const providerCache = new Map<string, Promise<ResolvedOptions>>();
@@ -175,9 +202,27 @@ export async function collectInputs(
   const resolvedProviders = new Set<string>();
 
   // Back history snapshots only prompted steps; skipped and pre-filled steps are crossed over.
-  const history: { pos: number; answers: Answers }[] = [];
+  const history: WalkHistoryEntry[] =
+    walkOptions.resume !== undefined ? [...walkOptions.resume.history] : [];
 
-  let pos = 0;
+  let answers: Answers;
+  let pos: number;
+  if (walkOptions.resume !== undefined) {
+    // Re-enter the resumed walk at its last prompted question (one `back`).
+    const restore = history.pop();
+    if (restore === undefined) {
+      return walkOptions.backable === true
+        ? ok({ kind: "back", history: [], promptCount: 0 })
+        : err(walkCancelled());
+    }
+    answers = { ...restore.answers };
+    pos = restore.pos;
+  } else {
+    // Pre-filled entry params must be visible to question conditions.
+    answers = { ...entryParams };
+    pos = 0;
+  }
+
   while (pos < questions.length) {
     const q = questions[pos];
 
@@ -281,13 +326,16 @@ export async function collectInputs(
 
     // multiSelect must preserve its typed string[] answer.
     if (q.type === "multiSelect") {
-      const picked = await port.ui.askMulti(q, options, history.length + 1);
+      const picked = await port.ui.askMulti(q, options, baseStep + history.length + 1);
       if (picked.isErr()) {
         return err(picked.error);
       }
       if (picked.value.kind === "back") {
         const restore = history.pop();
         if (restore === undefined) {
+          if (walkOptions.backable === true) {
+            return ok({ kind: "back", history: [], promptCount: 0 });
+          }
           return err(walkCancelled());
         }
         answers = restore.answers;
@@ -305,7 +353,10 @@ export async function collectInputs(
           return err(mergeResult.error);
         }
       }
-      history.push({ pos, answers: { ...answers } });
+      // A surface auto-skip (skipSingleOption) records the answer but is not a back-stop.
+      if (picked.value.kind === "value") {
+        history.push({ pos, answers: { ...answers } });
+      }
       answers[q.name] = picked.value.value;
       pos++;
       continue;
@@ -326,13 +377,22 @@ export async function collectInputs(
       return err(inputBoxValidationResult.error);
     }
     const inputBoxValidation = inputBoxValidationResult.value;
-    const asked = await port.ui.ask(q, options, history.length + 1, validation, inputBoxValidation);
+    const asked = await port.ui.ask(
+      q,
+      options,
+      baseStep + history.length + 1,
+      validation,
+      inputBoxValidation
+    );
     if (asked.isErr()) {
       return err(asked.error);
     }
     if (asked.value.kind === "back") {
       const restore = history.pop();
       if (restore === undefined) {
+        if (walkOptions.backable === true) {
+          return ok({ kind: "back", history: [], promptCount: 0 });
+        }
         return err(walkCancelled());
       }
       answers = restore.answers;
@@ -353,12 +413,39 @@ export async function collectInputs(
       }
     }
 
-    history.push({ pos, answers: { ...answers } });
+    // A surface auto-skip (skipSingleOption) records the answer but is not a back-stop,
+    // so `back` at a later prompt crosses over it (matching a static skipSingleOption skip).
+    if (asked.value.kind === "value") {
+      history.push({ pos, answers: { ...answers } });
+    }
     answers[q.name] = value;
     pos++;
   }
 
-  return ok(answers);
+  return ok({ kind: "done", answers, history, promptCount: history.length });
+}
+
+/**
+ * Walk one template's questions into the resolved answer object — the stable
+ * non-resumable entry over {@link walkInputs} (no step offset, no resume,
+ * `backable` off), so a `back` past the first prompt cancels (INPUT-18) and the
+ * result is the plain answer object. Preserves the pre-cross-phase contract.
+ */
+export async function collectInputs(
+  questions: QuestionSpec[],
+  optionsSchema: OptionsSchema,
+  entryParams: Answers,
+  port: CollectInputsPort
+): Promise<Result<Answers, FxError>> {
+  const outcome = await walkInputs(questions, optionsSchema, entryParams, port);
+  if (outcome.isErr()) {
+    return err(outcome.error);
+  }
+  /* istanbul ignore next -- backable is off here, so the walk cancels before returning a top-level back */
+  if (outcome.value.kind === "back") {
+    return err(walkCancelled());
+  }
+  return ok(outcome.value.answers);
 }
 
 function resolveQuestionValidation(

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FxError, Inputs, UserInteraction } from "@microsoft/teamsfx-api";
-import { Result, err } from "neverthrow";
+import { FxError, Inputs, UserError, UserInteraction } from "@microsoft/teamsfx-api";
+import { Result, err, ok } from "neverthrow";
 import { MCPFetchResult, fetchMCPTools } from "../../component/utils/mcpToolFetcher";
 import { ODRProvider, type ODRServer } from "../../component/utils/odrProvider";
 import { readBooleanFeatureFlag } from "../../common/featureFlags";
@@ -11,7 +11,7 @@ import {
   CollectInputsPort,
   OptionsProvider,
   OptionsSchema,
-  collectInputs,
+  walkInputs,
 } from "../collectInputs/collectInputs";
 import { openDeclarativePackageMetadata } from "../distribution/declarativePackage";
 import { evaluateExpression } from "../expression/evaluateExpression";
@@ -103,16 +103,28 @@ export interface CreateInputsDeps {
   listLocalMcpServers?: () => Promise<ODRServer[]>;
   /** Search public OpenAPI descriptions for the v3-compatible OpenAPI source picker. */
   searchOpenAPISpec?: (query: string) => Promise<SearchOpenAPISpecResult[]>;
+  /** Continue Q1's step numbering (its `promptCount`) so Q2's first prompt shows a Back button. */
+  baseStep?: number;
+  /** When true, a back past Q2's first prompt returns `{ kind: "back" }` (the front door re-enters Q1). */
+  backable?: boolean;
 }
 
-/** Run one create template's Q2 over the host surface. */
-export async function runCreateInputs(
+/** The create-input walk's outcome: completed answers, or a `back` for the front door's re-entry loop. */
+export type CreateInputsOutcome = { kind: "done"; answers: Answers } | { kind: "back" };
+
+/**
+ * Run one create template's Q2 + common floor over the host surface, returning a
+ * resumable outcome. `deps.baseStep` continues Q1's step numbering and
+ * `deps.backable` turns a back past the first prompt into a `{ kind: "back" }`
+ * outcome (the front door then re-enters Q1). See collect-create-inputs CCI-25/26.
+ */
+export async function runCreateInputsWalk(
   floorBytes: Buffer,
   locator: DeclarativeLocator,
   entryParams: Answers,
   ui: UserInteraction,
   deps: CreateInputsDeps = {}
-): Promise<Result<Answers, FxError>> {
+): Promise<Result<CreateInputsOutcome, FxError>> {
   const opened = openDeclarativePackageMetadata(floorBytes, locator);
   if (opened.isErr()) {
     return err(opened.error);
@@ -159,25 +171,62 @@ export async function runCreateInputs(
     nonInteractive: deps.inputs?.nonInteractive === true ? "true" : "false",
   };
 
-  const answers = await collectInputs(
+  const walked = await walkInputs(
     [...opened.value.questions, ...floorTail.value.questions],
     declaredOptionsSchema(descriptor),
     initialAnswers,
-    port
+    port,
+    { baseStep: deps.baseStep, backable: deps.backable }
   );
-  if (answers.isErr()) {
-    return err(answers.error);
+  if (walked.isErr()) {
+    return err(walked.error);
   }
-  delete answers.value.nonInteractive;
-  const selectedOpenApiSpec = answers.value.selectOpenApiSpec;
-  if (answers.value.apiSpecLocation === undefined && typeof selectedOpenApiSpec === "string") {
-    answers.value.apiSpecLocation = selectedOpenApiSpec;
+  if (walked.value.kind === "back") {
+    return ok({ kind: "back" });
+  }
+  const answers = walked.value.answers;
+  delete answers.nonInteractive;
+  const selectedOpenApiSpec = answers.selectOpenApiSpec;
+  if (answers.apiSpecLocation === undefined && typeof selectedOpenApiSpec === "string") {
+    answers.apiSpecLocation = selectedOpenApiSpec;
   }
   if (deps.inputs !== undefined) {
-    const validation = await validateCreateFloorAnswers(deps.inputs, answers.value);
+    const validation = await validateCreateFloorAnswers(deps.inputs, answers);
     if (validation.isErr()) {
       return err(validation.error);
     }
   }
-  return answers;
+  return ok({ kind: "done", answers });
+}
+
+/**
+ * Run one create template's Q2 over the host surface — the stable non-resumable
+ * entry over {@link runCreateInputsWalk} (`backable` off), so a back past the
+ * first prompt cancels and the result is the plain `Answers`.
+ */
+export async function runCreateInputs(
+  floorBytes: Buffer,
+  locator: DeclarativeLocator,
+  entryParams: Answers,
+  ui: UserInteraction,
+  deps: CreateInputsDeps = {}
+): Promise<Result<Answers, FxError>> {
+  const outcome = await runCreateInputsWalk(floorBytes, locator, entryParams, ui, {
+    ...deps,
+    backable: false,
+  });
+  if (outcome.isErr()) {
+    return err(outcome.error);
+  }
+  /* istanbul ignore next -- backable is forced off, so the walk cancels before returning a top-level back */
+  if (outcome.value.kind === "back") {
+    return err(
+      new UserError({
+        source: "Scaffold",
+        name: "InputWalkCancelled",
+        message: "the input walk was cancelled by going back from the first question",
+      })
+    );
+  }
+  return ok(outcome.value.answers);
 }

--- a/packages/fx-core/src/v4/surface/createInputs.ts
+++ b/packages/fx-core/src/v4/surface/createInputs.ts
@@ -218,15 +218,14 @@ export async function runCreateInputs(
   if (outcome.isErr()) {
     return err(outcome.error);
   }
-  /* istanbul ignore next -- backable is forced off, so the walk cancels before returning a top-level back */
-  if (outcome.value.kind === "back") {
-    return err(
-      new UserError({
-        source: "Scaffold",
-        name: "InputWalkCancelled",
-        message: "the input walk was cancelled by going back from the first question",
-      })
-    );
-  }
-  return ok(outcome.value.answers);
+  // `backable` is forced off here, so the walk cancels rather than returning a top-level back.
+  return outcome.value.kind === "back"
+    ? err(
+        new UserError({
+          source: "Scaffold",
+          name: "InputWalkCancelled",
+          message: "the input walk was cancelled by going back from the first question",
+        })
+      )
+    : ok(outcome.value.answers);
 }

--- a/packages/fx-core/src/v4/surface/createSelectorWalk.ts
+++ b/packages/fx-core/src/v4/surface/createSelectorWalk.ts
@@ -14,9 +14,11 @@ import {
   PromptResult,
   RouteQuestion,
   RouteResolverPort,
+  SelectorWalkResult,
   resolveBuildTarget,
   v4RouteRegistryFromSelector,
 } from "../buildTarget/resolveBuildTarget";
+import { WalkHistoryEntry } from "../collectInputs/collectInputs";
 import {
   openCreateSelector,
   openCreateSelectorPresentation,
@@ -48,6 +50,8 @@ export interface CreateSelectorDeps {
   prefilled?: Record<string, string>;
   /** Whether unfilled required dimensions may be prompted. */
   interactive?: boolean;
+  /** Resume a prior Q1 walk (cross-phase back): re-ask its last dimension with the retained history. */
+  resume?: { history: WalkHistoryEntry[] };
 }
 
 /** The default env-backed feature-flag reader (a flag is on iff its env var is exactly `"true"`). */
@@ -151,7 +155,7 @@ export async function runCreateSelector(
   ui: UserInteraction,
   surface: string,
   deps: CreateSelectorDeps = {}
-): Promise<Result<BuildTarget, FxError>> {
+): Promise<Result<SelectorWalkResult, FxError>> {
   const flagReader = deps.flagReader ?? envFlagReader;
   const selectorBytesKind = deps.selectorBytesKind ?? "zip";
   const prefilled = deps.prefilled ?? {};
@@ -180,7 +184,9 @@ export async function runCreateSelector(
       (selectorBytesKind === "json" ? v4RouteRegistryFromSelector(spec.value) : undefined)
   );
   try {
-    return await resolveBuildTarget(spec.value, prefilled, interactive, port);
+    return await resolveBuildTarget(spec.value, prefilled, interactive, port, {
+      resume: deps.resume,
+    });
   } catch (e) {
     return err(toFxError(e));
   }

--- a/packages/fx-core/src/v4/surface/uiPromptUI.ts
+++ b/packages/fx-core/src/v4/surface/uiPromptUI.ts
@@ -121,6 +121,9 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
         if (result.value.type === "back") {
           return ok({ kind: "back" });
         }
+        if (result.value.type === "skip") {
+          return ok({ kind: "skip", value: selectedId(result.value.result) });
+        }
         return ok({ kind: "value", value: selectedId(result.value.result) });
       }
       if (question.type === "text") {
@@ -268,6 +271,9 @@ export function createUiPromptUI(ui: UserInteraction): PromptUI {
       }
       if (result.value.type === "back") {
         return ok({ kind: "back" });
+      }
+      if (result.value.type === "skip") {
+        return ok({ kind: "skip", value: selectedIds(result.value.result) });
       }
       return ok({ kind: "value", value: selectedIds(result.value.result) });
     },

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -15,7 +15,9 @@ import { assert } from "vitest";
 import {
   Answers,
   BuildTarget,
+  CreateInputsOutcome,
   DeclarativeLocator,
+  SelectorWalkResult,
   TemplateArtifactKind,
   TemplateArtifactSnapshot,
 } from "../../src/v4";
@@ -78,8 +80,8 @@ function recorder<A extends unknown[], R>(
 
 const okResult = (projectPath: string): Promise<Result<CreateProjectResult, FxError>> =>
   Promise.resolve(ok({ projectPath }));
-const okAnswers = (answers: Answers): Promise<Result<Answers, FxError>> =>
-  Promise.resolve(ok(answers));
+const okAnswers = (answers: Answers): Promise<Result<CreateInputsOutcome, FxError>> =>
+  Promise.resolve(ok({ kind: "done", answers }));
 const okArtifactSnapshot = (
   snapshot: TemplateArtifactSnapshot
 ): Promise<Result<TemplateArtifactSnapshot, FxError>> => {
@@ -88,8 +90,8 @@ const okArtifactSnapshot = (
   );
   return Promise.resolve(result);
 };
-const okTarget = (target: BuildTarget): Promise<Result<BuildTarget, FxError>> =>
-  Promise.resolve(ok(target));
+const okTarget = (target: BuildTarget): Promise<Result<SelectorWalkResult, FxError>> =>
+  Promise.resolve(ok({ ...target, history: [], promptCount: 0 }));
 const okFloor = (): Promise<Result<undefined, FxError>> => Promise.resolve(ok(undefined));
 const okScaffold = (
   _inputs: Inputs,
@@ -113,11 +115,11 @@ function selectorRecorder(target: BuildTarget) {
         selectorBytesKind?: "zip" | "json";
         v4Registry?: (templateId: string) => boolean;
       }
-    ): Promise<Result<BuildTarget, FxError>> => okTarget(target)
+    ): Promise<Result<SelectorWalkResult, FxError>> => okTarget(target)
   );
 }
 
-/** A typed `runCreateInputs` stub that records its `(floor, locator, entry, ui, deps)` args. */
+/** A typed `runCreateInputsWalk` stub that records its `(floor, locator, entry, ui, deps)` args. */
 function inputsRecorder(answers: Answers) {
   return recorder(
     (
@@ -126,7 +128,7 @@ function inputsRecorder(answers: Answers) {
       _entry: Answers,
       _ui: UserInteraction,
       _deps?: { flagReader?: (name: string) => boolean; surface?: string }
-    ): Promise<Result<Answers, FxError>> => okAnswers(answers)
+    ): Promise<Result<CreateInputsOutcome, FxError>> => okAnswers(answers)
   );
 }
 
@@ -189,10 +191,10 @@ const failCollectFloor = (
 ): Promise<Result<undefined, FxError>> => {
   throw new Error("collectCreateFloor must not run on this path");
 };
-const failRunInputs = (): Promise<Result<Answers, FxError>> => {
+const failRunInputs = (): Promise<Result<CreateInputsOutcome, FxError>> => {
   throw new Error("runInputs must not run on this path");
 };
-const failRunSelector = (): Promise<Result<BuildTarget, FxError>> => {
+const failRunSelector = (): Promise<Result<SelectorWalkResult, FxError>> => {
   throw new Error("runSelector must not run on this path");
 };
 const failResolveByTemplateId = (): Result<BuildTarget, FxError> => {
@@ -495,8 +497,12 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
       (_i: Inputs, _t: BuildTarget, _a: Answers, _flagReader: (name: string) => boolean) =>
         okResult("/v4-static")
     );
-    const runInputs = recorder((_floor: Buffer, _locator: DeclarativeLocator) =>
-      Promise.resolve(ok<Answers, FxError>({ selectedMcpTools: ["search"] }))
+    const runInputs = recorder(
+      (
+        _floor: Buffer,
+        _locator: DeclarativeLocator
+      ): Promise<Result<CreateInputsOutcome, FxError>> =>
+        Promise.resolve(ok({ kind: "done", answers: { selectedMcpTools: ["search"] } }))
     );
 
     const res = await createProjectFrontDoor(
@@ -1060,5 +1066,199 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     if (res.isErr()) {
       assert.equal(res.error.name, "UnsupportedCreateAction");
     }
+  });
+
+  it("DCE-22: a back at Q2's first prompt re-enters Q1 instead of cancelling the create", async () => {
+    const q2: Answers = { authType: "none" };
+    const walkResult: SelectorWalkResult = {
+      ...V4_TARGET,
+      history: [{ pos: 0, answers: {} }],
+      promptCount: 1,
+    };
+    const runSelector = recorder(
+      (
+        _f: Buffer,
+        _u: UserInteraction,
+        _s: string,
+        _d?: { resume?: { history: unknown[] } }
+      ): Promise<Result<SelectorWalkResult, FxError>> => Promise.resolve(ok(walkResult))
+    );
+    let q2Call = 0;
+    const runInputs = recorder(
+      (
+        _f: Buffer,
+        _l: DeclarativeLocator,
+        _e: Answers,
+        _u: UserInteraction,
+        _d?: { baseStep?: number; backable?: boolean }
+      ): Promise<Result<CreateInputsOutcome, FxError>> => {
+        q2Call++;
+        const outcome: CreateInputsOutcome =
+          q2Call === 1 ? { kind: "back" } : { kind: "done", answers: q2 };
+        return Promise.resolve(ok(outcome));
+      }
+    );
+    const scaffoldV4 = recorder(
+      (_i: Inputs, _t: BuildTarget, _a: Answers, _fr: (name: string) => boolean) => okResult("/v4")
+    );
+
+    const res = await createProjectFrontDoor(
+      baseInputs(),
+      deps({ runSelector: runSelector.fn, runInputs: runInputs.fn, scaffoldV4: scaffoldV4.fn })
+    );
+
+    assert.isTrue(res.isOk());
+    // Q1 re-walked once (re-entry), Q2 run twice, scaffold once — no cancel.
+    assert.equal(runSelector.calls.length, 2);
+    assert.equal(runInputs.calls.length, 2);
+    assert.equal(scaffoldV4.calls.length, 1);
+    // Q2 continues Q1's step numbering (baseStep = promptCount) and is backable.
+    assert.equal(runInputs.calls[0][4]?.baseStep, 1);
+    assert.strictEqual(runInputs.calls[0][4]?.backable, true);
+    // The first walk carries no resume; the re-entry resumes Q1 with the retained history.
+    assert.isUndefined(runSelector.calls[0][3]?.resume);
+    assert.deepEqual(runSelector.calls[1][3]?.resume, { history: walkResult.history });
+  });
+
+  it("DCE-23: re-entering Q1 with a different pick loads the new template's Q2 fresh", async () => {
+    const walkA: SelectorWalkResult = {
+      ...V4_TARGET,
+      history: [{ pos: 0, answers: {} }],
+      promptCount: 1,
+    };
+    const targetB: BuildTarget = { templateId: "da/no-action", engine: "v4", answers: {} };
+    const walkB: SelectorWalkResult = {
+      ...targetB,
+      history: [{ pos: 0, answers: {} }],
+      promptCount: 1,
+    };
+    let selCall = 0;
+    const runSelector = recorder(
+      (
+        _f: Buffer,
+        _u: UserInteraction,
+        _s: string,
+        _d?: { resume?: { history: unknown[] } }
+      ): Promise<Result<SelectorWalkResult, FxError>> => {
+        selCall++;
+        return Promise.resolve(ok(selCall === 1 ? walkA : walkB));
+      }
+    );
+    let q2Call = 0;
+    const runInputs = recorder(
+      (
+        _f: Buffer,
+        _l: DeclarativeLocator,
+        _e: Answers,
+        _u: UserInteraction,
+        _d?: { baseStep?: number; backable?: boolean }
+      ): Promise<Result<CreateInputsOutcome, FxError>> => {
+        q2Call++;
+        const outcome: CreateInputsOutcome =
+          q2Call === 1 ? { kind: "back" } : { kind: "done", answers: {} };
+        return Promise.resolve(ok(outcome));
+      }
+    );
+    const scaffoldV4 = recorder(
+      (_i: Inputs, _t: BuildTarget, _a: Answers, _fr: (name: string) => boolean) => okResult("/v4")
+    );
+
+    const res = await createProjectFrontDoor(
+      baseInputs(),
+      deps({ runSelector: runSelector.fn, runInputs: runInputs.fn, scaffoldV4: scaffoldV4.fn })
+    );
+
+    assert.isTrue(res.isOk());
+    // Q2's first locator was da/mcp-server; after the re-pick, the second is da/no-action (fresh load).
+    assert.equal(runInputs.calls[0][1].templateId, "da/mcp-server");
+    assert.equal(runInputs.calls[1][1].templateId, "da/no-action");
+    // The scaffold gets the re-picked target, not the discarded one.
+    assert.equal(scaffoldV4.calls[0][1].templateId, "da/no-action");
+  });
+
+  it("DCE-24: backing through Q2 into Q1 and past its first dimension cancels the whole create", async () => {
+    const cancel = new UserError({
+      source: "Scaffold",
+      name: "BuildTargetWalkCancelled",
+      message: "cancelled",
+    });
+    const walkResult: SelectorWalkResult = {
+      ...V4_TARGET,
+      history: [{ pos: 0, answers: {} }],
+      promptCount: 1,
+    };
+    let selCall = 0;
+    const runSelector = recorder(
+      (
+        _f: Buffer,
+        _u: UserInteraction,
+        _s: string,
+        _d?: { resume?: { history: unknown[] } }
+      ): Promise<Result<SelectorWalkResult, FxError>> => {
+        selCall++;
+        return Promise.resolve(selCall === 1 ? ok(walkResult) : err(cancel));
+      }
+    );
+    const runInputs = recorder((): Promise<Result<CreateInputsOutcome, FxError>> =>
+      Promise.resolve(ok({ kind: "back" }))
+    );
+    const scaffoldV4 = recorder(
+      (_i: Inputs, _t: BuildTarget, _a: Answers, _fr: (name: string) => boolean) => okResult("/v4")
+    );
+
+    const res = await createProjectFrontDoor(
+      baseInputs(),
+      deps({ runSelector: runSelector.fn, runInputs: runInputs.fn, scaffoldV4: scaffoldV4.fn })
+    );
+
+    assert.isTrue(res.isErr());
+    if (res.isErr()) {
+      assert.equal(res.error.name, "BuildTargetWalkCancelled");
+    }
+    assert.equal(scaffoldV4.calls.length, 0);
+  });
+
+  it("DCE-25: a re-entry iteration re-walks Q1 and never mistakes a prior template-name for a preset", async () => {
+    const walkResult: SelectorWalkResult = {
+      ...V4_TARGET,
+      history: [{ pos: 0, answers: {} }],
+      promptCount: 1,
+    };
+    const runSelector = recorder(
+      (
+        _f: Buffer,
+        _u: UserInteraction,
+        _s: string,
+        _d?: { resume?: { history: unknown[] } }
+      ): Promise<Result<SelectorWalkResult, FxError>> => Promise.resolve(ok(walkResult))
+    );
+    let q2Call = 0;
+    const runInputs = recorder(
+      (
+        _f: Buffer,
+        _l: DeclarativeLocator,
+        _e: Answers,
+        _u: UserInteraction,
+        _d?: { baseStep?: number; backable?: boolean }
+      ): Promise<Result<CreateInputsOutcome, FxError>> => {
+        q2Call++;
+        const outcome: CreateInputsOutcome =
+          q2Call === 1 ? { kind: "back" } : { kind: "done", answers: {} };
+        return Promise.resolve(ok(outcome));
+      }
+    );
+    const inputs = baseInputs();
+
+    // `resolveByTemplateId` (the preset short-circuit) defaults to fail-if-called: the loop must
+    // re-walk Q1 even though dispatchByEngine set inputs["template-name"] on the first iteration.
+    const res = await createProjectFrontDoor(
+      inputs,
+      deps({ runSelector: runSelector.fn, runInputs: runInputs.fn, scaffoldV4: okScaffold })
+    );
+
+    assert.isTrue(res.isOk());
+    assert.equal(runSelector.calls.length, 2);
+    // The v4 template-name was written (proving dispatch ran), yet Q1 was still re-walked.
+    assert.equal(inputs["template-name"], TemplateNames.DeclarativeAgentWithActionFromMCP);
   });
 });

--- a/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
+++ b/packages/fx-core/tests/core/createProjectFrontDoor.test.ts
@@ -603,6 +603,53 @@ describe("createProjectFrontDoor (dispatch-create-by-engine)", () => {
     assert.deepEqual(runInputs.calls[0][1], { kind: "create", templateId: "da/mcp-server" });
   });
 
+  it("DCE-12: a preset template-name with no route returns the resolve error, never createV3", async () => {
+    const notFound = new UserError({
+      source: "Test",
+      name: "BuildTargetUnknownTemplate",
+      message: "no route",
+    });
+    const createV3 = recorder((_inputs: Inputs) => okResult("/v3"));
+
+    const res = await createProjectFrontDoor(
+      presetInputs("future/unknown"),
+      deps({ createV3: createV3.fn, resolveByTemplateId: () => err(notFound) })
+    );
+
+    assert.isTrue(res.isErr());
+    if (res.isErr()) {
+      assert.equal(res.error.name, "BuildTargetUnknownTemplate");
+    }
+    assert.equal(createV3.calls.length, 0);
+  });
+
+  it("DCE-11c: a preset v4 route whose Q2 fails propagates the error and never scaffolds", async () => {
+    const q2Failed = new UserError({ source: "Test", name: "Q2Failed", message: "bad inputs" });
+    const resolveByTemplateId = resolveByTemplateIdRecorder({
+      templateId: "da/mcp-server",
+      engine: "v4",
+      answers: {},
+    });
+    const scaffoldV4 = recorder(
+      (_i: Inputs, _t: BuildTarget, _a: Answers, _fr: (name: string) => boolean) => okResult("/v4")
+    );
+
+    const res = await createProjectFrontDoor(
+      presetInputs("da/mcp-server"),
+      deps({
+        resolveByTemplateId: resolveByTemplateId.fn,
+        runInputs: () => Promise.resolve(err(q2Failed)),
+        scaffoldV4: scaffoldV4.fn,
+      })
+    );
+
+    assert.isTrue(res.isErr());
+    if (res.isErr()) {
+      assert.equal(res.error.name, "Q2Failed");
+    }
+    assert.equal(scaffoldV4.calls.length, 0);
+  });
+
   it("DCE-11b: preset v4 resolves templates artifact before resolving by template id", async () => {
     const artifactSnapshot = artifactSnapshotRecorder({
       "create-selector": Buffer.from("selector-json"),

--- a/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
+++ b/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
@@ -978,4 +978,40 @@ describe("collectInputs (v4)", () => {
       { name: "second", step: 1 },
     ]);
   });
+
+  it("INPUT-21b: a multiSelect first prompt returns a typed back when backable", async () => {
+    const questions: QuestionSpec[] = [
+      { name: "servers", type: "multiSelect", staticOptions: [{ id: "x" }, { id: "y" }] },
+    ];
+    const ui = new SequencedPromptUI([{ kind: "back" }]);
+    const res = await walkInputs(questions, { properties: { servers: {} } }, {}, makePort({ ui }), {
+      backable: true,
+    });
+    assert.isTrue(res.isOk());
+    assert.strictEqual(res._unsafeUnwrap().kind, "back");
+  });
+
+  it("INPUT-22b: resuming an empty history cancels, or hands a typed back when backable", async () => {
+    const questions: QuestionSpec[] = [
+      { name: "first", type: "singleSelect", staticOptions: [{ id: "a" }] },
+    ];
+    const cancelled = await walkInputs(
+      questions,
+      { properties: { first: {} } },
+      {},
+      makePort({ ui: new SequencedPromptUI([]) }),
+      { resume: { history: [] } }
+    );
+    assert.isTrue(cancelled.isErr());
+    assert.strictEqual(cancelled._unsafeUnwrapErr().name, INPUT_WALK_CANCELLED);
+    const back = await walkInputs(
+      questions,
+      { properties: { first: {} } },
+      {},
+      makePort({ ui: new SequencedPromptUI([]) }),
+      { resume: { history: [] }, backable: true }
+    );
+    assert.isTrue(back.isOk());
+    assert.strictEqual(back._unsafeUnwrap().kind, "back");
+  });
 });

--- a/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
+++ b/packages/fx-core/tests/v4/collectInputs/collectInputs.test.ts
@@ -26,6 +26,7 @@ import {
   ResolvedOptions,
   Validator,
   collectInputs,
+  walkInputs,
 } from "../../../src/v4/collectInputs/collectInputs";
 
 /**
@@ -81,7 +82,7 @@ class ScriptedUI implements PromptUI {
     const resolvedOptions = await resolveTestOptions(options);
     this.lastOptions[question.name] = resolvedOptions;
     if (question.skipSingleOption === true && resolvedOptions?.length === 1) {
-      return ok({ kind: "value", value: optionId(resolvedOptions[0]) });
+      return ok({ kind: "skip", value: optionId(resolvedOptions[0]) });
     }
     if (question.name in this.script) {
       const value = this.script[question.name];
@@ -113,7 +114,7 @@ class ScriptedUI implements PromptUI {
     const resolvedOptions = await resolveTestOptions(options);
     this.lastOptions[question.name] = resolvedOptions;
     if (question.skipSingleOption === true && resolvedOptions?.length === 1) {
-      return ok({ kind: "value", value: [optionId(resolvedOptions[0])] });
+      return ok({ kind: "skip", value: [optionId(resolvedOptions[0])] });
     }
     if (question.name in this.multiScript) {
       return ok({ kind: "value", value: this.multiScript[question.name] });
@@ -146,9 +147,12 @@ function noScripted(name: string): FxError {
   return new UserError({ source: "Test", name: "NoScriptedAnswer", message: name });
 }
 
-/** One scripted reply for the sequenced driver: a scalar value, a multi value, or a host back. */
+/** One scripted reply for the sequenced driver: a scalar value, a multi value, a surface skip, or a host back. */
 type SeqResponse =
-  { kind: "value"; value: string } | { kind: "multi"; value: string[] } | { kind: "back" };
+  | { kind: "value"; value: string }
+  | { kind: "multi"; value: string[] }
+  | { kind: "skip"; value: string }
+  | { kind: "back" };
 
 /**
  * A sequence-driven prompt driver: it answers each ask / askMulti from an ordered
@@ -172,6 +176,9 @@ class SequencedPromptUI implements PromptUI {
     if (response.kind === "back") {
       return Promise.resolve(ok({ kind: "back" }));
     }
+    if (response.kind === "skip") {
+      return Promise.resolve(ok({ kind: "skip", value: response.value }));
+    }
     return Promise.resolve(ok({ kind: "value", value: response.value }));
   }
   askMulti(
@@ -181,7 +188,7 @@ class SequencedPromptUI implements PromptUI {
   ): Promise<Result<Asked<string[]>, FxError>> {
     this.calls.push({ name: question.name, step });
     const response = this.responses[this.cursor++];
-    if (response === undefined || response.kind === "value") {
+    if (response === undefined || response.kind === "value" || response.kind === "skip") {
       return Promise.resolve(err(noScripted(question.name)));
     }
     if (response.kind === "back") {
@@ -841,5 +848,134 @@ describe("collectInputs (v4)", () => {
       ui.calls.map((c) => c.name),
       ["first", "servers", "first", "servers"]
     );
+  });
+
+  it("INPUT-20: a baseStep offset continues the step numbering so the first prompt shows a Back button", async () => {
+    const questions: QuestionSpec[] = [
+      { name: "first", type: "singleSelect", staticOptions: [{ id: "a" }, { id: "b" }] },
+      { name: "second", type: "singleSelect", staticOptions: [{ id: "x" }, { id: "y" }] },
+    ];
+    const ui = new SequencedPromptUI([
+      { kind: "value", value: "a" },
+      { kind: "value", value: "x" },
+    ]);
+    const res = await walkInputs(
+      questions,
+      { properties: { first: {}, second: {} } },
+      {},
+      makePort({ ui }),
+      { baseStep: 3 }
+    );
+    assert.isTrue(res.isOk());
+    const outcome = res._unsafeUnwrap();
+    assert.strictEqual(outcome.kind, "done");
+    if (outcome.kind === "done") {
+      assert.deepStrictEqual(outcome.answers, { first: "a", second: "x" });
+      assert.strictEqual(outcome.promptCount, 2);
+    }
+    // baseStep 3 → first prompt is step 4 (Back button shown), second is step 5
+    assert.deepStrictEqual(
+      ui.calls.map((c) => c.step),
+      [4, 5]
+    );
+  });
+
+  it("INPUT-21: with backable set, a back at the first prompt returns a typed back outcome instead of cancelling", async () => {
+    const questions: QuestionSpec[] = [
+      { name: "first", type: "singleSelect", staticOptions: [{ id: "a" }, { id: "b" }] },
+    ];
+    const ui = new SequencedPromptUI([{ kind: "back" }]);
+    const res = await walkInputs(questions, { properties: { first: {} } }, {}, makePort({ ui }), {
+      baseStep: 2,
+      backable: true,
+    });
+    assert.isTrue(res.isOk(), res.isErr() ? `${res.error.name}: ${res.error.message}` : "ok");
+    assert.strictEqual(res._unsafeUnwrap().kind, "back");
+    // default (backable false) still cancels — INPUT-18 unchanged
+    const uiCancel = new SequencedPromptUI([{ kind: "back" }]);
+    const cancelled = await walkInputs(
+      questions,
+      { properties: { first: {} } },
+      {},
+      makePort({ ui: uiCancel })
+    );
+    assert.isTrue(cancelled.isErr());
+    assert.strictEqual(cancelled._unsafeUnwrapErr().name, INPUT_WALK_CANCELLED);
+  });
+
+  it("INPUT-22: resuming a prior walk's history re-asks the last prompted question and preserves back", async () => {
+    const questions: QuestionSpec[] = [
+      { name: "first", type: "singleSelect", staticOptions: [{ id: "a" }, { id: "b" }] },
+      { name: "second", type: "singleSelect", staticOptions: [{ id: "x" }, { id: "y" }] },
+    ];
+    // First, run to done to capture the walk history.
+    const uiFirst = new SequencedPromptUI([
+      { kind: "value", value: "a" },
+      { kind: "value", value: "x" },
+    ]);
+    const firstRun = await walkInputs(
+      questions,
+      { properties: { first: {}, second: {} } },
+      {},
+      makePort({ ui: uiFirst })
+    );
+    assert.isTrue(firstRun.isOk());
+    const done = firstRun._unsafeUnwrap();
+    assert.strictEqual(done.kind, "done");
+    if (done.kind !== "done") {
+      return;
+    }
+    // Resume: re-asks 'second' (the last prompted question), then a back crosses into
+    // 'first' (the retained history is intact), then re-forward.
+    const uiResume = new SequencedPromptUI([
+      { kind: "back" },
+      { kind: "value", value: "b" },
+      { kind: "value", value: "y" },
+    ]);
+    const resumed = await walkInputs(
+      questions,
+      { properties: { first: {}, second: {} } },
+      {},
+      makePort({ ui: uiResume }),
+      { resume: { history: done.history } }
+    );
+    assert.isTrue(resumed.isOk());
+    const resumedOutcome = resumed._unsafeUnwrap();
+    assert.strictEqual(resumedOutcome.kind, "done");
+    if (resumedOutcome.kind === "done") {
+      assert.deepStrictEqual(resumedOutcome.answers, { first: "b", second: "y" });
+    }
+    assert.deepStrictEqual(
+      uiResume.calls.map((c) => c.name),
+      ["second", "first", "second"]
+    );
+    // 'second' re-asked at step 2 (history retains 'first'); back crosses to 'first' at step 1
+    assert.deepStrictEqual(
+      uiResume.calls.map((c) => c.step),
+      [2, 1, 2]
+    );
+  });
+
+  it("INPUT-24: a surface-skipped question is back-transparent (pushes no history)", async () => {
+    const questions: QuestionSpec[] = [
+      { name: "skipped", type: "singleSelect", staticOptions: [{ id: "auto" }] },
+      { name: "second", type: "singleSelect", staticOptions: [{ id: "x" }, { id: "y" }] },
+    ];
+    // 'skipped' auto-skips (records its answer, but is not a back-stop); a back at 'second'
+    // crosses straight over it into an empty history and cancels — it does NOT re-ask 'skipped'.
+    const ui = new SequencedPromptUI([{ kind: "skip", value: "auto" }, { kind: "back" }]);
+    const res = await collectInputs(
+      questions,
+      { properties: { skipped: {}, second: {} } },
+      {},
+      makePort({ ui })
+    );
+    assert.isTrue(res.isErr());
+    assert.strictEqual(res._unsafeUnwrapErr().name, INPUT_WALK_CANCELLED);
+    // both prompts are step 1: 'skipped' pushed no history, so 'second' is also the first step.
+    assert.deepStrictEqual(ui.calls, [
+      { name: "skipped", step: 1 },
+      { name: "second", step: 1 },
+    ]);
   });
 });

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -2131,6 +2131,21 @@ describe("createUiPromptUI (collect-create-inputs)", () => {
     }
   });
 
+  it("CCI-27b: askMulti projects a host skip on a skipSingleOption multiSelect to { kind: 'skip' }", async () => {
+    const ui = new ScriptedUserInteraction({});
+    const prompt = createUiPromptUI(asUI(ui));
+
+    const res = await prompt.askMulti(
+      { name: "servers", type: "multiSelect", title: "Servers", skipSingleOption: true },
+      [{ id: "only" }]
+    );
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { kind: "skip", value: ["only"] });
+    }
+  });
+
   it("ask projects a host back on a folder question to { kind: 'back' }", async () => {
     const ui = new ScriptedUserInteraction({ back: ["folder"] });
     const prompt = createUiPromptUI(asUI(ui));

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -31,7 +31,11 @@ import { openCreateQuestions } from "../../../src/v4/distribution/createQuestion
 import { openDeclarativePackageMetadata } from "../../../src/v4/distribution/declarativePackage";
 import { DeclarativeLocator } from "../../../src/v4/model/dataModel";
 import { createUiPromptUI } from "../../../src/v4/surface/uiPromptUI";
-import { gateLanguagesBySurface, runCreateInputs } from "../../../src/v4/surface/createInputs";
+import {
+  gateLanguagesBySurface,
+  runCreateInputs,
+  runCreateInputsWalk,
+} from "../../../src/v4/surface/createInputs";
 import { assert } from "vitest";
 
 /**
@@ -46,6 +50,7 @@ import { assert } from "vitest";
 
 const TEMPLATES_V4_DIR = path.resolve(__dirname, "../../../../../templates/v4");
 const MCP_DA: DeclarativeLocator = { kind: "create", templateId: "da/mcp-server" };
+const NO_ACTION: DeclarativeLocator = { kind: "create", templateId: "da/no-action" };
 const STATIC_MCP_DA: DeclarativeLocator = {
   kind: "create",
   templateId: "da/mcp-server-static",
@@ -421,6 +426,68 @@ describe("runCreateInputs (collect-create-inputs)", () => {
       assert.deepEqual(res.value, { language: "typescript", surface: "vscode" });
     }
     assert.deepEqual(ui.selectNames, []);
+  });
+
+  it("CCI-25: threads baseStep + backable so Q2's first prompt shows Back and a back returns a typed outcome", async () => {
+    const ui = new ScriptedUserInteraction({ back: ["llmService"] });
+    const res = await runCreateInputsWalk(buildFloor(), CUSTOM_COPILOT_BASIC, {}, asUI(ui), {
+      flagReader: () => false,
+      surface: "vscode",
+      baseStep: 3,
+      backable: true,
+    });
+    assert.isTrue(res.isOk(), res.isErr() ? `${res.error.name}: ${res.error.message}` : "ok");
+    if (res.isOk()) {
+      // a back at Q2's first prompt hands control back to the front door (no cancel).
+      assert.strictEqual(res.value.kind, "back");
+    }
+    // llmService is the first prompt, shown at baseStep + 1 = 4, so the host renders a
+    // Back button (step > 1).
+    assert.strictEqual(ui.lastSelectConfig?.step, 4);
+  });
+
+  it("CCI-26: a different locator rebuilds Q2+Q3 fresh — no stale question is carried across templates", async () => {
+    // The MCP server template asks its own Q2 (mcpServerType / url / authType).
+    const mcpUi = new ScriptedUserInteraction({
+      text: { mcpServerUrl: "https://api.example.com/mcp" },
+      select: { authType: "none" },
+    });
+    const mcp = await runCreateInputs(buildFloor(), MCP_DA, {}, asUI(mcpUi), {
+      listLocalMcpServers: async () => [],
+      flagReader: () => false,
+    });
+    assert.isTrue(mcp.isOk(), mcp.isErr() ? `${mcp.error.name}: ${mcp.error.message}` : "ok");
+    assert.deepEqual(mcpUi.promptNames, ["mcpServerType", "mcpServerUrl", "authType"]);
+
+    // The no-action template (empty Q2, common language) under a different locator asks none
+    // of the MCP questions — the Q2+Q3 set is a pure function of the current locator.
+    const noActionUi = new ScriptedUserInteraction({});
+    const noAction = await runCreateInputs(buildFloor(), NO_ACTION, {}, asUI(noActionUi), {
+      flagReader: () => false,
+    });
+    assert.isTrue(
+      noAction.isOk(),
+      noAction.isErr() ? `${noAction.error.name}: ${noAction.error.message}` : "ok"
+    );
+    assert.deepEqual(noActionUi.promptNames, []);
+  });
+
+  it("CCI-28: a provider-single-option first question is back-transparent, so a back at the next prompt re-enters Q1", async () => {
+    const ui = new ScriptedUserInteraction({ back: ["mcpServerUrl"] });
+    const res = await runCreateInputsWalk(buildFloor(), MCP_DA, {}, asUI(ui), {
+      listLocalMcpServers: async () => [], // remote-only → mcpServerType auto-skips
+      flagReader: () => false,
+      baseStep: 3,
+      backable: true,
+    });
+    assert.isTrue(res.isOk(), res.isErr() ? `${res.error.name}: ${res.error.message}` : "ok");
+    if (res.isOk()) {
+      // mcpServerType auto-skipped (records remote, no back-stop); backing mcpServerUrl now
+      // crosses straight into Q1 instead of re-asking the skipped provider question.
+      assert.strictEqual(res.value.kind, "back");
+    }
+    // mcpServerUrl is the first *visible* prompt, at baseStep + 1 = 4 (the skip left no step).
+    assert.strictEqual(ui.lastInputConfig?.step, 4);
   });
 
   it("CCI-17: VS Code Teams Agents and Apps Python language option carries the v3 Preview description", async () => {
@@ -2044,6 +2111,23 @@ describe("createUiPromptUI (collect-create-inputs)", () => {
     assert.isTrue(res.isOk());
     if (res.isOk()) {
       assert.deepEqual(res.value, { kind: "back" });
+    }
+  });
+
+  it("CCI-27: ask projects a host skip on a skipSingleOption singleSelect to { kind: 'skip' }", async () => {
+    const ui = new ScriptedUserInteraction({});
+    const prompt = createUiPromptUI(asUI(ui));
+
+    // A single option + skipSingleOption → the surface returns { type: "skip" }, which the
+    // bridge projects to { kind: "skip" } so the walk records it without a back-stop.
+    const res = await prompt.ask(
+      { name: "picker", type: "singleSelect", title: "Pick", skipSingleOption: true },
+      [{ id: "only" }]
+    );
+
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(res.value, { kind: "skip", value: "only" });
     }
   });
 

--- a/packages/fx-core/tests/v4/surface/createSelectorWalk.test.ts
+++ b/packages/fx-core/tests/v4/surface/createSelectorWalk.test.ts
@@ -925,6 +925,62 @@ describe("runCreateSelector (walk-create-selector)", () => {
       assert.equal(res.error.name, "BuildTargetWalkCancelled");
     }
   });
+
+  it("WCS-25: the walk result exposes the Q1 history and promptCount for the front door to retain", async () => {
+    const ui = new ScriptedUI(MCP_DA_PICKS);
+    const res = await runCreateSelector(buildFloor(), asUI(ui), "vscode", {
+      flagReader: flagsOn("TEAMSFX_MCP_FOR_DA_DT"),
+    });
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.strictEqual(res.value.templateId, "da/mcp-server");
+      // projectType, daTemplate, actionSource were all prompted.
+      assert.strictEqual(res.value.promptCount, 3);
+      assert.lengthOf(res.value.history, 3);
+    }
+  });
+
+  it("WCS-24: resuming a completed Q1 walk re-asks its last dimension with the history intact", async () => {
+    // First, walk Q1 to a done target and capture its history + promptCount.
+    const firstUi = new SequencedUI([
+      { type: "success", result: "copilot-agent-type" }, // projectType (step 1)
+      { type: "success", result: "add-action" }, // daTemplate (step 2)
+      { type: "success", result: "mcp" }, // actionSource (step 3)
+    ]);
+    const first = await runCreateSelector(buildFloor(), asUI(firstUi), "vscode", {
+      flagReader: flagsOn("TEAMSFX_MCP_FOR_DA_DT"),
+    });
+    assert.isTrue(first.isOk());
+    if (!first.isOk()) {
+      return;
+    }
+    assert.strictEqual(first.value.templateId, "da/mcp-server");
+
+    // Resume (the front door re-entering Q1 after a Q2 back): the last dimension
+    // (actionSource, step 3) is re-asked; a back crosses into daTemplate (step 2),
+    // and re-picking no-action re-routes to a different target.
+    const resumeUi = new SequencedUI([
+      { type: "back" }, // actionSource re-asked (step 3) → back
+      { type: "success", result: "no-action" }, // daTemplate re-asked (step 2)
+    ]);
+    const resumed = await runCreateSelector(buildFloor(), asUI(resumeUi), "vscode", {
+      flagReader: flagsOn("TEAMSFX_MCP_FOR_DA_DT"),
+      resume: { history: first.value.history },
+    });
+    assert.isTrue(resumed.isOk());
+    if (resumed.isOk()) {
+      assert.strictEqual(resumed.value.templateId, "da/no-action");
+      assert.deepEqual(resumed.value.answers, {
+        projectType: "copilot-agent-type",
+        daTemplate: "no-action",
+      });
+    }
+    // resume re-asks the last dimension first, then back multi-hops to daTemplate.
+    assert.deepEqual(resumeUi.calls, [
+      { name: "actionSource", step: 3 },
+      { name: "daTemplate", step: 2 },
+    ]);
+  });
 });
 
 describe("openCreateSelectorPresentation (walk-create-selector)", () => {


### PR DESCRIPTION
## What

Adds a continuous back-navigable wizard across the **Q1 selector → Q2 template inputs** phase boundary for the v4 create flow. From Q2's first prompt, **Back** now returns to Q1's last dimension (re-picking may load a different template's Q2+Q3); backing past Q1's first dimension cancels the create. Entirely behind `TEAMSFX_V4_ENABLED` (default off) — **zero shipped change**.

## Why

Q1 (selector) and Q2 (template inputs + common floor) are two separate runs of the one shared question-walk engine, glued by the dispatcher. Each phase already had *internal* back, but a Back at Q2's first prompt had nowhere to go — it showed no Back button and a forced back cancelled the whole create. Users expect one continuous wizard.

## How

- **collect-inputs** — new resumable `walkInputs` (`baseStep`, `backable`, `resume`) returning a `WalkOutcome`; `collectInputs` becomes a thin compat wrapper (existing contract unchanged). A surface auto-skip (`{ kind: "skip" }`) records its answer but pushes **no** history, so Back crosses over it — symmetric with a static `skipSingleOption` skip.
- **Q1** (`resolveBuildTarget` / `runCreateSelector`) — return a `SelectorWalkResult` superset (`history` + `promptCount`) and accept `resume`.
- **Q2** (`runCreateInputsWalk`) — resumable outcome + `baseStep` / `backable`; `runCreateInputs` kept as a compat wrapper.
- **Front door** (`createProjectFrontDoor`) — a re-entry loop: a Back at Q2's first prompt re-enters Q1 with the retained history; a changed pick rebuilds Q2+Q3 fresh (stateless, no invalidation logic); the loop is scoped below the preset short-circuit so a prior iteration's `template-name` never skips Q1.

## Design (specs)

- ADR-0014 **Amendment 4** — cross-phase back = front-door re-entry loop; Q1 history retained; Q2+Q3 stateless-rebuilt.
- Operation specs: `collect-inputs` (INPUT-20..24, INV-9), `collect-create-inputs` (CCI-25..28, INV-11), `walk-create-selector` (WCS-24/25, INV-6), `dispatch-create-by-engine` (DCE-22..25, INV-10).

## Tests

Every new AC has an AC-id-tagged test. Verified locally:

- `tests/v4` — 758 passing (incl. INPUT-20..24, WCS-24/25, CCI-25..28)
- consumer tests (front door / adapters / modify / bridge / generator) — passing (DCE-22..25)
- `tsc --noEmit` clean; eslint 0 errors; prettier clean

## Safety

Entirely behind `TEAMSFX_V4_ENABLED` (default off). `collectInputs` / `runCreateInputs` / `runCreateSelector` keep their existing contracts (a superset return or a compat wrapper), so all pre-existing tests pass unchanged.
