### PR TITLE
test(vscuse): support pinned image validation

### DIFF
--- a/.github/skills/local-vscuse-validation/SKILL.md
+++ b/.github/skills/local-vscuse-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-vscuse-validation
-description: "Use when: setting up shared local vscuse prerequisites, credentials, runner, Docker image, local VSIX, env variables, and common rules for Microsoft 365 Agents Toolkit vscuse work. Use vscuse-case-diagnosis for running/fixing existing cases; use vscuse-scenario-authoring for docs/mockup-driven recording and plan generation."
+description: "Use when: setting up shared local vscuse prerequisites, credentials, runner, local or pinned published Docker images, local VSIX, env variables, and common rules for Microsoft 365 Agents Toolkit vscuse work. Use vscuse-case-diagnosis for running/fixing existing cases; use vscuse-scenario-authoring for docs/mockup-driven recording and plan generation."
 argument-hint: "Describe the feature/change and which vscuse plan or scenario to validate"
 ---
 
@@ -10,11 +10,11 @@ argument-hint: "Describe the feature/change and which vscuse plan or scenario to
 
 - Use `vscuse-case-diagnosis` when the task is to run an existing vscuse case, reproduce a failure, classify product bug vs test plan drift vs setup failure vs flake, repair the smallest surface, and demonstrate the run through the integrated browser/noVNC.
 - Use `vscuse-scenario-authoring` when the task starts from docs, PRDs, scenarios, mockups, or expected user flows and needs vscuse-ui recording, generated steps, replacement of existing coverage, or creation of a new plan.
-- Use this skill for shared setup: local credentials, `TEMPLATE_VERSION=local`, local VSIX/image build, vscuse runner installation, GHCR/wheel access, and common safety rules.
+- Use this skill for shared setup: local credentials, template routing, local VSIX/image build, pinned published image selection, vscuse runner installation, GHCR/wheel access, and common safety rules.
 
 ## Goal
 
-Use this skill to prepare and troubleshoot the shared local vscuse environment for this repository: credentials, runner access, local VSIX packaging, Docker image build, env variables, noVNC/vscuse-ui service expectations, and common safety rules.
+Use this skill to prepare and troubleshoot the shared local vscuse environment for this repository: credentials, runner access, local VSIX packaging, local or pinned published Docker image selection, env variables, noVNC/vscuse-ui service expectations, and common safety rules.
 
 For the actual execution workflow, load `vscuse-case-diagnosis`. For docs/mockup-driven recording or plan generation, load `vscuse-scenario-authoring`.
 
@@ -27,8 +27,9 @@ This skill is the AI-first operational entry point for local vscuse validation. 
 Use this skill when the task mentions any of these shared setup concerns:
 
 - Build a local ATK vscuse Docker image that contains the current repository's VSIX.
+- Run local or dev test-plan JSON against a pinned image produced by a specific `Build VscUse ATK Docker Image` Actions run.
 - Install or verify the external `vscuse` and `vscuse-ui` Python runner.
-- Set up repo-root `set-azure-env.ps1`, `TEMPLATE_VERSION=local`, or `VSCUSE_VSCODE_IMAGE=vscuse-atk-local:latest`.
+- Set up repo-root `set-azure-env.ps1`, `TEMPLATE_VERSION=local`, or a branch-specific local image such as `VSCUSE_VSCODE_IMAGE=vscuse-atk-6.12:local`.
 - Troubleshoot `ghcr.io/microsoft/vscuse-base`, `ghcr.io/officedev/vscuse-atk-vscode`, or `microsoft/vscuse-doc` wheel access.
 - Confirm noVNC, Docker API, and vscuse-ui local service URLs.
 
@@ -46,16 +47,22 @@ Do not use this skill for ordinary unit tests, CLI E2E tests, or non-VS Code val
 - Local vscuse credentials should live in `set-azure-env.ps1` at the repository root. This path is gitignored because it contains secrets and should stay easy to find during local validation.
 - The ATK-specific Dockerfile is `packages/tests/vscuse/docker/vscuse-atk/Dockerfile`.
 - Local VSIX files must be copied into `packages/tests/vscuse/docker/vscuse-atk/build-extensions/` before building the local image.
-- Plan JSON is read from the local filesystem at execution time. Plan edits apply on the next `vscuse execute` run and do not require rebuilding the Docker image.
+- Local images used for branch validation must be branch-specific. Do not use `latest` for current-branch proof, because stale images can silently validate the wrong VSIX. Use tags such as `vscuse-atk-dev:local` for `dev` and `vscuse-atk-6.12:local` for `release/6.12`.
+- Published images may be used to run local or dev plan JSON when the product version under test is intentionally a CI-built version. Pin the exact tag from the requested Actions run and verify its OCI revision before interpreting failures; never substitute `latest`.
+- Plan JSON is read from the local filesystem at execution time and is independent of the selected product image. Plan edits apply on the next `vscuse execute` run and do not require rebuilding or republishing the Docker image.
 - When validating with the local repository, set `TEMPLATE_VERSION=local` explicitly and verify it is present inside the vscuse VS Code container. A host PowerShell env var is not enough unless the config used to launch vscuse passes it under `docker.environment`; otherwise the run may exercise released/v3 template behavior while the investigation assumes local/v4 content.
+- When validating a pinned published image, match the originating CI run's template routing. Do not set `TEMPLATE_VERSION=local` merely because the plan file comes from the local dev checkout. Leave it unset unless the originating test run or requested scenario explicitly supplied a template version.
 - Scenario-specific feature flags must not rely on ambient shell history. vscuse plans should declare required flags in `plan_metadata.tags` using `feature_flag:<NAME>=<VALUE>`, and the execution workflow must apply those flags before vscuse starts the container and VS Code extension host.
 - Direct `vscuse execute` has no verified native case-level feature-flag field. Treat `feature_flag:*` tags as the AI-readable source of truth, not as runner-enforced behavior by themselves.
 - The Docker environment is controlled by `config.yaml` at container start. Do not add blank global pass-through entries for feature flags because unset and explicit `false` can differ in product code. Only inject the flags declared by the current plan, preferably through a temporary run config or an explicit pre-run step.
+- A host-level npm registry in `.npmrc` is not inherited by the vscuse container. Set `NPM_CONFIG_REGISTRY` before starting `vscuse` or `vscuse-ui`; `config.yaml` passes it into the container and defaults to `https://registry.npmjs.org/` when unset.
+- Some npm-compatible proxies, including `https://packagefeedproxy.microsoft.io/npm/`, do not implement `/-/ping`. Validate them with `npm view` and `npm pack`; a 404 from `npm ping` alone is not a connectivity failure.
 - Rebuild the Docker image only when the VSIX, image tooling, base image, installed extensions, or Dockerfile content changes.
 - vscuse itself is an external Python wheel obtained by CI from the `microsoft/vscuse-doc` release assets. The runner implementation is not in this repository.
 - `vscuse` is the execute-only CLI. `vscuse-ui` starts the authoring/debug UI and the recording APIs.
 - Use `vscuse-ui` as the default authoring and repair workbench for vscuse cases. Use `vscuse execute` as the clean final verifier for CI parity.
-- Verified locally with vscuse `0.2.67`: `vscuse-ui --config-file .\config.yaml --project-path .\plans` serves the Web UI/API on `http://127.0.0.1:6082`, noVNC on `http://127.0.0.1:6080`, and Docker API on `http://127.0.0.1:6081`.
+- Verified locally with vscuse `0.2.67`: start from `packages/tests/vscuse/vscode-test-cases` and run `vscuse-ui --config-file .\config.yaml --project-path .` to serve the Web UI/API on `http://127.0.0.1:6082`, noVNC on `http://127.0.0.1:6080`, and Docker API on `http://127.0.0.1:6081`.
+- For plans that reference shared groups, `vscuse-ui` must scan the `vscode-test-cases` root, not only `plans`. The UI has no `--groups-dir` option; using `--project-path .\plans` can load the plan but fail Run with `Plan <group-id> not found`.
 - Recording-to-plan generation is implemented by the `vscuse-ui` backend: start recording, stop recording, then generate an executable plan from the recording. Generated files are written under the configured `--project-path` and must be reviewed before committing.
 - Non-empty preconditions in the current vscuse plans are visual `dhash` screenshot-region checks. Treat screenshot and hash updates as behavioral evidence, not cosmetic churn.
 - Prefer keyboard-driven interactions over coordinate clicks whenever the product UI supports them. For command palettes and quick picks, use `key_press` (`f1`, `enter`, arrows, `escape`) plus `type_text` filtering instead of clicking recorded coordinates. Use clicks only for controls without a reliable keyboard path.
@@ -164,12 +171,68 @@ Get-ChildItem packages/tests/vscuse/docker/vscuse-atk/build-extensions -Filter *
 Build the image:
 
 ```powershell
+$branchName = (git branch --show-current).Trim()
+$imageBranch = $branchName -replace '^release/', '' -replace '[^A-Za-z0-9_.-]', '-'
+$localImage = "vscuse-atk-${imageBranch}:local"
 Push-Location packages/tests/vscuse/docker/vscuse-atk
-docker build --build-arg NODE_VERSION=22 -t vscuse-atk-local:latest .
+docker build --build-arg NODE_VERSION=22 -t $localImage .
 Pop-Location
 ```
 
 If the build fails while loading metadata for `ghcr.io/microsoft/vscuse-base:latest`, run the credential checks above. A `401 Unauthorized` at that step means the base image is not accessible to the current Docker login.
+
+## Use a Published Image from a Specific Actions Run
+
+Use this mode when the plan should come from the current local or dev checkout but the extension and image tooling should come from a particular successful `Build VscUse ATK Docker Image` run.
+
+Treat these as independent inputs:
+
+- **Plan source:** local files under `packages/tests/vscuse/vscode-test-cases`.
+- **Product image:** one pinned `ghcr.io/officedev/vscuse-atk-vscode:<tag>` created by the requested Actions run.
+- **Template routing:** the value used by the originating CI scenario; usually unset for a published release image unless explicitly provided.
+
+Resolve the tag from the workflow dispatch input or authenticated job log. The workflow also publishes a `teamsfx-<run_id>` tag when its `run_id` input is present. Do not infer the tag from the Docker-build run ID or branch name. If the build was triggered by `cd.yml`, its `series` input is passed as the raw image tag and appears at the end of the CD run name: `CD-<run-id>-<branch>-<preid>-<series>`.
+
+Read the public build metadata and record its `head_sha`:
+
+```powershell
+$repository = "OfficeDev/microsoft-365-agents-toolkit"
+$dockerBuildRunId = "<docker-build-run-id>"
+$headers = @{
+   "User-Agent" = "vscuse-local-validation"
+   "Accept" = "application/vnd.github+json"
+   "X-GitHub-Api-Version" = "2022-11-28"
+}
+$buildRun = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$repository/actions/runs/$dockerBuildRunId"
+$buildRun | Select-Object id,head_branch,head_sha,status,conclusion,created_at,html_url
+```
+
+Pull the resolved tag and verify that the image revision matches the Actions run before using it:
+
+```powershell
+$imageTag = "<exact-tag-from-workflow-input-or-summary>"
+$publishedImage = "ghcr.io/officedev/vscuse-atk-vscode:$imageTag"
+docker pull $publishedImage
+
+$imageInspect = (docker image inspect $publishedImage | ConvertFrom-Json)[0]
+$imageRevision = $imageInspect.Config.Labels.'org.opencontainers.image.revision'
+if ($imageRevision -ne $buildRun.head_sha) {
+   throw "Image revision $imageRevision does not match Actions run head SHA $($buildRun.head_sha)."
+}
+
+[PSCustomObject]@{
+   Image = $publishedImage
+   Id = $imageInspect.Id
+   Created = $imageInspect.Created
+   Revision = $imageRevision
+   Version = $imageInspect.Config.Labels.'org.opencontainers.image.version'
+   RepoDigests = $imageInspect.RepoDigests -join ","
+}
+$env:VSCUSE_VSCODE_IMAGE = $publishedImage
+Remove-Item Env:TEMPLATE_VERSION -ErrorAction SilentlyContinue
+```
+
+If the image tag is mutable, record the pulled repo digest from `docker image inspect` in the final report. A provenance mismatch is a setup failure; do not run the plan against a nearby tag and claim it represents the requested Actions run.
 
 ## Install or Verify the vscuse Runner
 
@@ -258,8 +321,11 @@ $dockerCliDir = "C:\Program Files\Docker\Docker\resources\bin"
 if (Test-Path (Join-Path $dockerCliDir "docker.exe")) {
    $env:PATH = "$dockerCliDir;$env:PATH"
 }
+$env:NPM_CONFIG_REGISTRY = (npm config get registry).Trim()
 $env:TEMPLATE_VERSION = "local"
-$env:VSCUSE_VSCODE_IMAGE = "vscuse-atk-local:latest"
+$branchName = (git branch --show-current).Trim()
+$imageBranch = $branchName -replace '^release/', '' -replace '[^A-Za-z0-9_.-]', '-'
+$env:VSCUSE_VSCODE_IMAGE = "vscuse-atk-${imageBranch}:local"
 vscuse execute --config-file .\config.yaml --groups-dir groups .\plans\<plan-name>.json
 Pop-Location
 ```
@@ -276,6 +342,8 @@ After the container starts, verify the non-secret routing env before interpretin
 
 ```powershell
 docker exec vscuse-container env | Select-String -Pattern '^(TEMPLATE_VERSION|TEAMSFX_.*)='
+docker exec --user vscode vscuse-container npm config get registry
+docker exec --user vscode vscuse-container npm view lodash version
 ```
 
 Before interpreting a plan failure, distinguish setup success from runtime credential readiness. A local smoke run can successfully load config, expand groups, start `vscuse-atk-local:latest`, and expose noVNC at `http://localhost:6080`, then stop before executing steps if required scenario credentials are missing. For M365 scenarios, `M365_ACCOUNT_NAME` and `M365_ACCOUNT_PASSWORD` are required by the executor even when `m365.enabled` is false in `config.yaml`; check only whether variables are set, never print their values.
@@ -292,7 +360,7 @@ For CI parity, the command shape is:
 vscuse execute --config-file .\config.yaml --groups-dir groups .\plans\<plan-name>.json
 ```
 
-`config.yaml` defaults `docker.image_name` to `${VSCUSE_VSCODE_IMAGE:ghcr.io/officedev/vscuse-atk-vscode:latest}`. Set `VSCUSE_VSCODE_IMAGE` when validating the current local VSIX.
+`config.yaml` defaults `docker.image_name` to `${VSCUSE_VSCODE_IMAGE:ghcr.io/officedev/vscuse-atk-vscode:latest}`. Always set `VSCUSE_VSCODE_IMAGE` explicitly: use a branch-specific local image for the current local VSIX, or a provenance-checked published tag for a requested CI-built product version.
 
 ## Scenario Feature Flags
 
@@ -414,9 +482,11 @@ if (Test-Path (Join-Path $dockerCliDir "docker.exe")) {
    $env:PATH = "$dockerCliDir;$env:PATH"
 }
 
-$env:VSCUSE_VSCODE_IMAGE = "vscuse-atk-local:latest"
+$branchName = (git branch --show-current).Trim()
+$imageBranch = $branchName -replace '^release/', '' -replace '[^A-Za-z0-9_.-]', '-'
+$env:VSCUSE_VSCODE_IMAGE = "vscuse-atk-${imageBranch}:local"
 $vscuseUi = Join-Path $env:APPDATA "Python\Python312\Scripts\vscuse-ui.exe"
-& $vscuseUi --config-file .\config.yaml --project-path .\plans
+& $vscuseUi --config-file .\config.yaml --project-path .
 
 Pop-Location
 ```

--- a/.github/skills/vscuse-case-diagnosis/SKILL.md
+++ b/.github/skills/vscuse-case-diagnosis/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "Plan/case name, failing step, or feature workflow to diagnose"
 
 ## Goal
 
-Run an existing vscuse test case against the current local repository, show the real execution through the integrated browser, and classify any failure as one of:
+Run an existing local vscuse test case against an explicitly selected product image, show the real execution through the integrated browser, and classify any failure as one of:
 
 - `product bug`: the extension or generated app behavior is wrong.
 - `test plan drift`: the product behavior is correct but the vscuse plan/group/assertion/precondition is stale.
@@ -20,7 +20,7 @@ Do not make a case green by hiding the classification. The final answer must say
 ## Required Inputs
 
 - Plan name, case title, failing step id, report path, or feature workflow.
-- Whether the user expects local repository bits. For local validation, use `VSCUSE_VSCODE_IMAGE=vscuse-atk-local:latest` and `TEMPLATE_VERSION=local`.
+- Product image mode: either current local repository bits or a pinned published image from a specific successful Actions run. Local mode uses `TEMPLATE_VERSION=local` and a branch-specific image tag such as `VSCUSE_VSCODE_IMAGE=vscuse-atk-dev:local`; published mode uses an exact provenance-checked `ghcr.io/officedev/vscuse-atk-vscode:<tag>` and the originating run's template routing.
 - Any case-specific feature flags declared in `plan_metadata.tags` as `feature_flag:<NAME>=<VALUE>`, or in the docs scenario that owns the case.
 
 If local setup, image build, runner install, or credentials are missing, use the shared setup guidance in `local-vscuse-validation` first.
@@ -28,13 +28,17 @@ If local setup, image build, runner install, or credentials are missing, use the
 ## Core Rules
 
 - Use a real `vscuse execute` run. Do not mock the UI flow.
-- Prefer `vscuse-ui` for interactive repair after the first failure is classified. It is the default workbench for live inspection, recording changed steps, refreshing visual checks, and demonstrating the repaired flow.
+- After the first failure is classified, start `vscuse-ui` before any second full CLI run. It is the required workbench for live inspection, recording changed steps, refreshing visual checks, and demonstrating the repaired flow.
+- Open the integrated browser to the Web UI at `http://127.0.0.1:6082` and keep its embedded noVNC view visible while repairing. Also provide `http://127.0.0.1:6080/vnc.html` when a separate full-size live view is useful. Tell the user both URLs as soon as the services are ready.
+- Do not repeatedly run the complete create/login/provision/deploy workflow through `vscuse execute` while diagnosing plan drift. Use `Run`, `Continue`, and `Next` in `vscuse-ui` to iterate near the failing area, then use one clean CLI run for final validation.
 - Still finish with `vscuse execute`. A plan is not validated until it passes a clean CLI run or the remaining failure is explicitly classified.
 - Show the live execution through the integrated browser at `http://localhost:6080/vnc.html` when the user asks to demonstrate the process.
 - noVNC is a live view of the running container, not a replay. Open it while execution is still running.
 - Do not screenshot or print secrets, passwords, tokens, tenant secrets, or generated API keys.
 - `--start` and `--end` only work when the required UI state already exists. They do not recreate prior setup.
 - Plan/group JSON is read from disk at execution time; edits apply on the next run without rebuilding the image.
+- The local plan source and product image source are independent. It is valid to diagnose a dev plan against a pinned published image when that version is the requested product baseline.
+- Never replace a requested Actions-run image with `latest`, a branch-local image, or a guessed neighboring tag. Verify the pulled image's `org.opencontainers.image.revision` against the Actions run `head_sha` and record the digest.
 - A feature-flagged plan is not self-contained if the flags only live in a previous shell command. The plan should declare them with `feature_flag:*` tags, and the run must apply them before vscuse starts the container and VS Code extension host.
 - When the user identifies a docs scenario as the source of truth, compare the case to that doc before preserving old steps. If the doc removes a shipped sub-flow, classify the old steps as test plan drift and do not keep executing them merely because they appear in the existing plan.
 - Prefer `key_press` and `type_text` over `click` when a command palette, quick pick, focused button, or default selection can be driven by keyboard. Coordinate clicks with screenshot preconditions are more brittle under layout, zoom, focus, and tooltip changes.
@@ -53,20 +57,35 @@ Find the plan and any shared groups it expands. Prefer the smallest owning surfa
 - Edit a shared group when the drift belongs to a reused flow and should affect all consumers.
 - Edit product code when noVNC/report evidence shows the product behavior is wrong.
 
-### 2. Prepare the Local Runtime
+### 2. Prepare the Runtime and Select the Product Image
+
+Choose exactly one mode before starting the container.
+
+**Local product mode** validates the current checkout's VSIX:
 
 From the repository root:
 
 ```powershell
 .\set-azure-env.ps1 -Env atk06
 $env:TEMPLATE_VERSION = "local"
-$env:VSCUSE_VSCODE_IMAGE = "vscuse-atk-local:latest"
+$branchName = (git branch --show-current).Trim()
+$imageBranch = $branchName -replace '^release/', '' -replace '[^A-Za-z0-9_.-]', '-'
+$env:VSCUSE_VSCODE_IMAGE = "vscuse-atk-${imageBranch}:local"
 
 $dockerCliDir = "C:\Program Files\Docker\Docker\resources\bin"
 if (Test-Path (Join-Path $dockerCliDir "docker.exe")) {
    $env:PATH = "$dockerCliDir;$env:PATH"
 }
 ```
+
+**Published product mode** runs the local or dev plan files against a requested CI-built image. Resolve the exact tag and verify provenance using `local-vscuse-validation`, then set:
+
+```powershell
+$env:VSCUSE_VSCODE_IMAGE = "ghcr.io/officedev/vscuse-atk-vscode:<verified-tag>"
+Remove-Item Env:TEMPLATE_VERSION -ErrorAction SilentlyContinue
+```
+
+Only set `TEMPLATE_VERSION` in published mode when the originating CI run or scenario explicitly used it. A local plan path does not imply local template routing.
 
 If the plan declares feature flags, apply them before running `vscuse execute`:
 
@@ -118,14 +137,28 @@ Use this decision table:
 | Evidence | Classification | Next Action |
 |---|---|---|
 | Missing env vars, Docker, GHCR, vscuse wheel, noVNC, or image access | setup failure | Fix setup and rerun the same plan |
+| Pulled image tag does not resolve to the requested Actions run revision | setup failure | Resolve the exact published tag and verify OCI revision before running |
 | Plan declares feature flags but they were not applied before container/VS Code startup | setup failure | Apply plan-declared flags through the run config and rerun |
 | noVNC shows product does not match expected behavior | product bug | Fix product code, rebuild VSIX/image if needed, rerun |
 | Product behavior is correct but step text, click target, assertion, wait, or visual hash is stale | test plan drift | Repair plan/group and rerun |
 | Same behavior eventually passes; screenshot shows tooltip/toast/loading variance | flake | Stabilize hover/wait/precondition/assertion and rerun |
 
+If `execution_order` references missing step ids, inspect the plan history and current source-of-truth behavior before restoring deleted step objects. A previous UI-change commit may have intentionally removed obsolete assertions but missed the order list. If restored assertions disagree with current code or unit tests, treat them as test plan drift and update/remove the assertion instead of forcing the old expectation back into the case.
+
 ### 6. Repair the Smallest Surface with vscuse-ui First
 
-- Product bug: fix code, rebuild VSIX, rebuild the local vscuse image, then rerun.
+Before editing or starting a second full execution, launch the UI workbench from the testcase root so shared groups resolve:
+
+```powershell
+Push-Location packages/tests/vscuse/vscode-test-cases
+vscuse-ui --config-file .\config.yaml --project-path .
+Pop-Location
+```
+
+As soon as startup prints the service URLs, open `http://127.0.0.1:6082` in the integrated browser and confirm that its embedded noVNC view is connected. Do not leave the user waiting on an invisible CLI execution. Keep the UI service running while editing plan/group JSON; reload the plan or use `Restart`/`Clear` before interpreting results after an edit.
+
+- Product bug in local mode: fix code, rebuild VSIX, rebuild the local vscuse image, then rerun.
+- Product bug in published mode: preserve the pinned image as evidence and do not weaken the plan to hide the product failure. Fix product code only when requested, then validate with a new local or published image.
 - Plan drift: prefer `vscuse-ui` to inspect/re-record the affected steps, refresh screenshots, and validate the visual state interactively. Use direct JSON edits for metadata, variables, or small textual cleanups after the UI change is understood.
 - Flake: prefer stable precondition regions, tolerant assertions, and neutralizing hover/focus steps over delay-only fixes.
 - Setup failure: fix only the environment blocker before interpreting product behavior.
@@ -156,6 +189,7 @@ For `SCN-DA-CREATE-WITH-MCP-SERVER` with `TEAMSFX_MCP_FOR_DA_DT=true`, the new d
 Run the same focused plan again. Final report should include:
 
 - Plan name/path and result.
+- Product image mode, exact image reference, pulled digest, source Actions run, and provenance result.
 - Integrated browser evidence: whether noVNC showed the real live container and which step area was observed.
 - Failure classification.
 - Feature flags declared by the plan and whether they were applied.

--- a/packages/tests/vscuse/vscode-test-cases/config.yaml
+++ b/packages/tests/vscuse/vscode-test-cases/config.yaml
@@ -29,6 +29,7 @@ docker:
   vscode_insiders: false   
   environment:
     TEAMSFX_TELEMETRY_TEST: "true"                 # Default: false (set to true to use VS Code Insider)
+    NPM_CONFIG_REGISTRY: "${NPM_CONFIG_REGISTRY:https://registry.npmjs.org/}"
     AZURE_SEARCH_KEY: "${AZURE_SEARCH_KEY}"
     AZURE_SEARCH_ENDPOINT: "${AZURE_SEARCH_ENDPOINT}"
     AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: "${AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME}"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote.json
@@ -303,7 +303,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion there's a \"Let's go\" dialog with a blue \"Open\" button exist.",
+      "description": "@assertion there's an \"Added successfully!\" dialog with a blue \"Open\" button exist.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -327,7 +327,7 @@
         "x": 529,
         "y": 506
       },
-      "description": "Click the blue \"Open\" button in the \"Let's go\" dialog for the app in Microsoft Teams.",
+      "description": "Click the blue \"Open\" button in the \"Added successfully!\" dialog for the app in Microsoft Teams.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## Summary

- support running local/dev vscuse plans against a provenance-checked image from a specific GitHub Actions run
- require the UI-first diagnosis flow with visible vscuse-ui/noVNC before repeated full executions
- pass a configurable npm registry into the vscuse container
- update the Teams remote-debug flow for the current `Added successfully!` dialog

## Validation

- validated skill frontmatter, vscuse YAML configuration, JSON structure, and `git diff --check`
- validated against `ghcr.io/officedev/vscuse-atk-vscode:CY260707` from Actions run https://github.com/OfficeDev/microsoft-365-agents-toolkit/actions/runs/28990356198
- full visible vscuse-ui execution: 94 steps done, 0 errors
- clean `vscuse execute` execution: 94/94 successful, 0 errors, 100% success rate
- verified `Added successfully!` assertion and the subsequent OCR-resolved blue `Open` action in Teams

## Environment

- npm registry propagated into the container through `NPM_CONFIG_REGISTRY`
- published image revision and digest were verified before execution