### PR TITLE
test(vscuse): add force_run tag to dismiss agent-not-installed dialog step

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
@@ -377,7 +377,8 @@
       ],
       "postconditions": [],
       "tags": [
-        "precondition_wait_timeout:3"
+        "precondition_wait_timeout:3",
+        "force_run:true"
       ],
       "screenshot": "step_agent_not_installed",
       "created_at": "2026-07-14T05:14:10.000000",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action_Copilot_License.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action_Copilot_License.json
@@ -343,7 +343,8 @@
    ],
    "postconditions": [],
    "tags": [
-    "precondition_wait_timeout:3"
+    "precondition_wait_timeout:3",
+    "force_run:true"
    ],
    "screenshot": "step_agent_not_installed",
    "created_at": "2026-07-17T00:00:00.000000",


### PR DESCRIPTION
## What

Adds the `force_run:true` tag to the **"Press Esc to dismiss the 'This agent is not installed' dialog if it is shown before refreshing the M365 Copilot page"** step in the vscuse test cases.

## Why

This dismissal step should always execute (regardless of preceding step outcomes) so the "This agent is not installed" dialog is reliably cleared before the M365 Copilot page is refreshed.

## Files changed

- `packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json`
- `packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action_Copilot_License.json`

Both files gain a `"force_run:true"` entry in the step's `tags` array (alongside the existing `"precondition_wait_timeout:3"` tag). JSON validity for both files was verified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>