### PR TITLE
test(vscuse): fix Copilot BizChat chat-input for new view and add F5 recovery

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 60,
       "precondition_retry_interval": 2
     },
-    "total_steps": 20,
+    "total_steps": 22,
     "created_at": "2026-05-18T10:07:16.265795",
     "name": "group: debug_in_copilot_local",
     "description": {
@@ -37,6 +37,8 @@
       "step_a0762a17",
       "step_3bb29c8a",
       "step_ac955e3b",
+      "step_f5_retry2_da",
+      "step_f5_retry3_da",
       "step_670cbf14"
     ],
     "tags": [
@@ -477,7 +479,7 @@
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
-      "continue_on_error": "false",
+      "continue_on_error": "true",
       "depends_on": [],
       "preconditions": [
         "dhash:512:384:0:20:05e58c9cd88c80c0"
@@ -488,6 +490,60 @@
       ],
       "screenshot": "step_ac955e3b",
       "created_at": "2026-05-18T10:07:16.352198",
+      "plan_id": "plan_r_0928_095902"
+    },
+    {
+      "step_id": "step_f5_retry2_da",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f5"
+      },
+      "description": "If the \"This agent is not installed\" dialog is still shown after the first refresh, press F5 again to reload the M365 Copilot page (agent-not-installed recovery, attempt 2 of 3).",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:715:462:16:5:0001020402030102",
+        "dhash:715:462:96:8:000095181e120028",
+        "dhash:715:462:0:12:1c6c83dcc0630741"
+      ],
+      "postconditions": [],
+      "tags": [
+        "precondition_wait_timeout:5",
+        "delay:8"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-16T00:00:00.000000",
+      "plan_id": "plan_r_0928_095902"
+    },
+    {
+      "step_id": "step_f5_retry3_da",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f5"
+      },
+      "description": "If the \"This agent is not installed\" dialog is still shown after the second refresh, press F5 one more time to reload the M365 Copilot page (agent-not-installed recovery, attempt 3 of 3).",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:715:462:16:5:0001020402030102",
+        "dhash:715:462:96:8:000095181e120028",
+        "dhash:715:462:0:12:1c6c83dcc0630741"
+      ],
+      "postconditions": [],
+      "tags": [
+        "precondition_wait_timeout:5",
+        "delay:8"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-16T00:00:00.000000",
       "plan_id": "plan_r_0928_095902"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 60,
       "precondition_retry_interval": 2
     },
-    "total_steps": 16,
+    "total_steps": 18,
     "created_at": "2026-04-21T01:53:19.292868",
     "name": "group__debug_in_copilot_local_none_da",
     "description": {
@@ -33,6 +33,8 @@
       "step_c4bbcf2e",
       "step_44b3e2d1",
       "step_6c5a4ef6",
+      "step_f5_retry2",
+      "step_f5_retry3",
       "step_ba7f9051"
     ],
     "tags": [
@@ -394,7 +396,7 @@
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
-      "continue_on_error": "false",
+      "continue_on_error": "true",
       "depends_on": [],
       "preconditions": [
         "dhash:512:384:0:20:05e58c9c988c80c0"
@@ -405,6 +407,60 @@
       ],
       "screenshot": "step_6c5a4ef6",
       "created_at": "2026-04-21T03:02:12.339050",
+      "plan_id": "plan_f355465c"
+    },
+    {
+      "step_id": "step_f5_retry2",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f5"
+      },
+      "description": "If the \"This agent is not installed\" dialog is still shown after the first refresh, press F5 again to reload the M365 Copilot page (agent-not-installed recovery, attempt 2 of 3).",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:715:462:16:5:0001020402030102",
+        "dhash:715:462:96:8:000095181e120028",
+        "dhash:715:462:0:12:1c6c83dcc0630741"
+      ],
+      "postconditions": [],
+      "tags": [
+        "precondition_wait_timeout:5",
+        "delay:8"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-16T00:00:00.000000",
+      "plan_id": "plan_f355465c"
+    },
+    {
+      "step_id": "step_f5_retry3",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f5"
+      },
+      "description": "If the \"This agent is not installed\" dialog is still shown after the second refresh, press F5 one more time to reload the M365 Copilot page (agent-not-installed recovery, attempt 3 of 3).",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:715:462:16:5:0001020402030102",
+        "dhash:715:462:96:8:000095181e120028",
+        "dhash:715:462:0:12:1c6c83dcc0630741"
+      ],
+      "postconditions": [],
+      "tags": [
+        "precondition_wait_timeout:5",
+        "delay:8"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-16T00:00:00.000000",
       "plan_id": "plan_f355465c"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_only.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_only.json
@@ -398,7 +398,9 @@
       "depends_on": [],
       "preconditions": [],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "step_retry_timeout: 90"
+      ],
       "screenshot": null,
       "created_at": "2026-06-12T01:25:53.063039",
       "plan_id": "plan_r_1021_081410"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair.json
@@ -39,19 +39,15 @@
       "parameters": {
         "button": "left",
         "x": 350,
-        "y": 373
+        "y": 487
       },
-      "description": "Click on the \"Message Copilot\" input field in the chat interface within Microsoft 365 Copilot, positioning the cursor for text entry.",
+      "description": "Click the chat message input field at the bottom of the Microsoft 365 Copilot page (new BizChat layout; the placeholder is agent-specific, e.g. \"Message <agent name>\") to position the cursor for text entry.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:350:373:16:5:4c141314cc21c100",
-        "dhash:350:373:96:5:0040006367004000",
-        "dhash:350:373:0:10:159087f4a8c0c0c0"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "ocr:true"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_basic_ai_chat_bot_in_copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_basic_ai_chat_bot_in_copilot.json
@@ -36,19 +36,15 @@
       "parameters": {
         "button": "left",
         "x": 416,
-        "y": 369
+        "y": 487
       },
-      "description": "Click the \"Message Copilot\" input field to add a new message in the agent chat within the M365 Copilot web application.",
+      "description": "Click the chat message input field at the bottom of the M365 Copilot page (new BizChat layout; the placeholder is agent-specific, e.g. \"Message <agent name>\") to add a new message in the agent chat.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:416:369:16:5:0000000000000000",
-        "dhash:416:369:96:5:00200060f0002000",
-        "dhash:416:369:0:10:1391e7f4d2d3e4e0"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "ocr:true"


### PR DESCRIPTION
# Summary

Update the vscuse Copilot/BizChat test steps for the redesigned **M365 Copilot (BizChat)** web view, and make the intermittent **"This agent is not installed"** local‑debug flow resilient. JSON test‑asset changes only.

## Changes

### 1. New BizChat view — chat input moved
The M365 Copilot web view was redesigned: the chat input moved down (~`y=369` → ~`y=487`) and the placeholder became agent‑specific (`Message <agent name>`). Updated the input‑click step to the new position, an OCR / placeholder‑agnostic target, and removed the stale `dhash` preconditions:
- `group__validation_DA_repair.json` (`step_bee70d3d`)
- `group__validation_basic_ai_chat_bot_in_copilot.json` (`step_294018a0`)

Ref: OfficeDev/microsoft-365-agents-toolkit-test#15504

### 2. "Agent not installed" F5 recovery
Added up to **3 F5 refreshes** before the agent‑name assertion and made the F5 steps optional (`continue_on_error`), to recover from the intermittent "This agent is not installed" state:
- `group__debug_in_copilot_local.json`
- `group__debug_in_copilot_local_none_da.json`

### 3. Login robustness
Added a **90s retry window** to the M365 sign‑in assertion so slower first‑time sign‑ins are not cut off:
- `group__login_m365_only.json`

## Validation
Ran `Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Local_Debug` locally against image `20260715`: **61/61 steps, 100%**.
- The 3× F5 recovery cleared "This agent is not installed" and the agent‑name assertion passed.
- The new‑view step OCR‑matched the new placeholder `+ Message vscuse_app_…local` at **(412, 489)** and clicked it; the bot then responded successfully.
