### PR TITLE
test(vscuse): ignore underscores in DA Typespec agent name assertion

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_With_Action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_With_Action.json
@@ -352,7 +352,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the active agent name displayed on the M365 Copilot page starts with ${{var:app_name}} and may include an environment suffix such as local or dev, and no blocking dialog is open.",
+      "description": "@assertion the active agent name displayed on the M365 Copilot page starts with ${{var:app_name}} when underscore characters are ignored (the displayed name may omit underscores, so compare both the assertion value and the displayed name with all underscores removed) and may include an environment suffix such as local or dev, and no blocking dialog is open.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## Why

The `DA Typespec With Action` vscuse plan was failing on step `step_a678eb4c`. The assertion checked that the active agent name shown on the M365 Copilot page starts with `${{var:app_name}}` (e.g. `vscuse_app_y3dJv`), but M365 Copilot renders the name with underscores stripped (`vscuseappy3dJv`). The literal comparison therefore returned a false negative even though the correct agent was active.

## What changed

Updated the assertion description for `step_a678eb4c` in `packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_With_Action.json` to instruct the checker to remove all underscores from both the expected `app_name` value and the displayed name before comparing. The environment-suffix and no-blocking-dialog parts of the assertion are unchanged.

## Notes

- Single-line, test-plan-only change; no product code affected.
- JSON validity was verified after the edit.