### PR TITLE
fix(fx-core): include agentConnectors mcpToolDescription file in app …

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -466,6 +466,20 @@ export class CreateAppPackageDriver implements StepDriver {
       }
     }
 
+    // Agent connector MCP tool description files (Teams manifest agentConnectors, GA since 1.27)
+    const agentConnectors = (manifest as TeamsManifestVDevPreview.TeamsManifestVDevPreview)
+      .agentConnectors;
+    if (agentConnectors?.length) {
+      const addConnectorFilesRes = await this.addAgentConnectorFiles(
+        zip,
+        agentConnectors,
+        appDirectory
+      );
+      if (addConnectorFilesRes.isErr()) {
+        return err(addConnectorFilesRes.error);
+      }
+    }
+
     zip.writeZip(zipFileName);
 
     // Validate zip package size against 10 MB hard limit
@@ -577,6 +591,41 @@ export class CreateAppPackageDriver implements StepDriver {
         return err(new InvalidFileOutsideOfTheDirectotryError(skillFolderAbs));
       }
       await this.addLocalFolderRecursive(zip, skillFolderAbs, appDirectory);
+    }
+    return ok(undefined);
+  }
+
+  /**
+   * Add the MCP tool description files referenced by Teams manifest agent connectors
+   * (agentConnectors[].toolSource.remoteMcpServer.mcpToolDescription.file) to the zip.
+   * The file reference is a schema-declared relative path, mirroring the declarative-agent
+   * file reference; it is optional (v1.29+), so connectors without one add nothing.
+   */
+  private async addAgentConnectorFiles(
+    zip: AdmZip,
+    agentConnectors: TeamsManifestVDevPreview.AgentConnector[],
+    appDirectory: string
+  ): Promise<Result<undefined, FxError>> {
+    const addedFiles = new Set<string>();
+    for (const connector of agentConnectors) {
+      const toolFile = connector.toolSource?.remoteMcpServer?.mcpToolDescription?.file;
+      if (!toolFile) {
+        continue;
+      }
+      const toolFileAbsolutePath = path.resolve(appDirectory, toolFile);
+      if (addedFiles.has(toolFileAbsolutePath)) {
+        continue;
+      }
+      const checkExistenceRes = await this.validateReferencedFile(
+        toolFileAbsolutePath,
+        appDirectory
+      );
+      if (checkExistenceRes.isErr()) {
+        return err(checkExistenceRes.error);
+      }
+      const entryName = path.relative(appDirectory, toolFileAbsolutePath);
+      this.addFileInZip(zip, path.dirname(entryName), toolFileAbsolutePath);
+      addedFiles.add(toolFileAbsolutePath);
     }
     return ok(undefined);
   }

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -3013,6 +3013,158 @@ describe("teamsApp/createAppPackage", async () => {
     });
   });
 
+  describe("Teams manifest agentConnectors packaging", async () => {
+    const agentConnectorsArgs: CreateAppPackageArgs = {
+      manifestPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+      outputZipPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.agent-connectors.zip",
+      outputJsonPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.agent-connectors.json",
+    };
+
+    function createManifestWithConnectors(
+      agentConnectors: TeamsManifestVDevPreview.AgentConnector[]
+    ): TeamsManifestVDevPreview.TeamsManifestVDevPreview {
+      const manifest = {
+        manifestVersion: "1.29",
+      } as TeamsManifestVDevPreview.TeamsManifestVDevPreview;
+      manifest.icons = {
+        color: "resources/color.png",
+        outline: "resources/outline.png",
+      };
+      manifest.agentConnectors = agentConnectors;
+      return manifest;
+    }
+
+    it("should bundle agentConnectors mcpToolDescription file into the zip", async () => {
+      const manifest = createManifestWithConnectors([
+        {
+          id: "kusto",
+          displayName: "Kusto",
+          toolSource: {
+            remoteMcpServer: {
+              mcpServerUrl: "https://www.contoso.com",
+              mcpToolDescription: { file: "kusto-tools.json" },
+            },
+          },
+        },
+      ]);
+
+      vi.spyOn(manifestUtils, "getManifestV3").mockResolvedValue(ok(manifest));
+      vi.spyOn(fs, "chmod").mockImplementation(async () => {});
+      vi.spyOn(fs, "writeFile").mockImplementation(async () => {});
+      vi.spyOn(fs, "pathExists").mockResolvedValue(true);
+
+      const result = (await teamsAppDriver.execute(agentConnectorsArgs, mockedDriverContext))
+        .result;
+      chai.assert.isTrue(result.isOk());
+
+      const zip = new AdmZip(agentConnectorsArgs.outputZipPath);
+      const toolEntry = zip.getEntry("kusto-tools.json");
+      chai.assert.exists(toolEntry, "kusto-tools.json should be bundled in zip");
+      await fs.remove(agentConnectorsArgs.outputZipPath);
+    });
+
+    it("should succeed when an agent connector has no mcpToolDescription file", async () => {
+      const manifest = createManifestWithConnectors([
+        {
+          id: "urlOnly",
+          displayName: "Url Only",
+          toolSource: {
+            remoteMcpServer: { mcpServerUrl: "https://www.contoso.com" },
+          },
+        },
+      ]);
+
+      vi.spyOn(manifestUtils, "getManifestV3").mockResolvedValue(ok(manifest));
+      vi.spyOn(fs, "chmod").mockImplementation(async () => {});
+      vi.spyOn(fs, "writeFile").mockImplementation(async () => {});
+      vi.spyOn(fs, "pathExists").mockResolvedValue(true);
+
+      const result = (await teamsAppDriver.execute(agentConnectorsArgs, mockedDriverContext))
+        .result;
+      chai.assert.isTrue(result.isOk());
+      if (await fs.pathExists(agentConnectorsArgs.outputZipPath)) {
+        await fs.remove(agentConnectorsArgs.outputZipPath);
+      }
+    });
+
+    it("should de-duplicate the same mcpToolDescription file referenced by multiple connectors", async () => {
+      const manifest = createManifestWithConnectors([
+        {
+          id: "kusto1",
+          displayName: "Kusto 1",
+          toolSource: {
+            remoteMcpServer: {
+              mcpServerUrl: "https://www.contoso.com/1",
+              mcpToolDescription: { file: "kusto-tools.json" },
+            },
+          },
+        },
+        {
+          id: "kusto2",
+          displayName: "Kusto 2",
+          toolSource: {
+            remoteMcpServer: {
+              mcpServerUrl: "https://www.contoso.com/2",
+              mcpToolDescription: { file: "kusto-tools.json" },
+            },
+          },
+        },
+      ]);
+
+      vi.spyOn(manifestUtils, "getManifestV3").mockResolvedValue(ok(manifest));
+      vi.spyOn(fs, "chmod").mockImplementation(async () => {});
+      vi.spyOn(fs, "writeFile").mockImplementation(async () => {});
+      vi.spyOn(fs, "pathExists").mockResolvedValue(true);
+
+      const result = (await teamsAppDriver.execute(agentConnectorsArgs, mockedDriverContext))
+        .result;
+      chai.assert.isTrue(result.isOk());
+
+      const zip = new AdmZip(agentConnectorsArgs.outputZipPath);
+      const toolEntries = zip
+        .getEntries()
+        .filter((entry) => entry.entryName === "kusto-tools.json");
+      chai.assert.lengthOf(toolEntries, 1, "tool description file should only be packaged once");
+      await fs.remove(agentConnectorsArgs.outputZipPath);
+    });
+
+    it("should return error when the agentConnectors mcpToolDescription file is missing", async () => {
+      const manifest = createManifestWithConnectors([
+        {
+          id: "kusto",
+          displayName: "Kusto",
+          toolSource: {
+            remoteMcpServer: {
+              mcpServerUrl: "https://www.contoso.com",
+              mcpToolDescription: { file: "missing-tools.json" },
+            },
+          },
+        },
+      ]);
+
+      vi.spyOn(manifestUtils, "getManifestV3").mockResolvedValue(ok(manifest));
+      vi.spyOn(fs, "chmod").mockImplementation(async () => {});
+      vi.spyOn(fs, "writeFile").mockImplementation(async () => {});
+      vi.spyOn(fs, "pathExists").mockImplementation(async (filePath) => {
+        if (filePath.toString().includes("missing-tools.json")) {
+          return false;
+        }
+        return true;
+      });
+
+      const result = (await teamsAppDriver.execute(agentConnectorsArgs, mockedDriverContext))
+        .result;
+      chai.assert.isTrue(result.isErr());
+      if (result.isErr()) {
+        chai.assert.isTrue(result.error instanceof FileNotFoundError);
+        chai.assert.include(result.error.message, "missing-tools.json");
+      }
+    });
+  });
+
   describe("package size limit", () => {
     it("should fail when zip exceeds 10 MB", async () => {
       const manifest = {

--- a/packages/fx-core/tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/kusto-tools.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/kusto-tools.json
@@ -1,0 +1,8 @@
+{
+  "tools": [
+    {
+      "name": "get-kusto-logs",
+      "description": "Gets Kusto logs for diagnostics."
+    }
+  ]
+}


### PR DESCRIPTION
# fix(fx-core): include agentConnectors mcpToolDescription file in app package zip

## What / Why

`teamsApp/zipAppPackage` (`packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts`) collected capability files via hard-coded per-capability branches — `apiSpecificationFile`, `copilotAgents.declarativeAgents[].file`, and agent-skill folders — but had **no** branch for the Teams manifest `agentConnectors[].toolSource.remoteMcpServer.mcpToolDescription.file`.

That file is a schema-declared `#/definitions/relativePath` (the same marker as the declarative-agent `file` that *is* collected), so the built `.zip` omitted it and the next lifecycle step `teamsApp/validateAppPackage` failed with:

```
InvalidAgentConnector: The agent connector with ID <id> has its declared MCP tool description file <file> not found in the app package.
```

Any app/plugin with an agent connector that references a tool-description file could not provision or package.

## Change

- Add `addAgentConnectorFiles(...)`: for each connector declaring `toolSource.remoteMcpServer.mcpToolDescription.file`, validate the referenced file (`validateReferencedFile`) and add it to the zip (`addFileInZip`, consistent with the existing MCP-tool-description handling for API-plugin runtimes), de-duplicating files shared by multiple connectors.
- The field is optional (v1.29), so connectors without one add nothing. No feature flag — `agentConnectors` is GA since manifest 1.27.
- Unit tests in `createAppPackage.test.ts`: bundling into the zip, connector without a tool file still succeeds, de-duplication, and missing-file error. Adds fixture `.../resources-multi-env/templates/appPackage/kusto-tools.json`.

## Testing

`pnpm --filter @microsoft/teamsfx-core run build`, `... run test:unit:vitest` (createAppPackage test file), and `... run lint` — to be validated by CI.

Fixes #16379 
Downstream: gim-home/wiqd#1781
