### PR TITLE
test(vscuse): accept echo bot reply variants

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_echo_bot.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_echo_bot.json
@@ -86,7 +86,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion bot reply message: \"[1] you said: Hi\" exist.",
+      "description": "@assertion bot reply message: \"[1] you said: Hi\" or \"You said: Hi\" exist.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_ts_Local_Debug_With_Different_Account.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_ts_Local_Debug_With_Different_Account.json
@@ -1030,7 +1030,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion bot reply message: \"[1] you said: Hi\" exist.",
+      "description": "@assertion bot reply message: \"[1] you said: Hi\" or \"You said: Hi\" exist.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## Summary
- accept both `"[1] you said: Hi"` and `"You said: Hi"` in the shared echo-bot validation
- align the different-account Simple Bot plan with the same reply variants
- preserve the existing vscuse execution structure and assertion scope

## Validation
- parsed both changed files with `JSON.parse`
- `git diff --check origin/dev...HEAD`

The full UI cases were not run for this assertion-text-only change.