### PR TITLE
test(vscuse): set hover delay to three minutes

### DIFF
--- a/packages/tests/vscuse/docker/vscuse-atk/vscode-setting/setting.json
+++ b/packages/tests/vscuse/docker/vscuse-atk/vscode-setting/setting.json
@@ -10,5 +10,5 @@
     "strings": "off"
   },
   "editor.suggestOnTriggerCharacters": false,
-  "workbench.hover.delay": 1500
+  "workbench.hover.delay": 180000
 }


### PR DESCRIPTION
## Summary
- update vscuse docker VS Code setting: workbench.hover.delay from 1500 to 180000

## Why
- suppress explorer path hover tooltip during automated vscuse runs by delaying hover display to 3 minutes