### PR TITLE
test(vscuse): disable explorer hover tooltip in docker setting

### DIFF
--- a/packages/tests/vscuse/docker/vscuse-atk/vscode-setting/setting.json
+++ b/packages/tests/vscuse/docker/vscuse-atk/vscode-setting/setting.json
@@ -10,5 +10,6 @@
     "strings": "off"
   },
   "editor.suggestOnTriggerCharacters": false,
+  "workbench.hover.enabled": false,
   "workbench.hover.delay": 1500
 }


### PR DESCRIPTION
## Summary
- add workbench.hover.enabled: false in vscuse docker VS Code setting
- preserve existing workbench.hover.delay

## Purpose
- hide Explorer path hover tooltip in vscuse environment