### PR TITLE
test(vscuse): update remote MCP auth flows

### DIFF
--- a/.github/skills/local-vscuse-validation/SKILL.md
+++ b/.github/skills/local-vscuse-validation/SKILL.md
@@ -44,6 +44,7 @@ Do not use this skill for ordinary unit tests, CLI E2E tests, or non-VS Code val
 - Plans live in `packages/tests/vscuse/vscode-test-cases/plans`.
 - Groups live in `packages/tests/vscuse/vscode-test-cases/groups`.
 - vscuse config lives at `packages/tests/vscuse/vscode-test-cases/config.yaml`.
+- Preserve every local CLI run under the repository-root `.local/test-reports/<timestamp>-<plan-name>/`. This directory is gitignored. Each run directory must contain the streamed `run.log` and generated `test_report.html`; keep retries in new directories instead of overwriting earlier evidence.
 - Local vscuse credentials should live in `set-azure-env.ps1` at the repository root. This path is gitignored because it contains secrets and should stay easy to find during local validation.
 - The ATK-specific Dockerfile is `packages/tests/vscuse/docker/vscuse-atk/Dockerfile`.
 - Local VSIX files must be copied into `packages/tests/vscuse/docker/vscuse-atk/build-extensions/` before building the local image.
@@ -317,6 +318,7 @@ $vscuseEnvScript = ".\set-azure-env.ps1"
 . $vscuseEnvScript -Env atk06
 
 Push-Location packages/tests/vscuse/vscode-test-cases
+$repoRoot = (git rev-parse --show-toplevel).Trim()
 $dockerCliDir = "C:\Program Files\Docker\Docker\resources\bin"
 if (Test-Path (Join-Path $dockerCliDir "docker.exe")) {
    $env:PATH = "$dockerCliDir;$env:PATH"
@@ -326,9 +328,21 @@ $env:TEMPLATE_VERSION = "local"
 $branchName = (git branch --show-current).Trim()
 $imageBranch = $branchName -replace '^release/', '' -replace '[^A-Za-z0-9_.-]', '-'
 $env:VSCUSE_VSCODE_IMAGE = "vscuse-atk-${imageBranch}:local"
-vscuse execute --config-file .\config.yaml --groups-dir groups .\plans\<plan-name>.json
+$env:PYTHONUNBUFFERED = "1"
+$planPath = ".\plans\<plan-name>.json"
+$planName = [IO.Path]::GetFileNameWithoutExtension($planPath)
+$runId = "{0}-{1}" -f (Get-Date -Format "yyyyMMdd-HHmmss"), ($planName -replace '[^A-Za-z0-9_.-]', '-')
+$artifactDir = Join-Path $repoRoot ".local\test-reports\$runId"
+New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
+
+vscuse execute --config-file .\config.yaml --groups-dir groups --report-dir $artifactDir $planPath 2>&1 |
+   Tee-Object (Join-Path $artifactDir "run.log")
+$exitCode = $LASTEXITCODE
 Pop-Location
+if ($exitCode -ne 0) { exit $exitCode }
 ```
+
+Do not treat `test_report/test_report.html` as durable evidence. It is the runner's gitignored transient output and may be replaced by the next execution. Pass `--report-dir` for every local CLI run, stream unbuffered output to that same run directory, and report the project-relative artifact paths. Optional summaries such as `run-summary.json` or `run-summary.csv` belong in the same directory.
 
 If the config used for the run does not pass `TEMPLATE_VERSION` into `docker.environment`, create an ignored temporary config for the run and add only the required local validation env values:
 
@@ -432,8 +446,8 @@ The first goal is not to make the case green at any cost. The first goal is to c
 2. Separate harness/setup failures from product failures.
    Missing credentials, GHCR access, Docker CLI not on PATH, noVNC startup failure, or absent scenario env vars are setup problems. Fix those before interpreting UI behavior.
 
-3. Use the report and screenshots to inspect the failing step.
-   The default report is `packages/tests/vscuse/vscode-test-cases/test_report/test_report.html`. Look at before/after screenshots, failed preconditions, retry history, assertion reasoning, and the exact expanded step id.
+3. Use the archived report and screenshots to inspect the failing step.
+   Open the run-specific repository-root `.local/test-reports/<timestamp>-<plan-name>/test_report.html`. The runner may also create `test_report/test_report.html`, but that transient file is not durable evidence. Look at before/after screenshots, failed preconditions, retry history, assertion reasoning, and the exact expanded step id.
 
 4. Classify the failure.
    A product bug means the local extension produced the wrong behavior. Fix product code and rerun the focused plan. Test-plan drift means the product behavior intentionally changed but the recorded step, assertion, hash, wait, or generated data assumption is stale. Repair the plan with `vscuse-ui` or a direct JSON edit, then rerun. A flake means the behavior eventually matches but timing, service response, or visual stability is unreliable; improve waits/preconditions only when the evidence supports it.
@@ -577,6 +591,7 @@ When reporting back, include only the useful facts:
 - Docker image build result and image tag, or the exact access blocker.
 - vscuse runner availability: installed command, local wheel path, or missing external wheel.
 - Plan executed and result, or why execution could not start.
+- Repository-relative paths to the run-specific `run.log` and `test_report.html` under `.local/test-reports/`.
 - Failure classification: product bug, plan drift, setup failure, or flake.
 - Plan maintenance summary: which plan files changed and how they stay dynamic.
 - Integrated browser evidence when requested: whether noVNC showed a live running container, which failure-near step was observed, and whether the repaired rerun reached the expected passing state.

--- a/.github/skills/vscuse-case-diagnosis/SKILL.md
+++ b/.github/skills/vscuse-case-diagnosis/SKILL.md
@@ -27,11 +27,14 @@ If local setup, image build, runner install, or credentials are missing, use the
 
 ## Core Rules
 
+- Before launching a local run, compare the plan with its owning docs/scenario and the current implementation. Repair deterministic drift first: changed question order, removed flows, required feature flags, generated-file expectations, and over-broad shared groups. Use live execution to validate that static repair and to investigate visual or timing ambiguity, not to rediscover differences already explicit in source.
+- Use the narrowest login group required by the scenario. A Microsoft 365-only scaffold/provision flow must use an M365-only login group; include Azure login only when the case creates, reads, or deploys Azure resources.
 - Use a real `vscuse execute` run. Do not mock the UI flow.
 - After the first failure is classified, start `vscuse-ui` before any second full CLI run. It is the required workbench for live inspection, recording changed steps, refreshing visual checks, and demonstrating the repaired flow.
 - Open the integrated browser to the Web UI at `http://127.0.0.1:6082` and keep its embedded noVNC view visible while repairing. Also provide `http://127.0.0.1:6080/vnc.html` when a separate full-size live view is useful. Tell the user both URLs as soon as the services are ready.
 - Do not repeatedly run the complete create/login/provision/deploy workflow through `vscuse execute` while diagnosing plan drift. Use `Run`, `Continue`, and `Next` in `vscuse-ui` to iterate near the failing area, then use one clean CLI run for final validation.
 - Still finish with `vscuse execute`. A plan is not validated until it passes a clean CLI run or the remaining failure is explicitly classified.
+- For every local `vscuse execute`, use the repository-root artifact command from `local-vscuse-validation`: create a unique `.local/test-reports/<timestamp>-<plan-name>/` directory, pass it with `--report-dir`, and stream unbuffered output to `run.log`. Never overwrite the first failure with a retry.
 - Show the live execution through the integrated browser at `http://localhost:6080/vnc.html` when the user asks to demonstrate the process.
 - noVNC is a live view of the running container, not a replay. Open it while execution is still running.
 - Do not screenshot or print secrets, passwords, tokens, tenant secrets, or generated API keys.
@@ -51,7 +54,9 @@ If local setup, image build, runner install, or credentials are missing, use the
 
 ### 1. Locate the Owning Case
 
-Find the plan and any shared groups it expands. Prefer the smallest owning surface:
+Read the owning docs/scenario and current implementation, then find the plan and any shared groups it expands. Before running, statically compare the documented question order, feature flags, generated artifacts, removed legacy flows, login/resource prerequisites, and the plan's execution order. Fix clear mismatches immediately, then use the first local run as validation rather than discovery.
+
+Prefer the smallest owning surface:
 
 - Edit the plan when only that case is affected.
 - Edit a shared group when the drift belongs to a reused flow and should affect all consumers.
@@ -111,11 +116,7 @@ Check only whether required secrets are set, never their values:
 
 ### 3. Execute the Focused Plan
 
-```powershell
-Push-Location packages/tests/vscuse/vscode-test-cases
-vscuse execute --config-file .\config.yaml --groups-dir groups .\plans\<plan-name>.json
-Pop-Location
-```
+Use the complete repository-root artifact command under **Execute a Local Test Plan** in `local-vscuse-validation`, substituting the focused plan path. Confirm the resulting run directory contains both `run.log` and `test_report.html` before interpreting or editing the case.
 
 When the user needs to see the process, open the integrated browser to `http://localhost:6080/vnc.html`, click `Connect`, and keep it visible near the failing area.
 
@@ -125,7 +126,7 @@ Use the report and terminal logs to capture:
 
 - Plan id and execution id.
 - Failing expanded step id and nearby previous step.
-- Report path, usually `packages/tests/vscuse/vscode-test-cases/test_report/test_report.html`.
+- Repository-relative paths to the run-specific `.local/test-reports/<timestamp>-<plan-name>/run.log` and `test_report.html`. The runner's transient `test_report/test_report.html` is not the archived evidence.
 - Before/after screenshots and assertion reasoning.
 - Whether the local image and `TEMPLATE_VERSION=local` were used.
 - Declared and applied feature flags, by name and non-secret value only.
@@ -194,4 +195,4 @@ Run the same focused plan again. Final report should include:
 - Failure classification.
 - Feature flags declared by the plan and whether they were applied.
 - Files changed and why.
-- Final execution summary: successful count, errors count, and report path.
+- Final execution summary: successful count, errors count, and repository-relative paths to the archived log and HTML report.

--- a/.github/skills/vscuse-scenario-authoring/SKILL.md
+++ b/.github/skills/vscuse-scenario-authoring/SKILL.md
@@ -25,6 +25,7 @@ This workflow is for authoring or refreshing vscuse coverage. For diagnosing an 
 - Prefer `vscuse-ui` for creating or repairing case steps. It is the fastest way to inspect live UI state, record changed interactions, refresh screenshots, and edit steps. Treat the CLI as the final verifier, not the primary authoring surface.
 - Use the integrated browser at `http://localhost:6080/vnc.html` as the live evidence surface.
 - Treat `vscuse-ui` generated plans as drafts until cleaned, parsed, and rerun with `vscuse execute`.
+- Archive every local `vscuse execute` using the repository-root artifact command in `local-vscuse-validation`: a unique gitignored `.local/test-reports/<timestamp>-<plan-name>/` directory containing `run.log` and `test_report.html`.
 - If product behavior does not match the docs, classify it as a product gap or bug before changing coverage.
 - When a draft scenario explicitly replaces shipped behavior, treat the draft doc as the source of truth for the covered case. Existing vscuse steps that encode the old behavior are test plan drift, even if they used to pass.
 - Do not commit empty `r_*.json` recordings or exploratory generated plans.
@@ -183,13 +184,7 @@ Parse changed JSON:
 Get-Content packages/tests/vscuse/vscode-test-cases/plans/<plan-name>.json -Raw | ConvertFrom-Json | Out-Null
 ```
 
-Then run the focused case with `vscuse execute`. This final run is required even if the flow looked correct in `vscuse-ui`, because the CLI starts from a clean container and matches CI behavior:
-
-```powershell
-Push-Location packages/tests/vscuse/vscode-test-cases
-vscuse execute --config-file .\config.yaml --groups-dir groups .\plans\<plan-name>.json
-Pop-Location
-```
+Then run the focused case with the complete repository-root artifact command under **Execute a Local Test Plan** in `local-vscuse-validation`. This final run is required even if the flow looked correct in `vscuse-ui`, because the CLI starts from a clean container and matches CI behavior. Confirm its unique run directory contains both `run.log` and `test_report.html`.
 
 Final coverage is valid only after this executable run passes or after any failure is classified and reported.
 
@@ -204,4 +199,4 @@ Report:
 - Product behavior verdict: matches docs, product bug, product gap, setup failure, or flake.
 - Plan maintenance decision: updated existing plan/group, replaced steps, or generated a new plan.
 - Cleanup performed on generated content.
-- Final `vscuse execute` result and report path.
+- Final `vscuse execute` result and repository-relative paths to the archived `run.log` and `test_report.html`.

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_for_provision.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_for_provision.json
@@ -1,0 +1,280 @@
+{
+  "plan_metadata": {
+    "version": "1.1",
+    "plan_id": "plan_login_m365_for_provision",
+    "execution_context": {
+      "delay_between_steps": 0.5,
+      "stop_on_error": true,
+      "precondition_wait_timeout": 30,
+      "precondition_retry_interval": 2,
+      "step_retry_count": 0
+    },
+    "total_steps": 11,
+    "created_at": "2026-07-13T13:45:00.000000",
+    "name": "group: login_m365_for_provision",
+    "description": {
+      "other": "Sign in to Microsoft 365 without Azure login before provisioning.",
+      "owner": "",
+      "workitem": ""
+    },
+    "generated_at": "2026-07-13T13:45:00.000000",
+    "execution_order": [
+      "step_open_m365_accounts_command",
+      "step_filter_m365_accounts_command",
+      "step_select_m365_accounts_command",
+      "step_select_m365_sign_in",
+      "step_confirm_m365_sign_in",
+      "plan_dcd3b7c4",
+      "step_close_m365_login_browser",
+      "step_reopen_m365_accounts_command",
+      "step_refilter_m365_accounts_command",
+      "step_reselect_m365_accounts_command",
+      "step_verify_m365_account",
+      "step_close_m365_accounts_menu"
+    ],
+    "tags": [
+      "group",
+      "m365_login",
+      "no_azure_login"
+    ],
+    "updated_at": "2026-07-13T13:45:00.000000"
+  },
+  "steps": [
+    {
+      "step_id": "step_open_m365_accounts_command",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f1"
+      },
+      "description": "Press F1 to open the Visual Studio Code command palette before signing in to Microsoft 365.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_filter_m365_accounts_command",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Microsoft 365 Agents: Accounts"
+      },
+      "description": "Type 'Microsoft 365 Agents: Accounts' into the Visual Studio Code command palette.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_select_m365_accounts_command",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 461,
+        "y": 70
+      },
+      "description": "Click the exact 'Microsoft 365 Agents: Accounts' command below the similarly named Accounts View command.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_select_m365_sign_in",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 379,
+        "y": 52
+      },
+      "description": "Click the 'Sign in to Microsoft 365' option in the Accounts menu.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_confirm_m365_sign_in",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 762,
+        "y": 97
+      },
+      "description": "Click the Microsoft 365 sign-in confirmation button.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_close_m365_login_browser",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 1004,
+        "y": 19
+      },
+      "description": "Close the Microsoft 365 sign-in browser after authentication completes.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:1004:19:16:5:aac833964c9633cc",
+        "dhash:1004:19:96:5:d2232323c200e6e6"
+      ],
+      "postconditions": [],
+      "tags": [
+        "delay:3"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_reopen_m365_accounts_command",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f1"
+      },
+      "description": "Open the Visual Studio Code command palette after Microsoft 365 authentication completes.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_refilter_m365_accounts_command",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Microsoft 365 Agents: Accounts"
+      },
+      "description": "Filter the command palette to the Microsoft 365 Agents Accounts commands after sign-in.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_reselect_m365_accounts_command",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 461,
+        "y": 70
+      },
+      "description": "Open the exact 'Microsoft 365 Agents: Accounts' command so the signed-in account is visible.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_verify_m365_account",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion there's ${{env:M365_ACCOUNT_NAME}} in the Accounts section.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout:60"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    },
+    {
+      "step_id": "step_close_m365_accounts_menu",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "esc"
+      },
+      "description": "Close the Accounts menu after verifying the Microsoft 365 account.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-07-13T13:45:00.000000",
+      "plan_id": "plan_login_m365_for_provision"
+    }
+  ],
+  "screenshots": {}
+}

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_withoutCommand.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_withoutCommand.json
@@ -60,8 +60,8 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 626,
-        "y": 456
+        "x": 629,
+        "y": 484
       },
       "description": "Click the \"Next\" button on the Microsoft sign-in page after entering the email address in the browser.",
       "content_refs": [],
@@ -70,9 +70,9 @@
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:626:456:16:5:4a2698c9aab29a9b",
-        "dhash:626:456:96:5:00004e71714e0000",
-        "dhash:626:456:0:10:1b28d0d9e7e6dae4"
+        "dhash:629:484:16:5:23248c4b6c24d32c",
+        "dhash:629:484:96:5:00004eb131860000",
+        "dhash:629:484:0:10:1b28f0d9e7e6dae4"
       ],
       "postconditions": [],
       "tags": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Entra_SSO_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Entra_SSO_Remote.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 25,
+    "total_steps": 17,
     "created_at": "2026-06-29T02:44:33.029362",
     "name": "DA MCP Entra SSO Remote",
     "description": {
@@ -24,33 +24,31 @@
       "step_7437f6e8",
       "step_03fb1bee",
       "step_0e8ca12b",
-      "step_e02cd850",
-      "plan_r_0928_014459",
-      "plan_r_1021_081410",
-      "step_f61600cd",
-      "step_3470fc88",
-      "plan_26ac4c4e",
-      "step_4f38d99d",
-      "step_16e106fb",
-      "step_1a1ac380",
-      "step_a4d37792",
-      "step_90dd124f",
-      "step_4a28cd05",
       "step_a256a727",
       "step_ee1faafc",
+      "step_a49b5428",
+      "step_dc6672cb",
+      "step_e02cd850",
+      "plan_r_0928_014459",
+      "step_f61600cd",
+      "plan_login_m365_for_provision",
       "step_1421ce5a",
       "step_aeb351a0",
       "step_9ffc68ad",
-      "step_bc14f139",
-      "step_a49b5428",
-      "step_dc6672cb",
       "step_ba61c713",
       "step_add5088d",
       "step_38bdd0bf",
       "step_a996b3a7",
       "step_84004606"
     ],
-    "tags": [],
+    "tags": [
+      "scenario:SCN-DA-CREATE-WITH-MCP-SERVER",
+      "source_of_truth:docs/01-product/scenarios/da/draft/create-da-with-mcp-server.md",
+      "feature_flag:TEAMSFX_MCP_FOR_DA_DT=true",
+      "feature_flag:TEAMSFX_MCP_FOR_DA_DCR=true",
+      "auth_type:entra-sso",
+      "dynamic_tool_discovery"
+    ],
     "updated_at": "2026-06-29T03:18:28.708853"
   },
   "steps": [
@@ -152,206 +150,25 @@
     },
     {
       "step_id": "step_f61600cd",
-      "agent": "interaction",
-      "tool": "click",
+      "agent": "code",
+      "tool": "",
       "parameters": {
-        "button": "left",
-        "x": 629,
-        "y": 136
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\"\nPROJECT_DIR=\"$PROJECT_DIR\" python3 - <<'PY'\nimport json\nimport os\nfrom pathlib import Path\n\nproject = Path(os.environ[\"PROJECT_DIR\"])\nrequired = [\"appPackage/manifest.json\", \"appPackage/declarativeAgent.json\", \"appPackage/ai-plugin.json\", \"m365agents.yml\", \".vscode/mcp.json\", \"env/.env.dev\"]\nfor relative in required:\n    if not (project / relative).is_file():\n        raise AssertionError(f\"Missing required file: {relative}\")\nif (project / \"appPackage/mcp-tools-1.json\").exists():\n    raise AssertionError(\"Static MCP tools file must not be generated\")\nplugin = json.loads((project / \"appPackage/ai-plugin.json\").read_text(encoding=\"utf-8\"))\nif plugin.get(\"namespace\") != \"apigithubc\" or plugin.get(\"functions\") != []:\n    raise AssertionError(\"Unexpected dynamic MCP plugin namespace or functions\")\nruntimes = plugin.get(\"runtimes\")\nif not isinstance(runtimes, list) or len(runtimes) != 1:\n    raise AssertionError(\"Expected exactly one MCP runtime\")\nruntime = runtimes[0]\nif runtime.get(\"type\") != \"RemoteMCPServer\" or runtime.get(\"spec\") != {\"url\": \"https://api.githubcopilot.com/mcp/\"} or runtime.get(\"run_for_functions\") != [\"*\"]:\n    raise AssertionError(\"Unexpected dynamic MCP runtime shape\")\nif \"mcp_tool_description\" in runtime:\n    raise AssertionError(\"Dynamic MCP runtime must not contain mcp_tool_description\")\nauth = runtime.get(\"auth\", {})\nif auth.get(\"type\") != \"OAuthPluginVault\" or not str(auth.get(\"reference_id\", \"\")).endswith(\"MCP_DA_AUTH_ID_APIGITHUBC}}\"):\n    raise AssertionError(\"Unexpected OAuthPluginVault reference\")\nyml = (project / \"m365agents.yml\").read_text(encoding=\"utf-8\")\nfor expected in [\"oauth/register\", \"identityProvider: MicrosoftEntra\", \"MCP_DA_OAUTH_CLIENT_ID_APIGITHUBC\", \"MCP_DA_AUTH_ID_APIGITHUBC\"]:\n    if expected not in yml:\n        raise AssertionError(f\"Missing Entra SSO configuration in m365agents.yml: {expected}\")\nfor unexpected in [\"SECRET_MCP_DA_OAUTH_CLIENT_SECRET_APIGITHUBC\", \"MCP_DA_OAUTH_SCOPE_APIGITHUBC\"]:\n    if unexpected in yml:\n        raise AssertionError(f\"Unexpected Entra SSO configuration in m365agents.yml: {unexpected}\")\ndef env_value(relative, key):\n    for line in (project / relative).read_text(encoding=\"utf-8\").splitlines():\n        if line.startswith(key + \"=\"):\n            return line.split(\"=\", 1)[1]\n    return None\nif env_value(\"env/.env.dev\", \"MCP_DA_OAUTH_CLIENT_ID_APIGITHUBC\") != \"${{env:DA_MCP_ENTRA_SSO_CLIENTID}}\":\n    raise AssertionError(\"Entra application client ID was not persisted\")\nmcp = json.loads((project / \".vscode/mcp.json\").read_text(encoding=\"utf-8\"))\nif \"https://api.githubcopilot.com/mcp/\" not in json.dumps(mcp):\n    raise AssertionError(\"MCP URL missing from .vscode/mcp.json\")\nPY\n```"
       },
-      "description": "Click the \"Start\" link in the \"servers\" section of the mcp.json file within the Visual Studio Code editor to trigger a code action or fetch suggestion.",
+      "description": "@code verify the generated Entra SSO MCP DA project follows SCN-DA-CREATE-WITH-MCP-SERVER dynamic tool discovery shape, persists only the Entra application client ID, and injects oauth/register with MicrosoftEntra identity provider.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:629:136:16:5:2689b3cbebababc9",
-        "dhash:629:136:96:5:00008966e6091200",
-        "dhash:629:136:0:10:23b121212121232a"
-      ],
+      "preconditions": [],
       "postconditions": [],
-      "tags": [],
-      "screenshot": "step_f61600cd",
+      "tags": [
+        "source_of_truth:docs/01-product/scenarios/da/draft/create-da-with-mcp-server.md",
+        "scenario:SCN-DA-CREATE-WITH-MCP-SERVER"
+      ],
+      "screenshot": null,
       "created_at": "2026-06-29T03:17:40.264916",
-      "plan_id": "plan_b85e52ee"
-    },
-    {
-      "step_id": "step_3470fc88",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 481,
-        "y": 88
-      },
-      "description": "Click the \"Allow\" button in the GitHub authentication dialog for MCP Server Definition within the Visual Studio Code application interface.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:481:88:16:5:0000004d524d5552",
-        "dhash:481:88:96:5:000024189c4c1a10",
-        "dhash:481:88:0:10:d2b12d212121232a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_3470fc88",
-      "created_at": "2026-06-29T03:17:40.272943",
-      "plan_id": "plan_b85e52ee"
-    },
-    {
-      "step_id": "step_4f38d99d",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 489,
-        "y": 138
-      },
-      "description": "Click the \"ATK: Fetch from MCP\" link in the editor tab of Visual Studio Code to trigger an agent toolkit action.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:489:138:16:5:5186397d75355827",
-        "dhash:489:138:96:5:2890148dd9718e8e",
-        "dhash:489:138:0:10:23b131252121213a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_4f38d99d",
-      "created_at": "2026-06-29T03:17:40.280952",
-      "plan_id": "plan_b85e52ee"
-    },
-    {
-      "step_id": "step_16e106fb",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 468,
-        "y": 72
-      },
-      "description": "Click the ai-plugin.json file option in the \"Select the action manifest you want to update\" dropdown within Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:468:72:16:5:0000b24d3e226232",
-        "dhash:468:72:96:5:0000403788866e80",
-        "dhash:468:72:0:10:d8b020282020223a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_16e106fb",
-      "created_at": "2026-06-29T03:17:40.287955",
-      "plan_id": "plan_b85e52ee"
-    },
-    {
-      "step_id": "step_1a1ac380",
-      "agent": "interaction",
-      "tool": "type_text",
-      "parameters": {
-        "text": "get"
-      },
-      "description": "Type 'get' into the search input field of the \"Select Operation(s) Copilot can interact with\" dialog in Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:74c240406460623a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_1a1ac380",
-      "created_at": "2026-06-29T03:17:40.296033",
-      "plan_id": "plan_b85e52ee"
-    },
-    {
-      "step_id": "step_a4d37792",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 314,
-        "y": 81
-      },
-      "description": "Click on the search input field in the \"Select Operation(s) Copilot can interact with\" dialog within Visual Studio Code to focus and enter text.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:314:81:16:5:0000000000000052",
-        "dhash:314:81:96:5:4040209184a281c8",
-        "dhash:314:81:0:10:74c240406460623a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_a4d37792",
-      "created_at": "2026-06-29T03:17:40.304056",
-      "plan_id": "plan_b85e52ee"
-    },
-    {
-      "step_id": "step_90dd124f",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 788,
-        "y": 49
-      },
-      "description": "Click the blue plus (+) button in the \"Select Operation(s) Copilot can interact with\" dialog in Visual Studio Code to add the selected operation.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:788:49:16:5:8d92696d6d69132c",
-        "dhash:788:49:96:5:0909699191699d45",
-        "dhash:788:49:0:10:74c240406460623a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_90dd124f",
-      "created_at": "2026-06-29T03:17:40.310188",
-      "plan_id": "plan_b85e52ee"
-    },
-    {
-      "step_id": "step_4a28cd05",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 317,
-        "y": 38
-      },
-      "description": "Click the search input field in the \"Select Authentication Type\" dropdown dialog of Visual Studio Code to activate it for text entry.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:317:38:16:5:0000000000000000",
-        "dhash:317:38:96:5:000000000126d999",
-        "dhash:317:38:0:10:c0b030442020223a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_4a28cd05",
-      "created_at": "2026-06-29T03:17:40.324204",
       "plan_id": "plan_b85e52ee"
     },
     {
@@ -361,14 +178,14 @@
       "parameters": {
         "text": "entra"
       },
-      "description": "Type 'entra' into the \"Select Authentication Type\" input field in the Visual Studio Code command palette.",
+      "description": "Type 'entra' into the \"Select Authentication Type\" input field during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:c0b030242020223a"
+        "dhash:512:384:0:20:e0c8949492b17075"
       ],
       "postconditions": [],
       "tags": [],
@@ -385,16 +202,14 @@
         "x": 296,
         "y": 72
       },
-      "description": "Click the \"Entra SSO\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code, after typing \"entra\" in the filter box.",
+      "description": "Click the \"Entra SSO\" option in the filtered \"Select Authentication Type\" picker during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:296:72:16:5:00108c3269cd5d49",
-        "dhash:296:72:96:5:c020286060d9890d",
-        "dhash:296:72:0:10:d0b430242020223a"
+        "dhash:512:384:0:20:e0b8949492b17075"
       ],
       "postconditions": [],
       "tags": [],
@@ -473,46 +288,20 @@
       "plan_id": "plan_b85e52ee"
     },
     {
-      "step_id": "step_bc14f139",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 309,
-        "y": 36
-      },
-      "description": "Click the input field in the \"Enter Microsoft Entra SSO client id for registration in OpenAPI Description Document\" prompt at the top of the Visual Studio Code window.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:309:36:16:5:000000000005922c",
-        "dhash:309:36:96:5:0000200832a613da",
-        "dhash:309:36:0:10:d0b13052a078702a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_bc14f139",
-      "created_at": "2026-06-29T03:17:40.371345",
-      "plan_id": "plan_b85e52ee"
-    },
-    {
       "step_id": "step_a49b5428",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
-        "text": "4cfde729-32e4-4862-a409-07e14dbfd296"
+        "text": "${{env:DA_MCP_ENTRA_SSO_CLIENTID}}"
       },
-      "description": "Type the Entra SSO client id '4cfde729-32e4-4862-a409-07e14dbfd296' into the \"Enter Microsoft Entra SSO client id for registration in OpenAPI Description Document\" input field in the Visual Studio Code Microsoft 365 Agents extension modal.",
+      "description": "Type ${{env:DA_MCP_ENTRA_SSO_CLIENTID}} into the \"Microsoft Entra Application (Client) ID\" input field during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:d0b131332138303a"
+        "dhash:512:384:0:20:f0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],
@@ -527,14 +316,14 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press the Enter key to confirm the client ID input in the \"Enter Microsoft Entra SSO client id for registration in OpenAPI Description Document\" prompt within Visual Studio Code.",
+      "description": "Press Enter to confirm the Microsoft Entra Application (Client) ID during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:c0b131332138303a"
+        "dhash:512:384:0:20:c0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_None_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_None_Remote.json
@@ -28,7 +28,7 @@
                                                   "step_57cd1949",
                                                   "plan_r_0928_014459",
                                                   "step_verify_dynamic_mcp_project",
-                                                  "plan_r_0928_020230",
+                                                  "plan_login_m365_for_provision",
                                                   "step_start_provision_command",
                                                   "step_type_provision_command",
                                                   "step_confirm_provision_command",
@@ -125,7 +125,7 @@
 
                                      ],
                       "preconditions":  [
-
+                                            "dhash:512:384:0:20:e0c8949492b17075"
                                         ],
                       "postconditions":  [
 
@@ -155,7 +155,7 @@
 
                                      ],
                       "preconditions":  [
-
+                                            "dhash:512:384:0:20:e0b8949492b17075"
                                         ],
                       "postconditions":  [
 

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 34,
+    "total_steps": 24,
     "created_at": "2026-06-29T03:21:51.231595",
     "name": "DA_with_MCP Server(Oauth)",
     "description": {
@@ -24,42 +24,38 @@
       "step_5f1a8731",
       "step_9c87f073",
       "step_52c22c4c",
-      "step_9a8146c5",
-      "plan_r_0928_014459",
-      "plan_r_1021_081410",
-      "step_94025678",
-      "step_5b9f6257",
-      "plan_26ac4c4e",
-      "step_4b860701",
-      "step_35164443",
-      "step_a712386e",
-      "step_5120006b",
-      "step_289ade9c",
-      "step_d0c53170",
       "step_da1c5301",
       "step_da1c5302",
+      "step_10a9f134",
+      "step_5fa52f1b",
+      "step_6ed8712c",
+      "step_24e52ca7",
+      "step_9ecdaafc",
+      "step_3a870434",
+      "step_9a8146c5",
+      "plan_r_0928_014459",
+      "step_94025678",
+      "plan_login_m365_for_provision",
       "step_8ed7e3fe",
       "step_c83f7f58",
       "step_8db1832f",
       "step_0abfa1e9",
       "step_02fe6ba0",
       "step_ac7309cf",
-      "step_73df5e59",
-      "step_10a9f134",
-      "step_5fa52f1b",
-      "step_6ed8712c",
-      "step_24e52ca7",
-      "step_f1a98f32",
-      "step_9ecdaafc",
-      "step_3a870434",
-      "step_54e19323",
       "step_dcecd61a",
       "step_6278739e",
       "step_dc8a5e54",
       "step_11c1cd46",
       "step_5b6d6181"
     ],
-    "tags": [],
+    "tags": [
+      "scenario:SCN-DA-CREATE-WITH-MCP-SERVER",
+      "source_of_truth:docs/01-product/scenarios/da/draft/create-da-with-mcp-server.md",
+      "feature_flag:TEAMSFX_MCP_FOR_DA_DT=true",
+      "feature_flag:TEAMSFX_MCP_FOR_DA_DCR=true",
+      "auth_type:oauth",
+      "dynamic_tool_discovery"
+    ],
     "updated_at": "2026-07-10T02:34:22.000000"
   },
   "steps": [
@@ -161,206 +157,25 @@
     },
     {
       "step_id": "step_94025678",
-      "agent": "interaction",
-      "tool": "click",
+      "agent": "code",
+      "tool": "",
       "parameters": {
-        "button": "left",
-        "x": 628,
-        "y": 140
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\"\nPROJECT_DIR=\"$PROJECT_DIR\" python3 - <<'PY'\nimport json\nimport os\nfrom pathlib import Path\n\nproject = Path(os.environ[\"PROJECT_DIR\"])\nrequired = [\"appPackage/manifest.json\", \"appPackage/declarativeAgent.json\", \"appPackage/ai-plugin.json\", \"m365agents.yml\", \".vscode/mcp.json\", \"env/.env.dev\", \"env/.env.dev.user\"]\nfor relative in required:\n    if not (project / relative).is_file():\n        raise AssertionError(f\"Missing required file: {relative}\")\nif (project / \"appPackage/mcp-tools-1.json\").exists():\n    raise AssertionError(\"Static MCP tools file must not be generated\")\nplugin = json.loads((project / \"appPackage/ai-plugin.json\").read_text(encoding=\"utf-8\"))\nif plugin.get(\"namespace\") != \"apigithubc\" or plugin.get(\"functions\") != []:\n    raise AssertionError(\"Unexpected dynamic MCP plugin namespace or functions\")\nruntimes = plugin.get(\"runtimes\")\nif not isinstance(runtimes, list) or len(runtimes) != 1:\n    raise AssertionError(\"Expected exactly one MCP runtime\")\nruntime = runtimes[0]\nif runtime.get(\"type\") != \"RemoteMCPServer\" or runtime.get(\"spec\") != {\"url\": \"https://api.githubcopilot.com/mcp/\"} or runtime.get(\"run_for_functions\") != [\"*\"]:\n    raise AssertionError(\"Unexpected dynamic MCP runtime shape\")\nif \"mcp_tool_description\" in runtime:\n    raise AssertionError(\"Dynamic MCP runtime must not contain mcp_tool_description\")\nauth = runtime.get(\"auth\", {})\nif auth.get(\"type\") != \"OAuthPluginVault\" or not str(auth.get(\"reference_id\", \"\")).endswith(\"MCP_DA_AUTH_ID_APIGITHUBC}}\"):\n    raise AssertionError(\"Unexpected OAuthPluginVault reference\")\nyml = (project / \"m365agents.yml\").read_text(encoding=\"utf-8\")\nfor expected in [\"oauth/register\", \"identityProvider: Custom\", \"MCP_DA_OAUTH_CLIENT_ID_APIGITHUBC\", \"SECRET_MCP_DA_OAUTH_CLIENT_SECRET_APIGITHUBC\", \"MCP_DA_OAUTH_SCOPE_APIGITHUBC\", \"MCP_DA_AUTH_ID_APIGITHUBC\"]:\n    if expected not in yml:\n        raise AssertionError(f\"Missing OAuth configuration in m365agents.yml: {expected}\")\ndef env_value(relative, key):\n    for line in (project / relative).read_text(encoding=\"utf-8\").splitlines():\n        if line.startswith(key + \"=\"):\n            return line.split(\"=\", 1)[1]\n    return None\nif not env_value(\"env/.env.dev\", \"MCP_DA_OAUTH_CLIENT_ID_APIGITHUBC\"):\n    raise AssertionError(\"OAuth client ID was not persisted\")\nif env_value(\"env/.env.dev\", \"MCP_DA_OAUTH_SCOPE_APIGITHUBC\") != \"read:user\":\n    raise AssertionError(\"OAuth scopes were not persisted\")\nif not env_value(\"env/.env.dev.user\", \"SECRET_MCP_DA_OAUTH_CLIENT_SECRET_APIGITHUBC\"):\n    raise AssertionError(\"OAuth client secret was not persisted\")\nmcp = json.loads((project / \".vscode/mcp.json\").read_text(encoding=\"utf-8\"))\nif \"https://api.githubcopilot.com/mcp/\" not in json.dumps(mcp):\n    raise AssertionError(\"MCP URL missing from .vscode/mcp.json\")\nPY\n```"
       },
-      "description": "Click the \"Start\" badge link next to \"Fetch action from MCP\" in the mcp.json file header within the VS Code editor.",
+      "description": "@code verify the generated OAuth MCP DA project follows SCN-DA-CREATE-WITH-MCP-SERVER dynamic tool discovery shape, persists OAuth client ID, secret, and scopes without printing them, and injects oauth/register with the expected environment references.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:628:140:16:5:534de9a9a940b400",
-        "dhash:628:140:96:5:00120866f6090049",
-        "dhash:628:140:0:10:23b1212121213a1c"
-      ],
+      "preconditions": [],
       "postconditions": [],
-      "tags": [],
-      "screenshot": "step_94025678",
+      "tags": [
+        "source_of_truth:docs/01-product/scenarios/da/draft/create-da-with-mcp-server.md",
+        "scenario:SCN-DA-CREATE-WITH-MCP-SERVER"
+      ],
+      "screenshot": null,
       "created_at": "2026-06-29T03:21:51.300954",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_5b9f6257",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 464,
-        "y": 94
-      },
-      "description": "Click the \"Allow\" button in the GitHub authentication prompt for the MCP Server Definition within Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:464:94:16:5:10accc569692b245",
-        "dhash:464:94:96:5:00021827039484b3",
-        "dhash:464:94:0:10:d2b12d2121213a1c"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_5b9f6257",
-      "created_at": "2026-06-29T03:21:51.313980",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_4b860701",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 506,
-        "y": 137
-      },
-      "description": "Click the \"Fetch from MCP\" link above the \"servers\" section in the mcp.json file within Visual Studio Code, located in the MICROSOFT 365 AGENTS TOOLKIT interface.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:506:137:16:5:86584b4adc5a6391",
-        "dhash:506:137:96:5:80404ca232c42838",
-        "dhash:506:137:0:10:23b531212121213a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_4b860701",
-      "created_at": "2026-06-29T03:21:51.327519",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_35164443",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 445,
-        "y": 72
-      },
-      "description": "Click the \"ai-plugin.json\" file option in the manifest selection dropdown of Visual Studio Code when prompted with \"Select the action manifest you want to update\".",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:445:72:16:5:00408023d4aa2a2a",
-        "dhash:445:72:96:5:0000108eb2364ea1",
-        "dhash:445:72:0:10:f0b031282020223a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_35164443",
-      "created_at": "2026-06-29T03:21:51.338524",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_a712386e",
-      "agent": "interaction",
-      "tool": "type_text",
-      "parameters": {
-        "text": "get"
-      },
-      "description": "Type 'get' into the search input field of the \"Select Operation(s) Copilot can interact with\" dialog in Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:74c240406460623a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_a712386e",
-      "created_at": "2026-06-29T03:21:51.348700",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_5120006b",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 314,
-        "y": 81
-      },
-      "description": "Click on the search input field in the \"Select Operation(s) Copilot can interact with\" dialog within Visual Studio Code to focus and enter text.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:314:81:16:5:0000000000000052",
-        "dhash:314:81:96:5:4040209184a281c8",
-        "dhash:314:81:0:10:74c240406460623a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_5120006b",
-      "created_at": "2026-06-29T03:21:51.357709",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_289ade9c",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 788,
-        "y": 49
-      },
-      "description": "Click the blue plus (+) button in the \"Select Operation(s) Copilot can interact with\" dialog in Visual Studio Code to add the selected operation.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:788:49:16:5:8d92696d6d69132c",
-        "dhash:788:49:96:5:0909699191699d45",
-        "dhash:788:49:0:10:74c240406460623a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_289ade9c",
-      "created_at": "2026-06-29T03:21:51.364260",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_d0c53170",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 317,
-        "y": 38
-      },
-      "description": "Click the search input field in the \"Select Authentication Type\" dropdown dialog of Visual Studio Code to activate it for text entry.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:317:38:16:5:0000000000000000",
-        "dhash:317:38:96:5:000000000024d390",
-        "dhash:317:38:0:10:e0c020202020223a"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_d0c53170",
-      "created_at": "2026-06-29T03:21:51.370262",
       "plan_id": "plan_r_1024_023252"
     },
     {
@@ -370,13 +185,15 @@
       "parameters": {
         "text": "static"
       },
-      "description": "Type 'static' into the \"Select Authentication Type\" input field in Visual Studio Code to filter to the \"OAuth (with static registration)\" option.",
+      "description": "Type 'static' into the \"Select Authentication Type\" input field during MCP server scaffolding to filter to the \"OAuth (with static registration)\" option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:512:384:0:20:e0c8949492b17075"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "",
@@ -392,13 +209,15 @@
         "x": 296,
         "y": 72
       },
-      "description": "Click the \"OAuth (with static registration)\" option in the \"Select Authentication Type\" dropdown within Visual Studio Code, after typing \"static\" in the filter box.",
+      "description": "Click the \"OAuth (with static registration)\" option in the filtered \"Select Authentication Type\" picker during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:512:384:0:20:e0b8949492b17075"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "",
@@ -546,46 +365,20 @@
       "plan_id": "plan_r_1024_023252"
     },
     {
-      "step_id": "step_73df5e59",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 309,
-        "y": 36
-      },
-      "description": "Click the input field in the \"Enter client id for OAuth registration in OpenAPI Description Document\" prompt at the top of the Visual Studio Code window.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:309:36:16:5:000000000045d144",
-        "dhash:309:36:96:5:0000402a959513db",
-        "dhash:309:36:0:10:702022232362642b"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_73df5e59",
-      "created_at": "2026-06-29T03:21:51.444890",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
       "step_id": "step_10a9f134",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
         "text": "${{env:DA_MCP_OAUTH_CLIENTID}}"
       },
-      "description": "Type ${{env:DA_MCP_OAUTH_CLIENTID}}  into the \"Enter client id for OAuth registration in OpenAPI Description Document\" input field in the Visual Studio Code Microsoft 365 Agents extension modal.",
+      "description": "Type ${{env:DA_MCP_OAUTH_CLIENTID}} into the \"OAuth Client ID\" input field during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:702022232362642b"
+        "dhash:512:384:0:20:f0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],
@@ -600,14 +393,14 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press the Enter key to confirm the client ID input in the \"Enter client id for OAuth registration in OpenAPI Description Document\" prompt within Visual Studio Code.",
+      "description": "Press Enter to confirm the OAuth Client ID during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:40242a232362642b"
+        "dhash:512:384:0:20:c0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],
@@ -620,16 +413,16 @@
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
-        "text": "${{secret:DA_MCP_OAUTH_CLIENT_SECERT}}"
+        "text": "${{secret:DA_MCP_OAUTH_CLIENT_SECRET}}"
       },
-      "description": "Type ${{secret:DA_MCP_OAUTH_CLIENT_SECERT}}  into the \"Enter client secret for OAuth registration in OpenAPI Description Document\" input field in Visual Studio Code.",
+      "description": "Type ${{secret:DA_MCP_OAUTH_CLIENT_SECRET}} into the \"OAuth Client Secret\" input field during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:c0b130322030302a"
+        "dhash:512:384:0:20:f0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],
@@ -644,45 +437,19 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press 'Enter' to confirm the entered client secret in the \"Enter client secret for OAuth registration in OpenAPI Description Document\" input dialog within Visual Studio Code.",
+      "description": "Press Enter to confirm the OAuth Client Secret during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:70242a232362642b"
+        "dhash:512:384:0:20:f0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_24e52ca7",
       "created_at": "2026-06-29T03:21:51.482128",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_f1a98f32",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 296,
-        "y": 41
-      },
-      "description": "Click the \"Input scopes for OAuth registration\" text field in the Visual Studio Code extension setup dialog to begin entering OAuth scopes.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:296:41:16:5:00000810442126ad",
-        "dhash:296:41:96:5:0013166049984565",
-        "dhash:296:41:0:10:602022232362642b"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_f1a98f32",
-      "created_at": "2026-06-29T03:21:51.497015",
       "plan_id": "plan_r_1024_023252"
     },
     {
@@ -692,14 +459,14 @@
       "parameters": {
         "text": "read:user"
       },
-      "description": "Type 'read:user' into the \u201cScope(s) for OAuth registration\u201d input field at the top of the Visual Studio Code window.",
+      "description": "Type 'read:user' into the \"OAuth Scopes (optional)\" input field during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:70242a232362642b"
+        "dhash:512:384:0:20:f0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],
@@ -714,45 +481,19 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press Enter to confirm the \"read:user\" OAuth scope in the \"Scope(s) for OAuth registration\" input dialog within Visual Studio Code.",
+      "description": "Press Enter to confirm the 'read:user' OAuth scope during MCP server scaffolding.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:50242a232362642b"
+        "dhash:512:384:0:20:f0b0949492b17075"
       ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_3a870434",
       "created_at": "2026-06-29T03:21:51.515779",
-      "plan_id": "plan_r_1024_023252"
-    },
-    {
-      "step_id": "step_54e19323",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 464,
-        "y": 114
-      },
-      "description": "Click the \"Confirm\" button on the Microsoft 365 Agents Toolkit OAuth registration dialog in Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:464:114:16:5:10de2175d45434cb",
-        "dhash:464:114:96:5:0004789787780400",
-        "dhash:464:114:0:10:52322e232362642b"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_54e19323",
-      "created_at": "2026-06-29T03:21:51.530790",
       "plan_id": "plan_r_1024_023252"
     },
     {


### PR DESCRIPTION
## Summary

- align the None, Entra SSO, and OAuth remote MCP plans with the current URL-then-auth scaffolding flow
- replace the legacy Fetch MCP/static operation flow with dynamic MCP artifact validation
- add a focused Microsoft 365-only login group for provisioning and stabilize the shared browser Next step against the pinned 6.12 image
- make Entra/OAuth credentials environment-backed and document static-first diagnosis plus per-run report archival

## Validation

Executed all three plans with `vscuse-atk-6.12:local`:

- `DA_MCP_None_Remote`: 42/42 successful, 0 errors
- `DA_MCP_Entra_SSO_Remote`: 47/47 successful, 0 errors
- `DA_MCP_Oauth_Remote`: 54/54 successful, 0 errors

Run artifacts were archived locally under:

- `.local/test-reports/20260713-144327-DA_MCP_None_Remote/`
- `.local/test-reports/20260713-145821-DA_MCP_Entra_SSO_Remote/`
- `.local/test-reports/20260713-151048-DA_MCP_Oauth_Remote/`

Also validated JSON parsing, metadata step counts, M365-only group wiring, removal of obsolete Fetch/Azure login references, LF line endings, and `git diff --check`.