### PR TITLE
refactor: update no interactive model in creating office add-in templates

### DIFF
--- a/packages/fx-core/src/question/inputs/CreateProjectInputs.ts
+++ b/packages/fx-core/src/question/inputs/CreateProjectInputs.ts
@@ -55,6 +55,8 @@ export interface CreateProjectInputs extends Inputs {
   "app-name"?: string;
   /** @description Select the Office applications to support */
   "office-addin-hosts"?: string[];
+  /** @description Select the Office application to support for the Nested App Auth SSO add-in */
+  "office-addin-naa-host"?: string;
   /** @description MCP Server Type */
   "mcp-server-type"?: "remote";
   /** @description MCP Server URL */

--- a/packages/fx-core/src/question/options/CreateProjectOptions.ts
+++ b/packages/fx-core/src/question/options/CreateProjectOptions.ts
@@ -207,6 +207,13 @@ export const CreateProjectOptions: CLICommandOption[] = [
     choices: ["word", "powerpoint", "outlook", "excel"],
   },
   {
+    name: "office-addin-naa-host",
+    type: "string",
+    description: "Select the Office application the Nested App Auth SSO add-in supports.",
+    default: "word",
+    choices: ["word", "excel", "powerpoint"],
+  },
+  {
     name: "folder",
     type: "string",
     shortName: "f",


### PR DESCRIPTION
This pull request adds support for selecting a specific Office application when creating a Nested App Auth SSO add-in. The main changes introduce a new input and command-line option for specifying the Office host application.

<img width="1263" height="120" alt="image" src="https://github.com/user-attachments/assets/325a42e2-28f8-4c4b-874c-d60e6361e073" />
