### PR TITLE
fix(security): bump adm-zip to ^0.6.0 to resolve GHSA-xcpc-8h2w-3j85

### DIFF
--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -50,7 +50,7 @@
     "@microsoft/m365-spec-parser": "workspace:^",
     "@microsoft/teamsfx-api": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "adm-zip": "^0.5.10",
+    "adm-zip": "^0.6.0",
     "ajv": "^8.18.0",
     "axios": "^1.8.3",
     "axios-retry": "^3.3.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -83,7 +83,7 @@
     "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^6.5.0",
-    "adm-zip": "^0.5.9",
+    "adm-zip": "^0.6.0",
     "assertion-error": "^2.0.0",
     "axios-mock-adapter": "^1.20.0",
     "chai": "^4.3.4",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -77,7 +77,7 @@
     "@microsoft/teamsfx-api": "workspace:*",
     "@types/js-yaml": "^4.0.0",
     "@types/semver": "^7.3.8",
-    "adm-zip": "0.5.10",
+    "adm-zip": "0.6.0",
     "axios": "^1.6.8",
     "dotenv": "^8.2.0",
     "form-data": "4.0.0",

--- a/templates/package.json
+++ b/templates/package.json
@@ -42,7 +42,7 @@
     "vsc/ts/workflow"
   ],
   "devDependencies": {
-    "adm-zip": "^0.5.10",
+    "adm-zip": "^0.6.0",
     "copyfiles": "^2.4.1",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.0",


### PR DESCRIPTION
## Summary

Bumps every direct `adm-zip` declaration to `^0.6.0` to resolve **[GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85)** (high severity, denial of service).

`adm-zip` before `0.6.0` allocates memory based on the uncompressed size declared in a ZIP central-directory header **without bounds-checking it against the actual compressed data**, and the allocation happens **before** CRC validation. A crafted ~120-byte ZIP declaring ~4GB uncompressed size causes an allocation-amplification of >33,000,000:1, crashing the process. All extraction/read paths are affected (`readFile`, `readAsText`, `extractEntryTo`, `extractAllTo`, `extractAllToAsync`, `test`, `entry.getData`). The vulnerability was surfaced by `pnpm audit` in a downstream consumer, where `adm-zip` is pulled in transitively via `@microsoft/teamsfx-core`.

## Changes

| File | Before | After |
| --- | --- | --- |
| `packages/fx-core/package.json` | `^0.5.10` | `^0.6.0` |
| `packages/sdk/package.json` | `^0.5.9` | `^0.6.0` |
| `templates/package.json` | `^0.5.10` | `^0.6.0` |
| `packages/tests/package.json` | `0.5.10` | `0.6.0` |

`@types/adm-zip` is intentionally left unchanged — only the runtime dependency is affected by the advisory.

## Notes

- `0.6.0` is the only published release in the advisory's patched range (`>=0.6.0`); it is the current `latest` on npm.
- This PR fixes ATK's **direct** `adm-zip` declarations. The advisory can also reach ATK transitively through `@microsoft/kiota` and `office-addin-manifest`; those live in separate upstream packages and are out of scope for this repo.
- I was unable to run the full monorepo build/test locally — relying on CI to validate. Please re-run pipelines as needed.

## Security advisory

- **GHSA-xcpc-8h2w-3j85** — adm-zip DoS via crafted ZIP (Buffer.alloc amplification). Fixed in `adm-zip@0.6.0`.
