### PR TITLE
fix(vscuse): export MCP OAuth client secret

### DIFF
--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -179,7 +179,7 @@ jobs:
       GITHUB_MFA_SECRET: ${{ secrets.GH_MFA_SECRET }}
       #Additional value:
       DA_MCP_ENTRA_SSO_CLIENTID: ${{ secrets.DA_MCP_ENTRA_SSO_CLIENTID }}
-      DA_MCP_OAUTH_CLIENT_SECERT: ${{ secrets.DA_MCP_OAUTH_CLIENT_SECERT }}
+      DA_MCP_OAUTH_CLIENT_SECRET: ${{ secrets.DA_MCP_OAUTH_CLIENT_SECERT }}
       DA_MCP_OAUTH_CLIENTID: ${{ secrets.DA_MCP_OAUTH_CLIENTID }}
 
       # SQL server

--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -179,7 +179,7 @@ jobs:
       GITHUB_MFA_SECRET: ${{ secrets.GH_MFA_SECRET }}
       #Additional value:
       DA_MCP_ENTRA_SSO_CLIENTID: ${{ secrets.DA_MCP_ENTRA_SSO_CLIENTID }}
-      DA_MCP_OAUTH_CLIENT_SECRET: ${{ secrets.DA_MCP_OAUTH_CLIENT_SECERT }}
+      DA_MCP_OAUTH_CLIENT_SECRET: ${{ secrets.DA_MCP_OAUTH_CLIENT_SECRET }}
       DA_MCP_OAUTH_CLIENTID: ${{ secrets.DA_MCP_OAUTH_CLIENTID }}
 
       # SQL server


### PR DESCRIPTION
## Summary

- export `DA_MCP_OAUTH_CLIENT_SECRET`, matching the variable consumed by `DA_MCP_Oauth_Remote`
- source it from the correctly named `DA_MCP_OAUTH_CLIENT_SECRET` repository secret
- align the plan, workflow environment variable, and repository secret name to unblock vscuse preflight validation

## Validation

- parsed `.github/workflows/ui-test-vscuse-common.yml` with the repository Prettier YAML parser
- verified the plan, workflow environment variable, and repository secret all use `DA_MCP_OAUTH_CLIENT_SECRET`
- verified the misspelled `DA_MCP_OAUTH_CLIENT_SECERT` name is no longer present
