### PR TITLE
test(vscuse): fix Basic Tab assertion typo

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Tab_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Tab_Local_Debug.json
@@ -146,7 +146,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion there's message \"App name needs to begin with letters, include minimum two letters or digits, and exclude certain special chararcters.\"",
+      "description": "@assertion there's message \"App name needs to begin with letters, include minimum two letters or digits, and exclude certain special characters.\"",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## Summary
- correct `chararcters` to `characters` in the Basic Tab local-debug assertion text
- keep the vscuse plan behavior and execution structure unchanged

## Validation
- `node -e "JSON.parse(...)"` for `Basic_Tab_Local_Debug.json`
- `git diff --check origin/dev...HEAD`