### PR TITLE
fix(fx-core): gate v4 sandbox template files

### DIFF
--- a/packages/fx-core/tests/v4/validation/sandboxFilters.test.ts
+++ b/packages/fx-core/tests/v4/validation/sandboxFilters.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import fs from "fs-extra";
+import path from "path";
+import { assert } from "vitest";
+import { FeatureFlagName } from "../../../src/common/featureFlags";
+import { parsePipeline } from "../../../src/v4/runtime/packageParse";
+
+const CREATE_TEMPLATES_ROOT = path.resolve(__dirname, "../../../../../templates/v4/create");
+const SANDBOX_FLAG_CONDITION = `!featureFlag('${FeatureFlagName.SandBoxedTeam}')`;
+const SANDBOX_SOURCE_FILE_NAMES = new Set([
+  "m365agents.sandbox.yml.tpl",
+  "teamsapp.sandbox.yml.tpl",
+  ".env.sandbox",
+  ".env.sandbox.user.tpl",
+]);
+const SANDBOX_OUTPUT_PATHS = [
+  "m365agents.sandbox.yml",
+  "teamsapp.sandbox.yml",
+  "env/.env.sandbox",
+  "env/.env.sandbox.user",
+];
+
+interface RenderFilter {
+  when?: string;
+  exclude?: unknown;
+}
+
+function findTemplateRoots(directory: string): string[] {
+  const roots: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const child = path.join(directory, entry.name);
+    if (fs.existsSync(path.join(child, "pipeline.json"))) {
+      roots.push(child);
+    }
+    roots.push(...findTemplateRoots(child));
+  }
+  return roots;
+}
+
+function containsSandboxSource(directory: string): boolean {
+  return fs.readdirSync(directory, { withFileTypes: true }).some((entry) => {
+    if (entry.isDirectory()) {
+      return containsSandboxSource(path.join(directory, entry.name));
+    }
+    return SANDBOX_SOURCE_FILE_NAMES.has(entry.name);
+  });
+}
+
+function isRenderFilter(value: unknown): value is RenderFilter {
+  return typeof value === "object" && value !== null;
+}
+
+describe("v4 sandbox template filters", () => {
+  it("AC-23: every create package containing sandbox files declares the sandbox render filter", () => {
+    const templatesWithSandboxFiles = findTemplateRoots(CREATE_TEMPLATES_ROOT).filter(
+      (templateRoot) => {
+        const contentRoot = path.join(templateRoot, "content");
+        return fs.existsSync(contentRoot) && containsSandboxSource(contentRoot);
+      }
+    );
+
+    assert.isNotEmpty(templatesWithSandboxFiles, "expected authored sandbox templates");
+    for (const templateRoot of templatesWithSandboxFiles) {
+      const templateId = path.relative(CREATE_TEMPLATES_ROOT, templateRoot).replace(/\\/g, "/");
+      const pipeline = parsePipeline(
+        JSON.parse(fs.readFileSync(path.join(templateRoot, "pipeline.json"), "utf8"))
+      );
+      if (pipeline.isErr()) {
+        assert.fail(`${templateId} has an invalid pipeline: ${pipeline.error.message}`);
+      }
+      const filters: unknown = pipeline.value.render?.filters;
+      const sandboxFilter = Array.isArray(filters)
+        ? filters.filter(isRenderFilter).find((filter) => filter.when === SANDBOX_FLAG_CONDITION)
+        : undefined;
+
+      assert.exists(sandboxFilter, `${templateId} must declare the sandbox render filter`);
+      const excludedPaths = sandboxFilter?.exclude;
+      assert.isTrue(
+        Array.isArray(excludedPaths),
+        `${templateId} sandbox render filter must declare excluded paths`
+      );
+      if (!Array.isArray(excludedPaths)) {
+        continue;
+      }
+      assert.sameMembers(
+        excludedPaths,
+        SANDBOX_OUTPUT_PATHS,
+        `${templateId} must exclude every sandbox output path`
+      );
+    }
+  });
+});

--- a/templates/v4/create/basic-custom-engine-agent/pipeline.json
+++ b/templates/v4/create/basic-custom-engine-agent/pipeline.json
@@ -1,6 +1,20 @@
 {
   "pipeline": "default",
   "comment": "Basic custom engine agent create package: pure render. The require-empty-target step guards the create contract so render writes the selected language subtree without post-render injection.",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [
     {
       "step": "require-empty-target"

--- a/templates/v4/create/custom-copilot-basic/pipeline.json
+++ b/templates/v4/create/custom-copilot-basic/pipeline.json
@@ -1,5 +1,19 @@
 {
   "$schema": "../../schema/pipeline.schema.json",
   "pipeline": "default",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [{ "step": "require-empty-target" }]
 }

--- a/templates/v4/create/custom-copilot-rag-azure-ai-search/pipeline.json
+++ b/templates/v4/create/custom-copilot-rag-azure-ai-search/pipeline.json
@@ -1,5 +1,19 @@
 {
   "$schema": "../../schema/pipeline.schema.json",
   "pipeline": "default",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [{ "step": "require-empty-target" }]
 }

--- a/templates/v4/create/custom-copilot-rag-custom-api/pipeline.json
+++ b/templates/v4/create/custom-copilot-rag-custom-api/pipeline.json
@@ -2,6 +2,20 @@
   "$schema": "../../schema/pipeline.schema.json",
   "pipeline": "default",
   "comment": "Render the Teams AI custom API shell, then generate the filtered OpenAPI spec and custom API function wiring from the selected operations.",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [
     { "step": "require-empty-target" },
     {

--- a/templates/v4/create/custom-copilot-rag-customize/pipeline.json
+++ b/templates/v4/create/custom-copilot-rag-customize/pipeline.json
@@ -1,5 +1,19 @@
 {
   "$schema": "../../schema/pipeline.schema.json",
   "pipeline": "default",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [{ "step": "require-empty-target" }]
 }

--- a/templates/v4/create/default-bot/pipeline.json
+++ b/templates/v4/create/default-bot/pipeline.json
@@ -1,6 +1,20 @@
 {
   "pipeline": "default",
   "comment": "Teams simple bot create package: pure render. The require-empty-target step guards the create contract so render writes the selected language subtree without post-render injection.",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [
     {
       "step": "require-empty-target"

--- a/templates/v4/create/default-message-extension/pipeline.json
+++ b/templates/v4/create/default-message-extension/pipeline.json
@@ -1,6 +1,20 @@
 {
   "pipeline": "default",
   "comment": "Teams message extension create package: pure render. The require-empty-target step guards the create contract so render writes the selected language subtree without post-render injection.",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [
     {
       "step": "require-empty-target"

--- a/templates/v4/create/teams-collaborator-agent/pipeline.json
+++ b/templates/v4/create/teams-collaborator-agent/pipeline.json
@@ -1,5 +1,19 @@
 {
   "$schema": "../../schema/pipeline.schema.json",
   "pipeline": "default",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [{ "step": "require-empty-target" }]
 }

--- a/templates/v4/create/weather-agent/pipeline.json
+++ b/templates/v4/create/weather-agent/pipeline.json
@@ -1,5 +1,19 @@
 {
   "$schema": "../../schema/pipeline.schema.json",
   "pipeline": "default",
+  "render": {
+    "filters": [
+      {
+        "comment": "Sandbox files are opt-in.",
+        "when": "!featureFlag('TEAMSFX_SANDBOXED_TEAM')",
+        "exclude": [
+          "m365agents.sandbox.yml",
+          "teamsapp.sandbox.yml",
+          "env/.env.sandbox",
+          "env/.env.sandbox.user"
+        ]
+      }
+    ]
+  },
   "steps": [{ "step": "require-empty-target" }]
 }


### PR DESCRIPTION
## Summary
- declare sandbox render filters in every v4 create package that carries sandbox content
- keep sandbox YAML and environment files opt-in behind `TEAMSFX_SANDBOXED_TEAM`
- add an AC-23 real-template regression test so future sandbox-bearing packages cannot omit the filter

## Design
- `docs/03-specs/operations/scaffolding/run-scaffold-pipeline.md` AC-23
- capability-specific render omissions remain template-owned through `pipeline.render.filters`; no engine-specific file filtering is added

## Test Plan
- [x] `pnpm exec eslint tests/v4/validation/sandboxFilters.test.ts`
- [x] `pnpm exec vitest run --config vitest.config.ts tests/v4/pipeline/runScaffoldPipeline.test.ts tests/v4/runtime/packageParse.test.ts tests/v4/runtime/scaffoldFromPackageDir.test.ts tests/v4/validation/sandboxFilters.test.ts` (44 tests)
- [x] `pnpm exec prettier --check` for all changed files
- [x] `git diff --check`
- [x] `node scripts/generateV4Zip.js` (`Validated 27 v4 template packages`)