### PR TITLE
docs(vscuse): publish repair reports

### DIFF
--- a/.github/skills/local-vscuse-validation/SKILL.md
+++ b/.github/skills/local-vscuse-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-vscuse-validation
-description: "Use when: setting up shared local vscuse prerequisites, credentials, runner, local or pinned published Docker images, local VSIX, env variables, and common rules for Microsoft 365 Agents Toolkit vscuse work. Use vscuse-case-diagnosis for running/fixing existing cases; use vscuse-scenario-authoring for docs/mockup-driven recording and plan generation."
+description: "Use when: setting up shared local vscuse prerequisites, credentials, runner, local or pinned published Docker images, local VSIX, env variables, publishing test reports to storproxy, and common rules for Microsoft 365 Agents Toolkit vscuse work. Use vscuse-case-diagnosis for running/fixing existing cases; use vscuse-scenario-authoring for docs/mockup-driven recording and plan generation."
 argument-hint: "Describe the feature/change and which vscuse plan or scenario to validate"
 ---
 
@@ -344,6 +344,50 @@ if ($exitCode -ne 0) { exit $exitCode }
 
 Do not treat `test_report/test_report.html` as durable evidence. It is the runner's gitignored transient output and may be replaced by the next execution. Pass `--report-dir` for every local CLI run, stream unbuffered output to that same run directory, and report the project-relative artifact paths. Optional summaries such as `run-summary.json` or `run-summary.csv` belong in the same directory.
 
+## Publish Reports for a Repair PR
+
+Repair PRs must link the report that reproduces the original failure and the clean report that validates the fix. Publish only the canonical before and after reports; keep intermediate retries in `.local/test-reports/` unless they are needed to explain the repair.
+
+The repository workflow publishes reports through Azure Blob Storage account `storproxystvoazuxhhvtgiq`, container `content`, and proxy URL `https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/<guid>/index.html`. Local repair work must use the same path through [publish-vscuse-report.ps1](./scripts/publish-vscuse-report.ps1).
+
+Prerequisites (choose either authentication tool):
+
+- Azure CLI is installed and `az account show` succeeds; or Az.Accounts is installed and `Get-AzContext` returns a signed-in context.
+- The signed-in identity has `Storage Blob Data Contributor` access to `storproxystvoazuxhhvtgiq`.
+- The selected report is the run-specific self-contained `test_report.html`, not the transient report path.
+- Review the report before publishing. The proxy URL is organization-authenticated but shareable with authorized reviewers; never publish reports containing passwords, tokens, tenant secrets, generated API keys, or other sensitive values.
+
+From the repository root:
+
+```powershell
+$publisher = ".github/skills/local-vscuse-validation/scripts/publish-vscuse-report.ps1"
+$beforeReport = ".local/test-reports/<before-run>/test_report.html"
+$afterReport = ".local/test-reports/<after-run>/test_report.html"
+
+$beforeUrl = & $publisher -ReportPath $beforeReport
+$afterUrl = & $publisher -ReportPath $afterReport
+
+[PSCustomObject]@{
+   Before = $beforeUrl
+   After = $afterUrl
+} | ConvertTo-Json | Set-Content ".local/test-reports/<plan-name>-report-links.json"
+```
+
+The publisher uses the repository workflow's Azure CLI upload when `az` is available. Otherwise it uses Az.Accounts to request a storage data-plane token and uploads through the Blob REST API; neither path prints the access token. The storage account disables Shared Key authentication, so management-plane `Contributor` access is not sufficient: the signed-in identity needs the Blob data role stated above.
+
+If the initial report is already hosted under the same storproxy base URL, reuse that URL instead of duplicating the upload. If tooling, login, or RBAC blocks publication, classify it as a setup failure, preserve both local report paths, and do not claim the repair PR workflow is complete.
+
+Every repair PR body must include:
+
+```markdown
+## VscUse reports
+
+| State | Result | Report |
+|---|---|---|
+| Before | Failed at `<step-id>` | [Open report](<before-url>) |
+| After | `<successful>/<executed>`, 0 errors | [Open report](<after-url>) |
+```
+
 If the config used for the run does not pass `TEMPLATE_VERSION` into `docker.environment`, create an ignored temporary config for the run and add only the required local validation env values:
 
 ```yaml
@@ -592,6 +636,7 @@ When reporting back, include only the useful facts:
 - vscuse runner availability: installed command, local wheel path, or missing external wheel.
 - Plan executed and result, or why execution could not start.
 - Repository-relative paths to the run-specific `run.log` and `test_report.html` under `.local/test-reports/`.
+- Storproxy URLs for the canonical before and after reports when the work fixes a vscuse case.
 - Failure classification: product bug, plan drift, setup failure, or flake.
 - Plan maintenance summary: which plan files changed and how they stay dynamic.
 - Integrated browser evidence when requested: whether noVNC showed a live running container, which failure-near step was observed, and whether the repaired rerun reached the expected passing state.

--- a/.github/skills/local-vscuse-validation/scripts/publish-vscuse-report.ps1
+++ b/.github/skills/local-vscuse-validation/scripts/publish-vscuse-report.ps1
@@ -1,0 +1,112 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ReportPath,
+
+  [ValidatePattern("^[a-z0-9]{3,24}$")]
+  [string]$StorageAccount = "storproxystvoazuxhhvtgiq",
+
+  [string]$ProxyBaseUrl = "https://storproxy-app-voazuxhhvtgiq.azurewebsites.net"
+)
+
+$ErrorActionPreference = "Stop"
+
+$report = Get-Item -LiteralPath $ReportPath
+if ($report.PSIsContainer -or $report.Extension -ne ".html") {
+  throw "ReportPath must point to a vscuse HTML report: $ReportPath"
+}
+
+$reportId = [guid]::NewGuid().ToString()
+$stagingDirectory = Join-Path ([IO.Path]::GetTempPath()) "vscuse-report-$reportId"
+$indexPath = Join-Path $stagingDirectory "index.html"
+
+try {
+  New-Item -ItemType Directory -Path $stagingDirectory | Out-Null
+  Copy-Item -LiteralPath $report.FullName -Destination $indexPath
+
+  $az = Get-Command az -ErrorAction SilentlyContinue
+  if ($az) {
+    & $az.Source account show --output none 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      throw "Azure CLI is not signed in. Run 'az login' with an identity that can upload to '$StorageAccount'."
+    }
+
+    & $az.Source storage blob upload `
+      --account-name $StorageAccount `
+      --auth-mode login `
+      --container-name "content" `
+      --name "$reportId/index.html" `
+      --file $indexPath `
+      --content-type "text/html" `
+      --overwrite `
+      --output none
+
+    if ($LASTEXITCODE -ne 0) {
+      throw "Failed to upload '$($report.FullName)' to storage account '$StorageAccount'."
+    }
+  }
+  else {
+    $azAccounts = Get-Module -ListAvailable Az.Accounts | Select-Object -First 1
+    if (-not $azAccounts) {
+      throw "Azure CLI or the Az.Accounts PowerShell module is required to publish vscuse reports."
+    }
+
+    Import-Module Az.Accounts -ErrorAction Stop
+    $context = Get-AzContext -ErrorAction SilentlyContinue
+    if (-not $context) {
+      throw "Azure PowerShell is not signed in. Run 'Connect-AzAccount' with an identity that can upload to '$StorageAccount'."
+    }
+
+    $tokenResult = Get-AzAccessToken -ResourceUrl "https://storage.azure.com/" -ErrorAction Stop
+    if ($tokenResult.Token -is [Security.SecureString]) {
+      $tokenPointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($tokenResult.Token)
+      try {
+        $accessToken = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($tokenPointer)
+      }
+      finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($tokenPointer)
+      }
+    }
+    elseif ($tokenResult.Token -is [string]) {
+      $accessToken = $tokenResult.Token
+    }
+    else {
+      throw "Az.Accounts returned an unsupported access token type."
+    }
+
+    $blobUrl = "https://$StorageAccount.blob.core.windows.net/content/$reportId/index.html"
+    $headers = @{
+      Authorization = "Bearer $accessToken"
+      "x-ms-blob-type" = "BlockBlob"
+      "x-ms-date" = [DateTime]::UtcNow.ToString("R")
+      "x-ms-version" = "2023-11-03"
+    }
+
+    try {
+      Invoke-WebRequest `
+        -Uri $blobUrl `
+        -Method Put `
+        -Headers $headers `
+        -InFile $indexPath `
+        -ContentType "text/html" `
+        -UseBasicParsing | Out-Null
+    }
+    catch {
+      $statusCode = $_.Exception.Response.StatusCode
+      if ($statusCode -ne [Net.HttpStatusCode]::Forbidden) {
+        throw
+      }
+      throw "The signed-in identity cannot upload blobs to '$StorageAccount'. Grant it Storage Blob Data Contributor at the storage account scope."
+    }
+    finally {
+      $accessToken = $null
+      $headers = $null
+      $tokenResult = $null
+    }
+  }
+
+  Write-Output "$($ProxyBaseUrl.TrimEnd('/'))/$reportId/index.html"
+}
+finally {
+  Remove-Item -LiteralPath $stagingDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/.github/skills/vscuse-case-diagnosis/SKILL.md
+++ b/.github/skills/vscuse-case-diagnosis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vscuse-case-diagnosis
-description: "Use when: running an existing vscuse test case, reproducing a failing vscuse plan, deciding product bug vs test plan drift vs setup failure vs flake, repairing a failing case with vscuse-ui/noVNC when useful, and finishing with vscuse CLI validation."
+description: "Use when: running an existing vscuse test case, reproducing a failing vscuse plan, deciding product bug vs test plan drift vs setup failure vs flake, repairing a failing case with vscuse-ui/noVNC, publishing before/after reports to storproxy, and adding those links to a PR."
 argument-hint: "Plan/case name, failing step, or feature workflow to diagnose"
 ---
 
@@ -35,6 +35,7 @@ If local setup, image build, runner install, or credentials are missing, use the
 - Do not repeatedly run the complete create/login/provision/deploy workflow through `vscuse execute` while diagnosing plan drift. Use `Run`, `Continue`, and `Next` in `vscuse-ui` to iterate near the failing area, then use one clean CLI run for final validation.
 - Still finish with `vscuse execute`. A plan is not validated until it passes a clean CLI run or the remaining failure is explicitly classified.
 - For every local `vscuse execute`, use the repository-root artifact command from `local-vscuse-validation`: create a unique `.local/test-reports/<timestamp>-<plan-name>/` directory, pass it with `--report-dir`, and stream unbuffered output to `run.log`. Never overwrite the first failure with a retry.
+- Preserve one canonical failing report before the first repair edit and one clean passing report after the final edit. Publish both through `local-vscuse-validation` and include their storproxy URLs in every repair PR.
 - Show the live execution through the integrated browser at `http://localhost:6080/vnc.html` when the user asks to demonstrate the process.
 - noVNC is a live view of the running container, not a replay. Open it while execution is still running.
 - Do not screenshot or print secrets, passwords, tokens, tenant secrets, or generated API keys.
@@ -131,6 +132,8 @@ Use the report and terminal logs to capture:
 - Whether the local image and `TEMPLATE_VERSION=local` were used.
 - Declared and applied feature flags, by name and non-secret value only.
 
+Before editing, select the canonical failing `test_report.html` and publish it with [publish-vscuse-report.ps1](../local-vscuse-validation/scripts/publish-vscuse-report.ps1). If the supplied failing report already uses the repository storproxy URL, record that URL as the Before report instead of uploading a duplicate. Do not substitute a setup-failure report that never reached the behavior under repair.
+
 ### 5. Classify Before Editing
 
 Use this decision table:
@@ -185,7 +188,7 @@ Recommended UI-first repair loop:
 
 For `SCN-DA-CREATE-WITH-MCP-SERVER` with `TEAMSFX_MCP_FOR_DA_DT=true`, the new dynamic-tool-discovery create flow must not execute legacy fetch-tools steps (`Fetch action from MCP`, `Fetch from MCP`, or static operation selection). Repair the plan in `vscuse-ui` so the full saved case reaches project generation and validates the generated dynamic MCP files first; only then run the clean CLI validation.
 
-### 7. Validate and Report
+### 7. Validate, Publish, and Report
 
 Run the same focused plan again. Final report should include:
 
@@ -196,3 +199,12 @@ Run the same focused plan again. Final report should include:
 - Feature flags declared by the plan and whether they were applied.
 - Files changed and why.
 - Final execution summary: successful count, errors count, and repository-relative paths to the archived log and HTML report.
+
+After the clean final run:
+
+1. Publish its run-specific `test_report.html` with the shared publisher in `local-vscuse-validation`.
+2. Save the Before and After URLs under `.local/test-reports/` so later PR edits do not lose them.
+3. Add a `VscUse reports` table to the PR body with the failing step/result and final successful/error counts.
+4. Verify both organization-authenticated links use `https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/` and appear in the rendered PR body.
+
+A vscuse repair PR is not complete until both report links are present. If report publication is blocked by Azure tooling, authentication, or RBAC, report the setup failure and local artifact paths instead of creating or describing the PR as complete.


### PR DESCRIPTION
## Summary

- require every vscuse case repair to preserve and publish one canonical failing report and one clean passing report
- add a shared PowerShell publisher that uses the existing storproxy Blob path through Azure CLI or Az.Accounts
- standardize local link persistence and the `VscUse reports` table required in repair PR bodies

## Validation

- PowerShell AST parsing
- mocked Azure CLI upload contract
- mocked Az.Accounts and Blob REST upload contract
- live Blob data-plane upload, HEAD verification, and cleanup against `storproxystvoazuxhhvtgiq`
- canonical Before and After report uploads with Blob HEAD `200`
- skill frontmatter, relative links, LF endings, trailing newlines, VS Code diagnostics, and `git diff --check`

## VscUse reports

| State | Result | Report |
|---|---|---|
| Before | 44 successful, 1 error at `step_baa39070` (`exec_20260714_110248`) | [Open report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/6d6002ee-d740-431e-b874-e5a473d25575/index.html) |
| After | 59/59 successful, 0 errors (`exec_20260714_134527`) | [Open report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/fad42d51-3cc1-441d-992b-3dde0516e45b/index.html) |

## Related

Follow-up to #16343, which merged while this reusable workflow was being added.