### PR TITLE
test(vscuse): ignore underscore diffs in DA Typespec agent name assertion

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_With_Action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_With_Action.json
@@ -352,7 +352,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the active agent name displayed on the M365 Copilot page starts with ${{var:app_name}} and may include an environment suffix such as local or dev, and no blocking dialog is open.",
+      "description": "@assertion the active agent name displayed on the M365 Copilot page starts with ${{var:app_name}}, ignoring any underscore differences because the TypeSpec template applies safe-name processing that strips underscores from the app name, and may include an environment suffix such as local or dev, and no blocking dialog is open.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## What

Update the assertion in step `step_a678eb4c` of the `DA_Typespec_With_Action` vscuse test plan to ignore underscore differences when comparing the displayed agent name against `${{var:app_name}}`.

## Why

The `app_name` test variable defaults to `vscuse_app_#####` (with underscores). When scaffolding a TypeSpec Declarative Agent, the toolkit applies **safe-name processing** (`convertToAlphanumericOnly` → `replace(/[^\da-zA-Z]/g, "")`) that strips all non-alphanumeric characters, including underscores. As a result, the agent name shown in M365 Copilot has no underscores (e.g. `vscuse_app_yccHG` → `vscuseappyccHG`), while `${{var:app_name}}` retains them.

The previous assertion `... starts with ${{var:app_name}} ...` therefore failed on this mismatch. The updated wording tells the assertion to tolerate underscore differences.

## Change

Single-line description update to `step_a678eb4c`; no behavioral/code changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>