### PR TITLE
test(vscuse): stabilize Copilot UI validation

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action.json
@@ -165,15 +165,13 @@
         "x": 455,
         "y": 351
       },
-      "description": "Click the red plus icon next to the \"Email or phone\" field in the Microsoft login form.",
+      "description": "Click the account identifier input field in the Microsoft sign-in form to focus it for credential entry.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:455:351:16:5:0000000000000000",
-        "dhash:455:351:96:5:0040006060020046",
         "dhash:455:351:0:10:0b28d0d9e7e6dae4"
       ],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 60,
       "precondition_retry_interval": 2
     },
-    "total_steps": 6,
+    "total_steps": 7,
     "created_at": "2026-04-20T11:56:20.740014",
     "name": "group: DA_validation_repair",
     "description": {
@@ -20,6 +20,7 @@
     "execution_order": [
       "step_bee70d3d",
       "step_21cd2a2f",
+      "step_f73b6a41",
       "step_7f88d7b2",
       "step_c5e518d3",
       "step_70d3a56e",
@@ -82,6 +83,26 @@
       "plan_id": "plan_r_0928_091745"
     },
     {
+      "step_id": "step_f73b6a41",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion the active agent name displayed on the M365 Copilot page starts with ${{var:app_name}} and may include an environment suffix such as local or dev.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 30"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-14T16:15:00.000000",
+      "plan_id": "plan_r_0928_091745"
+    },
+    {
       "step_id": "step_7f88d7b2",
       "agent": "interaction",
       "tool": "key_press",
@@ -94,9 +115,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:11dce3e7f8e0e0e0"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_7f88d7b2",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_With_Action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_With_Action.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2.0,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 19,
+    "total_steps": 20,
     "created_at": "2026-07-01T05:36:31.274541",
     "name": "DA Typespec With Action",
     "description": {
@@ -37,6 +37,7 @@
       "step_56362671",
       "step_97b53f60",
       "plan_r_1021_031941",
+      "step_a678eb4c",
       "step_92756e1a",
       "step_ad09f448",
       "step_b2e9a5f3",
@@ -347,6 +348,26 @@
       "plan_id": "plan_621326ee"
     },
     {
+      "step_id": "step_a678eb4c",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion the active agent name displayed on the M365 Copilot page starts with ${{var:app_name}} and may include an environment suffix such as local or dev, and no blocking dialog is open.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 60"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-14T16:25:00.000000",
+      "plan_id": "plan_621326ee"
+    },
+    {
       "step_id": "step_92756e1a",
       "agent": "interaction",
       "tool": "click",
@@ -355,17 +376,13 @@
         "x": 363,
         "y": 370
       },
-      "description": "Click the \"Message Copilot\" text input box in the vsduseappGVMjD agent chat interface within the M365 web application.",
+      "description": "Click the message input box for the ${{var:app_name}} agent in the M365 Copilot web application.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:363:370:16:5:a50535d5d5b5e7da",
-        "dhash:363:370:96:5:00440086de004400",
-        "dhash:363:370:0:10:15b586f0a6c6c0c0"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_92756e1a",


### PR DESCRIPTION
## Summary

- keep a page-level Microsoft sign-in guard while removing spot hashes tied to upstream field styling
- validate the active M365 Copilot agent with `${{var:app_name}}` before submitting validation queries
- replace the hardcoded agent name in `step_92756e1a` and remove its brittle screenshot preconditions

## Validation

- Parsed the edited JSON plans and verified `total_steps`, local step definitions, and `execution_order` are consistent.
- Ran `DA Typespec With Action` with `ghcr.io/officedev/vscuse-atk-vscode:20260713` (`sha256:9b5951d5b3cb1830526952b3bcffc41875f996bedd27155a8fafaa39e74398a3`).
- The updated Microsoft sign-in focus step passed against the revised upstream UI.
- The new semantic agent assertion correctly rejected a real incompatible state: the runtime app was `vscuse_app_HA3vd`, while Copilot displayed stale app `vscuse_app_YeDhDdev` with a blocking `This agent is not installed` dialog. This remains a separate agent installation/deep-link issue rather than screenshot drift.

Execution: `exec_20260714_162204` (56 successful, 1 correctly classified assertion failure).