### PR TITLE
fix(scaffold): avoid duplicate operation loading in Regenerate Action

### DIFF
--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1367,7 +1367,8 @@ export function selectApiOperationForRegenerateQuestion(): MultiSelectQuestion {
       if (res.isOk()) {
         inputs.supportedApisFromApiSpec = res.value;
       } else {
-        throw res.error;
+        const message = res.error.map((error) => error.content).join("\n");
+        throw new UserError("FxCore", "ListOpenAPISpecOperationsError", message, message);
       }
 
       if (!inputs.supportedApisFromApiSpec || inputs.supportedApisFromApiSpec.length === 0) {

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -1206,14 +1206,14 @@ describe("scaffold question", () => {
       }
     });
 
-    it("dynamicOptions: should throw error when listOperations returns error", async () => {
+    it("dynamicOptions: should preserve listOperations errors as a typed UserError", async () => {
       const question = selectApiOperationForRegenerateQuestion();
       const inputs: any = {
         [QuestionNames.SelectOpenAPISpecFromPlugin]: "path/to/spec",
       };
 
       const errorMessage = "List operations failed";
-      const mockError = [new Error(errorMessage)];
+      const mockError = [{ content: errorMessage }];
 
       vi.spyOn(fs, "pathExists").mockResolvedValue(true);
       vi.spyOn(createQuestionDeps.createQuestionDeps, "createContext").mockReturnValue(
@@ -1227,7 +1227,12 @@ describe("scaffold question", () => {
         await question.dynamicOptions!(inputs);
         assert.fail("Should throw error");
       } catch (e) {
-        assert.deepEqual(e, mockError);
+        assert.instanceOf(e, UserError);
+        if (!(e instanceof UserError)) {
+          assert.fail("Expected UserError");
+        }
+        assert.equal(e.name, "ListOpenAPISpecOperationsError");
+        assert.equal(e.message, errorMessage);
       }
     });
 

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
@@ -539,9 +539,9 @@
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
-        "text": "Regenerate Plugin"
+        "text": "Regenerate Action"
       },
-      "description": "Type 'Regenerate Plugin' into the VS Code command palette input box at the top of the Microsoft Visual Studio Code interface.",
+      "description": "Type 'Regenerate Action' into the VS Code command palette input box at the top of the Microsoft Visual Studio Code interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -563,7 +563,7 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press Enter to select \"Microsoft 365 Agents: Regenerate Plugin\" from the command palette in Visual Studio Code.",
+      "description": "Press Enter to select \"Microsoft 365 Agents: Regenerate Action\" from the command palette in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/vscode-ui/src/ui.ts
+++ b/packages/vscode-ui/src/ui.ts
@@ -321,7 +321,8 @@ export class VSCodeUI implements UserInteraction {
           const timeoutPromise = new Promise((resolve) => {
             setTimeout(resolve, 500, this.localizer.loadingOptionsTimeoutMessage());
           });
-          Promise.race([loadDynamicData(), timeoutPromise])
+          const loadPromise = loadDynamicData();
+          Promise.race([loadPromise, timeoutPromise])
             .then((value) => {
               if (value != this.localizer.loadingOptionsTimeoutMessage()) {
                 if (config.skipSingleOption && options.length === 1) {
@@ -336,9 +337,7 @@ export class VSCodeUI implements UserInteraction {
                 }
               } else {
                 quickPick.show();
-                loadDynamicData()
-                  .then(onDataLoaded)
-                  .catch((e) => resolve(err(this.assembleError(e))));
+                loadPromise.then(onDataLoaded).catch((e) => resolve(err(this.assembleError(e))));
               }
             })
             .catch((e) => resolve(err(this.assembleError(e))));
@@ -505,7 +504,8 @@ export class VSCodeUI implements UserInteraction {
           const timeoutPromise = new Promise((resolve) => {
             setTimeout(resolve, 500, this.localizer.loadingOptionsTimeoutMessage());
           });
-          Promise.race([loadDynamicData(), timeoutPromise])
+          const loadPromise = loadDynamicData();
+          Promise.race([loadPromise, timeoutPromise])
             .then((value) => {
               if (value != this.localizer.loadingOptionsTimeoutMessage()) {
                 if (config.skipSingleOption && options.length === 1) {
@@ -520,9 +520,7 @@ export class VSCodeUI implements UserInteraction {
                 }
               } else {
                 quickPick.show();
-                loadDynamicData()
-                  .then(onDataLoaded)
-                  .catch((e) => resolve(err(this.assembleError(e))));
+                loadPromise.then(onDataLoaded).catch((e) => resolve(err(this.assembleError(e))));
               }
             })
             .catch((e) => resolve(err(this.assembleError(e))));
@@ -1058,15 +1056,15 @@ export class VSCodeUI implements UserInteraction {
         let promise: Thenable<string | undefined>;
         switch (level) {
           case "info": {
-            promise = window.showInformationMessage(message as string, option, ...items);
+            promise = window.showInformationMessage(message, option, ...items);
             break;
           }
           case "warn": {
-            promise = window.showWarningMessage(message as string, option, ...items);
+            promise = window.showWarningMessage(message, option, ...items);
             break;
           }
           case "error":
-            promise = window.showErrorMessage(message as string, option, ...items);
+            promise = window.showErrorMessage(message, option, ...items);
         }
         promise.then(
           (v) => {
@@ -1081,7 +1079,7 @@ export class VSCodeUI implements UserInteraction {
                 )
               );
           },
-          (error) => {}
+          () => {}
         );
       } catch (error) {
         resolve(err(this.assembleError(error)));

--- a/packages/vscode-ui/tests/ui.test.ts
+++ b/packages/vscode-ui/tests/ui.test.ts
@@ -6,6 +6,7 @@ import "./mocks/vscode-mock";
 
 import {
   err,
+  MultiSelectConfig,
   ok,
   SelectFileConfig,
   SelectFolderConfig,
@@ -616,14 +617,15 @@ describe("UI Unit Tests", async () => {
     });
 
     it("loads dynamic option in a long time and shows", async function (this: Mocha.Context) {
+      const loadOptions = sandbox.spy(async () => {
+        await sleep(1000);
+        return Promise.resolve([{ id: "1", label: "label1" }]);
+      });
       const config: SingleSelectConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
-        options: async () => {
-          await sleep(1000);
-          return Promise.resolve([{ id: "1", label: "label1" }]);
-        },
+        options: loadOptions,
         skipSingleOption: true,
       };
 
@@ -658,7 +660,59 @@ describe("UI Unit Tests", async () => {
         expect(result.value.result).to.equal("1");
         expect(mockQuickPick.show.called).is.true;
       }
+      expect(loadOptions.calledOnce).is.true;
       sandbox.restore();
+    });
+  });
+
+  describe("multi select", () => {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("loads slow dynamic options only once", async () => {
+      const clock = sandbox.useFakeTimers();
+      let resolveOptions: ((options: { id: string; label: string }[]) => void) | undefined;
+      const optionsPromise = new Promise<{ id: string; label: string }[]>((resolve) => {
+        resolveOptions = resolve;
+      });
+      const loadOptions = sandbox.spy(() => optionsPromise);
+      const config: MultiSelectConfig = {
+        name: "name",
+        title: "title",
+        placeholder: "placeholder",
+        options: loadOptions,
+      };
+
+      const mockQuickPick = stubInterface<QuickPick<FxQuickPickItem>>();
+      const mockDisposable = stubInterface<Disposable>();
+      let acceptListener: (e: void) => any;
+      mockQuickPick.onDidAccept.callsFake((listener: (e: void) => unknown) => {
+        acceptListener = listener;
+        return mockDisposable;
+      });
+      mockQuickPick.onDidHide.callsFake(() => mockDisposable);
+      mockQuickPick.onDidTriggerButton.callsFake(() => mockDisposable);
+      sandbox.stub(window, "createQuickPick").returns(mockQuickPick);
+
+      const resultPromise = ui.selectOptions(config);
+      await clock.tickAsync(501);
+
+      expect(loadOptions.calledOnce).is.true;
+      expect(mockQuickPick.show.calledOnce).is.true;
+
+      resolveOptions?.([{ id: "1", label: "label1" }]);
+      await clock.tickAsync(0);
+      mockQuickPick.selectedItems = [{ id: "1", label: "label1" }];
+      acceptListener!();
+
+      const result = await resultPromise;
+      expect(result.isOk()).is.true;
+      if (result.isOk()) {
+        expect(result.value.result).to.deep.equal(["1"]);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Fix the first Regenerate Action attempt in v4 projects so the operation picker loads reliably from a cold Kiota cache.

- reuse a single dynamic-options promise before and after the 500 ms loading timeout
- preserve operation-list parser failures as a typed `ListOpenAPISpecOperationsError`
- add single-select, multi-select, and typed-error regression coverage
- update the vscuse plan to use the current `Regenerate Action` command name
- remove existing error-level lint findings in the touched `showMessage` implementation

## Root cause

V4 creation uses `SpecParser`, so Kiota can remain cold until Regenerate Action. The VS Code UI invoked a slow dynamic-options provider again after the loading timeout. Two concurrent first-use Kiota calls could race: one downloaded the binary while the other attempted to spawn it, producing `ENOENT` before operations were listed.

## Design reference

The existing create-output contract remains unchanged:

- `docs/03-specs/scenarios/da/create-api-plugin-from-existing-api.md`

This is a bug fix restoring the existing Regenerate Action flow; it does not introduce a new workflow or output contract.

## Validation

- `packages/vscode-ui`: `npm run lint` (0 errors), `npm run build`, 129 unit tests passed
- `packages/fx-core`: `npm run lint` (0 errors), `npm run build`, focused `create.test.ts` 96 tests passed
- Prettier check and `git diff --check` passed
- Local VSIX build/package passed
- Cold-cache v4 vscuse run passed: 47/47 execution items, 0 errors
- `step_2991de14` displayed and selected `GET /pet/findByStatus` on the first Regenerate Action attempt
- final `ai-plugin.json` assertion for `findPetsByStatus` passed

Related work item: 32550020