### PR TITLE
test(vscuse): stabilize Teams Agents and Apps selection

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__click_the_Teams_Agents_and_Apps.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__click_the_Teams_Agents_and_Apps.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 1,
+    "total_steps": 2,
     "created_at": "2026-06-24T02:48:42.584762",
     "name": "Click_the_Teams_Agents_and_Apps",
     "description": {
@@ -19,7 +19,8 @@
     },
     "generated_at": "2026-06-24T02:48:42.584753",
     "execution_order": [
-      "step_51279b5b"
+      "step_51279b5b",
+      "step_4fa59f6a"
     ],
     "tags": [
       "group"
@@ -30,27 +31,49 @@
     {
       "step_id": "step_51279b5b",
       "agent": "interaction",
-      "tool": "click",
+      "tool": "type_text",
       "parameters": {
-        "button": "left",
-        "x": 307,
-        "y": 266
+        "text": "Teams Agents and Apps"
       },
-      "description": "Click the \"Teams Agents and Apps\" option in the \"New Project\" dropdown menu within the Microsoft 365 Agents Toolkit interface.",
+      "description": "Type \"Teams Agents and Apps\" into the \"New Project\" search input in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:307:266:16:5:dc38314eb1964652",
-        "dhash:307:266:96:5:1352b511664a30a1",
-        "dhash:307:266:0:10:c4c8889692b17075"
+        "dhash:512:384:0:20:c0c8268484848001"
       ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_51279b5b",
       "created_at": "2026-06-24T02:48:42.590588",
+      "plan_id": "plan_r_0624_024810"
+    },
+    {
+      "step_id": "step_4fa59f6a",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to select the filtered \"Teams Agents and Apps\" result from the \"New Project\" dropdown in Visual Studio Code.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:424:79:16:5:433be585e5e5c548",
+        "dhash:424:79:96:5:004018c444d9b906",
+        "dhash:424:79:0:10:c0c8268484848001"
+      ],
+      "postconditions": [],
+      "tags": [
+        "precondition_wait_timeout:10"
+      ],
+      "screenshot": null,
+      "created_at": "2026-07-23T02:36:39.000000",
       "plan_id": "plan_r_0624_024810"
     }
   ],


### PR DESCRIPTION
## Summary

- replace the stale coordinate click for `Teams Agents and Apps` with exact quick-pick filtering
- guard the filtered target row before pressing Enter
- keep the shared group reusable for all existing consumers

## Root cause

This was test plan drift, not a product bug. The coordinate interaction no longer opened the intended submenu, while the `CY260721` product image correctly showed all four Teams scaffolding options.

## Validation

- vscuse-ui: repaired shared group completed both steps and opened the four-option Teams menu
- `Feature_Verify_Sub_Options_On_App_Created_By_TDP` against `ghcr.io/officedev/vscuse-atk-vscode:CY260721`: 49/49 successful, 0 errors
- original failing assertion `step_1c5748dd`: passed
- `git diff --check`: passed

Image digest: `sha256:9931faa84cfde95b66a74c48613ad152885257ba3b59684eedcf7e5612fd4387`