### PR TITLE
fix(vscuse): Auto-fix DA_MCP_Oauth_Remote

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -188,7 +188,7 @@
       "parameters": {
         "text": "${{env:DA_MCP_OAUTH_CLIENTID}}"
       },
-      "description": "Type ${{env:DA_MCP_OAUTH_CLIENTID}} into the \"Enter the client ID\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
+      "description": "Type ${{env:DA_MCP_OAUTH_CLIENTID}} into the \"OAuth Client ID\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -228,7 +228,7 @@
       "parameters": {
         "text": "${{secret:DA_MCP_OAUTH_CLIENT_SECERT}}"
       },
-      "description": "Type ${{secret:DA_MCP_OAUTH_CLIENT_SECERT}} into the \"Enter the client secret\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
+      "description": "Type ${{secret:DA_MCP_OAUTH_CLIENT_SECERT}} into the \"OAuth Client Secret\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -268,7 +268,7 @@
       "parameters": {
         "text": "read:user"
       },
-      "description": "Type 'read:user' into the \"Enter the OAuth scopes\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
+      "description": "Type 'read:user' into the \"OAuth Scopes (optional)\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -316,11 +316,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:364:74:16:5:08146a985d551696",
-        "dhash:364:74:96:5:44232282e2068e01",
-        "dhash:364:74:0:10:f0b09494b2717075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_9a8146c5",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 42,
+    "total_steps": 34,
     "created_at": "2026-06-29T03:21:51.231595",
     "name": "DA_with_MCP Server(Oauth)",
     "description": {
@@ -24,14 +24,6 @@
       "step_5f1a8731",
       "step_9c87f073",
       "step_52c22c4c",
-      "step_mcp_auth_type_static",
-      "step_mcp_auth_type_enter",
-      "step_mcp_clientid_type",
-      "step_mcp_clientid_enter",
-      "step_mcp_secret_type",
-      "step_mcp_secret_enter",
-      "step_mcp_scopes_type",
-      "step_mcp_scopes_enter",
       "step_9a8146c5",
       "plan_r_0928_014459",
       "plan_r_1021_081410",
@@ -139,166 +131,6 @@
       "tags": [],
       "screenshot": "step_52c22c4c",
       "created_at": "2026-06-29T03:21:51.277234",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_mcp_auth_type_static",
-      "agent": "interaction",
-      "tool": "type_text",
-      "parameters": {
-        "text": "static"
-      },
-      "description": "Type 'static' into the \"Select Authentication Type\" quick pick that appears inline after submitting the MCP server URL, to filter to the \"OAuth (with static registration)\" option.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": null,
-      "created_at": "2026-07-10T02:34:22.000000",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_mcp_auth_type_enter",
-      "agent": "interaction",
-      "tool": "key_press",
-      "parameters": {
-        "key": "enter"
-      },
-      "description": "Press Enter to select the \"OAuth (with static registration)\" authentication type in the \"Select Authentication Type\" quick pick.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": null,
-      "created_at": "2026-07-10T02:34:22.000000",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_mcp_clientid_type",
-      "agent": "interaction",
-      "tool": "type_text",
-      "parameters": {
-        "text": "${{env:DA_MCP_OAUTH_CLIENTID}}"
-      },
-      "description": "Type ${{env:DA_MCP_OAUTH_CLIENTID}} into the \"OAuth Client ID\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": null,
-      "created_at": "2026-07-10T02:34:22.000000",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_mcp_clientid_enter",
-      "agent": "interaction",
-      "tool": "key_press",
-      "parameters": {
-        "key": "enter"
-      },
-      "description": "Press Enter to confirm the client ID for the OAuth (static registration) MCP server.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": null,
-      "created_at": "2026-07-10T02:34:22.000000",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_mcp_secret_type",
-      "agent": "interaction",
-      "tool": "type_text",
-      "parameters": {
-        "text": "${{secret:DA_MCP_OAUTH_CLIENT_SECERT}}"
-      },
-      "description": "Type ${{secret:DA_MCP_OAUTH_CLIENT_SECERT}} into the \"OAuth Client Secret\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": null,
-      "created_at": "2026-07-10T02:34:22.000000",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_mcp_secret_enter",
-      "agent": "interaction",
-      "tool": "key_press",
-      "parameters": {
-        "key": "enter"
-      },
-      "description": "Press Enter to confirm the client secret for the OAuth (static registration) MCP server.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": null,
-      "created_at": "2026-07-10T02:34:22.000000",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_mcp_scopes_type",
-      "agent": "interaction",
-      "tool": "type_text",
-      "parameters": {
-        "text": "read:user"
-      },
-      "description": "Type 'read:user' into the \"OAuth Scopes (optional)\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": null,
-      "created_at": "2026-07-10T02:34:22.000000",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_mcp_scopes_enter",
-      "agent": "interaction",
-      "tool": "key_press",
-      "parameters": {
-        "key": "enter"
-      },
-      "description": "Press Enter to confirm the OAuth scopes for the OAuth (static registration) MCP server.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": null,
-      "created_at": "2026-07-10T02:34:22.000000",
       "plan_id": "plan_r_1024_023252"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 34,
+    "total_steps": 42,
     "created_at": "2026-06-29T03:21:51.231595",
     "name": "DA_with_MCP Server(Oauth)",
     "description": {
@@ -24,6 +24,14 @@
       "step_5f1a8731",
       "step_9c87f073",
       "step_52c22c4c",
+      "step_mcp_auth_type_static",
+      "step_mcp_auth_type_enter",
+      "step_mcp_clientid_type",
+      "step_mcp_clientid_enter",
+      "step_mcp_secret_type",
+      "step_mcp_secret_enter",
+      "step_mcp_scopes_type",
+      "step_mcp_scopes_enter",
       "step_9a8146c5",
       "plan_r_0928_014459",
       "plan_r_1021_081410",
@@ -60,7 +68,7 @@
       "step_5b6d6181"
     ],
     "tags": [],
-    "updated_at": "2026-06-29T03:25:40.465092"
+    "updated_at": "2026-07-10T02:34:22.000000"
   },
   "steps": [
     {
@@ -131,6 +139,166 @@
       "tags": [],
       "screenshot": "step_52c22c4c",
       "created_at": "2026-06-29T03:21:51.277234",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_mcp_auth_type_static",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "static"
+      },
+      "description": "Type 'static' into the \"Select Authentication Type\" quick pick that appears inline after submitting the MCP server URL, to filter to the \"OAuth (with static registration)\" option.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-10T02:34:22.000000",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_mcp_auth_type_enter",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to select the \"OAuth (with static registration)\" authentication type in the \"Select Authentication Type\" quick pick.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-10T02:34:22.000000",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_mcp_clientid_type",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "${{env:DA_MCP_OAUTH_CLIENTID}}"
+      },
+      "description": "Type ${{env:DA_MCP_OAUTH_CLIENTID}} into the \"Enter the client ID\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-10T02:34:22.000000",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_mcp_clientid_enter",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to confirm the client ID for the OAuth (static registration) MCP server.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-10T02:34:22.000000",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_mcp_secret_type",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "${{secret:DA_MCP_OAUTH_CLIENT_SECERT}}"
+      },
+      "description": "Type ${{secret:DA_MCP_OAUTH_CLIENT_SECERT}} into the \"Enter the client secret\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-10T02:34:22.000000",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_mcp_secret_enter",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to confirm the client secret for the OAuth (static registration) MCP server.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-10T02:34:22.000000",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_mcp_scopes_type",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "read:user"
+      },
+      "description": "Type 'read:user' into the \"Enter the OAuth scopes\" input box shown inline during declarative agent creation for the OAuth (static registration) MCP server.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-10T02:34:22.000000",
+      "plan_id": "plan_r_1024_023252"
+    },
+    {
+      "step_id": "step_mcp_scopes_enter",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to confirm the OAuth scopes for the OAuth (static registration) MCP server.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-10T02:34:22.000000",
       "plan_id": "plan_r_1024_023252"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -148,7 +148,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:364:74:16:5:a108857b991d5536",
+        "dhash:364:74:96:5:44232a86a2110000",
+        "dhash:364:74:0:10:d0b0949492b17075"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_9a8146c5",


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `DA_MCP_Oauth_Remote`
**Status:** :white_check_mark: FIXED (attempt 3/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/2c13d492-7bd7-46dd-8b5d-04b357ed71e8/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/264a9edf-58d7-46c0-9059-059d78e98125/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Added 8 inline steps (select "OAuth (with static registration)" auth type, then  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/06c52a28-e12e-4bda-b880-721721d872ca/test_report.html) |
| 2 | Removed the stale dhash preconditions on step_9a8146c5 (Workspace Folder "Defaul | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/68816a15-d4b3-43ea-ab1f-3a9b7f4c40a6/test_report.html) |
| 3 | Removed the 8 phantom inline auth steps (step_mcp_auth_type_static…step_mcp_scop | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/264a9edf-58d7-46c0-9059-059d78e98125/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/DA_MCP_Oauth_Remote.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
index 9faeefb..7f8137c 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -60,7 +60,7 @@
       "step_5b6d6181"
     ],
     "tags": [],
-    "updated_at": "2026-06-29T03:25:40.465092"
+    "updated_at": "2026-07-10T02:34:22.000000"
   },
   "steps": [
     {
@@ -149,9 +149,9 @@
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:364:74:16:5:08146a985d551696",
-        "dhash:364:74:96:5:44232282e2068e01",
-        "dhash:364:74:0:10:f0b09494b2717075"
+        "dhash:364:74:16:5:a108857b991d5536",
+        "dhash:364:74:96:5:44232a86a2110000",
+        "dhash:364:74:0:10:d0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>