### PR TITLE
fix: manifest check with conditional type

### DIFF
--- a/packages/manifest/src/generated-types/index.ts
+++ b/packages/manifest/src/generated-types/index.ts
@@ -484,7 +484,18 @@ export class AppManifestUtils {
       addFormats(ajv, ["uri", "email", "regex"]);
       validate = ajv.compile(schema);
     }
-    const valid = validate(manifest);
+    // The generated converters (jsonToManifest) populate every declared
+    // optional property with `undefined`, even when it is absent from the
+    // source JSON. Such keys have no JSON representation and are dropped when
+    // the manifest is serialized to disk, but they remain as own enumerable
+    // keys on the in-memory object. AJV counts them via Object.keys(), which
+    // produces spurious "must NOT have additional properties" errors against
+    // schema branches that use `additionalProperties: false` (for example a
+    // ribbon group under a built-in tab reporting phantom `builtInGroupId` /
+    // `overriddenByRibbonApi`). Validate a JSON round-tripped copy so the
+    // object matches what is actually persisted and sent for validation.
+    const manifestToValidate: unknown = JSON.parse(JSON.stringify(manifest));
+    const valid = validate(manifestToValidate);
     if (!valid && validate.errors) {
       return validate.errors.map(
         (error) =>

--- a/packages/manifest/test/AppManifestUtils.test.ts
+++ b/packages/manifest/test/AppManifestUtils.test.ts
@@ -83,4 +83,74 @@ describe("AppManifestUtils", async () => {
       assert.isTrue(mockResponse.text.calledOnce);
     });
   });
+
+  describe("validateAgainstSchema", async () => {
+    const schema = {
+      $schema: "http://json-schema.org/draft-04/schema#",
+      type: "object",
+      properties: {
+        id: { type: "string" },
+      },
+      additionalProperties: false,
+    };
+
+    it("should ignore undefined-valued keys injected by the converter", async () => {
+      // The generated converters populate absent optional fields with
+      // `undefined` (e.g. a ribbon group under a built-in tab gains phantom
+      // `builtInGroupId` / `overriddenByRibbonApi` keys). These have no JSON
+      // representation and must not trigger additionalProperties errors.
+      const manifest = {
+        id: "abc",
+        builtInGroupId: undefined,
+        overriddenByRibbonApi: undefined,
+      };
+      const errors = await AppManifestUtils.validateAgainstSchema(manifest as any, schema as any);
+      assert.deepEqual(errors, []);
+    });
+
+    it("should ignore undefined-valued keys on nested objects", async () => {
+      // Mirrors the real scenario: a ribbon group nested under a built-in tab
+      // gains phantom `builtInGroupId` / `overriddenByRibbonApi` keys from the
+      // converter. The undefined keys sit on a nested object guarded by
+      // `additionalProperties: false`, and must be stripped recursively.
+      const nestedSchema = {
+        $schema: "http://json-schema.org/draft-04/schema#",
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          group: {
+            type: "object",
+            properties: {
+              label: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      };
+      const manifest = {
+        id: "abc",
+        group: {
+          label: "g1",
+          builtInGroupId: undefined,
+          overriddenByRibbonApi: undefined,
+        },
+      };
+      const errors = await AppManifestUtils.validateAgainstSchema(
+        manifest as any,
+        nestedSchema as any
+      );
+      assert.deepEqual(errors, []);
+    });
+
+    it("should still report real additional properties", async () => {
+      const manifest = {
+        id: "abc",
+        bogusProp: "x",
+      };
+      const errors = await AppManifestUtils.validateAgainstSchema(manifest as any, schema as any);
+      assert.isTrue(errors.length > 0);
+      assert.isTrue(errors.some((e) => e.includes("bogusProp")));
+    });
+  });
 });


### PR DESCRIPTION
This pull request addresses issues with JSON schema validation in `AppManifestUtils` by ensuring that optional properties with `undefined` values, which are added by generated converters, do not cause spurious "additionalProperties" errors during validation. It also adds comprehensive tests to verify this behavior, including both shallow and nested object scenarios.