### PR TITLE
test(vscuse): replace TDP assertion with readme wait in Feature Add App From TDP

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Add_App_From_TDP.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Add_App_From_TDP.json
@@ -271,10 +271,10 @@
     },
     {
       "step_id": "step_20f65283",
-      "agent": "assertion",
+      "agent": "code",
       "tool": "",
       "parameters": {},
-      "description": "@assertion 'TDP' is exist",
+      "description": "@code wait for readme.md to be viewed. Timeout: 60s",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -282,9 +282,7 @@
       "depends_on": [],
       "preconditions": [],
       "postconditions": [],
-      "tags": [
-        "step_retry_timeout:60"
-      ],
+      "tags": [],
       "screenshot": null,
       "created_at": "2026-05-18T02:19:09.603514",
       "plan_id": "plan_06dbd424"


### PR DESCRIPTION
## Summary

Instead of deleting the assertion step, this converts `step_20f65283` in the **Feature Add App From TDP** vscuse plan from a hard assertion into a wait step.

## Change

In `packages/tests/vscuse/vscode-test-cases/plans/Feature_Add_App_From_TDP.json`, step `step_20f65283`:

- `agent`: `assertion` → `code`
- `description`: `@assertion 'TDP' is exist` → `@code wait for readme.md to be viewed. Timeout: 60s`
- `tags`: `["step_retry_timeout:60"]` → `[]` (the 60s timeout is now expressed in the `@code` wait description, matching the existing `@code wait for ... Timeout: Ns` convention)

The step stays in `execution_order`, and `total_steps` remains `13`. So instead of hard-asserting that "TDP" exists (which was flaky), the plan now waits up to 60s for the project README preview to be viewed before continuing.

## Verification

- JSON re-parses successfully.
- Net diff vs `dev` is limited to the single step's `agent`, `description`, and `tags` fields.
- `total_steps = 13`, `steps.length = 13`, `execution_order` unchanged (19 entries, step still present).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>