### PR TITLE
test(vscuse): stabilize debug options validation

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group_validation_debug_options_order.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group_validation_debug_options_order.json
@@ -148,23 +148,17 @@
     {
       "step_id": "step_039e984f",
       "agent": "interaction",
-      "tool": "click",
+      "tool": "key_press",
       "parameters": {
-        "button": "left",
-        "x": 621,
-        "y": 177
+        "key": "escape"
       },
-      "description": "Click the \"Debug in Microsoft 365 Agents Playground\" option in the Run and Debug dropdown menu within the Visual Studio Code interface. The red crosshair at (621, 177) precisely marks this menu item for selection.",
+      "description": "Press Escape to close the Run and Debug configuration dropdown after validating its option order.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:621:177:16:5:0000000000000000",
-        "dhash:621:177:96:5:0000000000000000",
-        "dhash:621:177:0:10:82ccca83e3236421"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_039e984f",


### PR DESCRIPTION
## Summary

- dismiss the Run and Debug configuration dropdown with `Escape` after validating its option order
- remove screenshot hash preconditions that were sensitive to VS Code's active-row highlight
- align the step description with its actual intent: closing the dropdown rather than selecting a configuration

## Validation

- validated with `ghcr.io/officedev/vscuse-atk-vscode:V4TEST0717` (`sha256:73c2db786e4ed9bcce7ce1d9346b9a58ab515a1c7a8873fd149fe6f6fd1c9aa7`)
- `step_8cf91e7c` option-order assertion passed
- repaired `step_039e984f` passed directly in 0.50s with no condition-agent fallback
- full `Basic_Custom_Engine_Agent_Azure_OpenAI_py_Local_Debug` run reached 80/81 successful steps; the unrelated later `step_18c4c16f` failed because the browser displayed a Microsoft Learn 404 page instead of the Teams chat UI