### PR TITLE
fix(vscuse): Auto-fix Basic_Custom_Engine_OpenAI_js_Copilot_Local_Debug

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
@@ -23,6 +23,9 @@
       "step_6861ac1e",
       "step_41dc25cd",
       "step_c923dbdb",
+      "step_e1a11f01",
+      "step_e1a11f02",
+      "step_e1a11f03",
       "step_baa39070",
       "step_e0bd25da",
       "step_f46232aa",
@@ -148,6 +151,76 @@
       "plan_id": "plan_f355465c"
     },
     {
+      "step_id": "step_e1a11f01",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 389,
+        "y": 351
+      },
+      "description": "Click on the \"Email or phone\" input field within the Microsoft account login page to focus and enable input.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:180"
+      ],
+      "screenshot": "step_e1a11f01",
+      "created_at": "2026-07-14T02:39:00.000000",
+      "plan_id": "plan_f355465c"
+    },
+    {
+      "step_id": "step_e1a11f02",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "${{env:M365_ACCOUNT_NAME}}"
+      },
+      "description": "Type ${{env:M365_ACCOUNT_NAME}} into the email or phone input field on the Microsoft sign-in page.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:3"
+      ],
+      "screenshot": "step_e1a11f02",
+      "created_at": "2026-07-14T02:39:00.000000",
+      "plan_id": "plan_f355465c"
+    },
+    {
+      "step_id": "step_e1a11f03",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 635,
+        "y": 487
+      },
+      "description": "Click the \"Next\" button on the Microsoft sign-in page to advance from the email step to the password step.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:3"
+      ],
+      "screenshot": "step_e1a11f03",
+      "created_at": "2026-07-14T02:39:00.000000",
+      "plan_id": "plan_f355465c"
+    },
+    {
       "step_id": "step_baa39070",
       "agent": "interaction",
       "tool": "click",
@@ -169,7 +242,7 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay:180"
+        "delay:5"
       ],
       "screenshot": "step_baa39070",
       "created_at": "2026-04-21T03:02:12.293313",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
@@ -230,8 +230,8 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 363,
-        "y": 400
+        "x": 450,
+        "y": 420
       },
       "description": "Click on the \"Password\" text field within the Microsoft account login page to focus and enable input.",
       "content_refs": [],
@@ -239,11 +239,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:363:400:16:5:00000020cb9a9a69",
-        "dhash:363:400:96:5:2e2e00291b100022",
-        "dhash:363:400:0:10:1308f0d9d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:5"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
@@ -156,8 +156,8 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 389,
-        "y": 351
+        "x": 369,
+        "y": 350
       },
       "description": "Click on the \"Email or phone\" input field within the Microsoft account login page to focus and enable input.",
       "content_refs": [],
@@ -165,10 +165,14 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:369:350:16:5:2113d25252525221",
+        "dhash:369:350:96:5:0919006d19220812",
+        "dhash:369:350:0:10:1b88d0d1e5e6dae4"
+      ],
       "postconditions": [],
       "tags": [
-        "delay:180"
+        "precondition_wait_timeout:300"
       ],
       "screenshot": "step_e1a11f01",
       "created_at": "2026-07-14T02:39:00.000000",
@@ -202,8 +206,8 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 635,
-        "y": 487
+        "x": 629,
+        "y": 484
       },
       "description": "Click the \"Next\" button on the Microsoft sign-in page to advance from the email step to the password step.",
       "content_refs": [],


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Basic_Custom_Engine_OpenAI_js_Copilot_Local_Debug`
**Status:** :white_check_mark: FIXED (attempt 4/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/32ca3587-1d5e-47e1-b34f-a82eaea619db/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/63fe4f53-ebf7-4b19-8f0d-ec68f4cb1e58/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Added missing email-entry steps (click "Email or phone" field → type ${{env:M365 | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/fc781e89-8b73-4f05-a3b9-11cbd9e8fd2e/test_report.html) |
| 2 | In group `group__debug_in_copilot_local_none_da.json`, made the email-entry step | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/6d8b9a58-095e-44e2-8e92-98ae11b7a1a7/test_report.html) |
| 3 | INVALID AI OUTPUT | :warning: Invalid AI output | — |
| 4 | Fixed the password-field click (step_baa39070) in group `group__debug_in_copilot | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/63fe4f53-ebf7-4b19-8f0d-ec68f4cb1e58/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Basic_Custom_Engine_OpenAI_js_Copilot_Local_Debug.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>