### PR TITLE
test(vscuse): tag no-screenshot steps with precondition:old

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Local_Debug.json
@@ -50,7 +50,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c1920713",
       "created_at": "2026-05-11T06:46:37.819279",
       "plan_id": "plan_be7fa060"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_Copilot_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:338:135:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fbd68b9b",
       "created_at": "2025-12-16T06:34:23.299435",
       "plan_id": "plan_c917256b"
@@ -81,7 +83,9 @@
         "dhash:401:83:0:10:c0d09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3f4e2fae",
       "created_at": "2025-12-16T06:34:23.308117",
       "plan_id": "plan_c917256b"
@@ -103,7 +107,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cc5ba507",
       "created_at": "2025-12-16T06:34:23.315143",
       "plan_id": "plan_c917256b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_ts_Copilot_Remote_Debug.json
@@ -106,7 +106,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a03bef9e",
       "created_at": "2026-02-24T11:21:45.532191",
       "plan_id": "plan_f6e3cade"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_js_Copilot_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:338:135:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c7c6698b",
       "created_at": "2025-11-25T07:03:58.836653",
       "plan_id": "plan_42d92695"
@@ -81,7 +83,9 @@
         "dhash:401:83:0:10:c0d09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_697fc597",
       "created_at": "2025-11-25T07:03:58.842830",
       "plan_id": "plan_42d92695"
@@ -107,7 +111,9 @@
         "dhash:294:101:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4203f0cf",
       "created_at": "2025-11-25T07:03:58.846846",
       "plan_id": "plan_42d92695"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_js_Copilot_Remote_Debug.json
@@ -62,7 +62,9 @@
         "dhash:369:134:0:10:c8c88094b0717c6f"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a0d2a8b4",
       "created_at": "2025-12-16T07:52:06.531160",
       "plan_id": "plan_3210a88e"
@@ -93,7 +95,9 @@
         "dhash:352:83:0:10:c0d09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_57c1a147",
       "created_at": "2025-12-16T07:52:06.537248",
       "plan_id": "plan_3210a88e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_js_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:338:135:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5f13ca56",
       "created_at": "2025-11-25T06:01:16.375985",
       "plan_id": "plan_14730820"
@@ -81,7 +83,9 @@
         "dhash:401:83:0:10:c0d09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4a6e1fe3",
       "created_at": "2025-11-25T06:01:16.383159",
       "plan_id": "plan_14730820"
@@ -107,7 +111,9 @@
         "dhash:294:101:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ed172eab",
       "created_at": "2025-11-25T06:01:16.393569",
       "plan_id": "plan_14730820"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_js_Remote_Debug.json
@@ -62,7 +62,9 @@
         "dhash:369:134:0:10:c8c88094b0717c6f"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_54cc8630",
       "created_at": "2026-01-26T09:33:39.444854",
       "plan_id": "plan_80e1d16a"
@@ -93,7 +95,9 @@
         "dhash:352:83:0:10:c0d09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b2f36dbe",
       "created_at": "2026-01-26T09:33:39.450573",
       "plan_id": "plan_80e1d16a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_ts_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_ts_Copilot_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:338:135:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_aeec2e5f",
       "created_at": "2025-11-25T07:26:00.858484",
       "plan_id": "plan_cb218eb9"
@@ -81,7 +83,9 @@
         "dhash:401:83:0:10:c0d09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0384141a",
       "created_at": "2025-11-25T07:26:00.868239",
       "plan_id": "plan_cb218eb9"
@@ -107,7 +111,9 @@
         "dhash:279:72:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_99a178ba",
       "created_at": "2025-11-25T07:26:00.875774",
       "plan_id": "plan_cb218eb9"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_ts_Copilot_Remote_Debug.json
@@ -107,7 +107,9 @@
         "dhash:352:83:0:10:c0d09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bd641d24",
       "created_at": "2026-01-22T01:26:43.956067",
       "plan_id": "plan_97c90449"
@@ -138,7 +140,9 @@
         "dhash:344:69:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_52028e00",
       "created_at": "2026-01-22T01:26:43.960964",
       "plan_id": "plan_97c90449"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_OpenAI_ts_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:338:135:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cad3b175",
       "created_at": "2025-11-25T06:06:49.686500",
       "plan_id": "plan_82beab83"
@@ -81,7 +83,9 @@
         "dhash:401:83:0:10:c0d09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0cbcd9c7",
       "created_at": "2025-11-25T06:06:49.693498",
       "plan_id": "plan_82beab83"
@@ -107,7 +111,9 @@
         "dhash:279:72:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fef99695",
       "created_at": "2025-11-25T06:06:49.700267",
       "plan_id": "plan_82beab83"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_API_Key.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_API_Key.json
@@ -161,7 +161,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4b1955e0",
       "created_at": "2026-05-11T05:19:16.174015",
       "plan_id": "plan_b88f456d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_No_Auth.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_No_Auth.json
@@ -158,7 +158,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_75d64c6d",
       "created_at": "2026-05-11T05:08:43.999432",
       "plan_id": "plan_d40ec085"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_OAuth.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_OAuth.json
@@ -165,7 +165,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b20287ae",
       "created_at": "2026-05-11T05:27:45.252075",
       "plan_id": "plan_7ca218e3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Bearer_token.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Bearer_token.json
@@ -162,7 +162,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cd450c8e",
       "created_at": "2026-05-11T05:20:12.194457",
       "plan_id": "plan_d847597e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_None_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_None_Remote.json
@@ -102,7 +102,9 @@
       "depends_on": [],
       "preconditions": ["dhash:512:384:0:20:e0c8949492b17075"],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-08T07:18:15.090813",
       "plan_id": "plan_e97eedd8"
@@ -122,7 +124,9 @@
       "depends_on": [],
       "preconditions": ["dhash:512:384:0:20:e0b8949492b17075"],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-08T07:18:15.883280",
       "plan_id": "plan_e97eedd8"
@@ -255,7 +259,8 @@
       "postconditions": [],
       "tags": [
         "optional_if_prompted:select_environment_dev",
-        "precondition_wait_timeout:10"
+        "precondition_wait_timeout:10",
+        "precondition:old"
       ],
       "screenshot": "step_f96cc0f5",
       "created_at": "2026-07-08T09:00:00.000000",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -189,7 +189,9 @@
       "depends_on": [],
       "preconditions": ["dhash:512:384:0:20:e0c8949492b17075"],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "",
       "created_at": "2026-06-29T03:21:51.370500",
       "plan_id": "plan_r_1024_023252"
@@ -211,7 +213,9 @@
       "depends_on": [],
       "preconditions": ["dhash:512:384:0:20:e0b8949492b17075"],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "",
       "created_at": "2026-06-29T03:21:51.370600",
       "plan_id": "plan_r_1024_023252"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Add_Knowledge_Onedrive.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Add_Knowledge_Onedrive.json
@@ -141,7 +141,9 @@
         "dhash:512:384:0:20:b28c2a2323232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_af6e89ad",
       "created_at": "2026-05-20T04:53:33.898438",
       "plan_id": "plan_0575e493"
@@ -163,7 +165,9 @@
         "dhash:512:384:0:20:e4e4322323232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cee65ff3",
       "created_at": "2026-05-20T04:53:33.904823",
       "plan_id": "plan_0575e493"
@@ -185,7 +189,9 @@
         "dhash:512:384:0:20:e484322323232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_123bb1a2",
       "created_at": "2026-05-20T04:53:33.908802",
       "plan_id": "plan_0575e493"
@@ -207,7 +213,9 @@
         "dhash:512:384:0:20:c484222323232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_dc8431d9",
       "created_at": "2026-05-20T04:53:33.914809",
       "plan_id": "plan_0575e493"
@@ -229,7 +237,9 @@
         "dhash:512:384:0:20:c484222323232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d0630946",
       "created_at": "2026-05-20T04:53:33.919492",
       "plan_id": "plan_0575e493"
@@ -255,7 +265,9 @@
         "dhash:430:352:0:10:0b28d0d9e7e6dae4"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_536da074",
       "created_at": "2026-05-20T04:53:33.924011",
       "plan_id": "plan_0575e493"
@@ -277,7 +289,9 @@
         "dhash:512:384:0:20:1b28f0d9e7e6dae4"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f804cda1",
       "created_at": "2026-05-20T04:53:33.929042",
       "plan_id": "plan_0575e493"
@@ -325,7 +339,9 @@
         "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9b5d64bc",
       "created_at": "2026-05-20T04:53:33.937144",
       "plan_id": "plan_0575e493"
@@ -348,7 +364,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay: 3"
+        "delay: 3",
+        "precondition:old"
       ],
       "screenshot": "step_e3bb0624",
       "created_at": "2026-05-20T04:53:33.940738",
@@ -372,7 +389,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay: 3"
+        "delay: 3",
+        "precondition:old"
       ],
       "screenshot": "step_641a5e7e",
       "created_at": "2026-05-20T04:53:33.944739",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Remote_Debug.json
@@ -187,7 +187,9 @@
         "dhash:512:384:0:20:328c2a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_786974b4",
       "created_at": "2026-01-13T01:10:57.661768",
       "plan_id": "plan_de947884"
@@ -216,7 +218,9 @@
         "dhash:512:384:0:20:e4c048672303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_16e5c0c3",
       "created_at": "2026-01-13T01:10:57.673884",
       "plan_id": "plan_de947884"
@@ -245,7 +249,9 @@
         "dhash:512:384:0:20:cc8422232303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b46e6d95",
       "created_at": "2026-01-13T01:10:57.687665",
       "plan_id": "plan_de947884"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Web_Search.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Web_Search.json
@@ -595,7 +595,9 @@
         "dhash:512:384:0:20:32ac2a23636c6c2d"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_935a8f73",
       "created_at": "2026-03-06T00:22:01.384530",
       "plan_id": "plan_02154016"
@@ -617,7 +619,9 @@
         "dhash:512:384:0:20:60a02223636c6c2d"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f01a94cb",
       "created_at": "2026-03-06T00:22:01.392487",
       "plan_id": "plan_02154016"
@@ -643,7 +647,9 @@
         "dhash:410:52:0:10:648c3223636c6c2d"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ecb4c1e5",
       "created_at": "2026-03-06T00:22:01.400033",
       "plan_id": "plan_02154016"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_Oauth_Without_Reference_Id.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_Oauth_Without_Reference_Id.json
@@ -72,7 +72,9 @@
         "dhash:368:84:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7d555a0e",
       "created_at": "2026-04-22T01:52:17.427726",
       "plan_id": "plan_1951448c"
@@ -98,7 +100,9 @@
         "dhash:361:223:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d01ead17",
       "created_at": "2026-04-22T01:52:17.435750",
       "plan_id": "plan_1951448c"
@@ -124,7 +128,9 @@
         "dhash:319:72:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_57b3f8f1",
       "created_at": "2026-04-22T01:52:17.441308",
       "plan_id": "plan_1951448c"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_With_EK_Happy_Path.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_With_EK_Happy_Path.json
@@ -445,7 +445,9 @@
         "dhash:512:384:0:20:328c2a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_72ec1606",
       "created_at": "2026-06-17T00:08:47.580184",
       "plan_id": "plan_13457846"
@@ -474,7 +476,9 @@
         "dhash:512:384:0:20:e4c048672303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8bbd9a59",
       "created_at": "2026-06-17T00:08:47.591434",
       "plan_id": "plan_13457846"
@@ -503,7 +507,9 @@
         "dhash:512:384:0:20:cc8422232303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cf4a4c80",
       "created_at": "2026-06-17T00:08:47.596527",
       "plan_id": "plan_13457846"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_AppYmlFile_Invalid_Syntax.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_AppYmlFile_Invalid_Syntax.json
@@ -249,7 +249,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_51b6752a",
       "created_at": "2026-05-21T03:08:16.052097",
       "plan_id": "plan_d6b2397d"
@@ -271,7 +273,9 @@
         "dhash:512:384:0:20:64c0c86723636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_dfe51a2d",
       "created_at": "2026-05-21T03:08:16.057036",
       "plan_id": "plan_d6b2397d"
@@ -293,7 +297,9 @@
         "dhash:512:384:0:20:44242a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c95bc873",
       "created_at": "2026-05-21T03:08:16.061944",
       "plan_id": "plan_d6b2397d"
@@ -315,7 +321,9 @@
         "dhash:512:384:0:20:7024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b8ab6f7a",
       "created_at": "2026-05-21T03:08:16.067806",
       "plan_id": "plan_d6b2397d"
@@ -337,7 +345,9 @@
         "dhash:512:384:0:20:5024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7a440c78",
       "created_at": "2026-05-21T03:08:16.073162",
       "plan_id": "plan_d6b2397d"
@@ -377,7 +387,9 @@
         "dhash:512:384:0:20:322327637a6c6819"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d82826fc",
       "created_at": "2026-05-21T03:08:16.080971",
       "plan_id": "plan_d6b2397d"
@@ -399,7 +411,9 @@
         "dhash:512:384:0:20:32232763726a0819"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_38389ccc",
       "created_at": "2026-05-21T03:08:16.085325",
       "plan_id": "plan_d6b2397d"
@@ -421,7 +435,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_72ffe906",
       "created_at": "2026-05-21T03:08:16.090007",
       "plan_id": "plan_d6b2397d"
@@ -443,7 +459,9 @@
         "dhash:512:384:0:20:44c0c86723636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9a561341",
       "created_at": "2026-05-21T03:08:16.093747",
       "plan_id": "plan_d6b2397d"
@@ -465,7 +483,9 @@
         "dhash:512:384:0:20:4c242a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_20b17c3d",
       "created_at": "2026-05-21T03:08:16.097768",
       "plan_id": "plan_d6b2397d"
@@ -487,7 +507,9 @@
         "dhash:512:384:0:20:7024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_507de875",
       "created_at": "2026-05-21T03:08:16.101587",
       "plan_id": "plan_d6b2397d"
@@ -509,7 +531,9 @@
         "dhash:512:384:0:20:7024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fb25c645",
       "created_at": "2026-05-21T03:08:16.106088",
       "plan_id": "plan_d6b2397d"
@@ -549,7 +573,9 @@
         "dhash:512:384:0:20:32232763786c6839"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a060e42e",
       "created_at": "2026-05-21T03:08:16.115814",
       "plan_id": "plan_d6b2397d"
@@ -571,7 +597,9 @@
         "dhash:512:384:0:20:32232763726a0819"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d7a081f7",
       "created_at": "2026-05-21T03:08:16.122577",
       "plan_id": "plan_d6b2397d"
@@ -593,7 +621,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_facbc112",
       "created_at": "2026-05-21T03:08:16.128071",
       "plan_id": "plan_d6b2397d"
@@ -615,7 +645,9 @@
         "dhash:512:384:0:20:4ce4c06523636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_aa7f72c1",
       "created_at": "2026-05-21T03:08:16.132855",
       "plan_id": "plan_d6b2397d"
@@ -637,7 +669,9 @@
         "dhash:512:384:0:20:44e02a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c64d23ef",
       "created_at": "2026-05-21T03:08:16.138252",
       "plan_id": "plan_d6b2397d"
@@ -659,7 +693,9 @@
         "dhash:512:384:0:20:7024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9841cbe4",
       "created_at": "2026-05-21T03:08:16.142938",
       "plan_id": "plan_d6b2397d"
@@ -681,7 +717,9 @@
         "dhash:512:384:0:20:7024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_dc7032a9",
       "created_at": "2026-05-21T03:08:16.146963",
       "plan_id": "plan_d6b2397d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_AppYmlFile_Remove_DeployOrPublish_Section.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_AppYmlFile_Remove_DeployOrPublish_Section.json
@@ -68,7 +68,9 @@
         "dhash:325:85:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4a02377e",
       "created_at": "2026-05-21T01:56:42.287648",
       "plan_id": "plan_ce2002bb"
@@ -94,7 +96,9 @@
         "dhash:330:78:0:10:c0c4b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_341f49e4",
       "created_at": "2026-05-21T01:56:42.295578",
       "plan_id": "plan_ce2002bb"
@@ -236,7 +240,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a5d96e41",
       "created_at": "2026-05-21T01:56:42.339608",
       "plan_id": "plan_ce2002bb"
@@ -258,7 +264,9 @@
         "dhash:512:384:0:20:64c0c86723636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7f5961d7",
       "created_at": "2026-05-21T01:56:42.347629",
       "plan_id": "plan_ce2002bb"
@@ -280,7 +288,9 @@
         "dhash:512:384:0:20:44242a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_89cc2e5e",
       "created_at": "2026-05-21T01:56:42.354246",
       "plan_id": "plan_ce2002bb"
@@ -302,7 +312,9 @@
         "dhash:512:384:0:20:7024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d9f4727b",
       "created_at": "2026-05-21T01:56:42.359718",
       "plan_id": "plan_ce2002bb"
@@ -324,7 +336,9 @@
         "dhash:512:384:0:20:5024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9544eb22",
       "created_at": "2026-05-21T01:56:42.365131",
       "plan_id": "plan_ce2002bb"
@@ -364,7 +378,9 @@
         "dhash:512:384:0:20:322327637a6c6819"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1d72298c",
       "created_at": "2026-05-21T01:56:42.376545",
       "plan_id": "plan_ce2002bb"
@@ -386,7 +402,9 @@
         "dhash:512:384:0:20:32232763726a0819"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c145cd5f",
       "created_at": "2026-05-21T01:56:42.381228",
       "plan_id": "plan_ce2002bb"
@@ -408,7 +426,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8decab9d",
       "created_at": "2026-05-21T01:56:42.386769",
       "plan_id": "plan_ce2002bb"
@@ -430,7 +450,9 @@
         "dhash:512:384:0:20:4ce4c06523636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8091a82d",
       "created_at": "2026-05-21T01:56:42.391871",
       "plan_id": "plan_ce2002bb"
@@ -452,7 +474,9 @@
         "dhash:512:384:0:20:44e02a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3a5b7b85",
       "created_at": "2026-05-21T01:56:42.396691",
       "plan_id": "plan_ce2002bb"
@@ -474,7 +498,9 @@
         "dhash:512:384:0:20:7024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3779c40d",
       "created_at": "2026-05-21T01:56:42.402315",
       "plan_id": "plan_ce2002bb"
@@ -496,7 +522,9 @@
         "dhash:512:384:0:20:7024226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fa21d0ad",
       "created_at": "2026-05-21T01:56:42.406857",
       "plan_id": "plan_ce2002bb"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Basic_Tab_Instant_Tab_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Basic_Tab_Instant_Tab_Remote.json
@@ -55,7 +55,9 @@
         "dhash:474:210:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6807d67f",
       "created_at": "2026-01-27T02:07:55.189477",
       "plan_id": "plan_d1c0c88e"
@@ -81,7 +83,9 @@
         "dhash:328:76:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7f3bff74",
       "created_at": "2026-01-27T02:07:55.213602",
       "plan_id": "plan_d1c0c88e"
@@ -107,7 +111,9 @@
         "dhash:473:77:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e1d23cdd",
       "created_at": "2026-01-27T02:07:55.233367",
       "plan_id": "plan_d1c0c88e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_MCP_Server.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_MCP_Server.json
@@ -252,7 +252,9 @@
         "dhash:512:384:0:20:e0c06023a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -274,7 +276,9 @@
         "dhash:512:384:0:20:d0842a23a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -531,7 +535,9 @@
         "dhash:512:384:0:20:e0c06023a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -553,7 +559,9 @@
         "dhash:512:384:0:20:c0802223a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -575,7 +583,9 @@
         "dhash:512:384:0:20:d0902223a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -597,7 +607,9 @@
         "dhash:512:384:0:20:c0902223a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -619,7 +631,9 @@
         "dhash:512:384:0:20:d0902223a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -641,7 +655,9 @@
         "dhash:512:384:0:20:d0902223a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -663,7 +679,9 @@
         "dhash:512:384:0:20:d0902223a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"
@@ -685,7 +703,9 @@
         "dhash:512:384:0:20:d0902223a3222421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": null,
       "created_at": "2026-07-20T00:00:00.000000",
       "plan_id": "plan_b3d73b8c"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Advanced_Personal_Scope_Provision_with_Copilot_License.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Advanced_Personal_Scope_Provision_with_Copilot_License.json
@@ -61,7 +61,9 @@
         "dhash:354:78:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c3776fa0",
       "created_at": "2025-12-30T07:17:04.627595",
       "plan_id": "plan_b654165d"
@@ -87,7 +89,9 @@
         "dhash:312:124:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_16066167",
       "created_at": "2025-12-30T07:17:04.646670",
       "plan_id": "plan_b654165d"
@@ -113,7 +117,9 @@
         "dhash:337:77:0:10:c0e08294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_831d26e6",
       "created_at": "2025-12-30T07:17:04.663515",
       "plan_id": "plan_b654165d"
@@ -139,7 +145,9 @@
         "dhash:295:76:0:10:c0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_76c42321",
       "created_at": "2025-12-30T07:17:04.685566",
       "plan_id": "plan_b654165d"
@@ -165,7 +173,9 @@
         "dhash:292:78:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_df1089f7",
       "created_at": "2025-12-30T07:17:04.702015",
       "plan_id": "plan_b654165d"
@@ -191,7 +201,9 @@
         "dhash:331:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f72dc410",
       "created_at": "2025-12-30T07:17:04.722190",
       "plan_id": "plan_b654165d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Manifest_File_Function_Env_Support.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Manifest_File_Function_Env_Support.json
@@ -83,7 +83,9 @@
         "dhash:354:88:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_da53fa4f",
       "created_at": "2026-01-13T07:41:29.060581",
       "plan_id": "plan_15c94e14"
@@ -114,7 +116,9 @@
         "dhash:372:83:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_87d4f789",
       "created_at": "2026-01-13T07:41:29.072879",
       "plan_id": "plan_15c94e14"
@@ -145,7 +149,9 @@
         "dhash:277:75:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e4ae3a07",
       "created_at": "2026-01-13T07:41:29.089075",
       "plan_id": "plan_15c94e14"
@@ -174,7 +180,9 @@
         "dhash:512:384:0:20:328c2a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f2c526b3",
       "created_at": "2026-01-13T07:41:29.107528",
       "plan_id": "plan_15c94e14"
@@ -203,7 +211,9 @@
         "dhash:512:384:0:20:e4c048672303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_51d06256",
       "created_at": "2026-01-13T07:41:29.127583",
       "plan_id": "plan_15c94e14"
@@ -232,7 +242,9 @@
         "dhash:512:384:0:20:cc8422232303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8bf0b504",
       "created_at": "2026-01-13T07:41:29.147252",
       "plan_id": "plan_15c94e14"
@@ -382,7 +394,9 @@
         "dhash:512:384:0:20:b28c2a23231a2c2c"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6610109a",
       "created_at": "2026-01-13T07:41:29.281412",
       "plan_id": "plan_15c94e14"
@@ -404,7 +418,9 @@
         "dhash:512:384:0:20:e48c3223231a2c2c"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1064fd11",
       "created_at": "2026-01-13T07:41:29.305761",
       "plan_id": "plan_15c94e14"
@@ -426,7 +442,9 @@
         "dhash:512:384:0:20:ec8c3223231a2c2c"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_430ef3f2",
       "created_at": "2026-01-13T07:41:29.325043",
       "plan_id": "plan_15c94e14"
@@ -448,7 +466,9 @@
         "dhash:512:384:0:20:b28c2a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0a9f3dfb",
       "created_at": "2026-01-13T07:41:29.341373",
       "plan_id": "plan_15c94e14"
@@ -470,7 +490,9 @@
         "dhash:512:384:0:20:c4942a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8dbee599",
       "created_at": "2026-01-13T07:41:29.356410",
       "plan_id": "plan_15c94e14"
@@ -492,7 +514,9 @@
         "dhash:512:384:0:20:c4942a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8b220be6",
       "created_at": "2026-01-13T07:41:29.374697",
       "plan_id": "plan_15c94e14"
@@ -540,7 +564,9 @@
         "dhash:512:384:0:20:b28c2a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0817d4d5",
       "created_at": "2026-01-13T07:41:29.408508",
       "plan_id": "plan_15c94e14"
@@ -562,7 +588,9 @@
         "dhash:512:384:0:20:e0a4322323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e2147fda",
       "created_at": "2026-01-13T07:41:29.424906",
       "plan_id": "plan_15c94e14"
@@ -584,7 +612,9 @@
         "dhash:512:384:0:20:e484222323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a4a0b56d",
       "created_at": "2026-01-13T07:41:29.437978",
       "plan_id": "plan_15c94e14"
@@ -630,7 +660,9 @@
         "dhash:24:57:0:10:328c2a2323032929"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_255598fd",
       "created_at": "2026-01-13T07:41:29.464075",
       "plan_id": "plan_15c94e14"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Manifest_File_Function_Manifest_Plugin_Support.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Manifest_File_Function_Manifest_Plugin_Support.json
@@ -84,7 +84,9 @@
         "dhash:354:88:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9e5fbb93",
       "created_at": "2026-03-05T05:32:20.937271",
       "plan_id": "plan_5b46db62"
@@ -353,7 +355,9 @@
         "dhash:277:75:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3e6eb2f2",
       "created_at": "2026-03-05T05:32:21.172836",
       "plan_id": "plan_5b46db62"
@@ -418,7 +422,9 @@
         "dhash:512:384:0:20:328c2a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fe8a4019",
       "created_at": "2026-03-05T05:32:21.234084",
       "plan_id": "plan_5b46db62"
@@ -447,7 +453,9 @@
         "dhash:512:384:0:20:e4c048672303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_849035f2",
       "created_at": "2026-03-05T05:32:21.252055",
       "plan_id": "plan_5b46db62"
@@ -476,7 +484,9 @@
         "dhash:512:384:0:20:cc8422232303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_851318b7",
       "created_at": "2026-03-05T05:32:21.276188",
       "plan_id": "plan_5b46db62"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Manifest_File_Function_Path_Support.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Manifest_File_Function_Path_Support.json
@@ -98,7 +98,9 @@
         "dhash:354:88:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_74a7b615",
       "created_at": "2026-01-13T05:43:04.334093",
       "plan_id": "plan_5dff80b2"
@@ -129,7 +131,9 @@
         "dhash:372:83:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_228287d5",
       "created_at": "2026-01-13T05:43:04.344141",
       "plan_id": "plan_5dff80b2"
@@ -160,7 +164,9 @@
         "dhash:277:75:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3895cf9c",
       "created_at": "2026-01-13T05:43:04.353737",
       "plan_id": "plan_5dff80b2"
@@ -189,7 +195,9 @@
         "dhash:512:384:0:20:328c2a2323032421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_41348483",
       "created_at": "2026-01-13T05:43:04.367312",
       "plan_id": "plan_5dff80b2"
@@ -218,7 +226,9 @@
         "dhash:512:384:0:20:e4c048672303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7cb3871c",
       "created_at": "2026-01-13T05:43:04.374379",
       "plan_id": "plan_5dff80b2"
@@ -247,7 +257,9 @@
         "dhash:512:384:0:20:cc8422232303a421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_010a4e75",
       "created_at": "2026-01-13T05:43:04.381409",
       "plan_id": "plan_5dff80b2"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_ApiKey_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_ApiKey_Auth_Configurations.json
@@ -104,7 +104,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0edd5748",
       "created_at": "2026-06-15T08:19:33.392966",
       "plan_id": "plan_29ee3046"
@@ -131,7 +133,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "precondition_wait_timeout: 60"
+        "precondition_wait_timeout: 60",
+        "precondition:old"
       ],
       "screenshot": "step_8e0df260",
       "created_at": "2026-06-15T08:19:33.415325",
@@ -158,7 +161,9 @@
         "dhash:797:49:0:10:e4b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_683d2410",
       "created_at": "2026-06-15T08:19:33.425347",
       "plan_id": "plan_29ee3046"
@@ -184,7 +189,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6eac184d",
       "created_at": "2026-06-15T08:19:33.433146",
       "plan_id": "plan_29ee3046"
@@ -206,7 +213,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c36ab723",
       "created_at": "2026-06-15T08:19:33.439146",
       "plan_id": "plan_29ee3046"
@@ -228,7 +237,9 @@
         "dhash:512:384:0:20:6820226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d6d3135c",
       "created_at": "2026-06-15T08:19:33.445883",
       "plan_id": "plan_29ee3046"
@@ -250,7 +261,9 @@
         "dhash:512:384:0:20:6820226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_650fc482",
       "created_at": "2026-06-15T08:19:33.453655",
       "plan_id": "plan_29ee3046"
@@ -272,7 +285,9 @@
         "dhash:512:384:0:20:4020226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_256e2d75",
       "created_at": "2026-06-15T08:19:33.462976",
       "plan_id": "plan_29ee3046"
@@ -294,7 +309,9 @@
         "dhash:512:384:0:20:70242a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_63ba6d34",
       "created_at": "2026-06-15T08:19:33.477573",
       "plan_id": "plan_29ee3046"
@@ -316,7 +333,9 @@
         "dhash:512:384:0:20:70242a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7c7d7e09",
       "created_at": "2026-06-15T08:19:33.485218",
       "plan_id": "plan_29ee3046"
@@ -342,7 +361,9 @@
         "dhash:254:49:0:10:c8c4226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8a37563e",
       "created_at": "2026-06-15T08:19:33.493979",
       "plan_id": "plan_29ee3046"
@@ -652,7 +673,9 @@
         "dhash:512:384:0:20:d0842a632303242d"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7e2789f3",
       "created_at": "2026-06-15T08:19:33.605498",
       "plan_id": "plan_29ee3046"
@@ -675,7 +698,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay: 3"
+        "delay: 3",
+        "precondition:old"
       ],
       "screenshot": "step_c7aa426c",
       "created_at": "2026-06-15T08:19:33.614637",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_Bearer_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_Bearer_Auth_Configurations.json
@@ -172,7 +172,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bad0fcdc",
       "created_at": "2026-06-15T08:13:01.031369",
       "plan_id": "plan_d53c2442"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_Microsoft_Entra_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_Microsoft_Entra_Auth_Configurations.json
@@ -92,7 +92,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8b7b5d60",
       "created_at": "2026-06-15T08:09:06.990665",
       "plan_id": "plan_4cc87bed"
@@ -119,7 +121,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "precondition_wait_timeout: 60"
+        "precondition_wait_timeout: 60",
+        "precondition:old"
       ],
       "screenshot": "step_3d71b8fd",
       "created_at": "2026-06-15T08:09:07.002395",
@@ -146,7 +149,9 @@
         "dhash:797:49:0:10:e4b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_439c5d5c",
       "created_at": "2026-06-15T08:09:07.014736",
       "plan_id": "plan_4cc87bed"
@@ -172,7 +177,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9df46dd6",
       "created_at": "2026-06-15T08:09:07.024893",
       "plan_id": "plan_4cc87bed"
@@ -194,7 +201,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cb307ac6",
       "created_at": "2026-06-15T08:09:07.036810",
       "plan_id": "plan_4cc87bed"
@@ -216,7 +225,9 @@
         "dhash:512:384:0:20:6820226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_01c087ca",
       "created_at": "2026-06-15T08:09:07.045880",
       "plan_id": "plan_4cc87bed"
@@ -238,7 +249,9 @@
         "dhash:512:384:0:20:6820226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c053ca70",
       "created_at": "2026-06-15T08:09:07.059315",
       "plan_id": "plan_4cc87bed"
@@ -260,7 +273,9 @@
         "dhash:512:384:0:20:4020226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_62373d69",
       "created_at": "2026-06-15T08:09:07.069636",
       "plan_id": "plan_4cc87bed"
@@ -448,7 +463,8 @@
       "postconditions": [],
       "tags": [
         "delay:10",
-        "force_run:true"
+        "force_run:true",
+        "precondition:old"
       ],
       "screenshot": "step_e8f5eac9",
       "created_at": "2026-06-15T08:09:07.156646",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_OAuth_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_OAuth_Auth_Configurations.json
@@ -103,7 +103,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0bdd2503",
       "created_at": "2026-06-15T07:53:52.084299",
       "plan_id": "plan_e768afbb"
@@ -130,7 +132,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "precondition_wait_timeout: 60"
+        "precondition_wait_timeout: 60",
+        "precondition:old"
       ],
       "screenshot": "step_a0dc0b2a",
       "created_at": "2026-06-15T07:53:52.095013",
@@ -157,7 +160,9 @@
         "dhash:797:49:0:10:e4b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b566a4a3",
       "created_at": "2026-06-15T07:53:52.104195",
       "plan_id": "plan_e768afbb"
@@ -183,7 +188,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e50897d4",
       "created_at": "2026-06-15T07:53:52.114513",
       "plan_id": "plan_e768afbb"
@@ -205,7 +212,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b4e8c6e7",
       "created_at": "2026-06-15T07:53:52.123678",
       "plan_id": "plan_e768afbb"
@@ -227,7 +236,9 @@
         "dhash:512:384:0:20:6820226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_85466476",
       "created_at": "2026-06-15T07:53:52.132950",
       "plan_id": "plan_e768afbb"
@@ -249,7 +260,9 @@
         "dhash:512:384:0:20:6820226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c04ae86e",
       "created_at": "2026-06-15T07:53:52.142881",
       "plan_id": "plan_e768afbb"
@@ -271,7 +284,9 @@
         "dhash:512:384:0:20:4020226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_441c5803",
       "created_at": "2026-06-15T07:53:52.152888",
       "plan_id": "plan_e768afbb"
@@ -669,7 +684,8 @@
       "postconditions": [],
       "tags": [
         "delay:10",
-        "force_run:true"
+        "force_run:true",
+        "precondition:old"
       ],
       "screenshot": "step_2f61a9a6",
       "created_at": "2026-06-15T07:53:52.303417",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_PKCE_OAuth_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_PKCE_OAuth_Auth_Configurations.json
@@ -101,7 +101,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_636dbdbf",
       "created_at": "2026-06-15T08:16:26.010302",
       "plan_id": "plan_f1b0cfbf"
@@ -128,7 +130,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "precondition_wait_timeout: 60"
+        "precondition_wait_timeout: 60",
+        "precondition:old"
       ],
       "screenshot": "step_1071bb7d",
       "created_at": "2026-06-15T08:16:26.020350",
@@ -155,7 +158,9 @@
         "dhash:797:49:0:10:e4b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3ea1fb5e",
       "created_at": "2026-06-15T08:16:26.037576",
       "plan_id": "plan_f1b0cfbf"
@@ -181,7 +186,9 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0ff70afb",
       "created_at": "2026-06-15T08:16:26.047087",
       "plan_id": "plan_f1b0cfbf"
@@ -203,7 +210,9 @@
         "dhash:512:384:0:20:322c2a6363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e45c2e3c",
       "created_at": "2026-06-15T08:16:26.058406",
       "plan_id": "plan_f1b0cfbf"
@@ -225,7 +234,9 @@
         "dhash:512:384:0:20:6820226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4f5c973e",
       "created_at": "2026-06-15T08:16:26.070453",
       "plan_id": "plan_f1b0cfbf"
@@ -247,7 +258,9 @@
         "dhash:512:384:0:20:6820226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_66e64f45",
       "created_at": "2026-06-15T08:16:26.080857",
       "plan_id": "plan_f1b0cfbf"
@@ -269,7 +282,9 @@
         "dhash:512:384:0:20:4020226363636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cc3e9499",
       "created_at": "2026-06-15T08:16:26.091288",
       "plan_id": "plan_f1b0cfbf"
@@ -611,7 +626,8 @@
       "postconditions": [],
       "tags": [
         "delay:10",
-        "force_run:true"
+        "force_run:true",
+        "precondition:old"
       ],
       "screenshot": "step_da80314a",
       "created_at": "2026-06-15T08:16:26.231100",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Del_Resource_Group_And_Reprovision_For_Bot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Del_Resource_Group_And_Reprovision_For_Bot.json
@@ -198,7 +198,9 @@
         "dhash:512:384:0:20:b2822323a8b82425"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8f713c9f",
       "created_at": "2026-03-27T06:54:58.953859",
       "plan_id": "plan_0fbdd53e"
@@ -220,7 +222,9 @@
         "dhash:512:384:0:20:cc932323a8b82425"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_681148ae",
       "created_at": "2026-03-27T06:54:58.960813",
       "plan_id": "plan_0fbdd53e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Del_Resource_Group_And_Reprovision_For_Tab.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Del_Resource_Group_And_Reprovision_For_Tab.json
@@ -62,7 +62,9 @@
         "dhash:474:210:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0f3abd6d",
       "created_at": "2026-03-16T08:20:40.570974",
       "plan_id": "plan_82a790fb"
@@ -88,7 +90,9 @@
         "dhash:328:76:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2c440fea",
       "created_at": "2026-03-16T08:20:40.592990",
       "plan_id": "plan_82a790fb"
@@ -114,7 +118,9 @@
         "dhash:368:75:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f27138f4",
       "created_at": "2026-03-16T08:20:40.614321",
       "plan_id": "plan_82a790fb"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Deploy_Triggered_Codelens_Support.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Deploy_Triggered_Codelens_Support.json
@@ -57,7 +57,9 @@
         "dhash:474:210:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b1c7bf35",
       "created_at": "2026-02-02T09:22:29.483246",
       "plan_id": "plan_724df082"
@@ -83,7 +85,9 @@
         "dhash:328:76:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0be4ea59",
       "created_at": "2026-02-02T09:22:29.503466",
       "plan_id": "plan_724df082"
@@ -109,7 +113,9 @@
         "dhash:473:77:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_dafef1b7",
       "created_at": "2026-02-02T09:22:29.526472",
       "plan_id": "plan_724df082"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Deploy_Without_Provision.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Deploy_Without_Provision.json
@@ -56,7 +56,9 @@
         "dhash:474:210:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ee8b1ebf",
       "created_at": "2026-01-27T10:11:02.093647",
       "plan_id": "plan_01e7d9b8"
@@ -82,7 +84,9 @@
         "dhash:328:76:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_dd7c62bb",
       "created_at": "2026-01-27T10:11:02.112977",
       "plan_id": "plan_01e7d9b8"
@@ -108,7 +112,9 @@
         "dhash:473:77:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a1dfbb73",
       "created_at": "2026-01-27T10:11:02.134104",
       "plan_id": "plan_01e7d9b8"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Message_Extension_With_Action_Command_ts_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Message_Extension_With_Action_Command_ts_Playground_Debug.json
@@ -96,7 +96,9 @@
         "dhash:382:218:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_07d1cb49",
       "created_at": "2026-03-31T06:19:07.242253",
       "plan_id": "plan_0315cf6f"
@@ -122,7 +124,9 @@
         "dhash:332:133:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4c882a5b",
       "created_at": "2026-03-31T06:19:07.252571",
       "plan_id": "plan_0315cf6f"
@@ -148,7 +152,9 @@
         "dhash:391:69:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8a71edaf",
       "created_at": "2026-03-31T06:19:07.263869",
       "plan_id": "plan_0315cf6f"
@@ -174,7 +180,9 @@
         "dhash:394:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_aedfd4fb",
       "created_at": "2026-03-31T06:19:07.272894",
       "plan_id": "plan_0315cf6f"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Prompt_Use_Run_From_Package.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Prompt_Use_Run_From_Package.json
@@ -68,7 +68,9 @@
         "dhash:584:217:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_efd117c7",
       "created_at": "2026-05-20T00:27:25.400749",
       "plan_id": "plan_280b8261"
@@ -99,7 +101,9 @@
         "dhash:270:74:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ba190a7a",
       "created_at": "2026-05-20T00:27:25.411133",
       "plan_id": "plan_280b8261"
@@ -130,7 +134,9 @@
         "dhash:337:78:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_90d50ac0",
       "created_at": "2026-05-20T00:27:25.421129",
       "plan_id": "plan_280b8261"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Provision_Triggered_Codelens_Support.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Provision_Triggered_Codelens_Support.json
@@ -55,7 +55,9 @@
         "dhash:474:210:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bb1c7ec9",
       "created_at": "2026-01-29T08:07:47.698628",
       "plan_id": "plan_4cd86312"
@@ -81,7 +83,9 @@
         "dhash:328:76:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_de2da0aa",
       "created_at": "2026-01-29T08:07:47.715927",
       "plan_id": "plan_4cd86312"
@@ -107,7 +111,9 @@
         "dhash:473:77:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_58d711a6",
       "created_at": "2026-01-29T08:07:47.728969",
       "plan_id": "plan_4cd86312"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Provision_Without_Account.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Provision_Without_Account.json
@@ -67,7 +67,9 @@
         "dhash:474:210:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a60e64d9",
       "created_at": "2026-01-29T08:55:17.431100",
       "plan_id": "plan_9603bf77"
@@ -93,7 +95,9 @@
         "dhash:328:76:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4f022cc4",
       "created_at": "2026-01-29T08:55:17.451552",
       "plan_id": "plan_9603bf77"
@@ -119,7 +123,9 @@
         "dhash:473:77:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a8f39118",
       "created_at": "2026-01-29T08:55:17.468381",
       "plan_id": "plan_9603bf77"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Remove_App_From_Devportal_And_Reprovision.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Remove_App_From_Devportal_And_Reprovision.json
@@ -87,7 +87,9 @@
         "dhash:474:210:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7d3d5c74",
       "created_at": "2026-06-02T00:43:24.584107",
       "plan_id": "plan_66c34e56"
@@ -113,7 +115,9 @@
         "dhash:328:76:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6af98db9",
       "created_at": "2026-06-02T00:43:24.592205",
       "plan_id": "plan_66c34e56"
@@ -139,7 +143,9 @@
         "dhash:368:75:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_20908d70",
       "created_at": "2026-06-02T00:43:24.599310",
       "plan_id": "plan_66c34e56"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Report_Issue.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Report_Issue.json
@@ -127,7 +127,9 @@
         "dhash:288:101:0:10:d0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_287f0fcb",
       "created_at": "2026-05-21T02:04:47.520832",
       "plan_id": "plan_9edb8886"
@@ -153,7 +155,9 @@
         "dhash:405:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bee3d63e",
       "created_at": "2026-05-21T02:04:47.531415",
       "plan_id": "plan_9edb8886"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Set_Sub_Id_And_Rg_Name.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Set_Sub_Id_And_Rg_Name.json
@@ -61,7 +61,9 @@
         "dhash:474:210:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0dbd7edc",
       "created_at": "2026-03-04T05:47:13.708410",
       "plan_id": "plan_6aeb7198"
@@ -87,7 +89,9 @@
         "dhash:328:76:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6171ca5f",
       "created_at": "2026-03-04T05:47:13.717276",
       "plan_id": "plan_6aeb7198"
@@ -113,7 +117,9 @@
         "dhash:473:77:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_027eb0c7",
       "created_at": "2026-03-04T05:47:13.726793",
       "plan_id": "plan_6aeb7198"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Sign_In_No_Subscription.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Sign_In_No_Subscription.json
@@ -62,7 +62,9 @@
         "dhash:339:90:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_686b6e31",
       "created_at": "2026-05-21T05:23:56.341430",
       "plan_id": "plan_61065e46"
@@ -88,7 +90,9 @@
         "dhash:330:78:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b06e4c3d",
       "created_at": "2026-05-21T05:23:56.373875",
       "plan_id": "plan_61065e46"
@@ -114,7 +118,9 @@
         "dhash:352:74:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_142fccae",
       "created_at": "2026-05-21T05:23:56.393878",
       "plan_id": "plan_61065e46"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Sign_Out.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Sign_Out.json
@@ -103,7 +103,9 @@
         "dhash:330:78:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_89bba645",
       "created_at": "2026-03-09T05:43:06.819862",
       "plan_id": "plan_539bda4a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_Remote_Template_Verification.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_Remote_Template_Verification.json
@@ -127,7 +127,9 @@
         "dhash:381:74:0:10:d0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4dda74af",
       "created_at": "2026-05-25T10:06:39.848602",
       "plan_id": "plan_a94bb561"
@@ -153,7 +155,9 @@
         "dhash:405:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_25460bc8",
       "created_at": "2026-05-25T10:06:39.855674",
       "plan_id": "plan_a94bb561"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_With_Symbol_Link_Target_js_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_With_Symbol_Link_Target_js_playground.json
@@ -67,7 +67,9 @@
         "dhash:389:217:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d24e9414",
       "created_at": "2026-05-20T03:22:51.739090",
       "plan_id": "plan_35f71b94"
@@ -93,7 +95,9 @@
         "dhash:296:174:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_27b83f03",
       "created_at": "2026-05-20T03:22:51.750091",
       "plan_id": "plan_35f71b94"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Validate_Plugin_Manifest.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Validate_Plugin_Manifest.json
@@ -65,7 +65,9 @@
         "dhash:360:84:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a7059643",
       "created_at": "2026-05-11T03:42:03.017064",
       "plan_id": "plan_82fa8c95"
@@ -96,7 +98,9 @@
         "dhash:355:138:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_966d351e",
       "created_at": "2026-05-11T03:42:03.025531",
       "plan_id": "plan_82fa8c95"
@@ -127,7 +131,9 @@
         "dhash:353:82:0:10:c0e08294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5366630a",
       "created_at": "2026-05-11T03:42:03.034960",
       "plan_id": "plan_82fa8c95"
@@ -158,7 +164,9 @@
         "dhash:275:80:0:10:c0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6a6c4999",
       "created_at": "2026-05-11T03:42:03.044490",
       "plan_id": "plan_82fa8c95"
@@ -189,7 +197,9 @@
         "dhash:281:103:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2c6c21cc",
       "created_at": "2026-05-11T03:42:03.053714",
       "plan_id": "plan_82fa8c95"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Validate_copilot_manifest.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Validate_copilot_manifest.json
@@ -110,7 +110,9 @@
         "dhash:294:79:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8daf9a98",
       "created_at": "2026-05-27T01:51:31.414070",
       "plan_id": "plan_308544cb"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature__Debug_All_Telemetry_Check_And_Terminated_Previous_Tasks.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature__Debug_All_Telemetry_Check_And_Terminated_Previous_Tasks.json
@@ -781,7 +781,9 @@
         "dhash:512:384:0:20:b271716375696028"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5f83ea73",
       "created_at": "2025-11-15T16:25:47.131720",
       "plan_id": "plan_r_1016_081758"
@@ -810,7 +812,9 @@
         "dhash:512:384:0:20:b971757471e36020"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_644a5f3c",
       "created_at": "2025-11-15T16:25:47.148353",
       "plan_id": "plan_r_1016_081758"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_Copilot_Local_Debug.json
@@ -82,7 +82,9 @@
         "dhash:308:98:0:10:d0989094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a47811bd",
       "created_at": "2025-11-27T06:13:16.953624",
       "plan_id": "plan_5ee748e8"
@@ -108,7 +110,9 @@
         "dhash:436:77:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ed337f6f",
       "created_at": "2025-11-27T06:13:16.972705",
       "plan_id": "plan_5ee748e8"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_js_Copilot_Remote_Debug.json
@@ -84,7 +84,9 @@
         "dhash:303:98:0:10:d0989094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7e94a24a",
       "created_at": "2025-11-28T02:17:48.689929",
       "plan_id": "plan_ea2d8716"
@@ -110,7 +112,9 @@
         "dhash:433:75:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ece3c9a1",
       "created_at": "2025-11-28T02:17:48.721064",
       "plan_id": "plan_ea2d8716"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_Copilot_Local_Debug.json
@@ -84,7 +84,9 @@
         "dhash:341:120:0:10:d09c9094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c923ccdb",
       "created_at": "2025-11-27T08:07:35.354930",
       "plan_id": "plan_cc13dbcf"
@@ -110,7 +112,9 @@
         "dhash:436:77:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cadca5fb",
       "created_at": "2025-11-27T08:07:35.373795",
       "plan_id": "plan_cc13dbcf"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_Azure_OpenAI_py_playground.json
@@ -81,7 +81,9 @@
         "dhash:264:119:0:10:d0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_50f024fe",
       "created_at": "2026-01-27T01:54:07.548930",
       "plan_id": "plan_7fb5e663"
@@ -107,7 +109,9 @@
         "dhash:436:77:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4fcadec9",
       "created_at": "2026-01-27T01:54:07.572441",
       "plan_id": "plan_7fb5e663"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_js_Local_Debug.json
@@ -81,7 +81,9 @@
         "dhash:308:98:0:10:d0989094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f669943b",
       "created_at": "2026-02-24T08:22:47.249052",
       "plan_id": "plan_2545a770"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_py_Remote_Debug.json
@@ -85,7 +85,9 @@
         "dhash:333:122:0:10:d09c9094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_41590ae5",
       "created_at": "2026-02-24T15:37:43.578743",
       "plan_id": "plan_8c8b15c8"
@@ -111,7 +113,9 @@
         "dhash:433:75:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3cc188a4",
       "created_at": "2026-02-24T15:37:43.585181",
       "plan_id": "plan_8c8b15c8"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_ts_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:413:84:0:10:c0c89294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0d014451",
       "created_at": "2025-11-26T02:07:10.594441",
       "plan_id": "plan_e92d6998"
@@ -81,7 +83,9 @@
         "dhash:318:77:0:10:d0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a9109f46",
       "created_at": "2025-11-26T02:07:10.610457",
       "plan_id": "plan_e92d6998"
@@ -107,7 +111,9 @@
         "dhash:436:77:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_80897ea6",
       "created_at": "2025-11-26T02:07:10.628191",
       "plan_id": "plan_e92d6998"

--- a/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/General_Teams_Agent_OpenAI_ts_Remote_Debug.json
@@ -58,7 +58,9 @@
         "dhash:342:83:0:10:c0c89294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1f520370",
       "created_at": "2025-11-26T02:07:28.150557",
       "plan_id": "plan_03bc47c5"
@@ -84,7 +86,9 @@
         "dhash:312:76:0:10:d0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2a07b363",
       "created_at": "2025-11-26T02:07:28.167093",
       "plan_id": "plan_03bc47c5"
@@ -110,7 +114,9 @@
         "dhash:433:75:0:10:f0b0949492b17071"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bf066c17",
       "created_at": "2025-11-26T02:07:28.187341",
       "plan_id": "plan_03bc47c5"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_ts_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Message_Extension_ts_Playground_Debug.json
@@ -54,7 +54,9 @@
         "dhash:382:218:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3c04595d",
       "created_at": "2025-12-17T09:52:18.020295",
       "plan_id": "plan_7c9ad3b3"
@@ -80,7 +82,9 @@
         "dhash:332:133:0:10:d0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bda81ecc",
       "created_at": "2025-12-17T09:52:18.037448",
       "plan_id": "plan_7c9ad3b3"
@@ -106,7 +110,9 @@
         "dhash:391:69:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_18d13a9a",
       "created_at": "2025-12-17T09:52:18.055304",
       "plan_id": "plan_7c9ad3b3"
@@ -132,7 +138,9 @@
         "dhash:394:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f7a87461",
       "created_at": "2025-12-17T09:52:18.072231",
       "plan_id": "plan_7c9ad3b3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_CoffeeAgent_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_CoffeeAgent_Remote.json
@@ -52,7 +52,9 @@
         "dhash:512:384:0:20:64a4b4b476764165"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9aa652cf",
       "created_at": "2026-05-09T08:15:49.943345",
       "plan_id": "plan_e2fdef47"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Remote_Debug.json
@@ -115,7 +115,9 @@
         "dhash:512:384:0:20:60a4a4b476766449"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c915911f",
       "created_at": "2026-05-14T02:10:08.160889",
       "plan_id": "plan_d5c6d79c"
@@ -477,7 +479,9 @@
         "dhash:1013:733:0:10:18b0b28cacce1b23"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d58e1920",
       "created_at": "2026-05-14T02:10:08.273670",
       "plan_id": "plan_d5c6d79c"
@@ -503,7 +507,9 @@
         "dhash:226:531:0:10:18b0352f3e6a2a0c"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_52da0a4c",
       "created_at": "2026-05-14T02:10:08.281547",
       "plan_id": "plan_d5c6d79c"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Da_Ristorante_Api_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Da_Ristorante_Api_Remote_Debug.json
@@ -248,7 +248,9 @@
         "dhash:361:354:0:10:0b28d0d9e7e6dae4"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9d01e727",
       "created_at": "2026-05-13T07:47:18.052352",
       "plan_id": "plan_cbfdb837"
@@ -298,7 +300,8 @@
       "postconditions": [],
       "tags": [
         "delay:30",
-        "force_run:true"
+        "force_run:true",
+        "precondition:old"
       ],
       "screenshot": "step_14ed8d85",
       "created_at": "2026-05-13T07:47:18.063355",
@@ -351,7 +354,8 @@
       "postconditions": [],
       "tags": [
         "delay: 30",
-        "ocr:true"
+        "ocr:true",
+        "precondition:old"
       ],
       "screenshot": "step_8af6f541",
       "created_at": "2026-05-13T07:47:18.069713",
@@ -374,7 +378,9 @@
         "dhash:512:384:0:20:34b8e6e6f8c2e2e4"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_74a001d3",
       "created_at": "2026-05-13T07:47:18.075131",
       "plan_id": "plan_cbfdb837"
@@ -396,7 +402,9 @@
         "dhash:512:384:0:20:34b8e6e6f8c2e2e4"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_88524055",
       "created_at": "2026-05-13T07:47:18.081129",
       "plan_id": "plan_cbfdb837"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Dice_Roller_in_meeting_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Dice_Roller_in_meeting_Local_Debug.json
@@ -554,7 +554,9 @@
         "dhash:512:384:0:20:b2842a23a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3989fd26",
       "created_at": "2026-06-16T05:32:19.483200",
       "plan_id": "plan_3f90cfaf"
@@ -673,7 +675,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "precondition_wait_timeout:120"
+        "precondition_wait_timeout:120",
+        "precondition:old"
       ],
       "screenshot": "step_7d5b2d76",
       "created_at": "2026-06-16T05:32:19.785285",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Dice_Roller_in_meeting_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Dice_Roller_in_meeting_Remote_Debug.json
@@ -227,7 +227,9 @@
         "dhash:512:384:0:20:b2842a23a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5bee74b6",
       "created_at": "2026-06-16T03:50:55.566300",
       "plan_id": "plan_c362f90e"
@@ -346,7 +348,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "precondition_wait_timeout:120"
+        "precondition_wait_timeout:120",
+        "precondition:old"
       ],
       "screenshot": "step_55d6f6b1",
       "created_at": "2026-06-16T03:50:55.613823",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Graph_RSC_Helper_Debug_in_Group_Chat.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Graph_RSC_Helper_Debug_in_Group_Chat.json
@@ -120,7 +120,9 @@
         "dhash:512:384:0:20:60a0b4b466c96061"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bb2ee6c6",
       "created_at": "2026-05-09T07:55:01.494343",
       "plan_id": "plan_c466ba4f"
@@ -160,7 +162,9 @@
         "dhash:512:384:0:20:32242aa323636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_defecf02",
       "created_at": "2026-05-09T07:55:01.511361",
       "plan_id": "plan_c466ba4f"
@@ -182,7 +186,9 @@
         "dhash:512:384:0:20:64404ca723e36421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_170e08bc",
       "created_at": "2026-05-09T07:55:01.517575",
       "plan_id": "plan_c466ba4f"
@@ -204,7 +210,9 @@
         "dhash:512:384:0:20:e46432a323636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2f2f1a98",
       "created_at": "2026-05-09T07:55:01.533201",
       "plan_id": "plan_c466ba4f"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Graph_RSC_Helper_Debug_in_Team_Channel.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Graph_RSC_Helper_Debug_in_Team_Channel.json
@@ -118,7 +118,9 @@
         "dhash:512:384:0:20:60a0b4b466c96061"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d39a8d6e",
       "created_at": "2026-05-09T07:59:23.823645",
       "plan_id": "plan_dfa4f8f0"
@@ -158,7 +160,9 @@
         "dhash:512:384:0:20:32242aa323636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2558ffb1",
       "created_at": "2026-05-09T07:59:23.835520",
       "plan_id": "plan_dfa4f8f0"
@@ -180,7 +184,9 @@
         "dhash:512:384:0:20:64404ca723e36421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_13e9fe82",
       "created_at": "2026-05-09T07:59:23.841696",
       "plan_id": "plan_dfa4f8f0"
@@ -202,7 +208,9 @@
         "dhash:512:384:0:20:e46432a323636421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_340182c1",
       "created_at": "2026-05-09T07:59:23.846597",
       "plan_id": "plan_dfa4f8f0"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Incoming_Webhook_Notification_Happy_Path.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Incoming_Webhook_Notification_Happy_Path.json
@@ -49,7 +49,9 @@
         "dhash:512:384:0:20:64a4a4b47c7c747c"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_54382195",
       "created_at": "2026-05-12T08:36:39.667330",
       "plan_id": "plan_728a9c98"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_One_Productivity_Hub_using_Toolkit_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_One_Productivity_Hub_using_Toolkit_Local_Debug.json
@@ -273,7 +273,9 @@
         "dhash:512:384:0:20:65008c0d15848084"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_eaef0d37",
       "created_at": "2026-05-09T08:01:22.020365",
       "plan_id": "plan_e40bffed"
@@ -295,7 +297,9 @@
         "dhash:512:384:0:20:74394c0d15848084"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9918dc90",
       "created_at": "2026-05-09T08:01:22.026336",
       "plan_id": "plan_e40bffed"
@@ -321,7 +325,9 @@
         "dhash:256:511:0:10:6010282e32238082"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6fb26876",
       "created_at": "2026-05-09T08:01:22.031814",
       "plan_id": "plan_e40bffed"
@@ -347,7 +353,9 @@
         "dhash:297:665:0:10:6010282e32233e70"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4e80f0dc",
       "created_at": "2026-05-09T08:01:22.036096",
       "plan_id": "plan_e40bffed"
@@ -399,7 +407,9 @@
         "dhash:997:198:0:10:18b836412c4c5040"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2dd773de",
       "created_at": "2026-05-09T08:01:22.044055",
       "plan_id": "plan_e40bffed"
@@ -425,7 +435,9 @@
         "dhash:961:238:0:10:18b833432c4c5040"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_18bbe487",
       "created_at": "2026-05-09T08:01:22.048978",
       "plan_id": "plan_e40bffed"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_One_Productivity_Hub_using_Toolkit_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_One_Productivity_Hub_using_Toolkit_Remote_Debug.json
@@ -60,7 +60,9 @@
         "dhash:512:384:0:20:64a4b4b474747474"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8ad1b9fb",
       "created_at": "2026-05-09T08:04:43.532542",
       "plan_id": "plan_9fc4788a"
@@ -108,7 +110,9 @@
         "dhash:512:384:0:20:60a0b4b466c96061"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5a656459",
       "created_at": "2026-05-09T08:04:43.546607",
       "plan_id": "plan_9fc4788a"
@@ -172,7 +176,9 @@
         "dhash:390:55:0:10:222232b276707231"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0541566d",
       "created_at": "2026-05-09T08:04:43.566195",
       "plan_id": "plan_9fc4788a"
@@ -198,7 +204,9 @@
         "dhash:432:84:0:10:2220662632727233"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_24cf71b8",
       "created_at": "2026-05-09T08:04:43.572259",
       "plan_id": "plan_9fc4788a"
@@ -319,7 +327,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay:3"
+        "delay:3",
+        "precondition:old"
       ],
       "screenshot": "step_ca28015e",
       "created_at": "2026-05-09T08:04:43.607120",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_SSO_Enabled_Tab_via_APIM_Proxy_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_SSO_Enabled_Tab_via_APIM_Proxy_Local_Debug.json
@@ -137,7 +137,9 @@
         "dhash:553:204:0:10:b2846a23a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0cee2a14",
       "created_at": "2026-06-12T05:58:58.112106",
       "plan_id": "plan_142a4eb5"
@@ -159,7 +161,9 @@
         "dhash:512:384:0:20:b2842a23a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0a54e8b9",
       "created_at": "2026-06-12T05:58:58.120200",
       "plan_id": "plan_142a4eb5"
@@ -181,7 +185,9 @@
         "dhash:512:384:0:20:e4c43223a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_aef6faa3",
       "created_at": "2026-06-12T05:58:58.127198",
       "plan_id": "plan_142a4eb5"
@@ -207,7 +213,9 @@
         "dhash:537:27:0:10:e4843223a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_074521fc",
       "created_at": "2026-06-12T05:58:58.133797",
       "plan_id": "plan_142a4eb5"
@@ -229,7 +237,9 @@
         "dhash:512:384:0:20:e4843223a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_80263308",
       "created_at": "2026-06-12T05:58:58.139837",
       "plan_id": "plan_142a4eb5"
@@ -251,7 +261,9 @@
         "dhash:512:384:0:20:cc842223a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_df507cf7",
       "created_at": "2026-06-12T05:58:58.145806",
       "plan_id": "plan_142a4eb5"
@@ -273,7 +285,9 @@
         "dhash:512:384:0:20:cc842223a3232421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6fe92028",
       "created_at": "2026-06-12T05:58:58.151796",
       "plan_id": "plan_142a4eb5"
@@ -296,7 +310,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay: 30"
+        "delay: 30",
+        "precondition:old"
       ],
       "screenshot": "step_149b1f7b",
       "created_at": "2026-06-12T05:58:58.157811",
@@ -320,7 +335,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay: 3"
+        "delay: 3",
+        "precondition:old"
       ],
       "screenshot": "step_d0a4c35b",
       "created_at": "2026-06-12T05:58:58.164103",
@@ -344,7 +360,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay: 3"
+        "delay: 3",
+        "precondition:old"
       ],
       "screenshot": "step_3fef2a75",
       "created_at": "2026-06-12T05:58:58.169097",
@@ -447,7 +464,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay: 3"
+        "delay: 3",
+        "precondition:old"
       ],
       "screenshot": "step_4bb0ab3b",
       "created_at": "2026-06-12T05:58:58.195622",
@@ -520,7 +538,9 @@
         "dhash:305:216:0:10:20b4b0d8fcfce0d8"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a53794bb",
       "created_at": "2026-06-12T05:58:58.214786",
       "plan_id": "plan_142a4eb5"
@@ -662,7 +682,9 @@
         "dhash:512:384:0:20:74394c0d15848084"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_51cfc757",
       "created_at": "2026-06-12T05:58:58.249035",
       "plan_id": "plan_142a4eb5"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Stocks_Update_Notification_Bot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Stocks_Update_Notification_Bot_Remote_Debug.json
@@ -174,7 +174,9 @@
         "dhash:366:58:0:10:22302538b0767430"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e647ee85",
       "created_at": "2026-05-09T08:10:19.782030",
       "plan_id": "plan_fb683cb4"
@@ -201,7 +203,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "force_run:true"
+        "force_run:true",
+        "precondition:old"
       ],
       "screenshot": "step_24ac4625",
       "created_at": "2026-05-09T08:10:19.788827",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Tab_And_Outlook_Addin_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Tab_And_Outlook_Addin_Local_Debug.json
@@ -111,7 +111,9 @@
         "dhash:299:20:0:10:38b832412c4c5040"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_47a59358",
       "created_at": "2026-05-09T09:04:57.836811",
       "plan_id": "plan_d4b2213d"
@@ -133,7 +135,9 @@
         "dhash:512:384:0:20:65008c0d15848084"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b0ab4f23",
       "created_at": "2026-05-09T09:04:57.841800",
       "plan_id": "plan_d4b2213d"
@@ -155,7 +159,9 @@
         "dhash:512:384:0:20:74394c0d15848084"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_42a1ca09",
       "created_at": "2026-05-09T09:04:57.846306",
       "plan_id": "plan_d4b2213d"
@@ -181,7 +187,9 @@
         "dhash:245:510:0:10:6010282e32238082"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e9f55f27",
       "created_at": "2026-05-09T09:04:57.855324",
       "plan_id": "plan_d4b2213d"
@@ -207,7 +215,9 @@
         "dhash:334:669:0:10:6010282e32233e70"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a3cf09e7",
       "created_at": "2026-05-09T09:04:57.860910",
       "plan_id": "plan_d4b2213d"
@@ -233,7 +243,9 @@
         "dhash:500:18:0:10:749a4ccc162b3733"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c8e6ca98",
       "created_at": "2026-05-09T09:04:57.866046",
       "plan_id": "plan_d4b2213d"
@@ -259,7 +271,9 @@
         "dhash:994:202:0:10:18b832412c4c5040"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b6a364aa",
       "created_at": "2026-05-09T09:04:57.870027",
       "plan_id": "plan_d4b2213d"
@@ -285,7 +299,9 @@
         "dhash:984:236:0:10:18b833432c4c5040"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c0d4388c",
       "created_at": "2026-05-09T09:04:57.874027",
       "plan_id": "plan_d4b2213d"
@@ -311,7 +327,9 @@
         "dhash:388:246:0:10:20e0908080808080"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_880f5f2f",
       "created_at": "2026-05-09T09:04:57.878027",
       "plan_id": "plan_d4b2213d"
@@ -337,7 +355,9 @@
         "dhash:697:326:0:10:10b0b28caccf3133"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_31dd046a",
       "created_at": "2026-05-09T09:04:57.882239",
       "plan_id": "plan_d4b2213d"
@@ -359,7 +379,9 @@
         "dhash:512:384:0:20:10b0b28caccf3133"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3579305f",
       "created_at": "2026-05-09T09:04:57.888260",
       "plan_id": "plan_d4b2213d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Tab_And_Outlook_Addin_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Tab_And_Outlook_Addin_Remote_Debug.json
@@ -294,7 +294,9 @@
         "dhash:338:364:0:10:10b8ba8caccf3137"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e06051fb",
       "created_at": "2026-05-09T09:07:43.909139",
       "plan_id": "plan_5b8ed3e7"
@@ -316,7 +318,9 @@
         "dhash:512:384:0:20:10b8ba8caccf3137"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_83f141d5",
       "created_at": "2026-05-09T09:07:43.915121",
       "plan_id": "plan_5b8ed3e7"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_js_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_js_playground.json
@@ -109,7 +109,9 @@
         "dhash:288:101:0:10:d0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_da46fc97",
       "created_at": "2026-06-24T02:35:29.474329",
       "plan_id": "plan_5d7a20d4"
@@ -135,7 +137,9 @@
         "dhash:405:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3f04f850",
       "created_at": "2026-06-24T02:35:29.478805",
       "plan_id": "plan_5d7a20d4"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_ts_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Simple_Bot_ts_playground.json
@@ -109,7 +109,9 @@
         "dhash:381:74:0:10:d0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0ac88b10",
       "created_at": "2026-01-29T05:35:36.731450",
       "plan_id": "plan_82273f1e"
@@ -135,7 +137,9 @@
         "dhash:405:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2e0c64ee",
       "created_at": "2026-01-29T05:35:36.746659",
       "plan_id": "plan_82273f1e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Local_Debug.json
@@ -57,7 +57,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c540d61e",
       "created_at": "2025-12-02T11:09:24.892146",
       "plan_id": "plan_60e462d3"
@@ -83,7 +85,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_348bd0f1",
       "created_at": "2025-12-02T11:09:24.907727",
       "plan_id": "plan_60e462d3"
@@ -135,7 +139,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1f840a49",
       "created_at": "2025-12-02T11:09:24.941282",
       "plan_id": "plan_60e462d3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Playground_Debug.json
@@ -56,7 +56,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b2f4123d",
       "created_at": "2025-12-18T09:55:56.108408",
       "plan_id": "plan_6a562e08"
@@ -82,7 +84,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_645a7309",
       "created_at": "2025-12-18T09:55:56.124029",
       "plan_id": "plan_6a562e08"
@@ -108,7 +112,9 @@
         "dhash:321:104:0:10:d0989094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9e950cf2",
       "created_at": "2025-12-18T09:55:56.137599",
       "plan_id": "plan_6a562e08"
@@ -134,7 +140,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_45e7ac51",
       "created_at": "2025-12-18T09:55:56.148569",
       "plan_id": "plan_6a562e08"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Remote_Debug.json
@@ -59,7 +59,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2e29dc19",
       "created_at": "2025-12-02T07:57:36.546867",
       "plan_id": "plan_b9fab3e1"
@@ -85,7 +87,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_49fff764",
       "created_at": "2025-12-02T07:57:36.562691",
       "plan_id": "plan_b9fab3e1"
@@ -137,7 +141,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4ddc33f9",
       "created_at": "2025-12-02T07:57:36.590279",
       "plan_id": "plan_b9fab3e1"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5a6a201a",
       "created_at": "2025-12-02T07:58:08.267010",
       "plan_id": "plan_46ed1075"
@@ -84,7 +86,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_dd12065a",
       "created_at": "2025-12-02T07:58:08.278315",
       "plan_id": "plan_46ed1075"
@@ -136,7 +140,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5885dcec",
       "created_at": "2025-12-02T07:58:08.310735",
       "plan_id": "plan_46ed1075"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Playground_Debug.json
@@ -57,7 +57,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7ae02caa",
       "created_at": "2025-12-18T09:43:44.849277",
       "plan_id": "plan_b003fd4d"
@@ -83,7 +85,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ec90c7a4",
       "created_at": "2025-12-18T09:43:44.865712",
       "plan_id": "plan_b003fd4d"
@@ -135,7 +139,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ba813bad",
       "created_at": "2025-12-18T09:43:44.893004",
       "plan_id": "plan_b003fd4d"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Remote_Debug.json
@@ -61,7 +61,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a5dbdf91",
       "created_at": "2026-02-12T06:24:49.736981",
       "plan_id": "plan_ec48f68b"
@@ -87,7 +89,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5871948d",
       "created_at": "2026-02-12T06:24:49.742602",
       "plan_id": "plan_ec48f68b"
@@ -113,7 +117,9 @@
         "dhash:388:120:0:10:d09c9094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3bc9b9a9",
       "created_at": "2026-02-12T06:24:49.748519",
       "plan_id": "plan_ec48f68b"
@@ -139,7 +145,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9f2a7020",
       "created_at": "2026-02-12T06:24:49.756824",
       "plan_id": "plan_ec48f68b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Playground_Debug.json
@@ -56,7 +56,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3fa5a188",
       "created_at": "2025-12-18T09:18:37.013211",
       "plan_id": "plan_b3f28e47"
@@ -82,7 +84,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_444ef0d8",
       "created_at": "2025-12-18T09:18:37.028197",
       "plan_id": "plan_b3f28e47"
@@ -134,7 +138,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_040e7563",
       "created_at": "2025-12-18T09:18:37.063750",
       "plan_id": "plan_b3f28e47"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Remote_Debug.json
@@ -111,7 +111,9 @@
         "dhash:369:72:0:10:d0949094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c9167ab0",
       "created_at": "2026-02-24T10:55:31.022114",
       "plan_id": "plan_656b5c31"
@@ -137,7 +139,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0040a3b6",
       "created_at": "2026-02-24T10:55:31.028280",
       "plan_id": "plan_656b5c31"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Remote_Debug.json
@@ -63,7 +63,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_872c7533",
       "created_at": "2025-12-16T07:54:06.595551",
       "plan_id": "plan_35215a46"
@@ -89,7 +91,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4404097f",
       "created_at": "2025-12-16T07:54:06.616281",
       "plan_id": "plan_35215a46"
@@ -115,7 +119,9 @@
         "dhash:321:104:0:10:d0989094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9fe151af",
       "created_at": "2025-12-16T07:54:06.635228",
       "plan_id": "plan_35215a46"
@@ -141,7 +147,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_dc74e025",
       "created_at": "2025-12-16T07:54:06.655103",
       "plan_id": "plan_35215a46"
@@ -167,7 +175,9 @@
         "dhash:294:722:0:10:30b0b08ead6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_435c03e0",
       "created_at": "2025-12-16T07:54:06.674783",
       "plan_id": "plan_35215a46"
@@ -189,7 +199,9 @@
         "dhash:512:384:0:20:30b0b08ead6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_36b6de23",
       "created_at": "2025-12-16T07:54:06.693112",
       "plan_id": "plan_35215a46"
@@ -211,7 +223,9 @@
         "dhash:512:384:0:20:30b0b08ead6988b1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_661d0d7b",
       "created_at": "2025-12-16T07:54:06.709198",
       "plan_id": "plan_35215a46"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bb6732f6",
       "created_at": "2025-12-15T05:51:44.561929",
       "plan_id": "plan_7bbcbd8a"
@@ -84,7 +86,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e044163b",
       "created_at": "2025-12-15T05:51:44.576806",
       "plan_id": "plan_7bbcbd8a"
@@ -136,7 +140,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c7fe7924",
       "created_at": "2025-12-15T05:51:44.603668",
       "plan_id": "plan_7bbcbd8a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Remote_Debug.json
@@ -63,7 +63,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_68492844",
       "created_at": "2025-12-17T01:14:47.486370",
       "plan_id": "plan_45c7b843"
@@ -89,7 +91,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ad5eb1e3",
       "created_at": "2025-12-17T01:14:47.499392",
       "plan_id": "plan_45c7b843"
@@ -167,7 +171,9 @@
         "dhash:294:722:0:10:30b0b08ead6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2a604c89",
       "created_at": "2025-12-17T01:14:47.540884",
       "plan_id": "plan_45c7b843"
@@ -189,7 +195,9 @@
         "dhash:512:384:0:20:30b0b08ead6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_39a54575",
       "created_at": "2025-12-17T01:14:47.555411",
       "plan_id": "plan_45c7b843"
@@ -211,7 +219,9 @@
         "dhash:512:384:0:20:30b0b08ead6988b1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_45d3e38b",
       "created_at": "2025-12-17T01:14:47.569871",
       "plan_id": "plan_45c7b843"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Local_Debug.json
@@ -60,7 +60,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4237ad21",
       "created_at": "2025-12-15T05:41:11.032353",
       "plan_id": "plan_3bd8afbd"
@@ -86,7 +88,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_031d0d3c",
       "created_at": "2025-12-15T05:41:11.050895",
       "plan_id": "plan_3bd8afbd"
@@ -138,7 +142,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a919201d",
       "created_at": "2025-12-15T05:41:11.080773",
       "plan_id": "plan_3bd8afbd"
@@ -164,7 +170,9 @@
         "dhash:294:722:0:10:30b0b08ead6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4b4c346a",
       "created_at": "2025-12-15T05:41:11.098160",
       "plan_id": "plan_3bd8afbd"
@@ -186,7 +194,9 @@
         "dhash:512:384:0:20:30b0b08ead6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8e080247",
       "created_at": "2025-12-15T05:41:11.108643",
       "plan_id": "plan_3bd8afbd"
@@ -208,7 +218,9 @@
         "dhash:512:384:0:20:30b0b08ead6988b1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b3c465ee",
       "created_at": "2025-12-15T05:41:11.130380",
       "plan_id": "plan_3bd8afbd"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Remote_Debug.json
@@ -63,7 +63,9 @@
         "dhash:410:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c28db5f0",
       "created_at": "2025-12-16T10:26:26.816064",
       "plan_id": "plan_f7818fc3"
@@ -89,7 +91,9 @@
         "dhash:420:130:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c8488766",
       "created_at": "2025-12-16T10:26:26.838145",
       "plan_id": "plan_f7818fc3"
@@ -141,7 +145,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7b504d2c",
       "created_at": "2025-12-16T10:26:26.876792",
       "plan_id": "plan_f7818fc3"
@@ -167,7 +173,9 @@
         "dhash:294:722:0:10:30b0b08ead6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8f16bd81",
       "created_at": "2025-12-16T10:26:26.894619",
       "plan_id": "plan_f7818fc3"
@@ -189,7 +197,9 @@
         "dhash:512:384:0:20:30b0b08ead6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7605e747",
       "created_at": "2025-12-16T10:26:26.912950",
       "plan_id": "plan_f7818fc3"
@@ -211,7 +221,9 @@
         "dhash:512:384:0:20:30b0b08ead6988b1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_65424edd",
       "created_at": "2025-12-16T10:26:26.925121",
       "plan_id": "plan_f7818fc3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Local_Debug.json
@@ -61,7 +61,9 @@
         "dhash:410:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_86dba6ed",
       "created_at": "2025-11-26T14:28:29.019632",
       "plan_id": "plan_b8dd182a"
@@ -87,7 +89,9 @@
         "dhash:405:170:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_04ee3a97",
       "created_at": "2025-11-26T14:28:29.035087",
       "plan_id": "plan_b8dd182a"
@@ -113,7 +117,9 @@
         "dhash:457:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_38acf8e7",
       "created_at": "2025-11-26T14:28:29.049989",
       "plan_id": "plan_b8dd182a"
@@ -135,7 +141,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_df2c661b",
       "created_at": "2025-11-26T14:28:29.065696",
       "plan_id": "plan_b8dd182a"
@@ -157,7 +165,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4c05eaca",
       "created_at": "2025-11-26T14:28:29.079609",
       "plan_id": "plan_b8dd182a"
@@ -183,7 +193,9 @@
         "dhash:225:49:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_696bc77e",
       "created_at": "2025-11-26T14:28:29.094494",
       "plan_id": "plan_b8dd182a"
@@ -209,7 +221,9 @@
         "dhash:795:46:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9d871fb7",
       "created_at": "2025-11-26T14:28:29.108698",
       "plan_id": "plan_b8dd182a"
@@ -261,7 +275,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_08859f31",
       "created_at": "2025-11-26T14:28:29.132383",
       "plan_id": "plan_b8dd182a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_PlayGround.json
@@ -60,7 +60,9 @@
         "dhash:410:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c4837869",
       "created_at": "2025-12-18T03:55:00.651231",
       "plan_id": "plan_43836b26"
@@ -86,7 +88,9 @@
         "dhash:405:170:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_60218d01",
       "created_at": "2025-12-18T03:55:00.658170",
       "plan_id": "plan_43836b26"
@@ -112,7 +116,9 @@
         "dhash:457:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_025a505e",
       "created_at": "2025-12-18T03:55:00.666374",
       "plan_id": "plan_43836b26"
@@ -134,7 +140,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a7c2bdb6",
       "created_at": "2025-12-18T03:55:00.674123",
       "plan_id": "plan_43836b26"
@@ -156,7 +164,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_20b2e9c9",
       "created_at": "2025-12-18T03:55:00.680249",
       "plan_id": "plan_43836b26"
@@ -182,7 +192,9 @@
         "dhash:225:49:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_816cc34c",
       "created_at": "2025-12-18T03:55:00.687872",
       "plan_id": "plan_43836b26"
@@ -208,7 +220,9 @@
         "dhash:795:46:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_aae779ef",
       "created_at": "2025-12-18T03:55:00.694062",
       "plan_id": "plan_43836b26"
@@ -234,7 +248,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c7d56405",
       "created_at": "2025-12-18T03:55:00.700731",
       "plan_id": "plan_43836b26"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Local_Debug.json
@@ -115,7 +115,9 @@
         "dhash:457:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a0443b85",
       "created_at": "2025-11-27T04:28:37.537423",
       "plan_id": "plan_8912358f"
@@ -137,7 +139,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b4037740",
       "created_at": "2025-11-27T04:28:37.559374",
       "plan_id": "plan_8912358f"
@@ -159,7 +163,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5b0e8cda",
       "created_at": "2025-11-27T04:28:37.586269",
       "plan_id": "plan_8912358f"
@@ -185,7 +191,9 @@
         "dhash:225:49:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_aad6dbbc",
       "created_at": "2025-11-27T04:28:37.600186",
       "plan_id": "plan_8912358f"
@@ -211,7 +219,9 @@
         "dhash:795:46:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a0cba418",
       "created_at": "2025-11-27T04:28:37.630383",
       "plan_id": "plan_8912358f"
@@ -263,7 +273,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9a8bb926",
       "created_at": "2025-11-27T04:28:37.676352",
       "plan_id": "plan_8912358f"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_PlayGround.json
@@ -61,7 +61,9 @@
         "dhash:410:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_04181793",
       "created_at": "2025-12-18T08:27:09.202716",
       "plan_id": "plan_fbbf2806"
@@ -87,7 +89,9 @@
         "dhash:405:170:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b265404d",
       "created_at": "2025-12-18T08:27:09.209427",
       "plan_id": "plan_fbbf2806"
@@ -113,7 +117,9 @@
         "dhash:457:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e58d8eaa",
       "created_at": "2025-12-18T08:27:09.215715",
       "plan_id": "plan_fbbf2806"
@@ -135,7 +141,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b5027988",
       "created_at": "2025-12-18T08:27:09.221432",
       "plan_id": "plan_fbbf2806"
@@ -157,7 +165,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ab02d281",
       "created_at": "2025-12-18T08:27:09.227207",
       "plan_id": "plan_fbbf2806"
@@ -183,7 +193,9 @@
         "dhash:225:49:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_671dae86",
       "created_at": "2025-12-18T08:27:09.234064",
       "plan_id": "plan_fbbf2806"
@@ -209,7 +221,9 @@
         "dhash:795:46:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d9709466",
       "created_at": "2025-12-18T08:27:09.241014",
       "plan_id": "plan_fbbf2806"
@@ -235,7 +249,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1255a3f4",
       "created_at": "2025-12-18T08:27:09.247024",
       "plan_id": "plan_fbbf2806"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Remote_Debug.json
@@ -292,7 +292,9 @@
         "dhash:314:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0b3c263a",
       "created_at": "2025-11-27T08:25:37.450033",
       "plan_id": "plan_9ed004c0"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_PlayGround.json
@@ -60,7 +60,9 @@
         "dhash:410:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7ed8e96f",
       "created_at": "2025-12-18T05:22:26.383202",
       "plan_id": "plan_2257b581"
@@ -86,7 +88,9 @@
         "dhash:405:170:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_810ecbf4",
       "created_at": "2025-12-18T05:22:26.389003",
       "plan_id": "plan_2257b581"
@@ -112,7 +116,9 @@
         "dhash:457:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b2ea21fa",
       "created_at": "2025-12-18T05:22:26.398616",
       "plan_id": "plan_2257b581"
@@ -134,7 +140,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fed9c2ee",
       "created_at": "2025-12-18T05:22:26.405839",
       "plan_id": "plan_2257b581"
@@ -156,7 +164,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_15e105f8",
       "created_at": "2025-12-18T05:22:26.414514",
       "plan_id": "plan_2257b581"
@@ -182,7 +192,9 @@
         "dhash:225:49:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4978f231",
       "created_at": "2025-12-18T05:22:26.422660",
       "plan_id": "plan_2257b581"
@@ -208,7 +220,9 @@
         "dhash:795:46:0:10:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5de7affa",
       "created_at": "2025-12-18T05:22:26.429750",
       "plan_id": "plan_2257b581"
@@ -234,7 +248,9 @@
         "dhash:311:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b9007367",
       "created_at": "2025-12-18T05:22:26.437018",
       "plan_id": "plan_2257b581"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Local_Debug.json
@@ -67,7 +67,9 @@
         "dhash:362:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6609ed2c",
       "created_at": "2025-12-01T07:30:52.990324",
       "plan_id": "plan_f422c281"
@@ -249,7 +251,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4a2ffa0d",
       "created_at": "2025-12-01T07:30:53.078560",
       "plan_id": "plan_f422c281"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Remote_Debug.json
@@ -70,7 +70,9 @@
         "dhash:362:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d2c5a068",
       "created_at": "2025-12-02T01:51:58.434921",
       "plan_id": "plan_4b408295"
@@ -92,7 +94,9 @@
         "dhash:512:384:0:20:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_784ceb63",
       "created_at": "2025-12-02T01:51:58.449673",
       "plan_id": "plan_4b408295"
@@ -114,7 +118,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0f14f2a5",
       "created_at": "2025-12-02T01:51:58.461943",
       "plan_id": "plan_4b408295"
@@ -136,7 +142,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_91b160da",
       "created_at": "2025-12-02T01:51:58.475545",
       "plan_id": "plan_4b408295"
@@ -158,7 +166,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9f2243cb",
       "created_at": "2025-12-02T01:51:58.488874",
       "plan_id": "plan_4b408295"
@@ -180,7 +190,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d00aa85f",
       "created_at": "2025-12-02T01:51:58.500482",
       "plan_id": "plan_4b408295"
@@ -207,7 +219,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay:3"
+        "delay:3",
+        "precondition:old"
       ],
       "screenshot": "step_a1b87616",
       "created_at": "2025-12-02T01:51:58.511863",
@@ -230,7 +243,9 @@
         "dhash:512:384:0:20:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_30b7eff5",
       "created_at": "2025-12-02T01:51:58.526978",
       "plan_id": "plan_4b408295"
@@ -252,7 +267,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fbc4479b",
       "created_at": "2025-12-02T01:51:58.538249",
       "plan_id": "plan_4b408295"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Local_Debug.json
@@ -69,7 +69,9 @@
         "dhash:362:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e59525a1",
       "created_at": "2025-12-01T09:32:51.532170",
       "plan_id": "plan_f40826db"
@@ -91,7 +93,9 @@
         "dhash:512:384:0:20:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_36c55354",
       "created_at": "2025-12-01T09:32:51.543561",
       "plan_id": "plan_f40826db"
@@ -113,7 +117,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e2176502",
       "created_at": "2025-12-01T09:32:51.558420",
       "plan_id": "plan_f40826db"
@@ -135,7 +141,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e72b1be2",
       "created_at": "2025-12-01T09:32:51.571570",
       "plan_id": "plan_f40826db"
@@ -157,7 +165,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_20d19a2f",
       "created_at": "2025-12-01T09:32:51.583892",
       "plan_id": "plan_f40826db"
@@ -179,7 +189,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f2a79fa3",
       "created_at": "2025-12-01T09:32:51.597217",
       "plan_id": "plan_f40826db"
@@ -206,7 +218,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay:3"
+        "delay:3",
+        "precondition:old"
       ],
       "screenshot": "step_84b46bb2",
       "created_at": "2025-12-01T09:32:51.609478",
@@ -229,7 +242,9 @@
         "dhash:512:384:0:20:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_aa975413",
       "created_at": "2025-12-01T09:32:51.624204",
       "plan_id": "plan_f40826db"
@@ -251,7 +266,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fb76332b",
       "created_at": "2025-12-01T09:32:51.635960",
       "plan_id": "plan_f40826db"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Local_Debug.json
@@ -67,7 +67,9 @@
         "dhash:362:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f960c894",
       "created_at": "2025-12-01T08:02:20.497296",
       "plan_id": "plan_86ac6a02"
@@ -89,7 +91,9 @@
         "dhash:512:384:0:20:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_71983625",
       "created_at": "2025-12-01T08:02:20.511381",
       "plan_id": "plan_86ac6a02"
@@ -111,7 +115,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c9310998",
       "created_at": "2025-12-01T08:02:20.528383",
       "plan_id": "plan_86ac6a02"
@@ -133,7 +139,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_57623fdb",
       "created_at": "2025-12-01T08:02:20.542738",
       "plan_id": "plan_86ac6a02"
@@ -155,7 +163,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2f3a62bd",
       "created_at": "2025-12-01T08:02:20.559465",
       "plan_id": "plan_86ac6a02"
@@ -177,7 +187,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9339c351",
       "created_at": "2025-12-01T08:02:20.576272",
       "plan_id": "plan_86ac6a02"
@@ -204,7 +216,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay:3"
+        "delay:3",
+        "precondition:old"
       ],
       "screenshot": "step_ea3ebcd9",
       "created_at": "2025-12-01T08:02:20.592459",
@@ -227,7 +240,9 @@
         "dhash:512:384:0:20:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e2568949",
       "created_at": "2025-12-01T08:02:20.608472",
       "plan_id": "plan_86ac6a02"
@@ -249,7 +264,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8d46eeb0",
       "created_at": "2025-12-01T08:02:20.622528",
       "plan_id": "plan_86ac6a02"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Remote_Debug.json
@@ -70,7 +70,9 @@
         "dhash:362:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f8d68c05",
       "created_at": "2025-12-02T02:27:32.922808",
       "plan_id": "plan_42cb7b61"
@@ -92,7 +94,9 @@
         "dhash:512:384:0:20:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e3049d8a",
       "created_at": "2025-12-02T02:27:32.932278",
       "plan_id": "plan_42cb7b61"
@@ -114,7 +118,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7ef6e51f",
       "created_at": "2025-12-02T02:27:32.941631",
       "plan_id": "plan_42cb7b61"
@@ -136,7 +142,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_646ad69a",
       "created_at": "2025-12-02T02:27:32.952343",
       "plan_id": "plan_42cb7b61"
@@ -158,7 +166,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e03a3fa1",
       "created_at": "2025-12-02T02:27:32.963437",
       "plan_id": "plan_42cb7b61"
@@ -180,7 +190,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2a5a45c0",
       "created_at": "2025-12-02T02:27:32.973738",
       "plan_id": "plan_42cb7b61"
@@ -207,7 +219,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay:3"
+        "delay:3",
+        "precondition:old"
       ],
       "screenshot": "step_c0c3b887",
       "created_at": "2025-12-02T02:27:32.983751",
@@ -230,7 +243,9 @@
         "dhash:512:384:0:20:e4989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_466cfbf0",
       "created_at": "2025-12-02T02:27:32.992593",
       "plan_id": "plan_42cb7b61"
@@ -252,7 +267,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_88e2a412",
       "created_at": "2025-12-02T02:27:33.000171",
       "plan_id": "plan_42cb7b61"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:512:384:0:20:f0c09294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7e21dd59",
       "created_at": "2025-12-01T08:04:07.378379",
       "plan_id": "plan_13b50d3c"
@@ -77,7 +79,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8bff723b",
       "created_at": "2025-12-01T08:04:07.391503",
       "plan_id": "plan_13b50d3c"
@@ -99,7 +103,9 @@
         "dhash:512:384:0:20:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_75270b1a",
       "created_at": "2025-12-01T08:04:07.409535",
       "plan_id": "plan_13b50d3c"
@@ -121,7 +127,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d2bbe311",
       "created_at": "2025-12-01T08:04:07.429532",
       "plan_id": "plan_13b50d3c"
@@ -143,7 +151,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_74c585ae",
       "created_at": "2025-12-01T08:04:07.453736",
       "plan_id": "plan_13b50d3c"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Playground_Debug.json
@@ -107,7 +107,9 @@
         "dhash:268:83:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0e429719",
       "created_at": "2025-12-18T02:34:55.533772",
       "plan_id": "plan_b654f73c"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:307:132:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4c2d549c",
       "created_at": "2025-12-02T07:18:21.120044",
       "plan_id": "plan_287cbe00"
@@ -84,7 +86,9 @@
         "dhash:288:87:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cb3da780",
       "created_at": "2025-12-02T07:18:21.130167",
       "plan_id": "plan_287cbe00"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Remote_Debug.json
@@ -66,7 +66,9 @@
         "dhash:385:128:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_87f335c2",
       "created_at": "2025-12-01T10:17:43.365583",
       "plan_id": "plan_b60e2d29"
@@ -88,7 +90,9 @@
         "dhash:512:384:0:20:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_39bd35c4",
       "created_at": "2025-12-01T10:17:43.385869",
       "plan_id": "plan_b60e2d29"
@@ -110,7 +114,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_919766c2",
       "created_at": "2025-12-01T10:17:43.403467",
       "plan_id": "plan_b60e2d29"
@@ -132,7 +138,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_24ef4872",
       "created_at": "2025-12-01T10:17:43.421727",
       "plan_id": "plan_b60e2d29"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Playground_Debug.json
@@ -56,7 +56,9 @@
         "dhash:304:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2fec54c6",
       "created_at": "2025-12-18T06:36:14.204575",
       "plan_id": "plan_0117a963"
@@ -82,7 +84,9 @@
         "dhash:289:81:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cb105d0a",
       "created_at": "2025-12-18T06:36:14.219662",
       "plan_id": "plan_0117a963"
@@ -108,7 +112,9 @@
         "dhash:268:83:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_815a1125",
       "created_at": "2025-12-18T06:36:14.230195",
       "plan_id": "plan_0117a963"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Remote_Debug.json
@@ -114,7 +114,9 @@
         "dhash:273:122:0:10:d09c9094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_cd0e731a",
       "created_at": "2026-03-17T01:47:12.461700",
       "plan_id": "plan_c24b1c2e"
@@ -166,7 +168,9 @@
         "dhash:318:705:0:10:30b0b08cad6988a1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0aecaf6f",
       "created_at": "2026-03-17T01:47:12.476770",
       "plan_id": "plan_c24b1c2e"
@@ -188,7 +192,9 @@
         "dhash:512:384:0:20:30b0b08cad6988b1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fa9ce821",
       "created_at": "2026-03-17T01:47:12.483591",
       "plan_id": "plan_c24b1c2e"
@@ -214,7 +220,9 @@
         "dhash:925:719:0:10:30b0b08cad6988b1"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_26b901e3",
       "created_at": "2026-03-17T01:47:12.491590",
       "plan_id": "plan_c24b1c2e"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Local_Debug.json
@@ -55,7 +55,9 @@
         "dhash:512:384:0:20:f0c09294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3ae709b9",
       "created_at": "2025-12-01T08:11:03.963646",
       "plan_id": "plan_5c512c58"
@@ -77,7 +79,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5d652c5d",
       "created_at": "2025-12-01T08:11:03.994948",
       "plan_id": "plan_5c512c58"
@@ -99,7 +103,9 @@
         "dhash:512:384:0:20:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3387a9c9",
       "created_at": "2025-12-01T08:11:04.017732",
       "plan_id": "plan_5c512c58"
@@ -121,7 +127,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bac27d9d",
       "created_at": "2025-12-01T08:11:04.036070",
       "plan_id": "plan_5c512c58"
@@ -143,7 +151,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c513db88",
       "created_at": "2025-12-01T08:11:04.053838",
       "plan_id": "plan_5c512c58"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Remote_Debug.json
@@ -65,7 +65,9 @@
         "dhash:385:128:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_eaa89d17",
       "created_at": "2025-12-01T08:59:25.977979",
       "plan_id": "plan_aab1f3fd"
@@ -87,7 +89,9 @@
         "dhash:512:384:0:20:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9c708629",
       "created_at": "2025-12-01T08:59:25.992472",
       "plan_id": "plan_aab1f3fd"
@@ -109,7 +113,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fee117c3",
       "created_at": "2025-12-01T08:59:26.015837",
       "plan_id": "plan_aab1f3fd"
@@ -131,7 +137,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5810c378",
       "created_at": "2025-12-01T08:59:26.040187",
       "plan_id": "plan_aab1f3fd"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Playground_Debug.json
@@ -55,7 +55,9 @@
         "dhash:304:127:0:10:c0c88294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_881745b9",
       "created_at": "2025-12-18T03:31:51.494104",
       "plan_id": "plan_3dd00864"
@@ -81,7 +83,9 @@
         "dhash:289:81:0:10:c0c0b094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4de620b0",
       "created_at": "2025-12-18T03:31:51.507357",
       "plan_id": "plan_3dd00864"
@@ -107,7 +111,9 @@
         "dhash:268:83:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a37fd7df",
       "created_at": "2025-12-18T03:31:51.521380",
       "plan_id": "plan_3dd00864"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Local_Debug.json
@@ -143,7 +143,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2e0f9d31",
       "created_at": "2025-11-28T04:00:03.040234",
       "plan_id": "plan_4fac1aa9"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Remote_Debug.json
@@ -145,7 +145,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5993fce6",
       "created_at": "2025-11-27T23:54:21.727261",
       "plan_id": "plan_d86fba79"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Local_Debug.json
@@ -62,7 +62,9 @@
         "dhash:362:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_057cb7e8",
       "created_at": "2025-11-28T04:01:28.057605",
       "plan_id": "plan_da37980a"
@@ -128,7 +130,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_84d19933",
       "created_at": "2025-11-28T04:01:28.080890",
       "plan_id": "plan_da37980a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Remote_Debug.json
@@ -130,7 +130,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_91223048",
       "created_at": "2026-02-24T14:29:16.228528",
       "plan_id": "plan_3db4a923"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Local_Debug.json
@@ -57,7 +57,9 @@
         "dhash:512:384:0:20:f0c09294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f431ab81",
       "created_at": "2025-11-28T04:11:43.068438",
       "plan_id": "plan_90bbe15a"
@@ -79,7 +81,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fabbbf91",
       "created_at": "2025-11-28T04:11:43.075842",
       "plan_id": "plan_90bbe15a"
@@ -145,7 +149,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_20e79941",
       "created_at": "2025-11-28T04:11:43.101875",
       "plan_id": "plan_90bbe15a"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Remote_Debug.json
@@ -58,7 +58,9 @@
         "dhash:512:384:0:20:f0c09294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_dc7a078b",
       "created_at": "2025-12-02T03:38:06.742938",
       "plan_id": "plan_b6860879"
@@ -80,7 +82,9 @@
         "dhash:512:384:0:20:e0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bf349edd",
       "created_at": "2025-12-02T03:38:06.749057",
       "plan_id": "plan_b6860879"
@@ -146,7 +150,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_397c442c",
       "created_at": "2025-12-02T03:38:06.773322",
       "plan_id": "plan_b6860879"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Local_Debug.json
@@ -59,7 +59,9 @@
         "dhash:307:132:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1d41c44d",
       "created_at": "2025-12-08T09:11:18.284278",
       "plan_id": "plan_3347d139"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Remote_Debug.json
@@ -64,7 +64,9 @@
         "dhash:385:128:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b6d48dab",
       "created_at": "2025-12-02T03:12:00.830092",
       "plan_id": "plan_358d3548"
@@ -130,7 +132,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1863bc5e",
       "created_at": "2025-12-02T03:12:00.852557",
       "plan_id": "plan_358d3548"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Copilot_Remote_Debug.json
@@ -145,7 +145,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fde2dc0b",
       "created_at": "2026-06-03T02:23:24.206998",
       "plan_id": "plan_bb4064ab"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Local_Debug.json
@@ -62,7 +62,9 @@
         "dhash:362:127:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_df4d4136",
       "created_at": "2025-11-28T04:09:08.656320",
       "plan_id": "plan_8d65e96b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Remote_Debug.json
@@ -64,7 +64,9 @@
         "dhash:385:128:0:10:c0c88694b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9cbb7326",
       "created_at": "2025-11-28T03:57:39.889308",
       "plan_id": "plan_8076024c"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Template_And_Sample_Readme_Verification.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Template_And_Sample_Readme_Verification.json
@@ -126,7 +126,9 @@
         "dhash:370:89:0:10:c0c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d870e05e",
       "created_at": "2026-06-25T07:16:12.881986",
       "plan_id": "plan_2aa92cad"
@@ -152,7 +154,9 @@
         "dhash:351:90:0:10:c0c09094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ffd602c4",
       "created_at": "2026-06-25T07:16:12.890070",
       "plan_id": "plan_2aa92cad"
@@ -178,7 +182,9 @@
         "dhash:348:74:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bf723cff",
       "created_at": "2026-06-25T07:16:12.896086",
       "plan_id": "plan_2aa92cad"
@@ -200,7 +206,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_20cc4b2c",
       "created_at": "2026-06-25T07:16:12.902093",
       "plan_id": "plan_2aa92cad"
@@ -222,7 +230,9 @@
         "dhash:512:384:0:20:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6ff99980",
       "created_at": "2026-06-25T07:16:12.919787",
       "plan_id": "plan_2aa92cad"
@@ -269,7 +279,9 @@
         "dhash:1011:22:0:10:2024306070707236"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_69f6fa64",
       "created_at": "2026-06-25T07:16:12.939129",
       "plan_id": "plan_2aa92cad"
@@ -295,7 +307,9 @@
         "dhash:196:292:0:10:21b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_47c0dc94",
       "created_at": "2026-06-25T07:16:12.944393",
       "plan_id": "plan_2aa92cad"
@@ -321,7 +335,9 @@
         "dhash:330:146:0:10:c4c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3442676d",
       "created_at": "2026-06-25T07:16:12.950480",
       "plan_id": "plan_2aa92cad"
@@ -347,7 +363,9 @@
         "dhash:330:85:0:10:c0d89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a7aadbe9",
       "created_at": "2026-06-25T07:16:12.959584",
       "plan_id": "plan_2aa92cad"
@@ -373,7 +391,9 @@
         "dhash:283:75:0:10:d0989094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_57c99052",
       "created_at": "2026-06-25T07:16:12.968366",
       "plan_id": "plan_2aa92cad"
@@ -399,7 +419,9 @@
         "dhash:283:75:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_367eb5a0",
       "created_at": "2026-06-25T07:16:12.978618",
       "plan_id": "plan_2aa92cad"
@@ -421,7 +443,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_feaeb0b4",
       "created_at": "2026-06-25T07:16:12.989143",
       "plan_id": "plan_2aa92cad"
@@ -443,7 +467,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2ca00f98",
       "created_at": "2026-06-25T07:16:12.995037",
       "plan_id": "plan_2aa92cad"
@@ -465,7 +491,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_10fc55be",
       "created_at": "2026-06-25T07:16:13.000479",
       "plan_id": "plan_2aa92cad"
@@ -512,7 +540,9 @@
         "dhash:1004:21:0:10:223230a030727030"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_68494265",
       "created_at": "2026-06-25T07:16:13.012895",
       "plan_id": "plan_2aa92cad"
@@ -539,7 +569,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "step_retry_timeout:60"
+        "step_retry_timeout:60",
+        "precondition:old"
       ],
       "screenshot": "step_267d4f2e",
       "created_at": "2026-06-25T07:16:13.023945",
@@ -566,7 +597,9 @@
         "dhash:350:178:0:10:c4c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7d7674b8",
       "created_at": "2026-06-25T07:16:13.042227",
       "plan_id": "plan_2aa92cad"
@@ -588,7 +621,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_53d00883",
       "created_at": "2026-06-25T07:16:13.048443",
       "plan_id": "plan_2aa92cad"
@@ -610,7 +645,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3c258540",
       "created_at": "2026-06-25T07:16:13.063657",
       "plan_id": "plan_2aa92cad"
@@ -632,7 +669,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c7a2f98c",
       "created_at": "2026-06-25T07:16:13.077869",
       "plan_id": "plan_2aa92cad"
@@ -654,7 +693,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7481c15b",
       "created_at": "2026-06-25T07:16:13.084171",
       "plan_id": "plan_2aa92cad"
@@ -680,7 +721,9 @@
         "dhash:336:86:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c1e0c20c",
       "created_at": "2026-06-25T07:16:13.089528",
       "plan_id": "plan_2aa92cad"
@@ -727,7 +770,9 @@
         "dhash:1009:21:0:10:2124223234747627"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_86472911",
       "created_at": "2026-06-25T07:16:13.108983",
       "plan_id": "plan_2aa92cad"
@@ -753,7 +798,9 @@
         "dhash:169:303:0:10:21b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fa808c22",
       "created_at": "2026-06-25T07:16:13.122854",
       "plan_id": "plan_2aa92cad"
@@ -779,7 +826,9 @@
         "dhash:308:225:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b735d79c",
       "created_at": "2026-06-25T07:16:13.131685",
       "plan_id": "plan_2aa92cad"
@@ -805,7 +854,9 @@
         "dhash:272:94:0:10:d0c0b294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_618d0393",
       "created_at": "2026-06-25T07:16:13.140562",
       "plan_id": "plan_2aa92cad"
@@ -831,7 +882,9 @@
         "dhash:276:77:0:10:d0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_090f51c5",
       "created_at": "2026-06-25T07:16:13.153961",
       "plan_id": "plan_2aa92cad"
@@ -853,7 +906,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b558c6b8",
       "created_at": "2026-06-25T07:16:13.164313",
       "plan_id": "plan_2aa92cad"
@@ -875,7 +930,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_26d05eb8",
       "created_at": "2026-06-25T07:16:13.178889",
       "plan_id": "plan_2aa92cad"
@@ -897,7 +954,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e3712c8b",
       "created_at": "2026-06-25T07:16:13.192127",
       "plan_id": "plan_2aa92cad"
@@ -944,7 +1003,9 @@
         "dhash:1011:17:0:10:22303030e0307032"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_976bcfbf",
       "created_at": "2026-06-25T07:16:13.204559",
       "plan_id": "plan_2aa92cad"
@@ -970,7 +1031,9 @@
         "dhash:233:300:0:10:21b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_65a5a14d",
       "created_at": "2026-06-25T07:16:13.214138",
       "plan_id": "plan_2aa92cad"
@@ -996,7 +1059,9 @@
         "dhash:274:302:0:10:c0c8889492b17075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ac71c544",
       "created_at": "2026-06-25T07:30:03.647433",
       "plan_id": "plan_2aa92cad"
@@ -1022,7 +1087,9 @@
         "dhash:313:85:0:10:c8e0a294b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6bc8d667",
       "created_at": "2026-06-25T07:16:13.236223",
       "plan_id": "plan_2aa92cad"
@@ -1071,7 +1138,9 @@
         "dhash:315:77:0:10:f0b0949492b17075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d38c6e1c",
       "created_at": "2026-06-25T07:16:13.245342",
       "plan_id": "plan_2aa92cad"
@@ -1093,7 +1162,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fbd7191e",
       "created_at": "2026-06-25T07:16:13.253063",
       "plan_id": "plan_2aa92cad"
@@ -1115,7 +1186,9 @@
         "dhash:512:384:0:20:d0b89494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1440cc6d",
       "created_at": "2026-06-25T07:16:13.269336",
       "plan_id": "plan_2aa92cad"
@@ -1137,7 +1210,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ad547778",
       "created_at": "2026-06-25T07:16:13.278654",
       "plan_id": "plan_2aa92cad"
@@ -1184,7 +1259,9 @@
         "dhash:1005:22:0:10:22303030e0706c31"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_091bcbe0",
       "created_at": "2026-06-25T07:16:13.293212",
       "plan_id": "plan_2aa92cad"
@@ -1210,7 +1287,9 @@
         "dhash:203:340:0:10:21b89494b0717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d5d9e162",
       "created_at": "2026-06-25T07:16:13.298734",
       "plan_id": "plan_2aa92cad"
@@ -1233,7 +1312,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "delay:2"
+        "delay:2",
+        "precondition:old"
       ],
       "screenshot": "step_a822b780",
       "created_at": "2026-06-25T07:16:13.305078",
@@ -1256,7 +1336,9 @@
         "dhash:512:384:0:20:64a4a4baaa646460"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6fc3d082",
       "created_at": "2026-06-25T07:16:13.310988",
       "plan_id": "plan_2aa92cad"
@@ -1282,7 +1364,9 @@
         "dhash:918:161:0:10:44216a6e4462626e"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1825ce0b",
       "created_at": "2026-06-25T07:16:13.320602",
       "plan_id": "plan_2aa92cad"
@@ -1308,7 +1392,9 @@
         "dhash:605:161:0:10:442126a662e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_077b035d",
       "created_at": "2026-06-25T07:16:13.331458",
       "plan_id": "plan_2aa92cad"
@@ -1334,7 +1420,9 @@
         "dhash:573:185:0:10:4c29a8a662f66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_ebb90d7b",
       "created_at": "2026-06-25T07:16:13.341112",
       "plan_id": "plan_2aa92cad"
@@ -1360,7 +1448,9 @@
         "dhash:573:211:0:10:4c2928a672e67666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_baa880ef",
       "created_at": "2026-06-25T07:16:13.347229",
       "plan_id": "plan_2aa92cad"
@@ -1386,7 +1476,9 @@
         "dhash:573:235:0:10:4c29a8a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9aac9740",
       "created_at": "2026-06-25T07:16:13.360640",
       "plan_id": "plan_2aa92cad"
@@ -1408,7 +1500,9 @@
         "dhash:512:384:0:20:4c29a8a662f66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_1d8b9dc1",
       "created_at": "2026-06-25T07:16:13.371070",
       "plan_id": "plan_2aa92cad"
@@ -1434,7 +1528,9 @@
         "dhash:811:299:0:10:4c2124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d43c4826",
       "created_at": "2026-06-25T07:16:13.386088",
       "plan_id": "plan_2aa92cad"
@@ -1460,7 +1556,9 @@
         "dhash:441:55:0:10:612124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d3011fa7",
       "created_at": "2026-06-25T07:16:13.400688",
       "plan_id": "plan_2aa92cad"
@@ -1507,7 +1605,9 @@
         "dhash:1013:17:0:10:203420b036767031"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c30ba689",
       "created_at": "2026-06-25T07:16:13.437938",
       "plan_id": "plan_2aa92cad"
@@ -1533,7 +1633,9 @@
         "dhash:811:332:0:10:4c2124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8ed55954",
       "created_at": "2026-06-25T07:16:13.452155",
       "plan_id": "plan_2aa92cad"
@@ -1559,7 +1661,9 @@
         "dhash:398:55:0:10:602124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2ecc9f5f",
       "created_at": "2026-06-25T07:16:13.461887",
       "plan_id": "plan_2aa92cad"
@@ -1606,7 +1710,9 @@
         "dhash:1015:18:0:10:21303082a1216c31"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0e10bd15",
       "created_at": "2026-06-25T07:16:13.481987",
       "plan_id": "plan_2aa92cad"
@@ -1632,7 +1738,9 @@
         "dhash:806:497:0:10:4c2124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_290573ad",
       "created_at": "2026-06-25T07:16:13.488024",
       "plan_id": "plan_2aa92cad"
@@ -1658,7 +1766,9 @@
         "dhash:383:54:0:10:602124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8590e359",
       "created_at": "2026-06-25T07:16:13.494321",
       "plan_id": "plan_2aa92cad"
@@ -1705,7 +1815,9 @@
         "dhash:1001:22:0:10:2034613234767221"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6302e393",
       "created_at": "2026-06-25T07:16:13.514791",
       "plan_id": "plan_2aa92cad"
@@ -1731,7 +1843,9 @@
         "dhash:819:531:0:10:442124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_859ca96f",
       "created_at": "2026-06-25T07:16:13.528343",
       "plan_id": "plan_2aa92cad"
@@ -1757,7 +1871,9 @@
         "dhash:399:55:0:10:602124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9d233dbc",
       "created_at": "2026-06-25T07:16:13.545054",
       "plan_id": "plan_2aa92cad"
@@ -1804,7 +1920,9 @@
         "dhash:1011:18:0:10:223078323a727221"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_32b270ba",
       "created_at": "2026-06-25T07:16:13.560114",
       "plan_id": "plan_2aa92cad"
@@ -1830,7 +1948,9 @@
         "dhash:795:564:0:10:442124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_be6c559c",
       "created_at": "2026-06-25T07:16:13.571127",
       "plan_id": "plan_2aa92cad"
@@ -1856,7 +1976,9 @@
         "dhash:439:56:0:10:602124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4d2a5d68",
       "created_at": "2026-06-25T07:16:13.582783",
       "plan_id": "plan_2aa92cad"
@@ -1903,7 +2025,9 @@
         "dhash:1011:18:0:10:253422b232707031"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a4f7cab1",
       "created_at": "2026-06-25T07:16:13.606980",
       "plan_id": "plan_2aa92cad"
@@ -1929,7 +2053,9 @@
         "dhash:810:623:0:10:442124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_8a682251",
       "created_at": "2026-06-25T07:16:13.615816",
       "plan_id": "plan_2aa92cad"
@@ -1955,7 +2081,9 @@
         "dhash:407:55:0:10:602124a666e66666"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_256d0577",
       "created_at": "2026-06-25T07:16:13.621709",
       "plan_id": "plan_2aa92cad"
@@ -2002,7 +2130,9 @@
         "dhash:1009:15:0:10:24243030727a7231"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9bda13ac",
       "created_at": "2026-06-25T07:16:13.642595",
       "plan_id": "plan_2aa92cad"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_Azure_OpenAI_js_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_Azure_OpenAI_js_playground.json
@@ -55,7 +55,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_334183ac",
       "created_at": "2025-12-18T06:42:01.046321",
       "plan_id": "plan_9f75f588"
@@ -81,7 +83,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c0e83907",
       "created_at": "2025-12-18T06:42:01.068073",
       "plan_id": "plan_9f75f588"
@@ -107,7 +111,9 @@
         "dhash:320:97:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_296599eb",
       "created_at": "2025-12-18T06:42:01.087807",
       "plan_id": "plan_9f75f588"
@@ -133,7 +139,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_83a7878f",
       "created_at": "2025-12-18T06:42:01.105669",
       "plan_id": "plan_9f75f588"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_Azure_OpenAI_ts_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_Azure_OpenAI_ts_playground.json
@@ -55,7 +55,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_977d006a",
       "created_at": "2025-12-18T06:45:43.290916",
       "plan_id": "plan_2a576435"
@@ -81,7 +83,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6afe3f70",
       "created_at": "2025-12-18T06:45:43.315580",
       "plan_id": "plan_2a576435"
@@ -133,7 +137,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_012b2178",
       "created_at": "2025-12-18T06:45:43.368972",
       "plan_id": "plan_2a576435"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_js_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_js_Copilot_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_80d45a05",
       "created_at": "2025-11-26T01:37:19.129856",
       "plan_id": "plan_60ebd3c6"
@@ -84,7 +86,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9420a298",
       "created_at": "2025-11-26T01:37:19.161006",
       "plan_id": "plan_60ebd3c6"
@@ -110,7 +114,9 @@
         "dhash:264:129:0:10:c0d09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_4903eb72",
       "created_at": "2025-11-26T01:37:19.188103",
       "plan_id": "plan_60ebd3c6"
@@ -132,7 +138,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9af2e695",
       "created_at": "2025-11-26T01:37:19.214649",
       "plan_id": "plan_60ebd3c6"
@@ -154,7 +162,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_89c7af73",
       "created_at": "2025-11-26T01:37:19.244994",
       "plan_id": "plan_60ebd3c6"
@@ -180,7 +190,9 @@
         "dhash:320:97:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d827a238",
       "created_at": "2025-11-26T01:37:19.273475",
       "plan_id": "plan_60ebd3c6"
@@ -206,7 +218,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_67b918c8",
       "created_at": "2025-11-26T01:37:19.303096",
       "plan_id": "plan_60ebd3c6"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_js_Copilot_Remote_Debug.json
@@ -60,7 +60,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_9ecd1639",
       "created_at": "2025-12-16T08:36:50.606998",
       "plan_id": "plan_49391486"
@@ -86,7 +88,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_2276ba25",
       "created_at": "2025-12-16T08:36:50.611554",
       "plan_id": "plan_49391486"
@@ -112,7 +116,9 @@
         "dhash:264:129:0:10:c0d09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a158bf99",
       "created_at": "2025-12-16T08:36:50.617093",
       "plan_id": "plan_49391486"
@@ -134,7 +140,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_27888317",
       "created_at": "2025-12-16T08:36:50.621078",
       "plan_id": "plan_49391486"
@@ -156,7 +164,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f69debdd",
       "created_at": "2025-12-16T08:36:50.624417",
       "plan_id": "plan_49391486"
@@ -182,7 +192,9 @@
         "dhash:246:106:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_795a3768",
       "created_at": "2025-12-16T08:36:50.628250",
       "plan_id": "plan_49391486"
@@ -208,7 +220,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6795c1c6",
       "created_at": "2025-12-16T08:36:50.632715",
       "plan_id": "plan_49391486"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_js_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_js_playground.json
@@ -133,7 +133,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_99533fd2",
       "created_at": "2026-01-30T09:40:41.919024",
       "plan_id": "plan_dcbdbcbf"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_Copilot_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7198e5cd",
       "created_at": "2025-11-26T01:39:49.115496",
       "plan_id": "plan_f3e69fdd"
@@ -84,7 +86,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_52a316c5",
       "created_at": "2025-11-26T01:39:49.135160",
       "plan_id": "plan_f3e69fdd"
@@ -110,7 +114,9 @@
         "dhash:264:129:0:10:c0d09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5b29acf4",
       "created_at": "2025-11-26T01:39:49.154238",
       "plan_id": "plan_f3e69fdd"
@@ -132,7 +138,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_0fb2dbc1",
       "created_at": "2025-11-26T01:39:49.176053",
       "plan_id": "plan_f3e69fdd"
@@ -154,7 +162,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d09ef496",
       "created_at": "2025-11-26T01:39:49.197832",
       "plan_id": "plan_f3e69fdd"
@@ -180,7 +190,9 @@
         "dhash:292:78:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_14f28290",
       "created_at": "2025-11-26T01:39:49.223203",
       "plan_id": "plan_f3e69fdd"
@@ -206,7 +218,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c2c295b3",
       "created_at": "2025-11-26T01:39:49.250015",
       "plan_id": "plan_f3e69fdd"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_Copilot_Remote_Debug.json
@@ -60,7 +60,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_d3c2177a",
       "created_at": "2025-12-16T08:50:46.718468",
       "plan_id": "plan_73d73a14"
@@ -86,7 +88,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f3187c72",
       "created_at": "2025-12-16T08:50:46.725481",
       "plan_id": "plan_73d73a14"
@@ -112,7 +116,9 @@
         "dhash:264:129:0:10:c0d09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_3e6afd10",
       "created_at": "2025-12-16T08:50:46.732690",
       "plan_id": "plan_73d73a14"
@@ -134,7 +140,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_032f3271",
       "created_at": "2025-12-16T08:50:46.739247",
       "plan_id": "plan_73d73a14"
@@ -156,7 +164,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a6b31df3",
       "created_at": "2025-12-16T08:50:46.746563",
       "plan_id": "plan_73d73a14"
@@ -182,7 +192,9 @@
         "dhash:292:78:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_349f473c",
       "created_at": "2025-12-16T08:50:46.752453",
       "plan_id": "plan_73d73a14"
@@ -208,7 +220,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_c51f5f19",
       "created_at": "2025-12-16T08:50:46.757450",
       "plan_id": "plan_73d73a14"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_Local_Debug.json
@@ -58,7 +58,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_f63cdcae",
       "created_at": "2025-11-25T02:29:00.819276",
       "plan_id": "plan_e7ced6fa"
@@ -84,7 +86,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fe54ae52",
       "created_at": "2025-11-25T02:29:00.851927",
       "plan_id": "plan_e7ced6fa"
@@ -110,7 +114,9 @@
         "dhash:264:129:0:10:c0d09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e841dc5f",
       "created_at": "2025-11-25T02:29:00.873560",
       "plan_id": "plan_e7ced6fa"
@@ -132,7 +138,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_40bbcbd9",
       "created_at": "2025-11-25T02:29:00.894630",
       "plan_id": "plan_e7ced6fa"
@@ -154,7 +162,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_31b51cb0",
       "created_at": "2025-11-25T02:29:00.920215",
       "plan_id": "plan_e7ced6fa"
@@ -206,7 +216,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_5110da29",
       "created_at": "2025-11-25T02:29:00.970995",
       "plan_id": "plan_e7ced6fa"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_Remote_Debug.json
@@ -60,7 +60,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_23911b69",
       "created_at": "2025-11-25T02:40:44.583875",
       "plan_id": "plan_4ce92f1b"
@@ -86,7 +88,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_b405ae08",
       "created_at": "2025-11-25T02:40:44.613690",
       "plan_id": "plan_4ce92f1b"
@@ -112,7 +116,9 @@
         "dhash:264:129:0:10:c0d09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_bf5023d0",
       "created_at": "2025-11-25T02:40:44.638883",
       "plan_id": "plan_4ce92f1b"
@@ -134,7 +140,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_fc27ede2",
       "created_at": "2025-11-25T02:40:44.665634",
       "plan_id": "plan_4ce92f1b"
@@ -156,7 +164,9 @@
         "dhash:512:384:0:20:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_6e4f77e0",
       "created_at": "2025-11-25T02:40:44.690626",
       "plan_id": "plan_4ce92f1b"
@@ -182,7 +192,9 @@
         "dhash:292:78:0:10:d0989494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_214ccff4",
       "created_at": "2025-11-25T02:40:44.715695",
       "plan_id": "plan_4ce92f1b"
@@ -208,7 +220,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_e785010a",
       "created_at": "2025-11-25T02:40:44.740877",
       "plan_id": "plan_4ce92f1b"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_OpenAI_ts_playground.json
@@ -55,7 +55,9 @@
         "dhash:360:131:0:10:c8c88094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_7854dfbf",
       "created_at": "2026-01-30T09:31:36.627612",
       "plan_id": "plan_50070146"
@@ -81,7 +83,9 @@
         "dhash:344:134:0:10:c0c89094b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_daeddccb",
       "created_at": "2026-01-30T09:31:36.643128",
       "plan_id": "plan_50070146"
@@ -133,7 +137,9 @@
         "dhash:344:76:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_76f0c641",
       "created_at": "2026-01-30T09:31:36.663204",
       "plan_id": "plan_50070146"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_ts_remote_copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Weather_Agent_ts_remote_copilot.json
@@ -88,7 +88,9 @@
         "dhash:322:127:0:10:c0c4909092b26461"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "precondition:old"
+      ],
       "screenshot": "step_a4eea9a2",
       "created_at": "2025-12-12T03:17:35.316665",
       "plan_id": "plan_6eb6854d"


### PR DESCRIPTION
## What

Adds the `precondition:old` step tag to **604 steps across 133 vscuse test plans**. These are exactly the steps that have a precondition but **no usable expected screenshot** stored in the plan.

> Rebased onto latest `dev`. Dev's rewrites of `Template_And_Sample_Readme_Verification.json` and `Feature_DA_Add_MCP_Server.json` exposed additional no-screenshot steps, and `DA_MCP_None_Remote.json` / `DA_MCP_Oauth_Remote.json` were reformatted — all re-tagged on top of dev's versions.

## Why

vscuse is moving to **OCR + AI as the default precondition mechanism** ([vsc-use#22](https://github.com/1openwindow/vsc-use/pull/22)). At migration time, every step with a precondition becomes an `ocr:v1:` precondition:

- Steps **with** a recorded screenshot → OCR of that screenshot provides the *expected text* the runtime judge compares against.
- Steps **without** a usable screenshot → an **empty-expected** OCR precondition: the LLM judge has no reference text and must decide readiness from the step description alone.

For the steps in this PR, the original **perceptual-hash (`dhash:`) precondition — computed at record time — is still stored in the plan** and is a more reliable check than empty-expected OCR. The `precondition:old` tag makes vscuse keep the legacy hash mechanism for these steps instead of converting them to empty-expected OCR.

> Note: the `dhash:` check does **not** need the recorded screenshot at replay time — it re-hashes a small spot at the recorded `(x, y)` and compares to the stored hash. So these steps stay fully protected on the hash path.

## Reason breakdown

**All 528 tagged steps already carry a `dhash:` precondition.** They split by why the expected screenshot is unusable:

| Screenshot state | Steps | What it means | Why `precondition:old` (hash) is better |
|---|--:|---|---|
| Stripped / unresolved ref | 590 | `screenshot` references an ID that isn't in the plan's `screenshots` map (dropped on export) | The record-time `dhash` value is still stored; OCR would have no reference text |
| `null` / missing | 14 | Hand-authored steps with `screenshot: null` | Never had a screenshot; OCR would be empty-expected |
| **Total** | **604** | | |

### By plan family

| Plan family | Steps tagged |
|---|--:|
| Teams_Agent | 177 |
| Feature_DA | 84 |
| Template_And | 66 |
| Weather_Agent | 53 |
| Feature_AppYmlFile | 33 |
| Basic_Custom | 23 |
| General_Teams | 17 |
| DA_No | 16 |
| Sample_SSO | 13 |
| Sample_Tab | 13 |
| Sample_One | 11 |
| Sample_Graph | 8 |
| Feature_Deploy | 6 |
| Feature_Provision | 6 |
| Feature_Validate | 6 |
| DA_MCP | 5 |
| Feature_Del | 5 |
| Sample_Da | 5 |
| DA_Add | 4 |
| Feature_Message | 4 |
| Feature_Sign | 4 |
| Feature_Simple | 4 |
| Message_Extension | 4 |
| Sample_Dice | 4 |
| Simple_Bot | 4 |
| DA_Typespec | 3 |
| DA_With | 3 |
| Feature_Basic | 3 |
| Feature_Prompt | 3 |
| Feature_Remove | 3 |
| Feature_Set | 3 |
| Sample_Copilot | 3 |
| Feature_ | 2 |
| Feature_Report | 2 |
| Sample_Stocks | 2 |
| Sample_CoffeeAgent | 1 |
| Sample_Incoming | 1 |

### Kinds of steps affected

These are deterministic VS Code UI interactions whose record-time hash spot is stable, e.g.:

- (17×) Click on the "Default folder" dropdown in the "Workspace Folder" dialog to select the dire
- (16×) Click the "General Teams Agent" dropdown option in the "Teams Agent or App Using Teams AI 
- (12×) Click the "Azure AI Search" option in the "Select an option to load your data" dropdown wi
- (11×) Press the "Enter" key to select the "Default folder" option under the "Choose the folder w
- (10×) Click the "Default folder" option under the "Choose the folder where your project root wil
- (9×) Click the "Default folder" option in the "Workspace Folder" dialog to select '/home/vscode
- (9×) Click on the "General Teams Agent" option within the dropdown menu titled "Teams Agent or 
- (9×) Click on the "Custom Engine Agent" option in the "New Project" dropdown menu to select it.
- (9×) Click on the dropdown menu option titled "Weather Agent" under the "App Features Using Mic
- (8×) Click on the dropdown option "Tab" under the "Teams Capability" menu in the Microsoft 365 
- (7×) Click on the "Teams Agent with D..." option in the dropdown menu under "Teams Agent or App
- (6×) Click on the "Default folder" dropdown input field in the "Workspace Folder" dialog to sel

## Intentionally NOT tagged

The earlier full-run failure analysis found the OCR precondition **timeouts** were on genuinely-different external Microsoft **sign-in pages** (`organizations` vs `common` endpoint) and **failed Azure provisioning** screens — i.e. correct blocks on a wrong/failed screen, inherently flaky under **any** precondition method (hash included). Reverting those to hash would not help, so login/provisioning steps that *do* have a screenshot are **not** tagged here. This PR only covers the no-screenshot set above.

## How it was generated

Steps were selected with the same screenshot-resolution logic as `scripts/migrate_preconditions_to_ocr.py`. Each file was tagged via a load→dump round-trip verified to be byte-identical except the added tag (one hand-authored file, `DA_MCP_None_Remote.json`, used a surgical insert to preserve its non-standard formatting). Every tagged step was re-parsed to confirm valid JSON and exactly one `precondition:old` tag.

<details><summary>Full per-plan counts (131 plans)</summary>

| Plan | Steps tagged |
|---|--:|
| Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Local_Debug.json | 1 |
| Basic_Custom_Engine_Azure_OpenAI_ts_Copilot_Local_Debug.json | 3 |
| Basic_Custom_Engine_Azure_OpenAI_ts_Copilot_Remote_Debug.json | 1 |
| Basic_Custom_Engine_OpenAI_js_Copilot_Local_Debug.json | 3 |
| Basic_Custom_Engine_OpenAI_js_Copilot_Remote_Debug.json | 2 |
| Basic_Custom_Engine_OpenAI_js_Local_Debug.json | 3 |
| Basic_Custom_Engine_OpenAI_js_Remote_Debug.json | 2 |
| Basic_Custom_Engine_OpenAI_ts_Copilot_Local_Debug.json | 3 |
| Basic_Custom_Engine_OpenAI_ts_Copilot_Remote_Debug.json | 2 |
| Basic_Custom_Engine_OpenAI_ts_Local_Debug.json | 3 |
| DA_Add_Action_Import_Existing_API_Basic_API_Key.json | 1 |
| DA_Add_Action_Import_Existing_API_Basic_No_Auth.json | 1 |
| DA_Add_Action_Import_Existing_API_Basic_OAuth.json | 1 |
| DA_Add_Action_Import_Existing_API_Bearer_token.json | 1 |
| DA_MCP_None_Remote.json | 3 |
| DA_MCP_Oauth_Remote.json | 2 |
| DA_No_Action_Add_Knowledge_Onedrive.json | 10 |
| DA_No_Action_Remote_Debug.json | 3 |
| DA_No_Action_Web_Search.json | 3 |
| DA_Typespec_Oauth_Without_Reference_Id.json | 3 |
| DA_With_EK_Happy_Path.json | 3 |
| Feature_AppYmlFile_Invalid_Syntax.json | 19 |
| Feature_AppYmlFile_Remove_DeployOrPublish_Section.json | 14 |
| Feature_Basic_Tab_Instant_Tab_Remote.json | 3 |
| Feature_DA_Add_MCP_Server.json | 10 |
| Feature_DA_Advanced_Personal_Scope_Provision_with_Copilot_License.json | 6 |
| Feature_DA_Manifest_File_Function_Env_Support.json | 16 |
| Feature_DA_Manifest_File_Function_Manifest_Plugin_Support.json | 5 |
| Feature_DA_Manifest_File_Function_Path_Support.json | 6 |
| Feature_DA_No_Action_Add_ApiKey_Auth_Configurations.json | 13 |
| Feature_DA_No_Action_Add_Bearer_Auth_Configurations.json | 1 |
| Feature_DA_No_Action_Add_Microsoft_Entra_Auth_Configurations.json | 9 |
| Feature_DA_No_Action_Add_OAuth_Auth_Configurations.json | 9 |
| Feature_DA_No_Action_Add_PKCE_OAuth_Auth_Configurations.json | 9 |
| Feature_Del_Resource_Group_And_Reprovision_For_Bot.json | 2 |
| Feature_Del_Resource_Group_And_Reprovision_For_Tab.json | 3 |
| Feature_Deploy_Triggered_Codelens_Support.json | 3 |
| Feature_Deploy_Without_Provision.json | 3 |
| Feature_Message_Extension_With_Action_Command_ts_Playground_Debug.json | 4 |
| Feature_Prompt_Use_Run_From_Package.json | 3 |
| Feature_Provision_Triggered_Codelens_Support.json | 3 |
| Feature_Provision_Without_Account.json | 3 |
| Feature_Remove_App_From_Devportal_And_Reprovision.json | 3 |
| Feature_Report_Issue.json | 2 |
| Feature_Set_Sub_Id_And_Rg_Name.json | 3 |
| Feature_Sign_In_No_Subscription.json | 3 |
| Feature_Sign_Out.json | 1 |
| Feature_Simple_Bot_Remote_Template_Verification.json | 2 |
| Feature_Simple_Bot_With_Symbol_Link_Target_js_playground.json | 2 |
| Feature_Validate_Plugin_Manifest.json | 5 |
| Feature_Validate_copilot_manifest.json | 1 |
| Feature__Debug_All_Telemetry_Check_And_Terminated_Previous_Tasks.json | 2 |
| General_Teams_Agent_Azure_OpenAI_js_Copilot_Local_Debug.json | 2 |
| General_Teams_Agent_Azure_OpenAI_js_Copilot_Remote_Debug.json | 2 |
| General_Teams_Agent_Azure_OpenAI_py_Copilot_Local_Debug.json | 2 |
| General_Teams_Agent_Azure_OpenAI_py_playground.json | 2 |
| General_Teams_Agent_OpenAI_js_Local_Debug.json | 1 |
| General_Teams_Agent_OpenAI_py_Remote_Debug.json | 2 |
| General_Teams_Agent_OpenAI_ts_Local_Debug.json | 3 |
| General_Teams_Agent_OpenAI_ts_Remote_Debug.json | 3 |
| Message_Extension_ts_Playground_Debug.json | 4 |
| Sample_CoffeeAgent_Remote.json | 1 |
| Sample_Copilot_Connection_Remote_Debug.json | 3 |
| Sample_Da_Ristorante_Api_Remote_Debug.json | 5 |
| Sample_Dice_Roller_in_meeting_Local_Debug.json | 2 |
| Sample_Dice_Roller_in_meeting_Remote_Debug.json | 2 |
| Sample_Graph_RSC_Helper_Debug_in_Group_Chat.json | 4 |
| Sample_Graph_RSC_Helper_Debug_in_Team_Channel.json | 4 |
| Sample_Incoming_Webhook_Notification_Happy_Path.json | 1 |
| Sample_One_Productivity_Hub_using_Toolkit_Local_Debug.json | 6 |
| Sample_One_Productivity_Hub_using_Toolkit_Remote_Debug.json | 5 |
| Sample_SSO_Enabled_Tab_via_APIM_Proxy_Local_Debug.json | 13 |
| Sample_Stocks_Update_Notification_Bot_Remote_Debug.json | 2 |
| Sample_Tab_And_Outlook_Addin_Local_Debug.json | 11 |
| Sample_Tab_And_Outlook_Addin_Remote_Debug.json | 2 |
| Simple_Bot_js_playground.json | 2 |
| Simple_Bot_ts_playground.json | 2 |
| Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Local_Debug.json | 3 |
| Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Playground_Debug.json | 4 |
| Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Remote_Debug.json | 3 |
| Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Local_Debug.json | 3 |
| Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Playground_Debug.json | 3 |
| Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Remote_Debug.json | 4 |
| Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Playground_Debug.json | 3 |
| Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Remote_Debug.json | 2 |
| Teams_Agent_With_Data_AI_Search_OpenAI_js_Remote_Debug.json | 7 |
| Teams_Agent_With_Data_AI_Search_OpenAI_py_Local_Debug.json | 3 |
| Teams_Agent_With_Data_AI_Search_OpenAI_py_Remote_Debug.json | 5 |
| Teams_Agent_With_Data_AI_Search_OpenAI_ts_Local_Debug.json | 6 |
| Teams_Agent_With_Data_AI_Search_OpenAI_ts_Remote_Debug.json | 6 |
| Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Local_Debug.json | 8 |
| Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_PlayGround.json | 8 |
| Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Local_Debug.json | 6 |
| Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_PlayGround.json | 8 |
| Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Remote_Debug.json | 1 |
| Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_PlayGround.json | 8 |
| Teams_Agent_With_Data_Custom_API_OpenAI_js_Local_Debug.json | 2 |
| Teams_Agent_With_Data_Custom_API_OpenAI_js_Remote_Debug.json | 9 |
| Teams_Agent_With_Data_Custom_API_OpenAI_py_Local_Debug.json | 9 |
| Teams_Agent_With_Data_Custom_API_OpenAI_ts_Local_Debug.json | 9 |
| Teams_Agent_With_Data_Custom_API_OpenAI_ts_Remote_Debug.json | 9 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Local_Debug.json | 5 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Playground_Debug.json | 1 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Local_Debug.json | 2 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Remote_Debug.json | 4 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Playground_Debug.json | 3 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Remote_Debug.json | 4 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Local_Debug.json | 5 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Remote_Debug.json | 4 |
| Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Playground_Debug.json | 3 |
| Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Local_Debug.json | 1 |
| Teams_Agent_With_Data_Customize_OpenAI_js_Copilot_Remote_Debug.json | 1 |
| Teams_Agent_With_Data_Customize_OpenAI_js_Local_Debug.json | 2 |
| Teams_Agent_With_Data_Customize_OpenAI_js_Remote_Debug.json | 1 |
| Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Local_Debug.json | 3 |
| Teams_Agent_With_Data_Customize_OpenAI_py_Copilot_Remote_Debug.json | 3 |
| Teams_Agent_With_Data_Customize_OpenAI_py_Local_Debug.json | 1 |
| Teams_Agent_With_Data_Customize_OpenAI_py_Remote_Debug.json | 2 |
| Teams_Agent_With_Data_Customize_OpenAI_ts_Copilot_Remote_Debug.json | 1 |
| Teams_Agent_With_Data_Customize_OpenAI_ts_Local_Debug.json | 1 |
| Teams_Agent_With_Data_Customize_OpenAI_ts_Remote_Debug.json | 1 |
| Template_And_Sample_Readme_Verification.json | 66 |
| Weather_Agent_Azure_OpenAI_js_playground.json | 4 |
| Weather_Agent_Azure_OpenAI_ts_playground.json | 3 |
| Weather_Agent_OpenAI_js_Copilot_Local_Debug.json | 7 |
| Weather_Agent_OpenAI_js_Copilot_Remote_Debug.json | 7 |
| Weather_Agent_OpenAI_js_playground.json | 1 |
| Weather_Agent_OpenAI_ts_Copilot_Local_Debug.json | 7 |
| Weather_Agent_OpenAI_ts_Copilot_Remote_Debug.json | 7 |
| Weather_Agent_OpenAI_ts_Local_Debug.json | 6 |
| Weather_Agent_OpenAI_ts_Remote_Debug.json | 7 |
| Weather_Agent_OpenAI_ts_playground.json | 3 |
| Weather_Agent_ts_remote_copilot.json | 1 |

</details>