### PR TITLE
test(vscuse): sync vscode-test-cases plan/group JSON updates

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/archived/Sample_Share_Now_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/archived/Sample_Share_Now_Local_Debug.json
@@ -307,9 +307,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_5c578a49",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__azure_openai_steps.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__azure_openai_steps.json
@@ -71,9 +71,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:f0b09494b2717075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_6e03c09d",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_launch_remote_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_launch_remote_none_da.json
@@ -277,9 +277,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:3"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local.json
@@ -383,9 +383,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_d3bcefd8",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_local_none_da.json
@@ -271,9 +271,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:3"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote.json
@@ -270,9 +270,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout:60"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action.json
@@ -240,9 +240,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout: 60"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action_Copilot_License.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_remote_DA_no_action_Copilot_License.json
@@ -235,9 +235,7 @@
    "retry_count": 0,
    "continue_on_error": "false",
    "depends_on": [],
-   "preconditions": [
-    "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-   ],
+   "preconditions": [],
    "postconditions": [],
    "tags": [
     "precondition_wait_timeout: 60"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_group_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_group_local.json
@@ -192,9 +192,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_0c8673fd",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_group_remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_group_remote.json
@@ -195,9 +195,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0f9e1e8e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_d124da4f",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
@@ -190,9 +190,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1c0cf0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_abda900e",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local_Reddit.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local_Reddit.json
@@ -189,9 +189,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1c0cf0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_c5b892ff",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local_With_Azure_Resource.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local_With_Azure_Resource.json
@@ -294,9 +294,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1c0cf0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_de5581d4",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local_coffee.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local_coffee.json
@@ -191,9 +191,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:5"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local_sample_data_analyst.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local_sample_data_analyst.json
@@ -190,9 +190,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:5"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_meeting_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_meeting_local.json
@@ -192,9 +192,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fcce0359",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_meeting_remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_meeting_remote.json
@@ -193,9 +193,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_3d91b941",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_npm_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_npm_local.json
@@ -188,9 +188,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_a599e91d",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_npm_remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_npm_remote.json
@@ -187,9 +187,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_9a1bd845",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote.json
@@ -191,9 +191,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_b2737c0c",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_Copilot_Auth.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_Copilot_Auth.json
@@ -191,9 +191,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_1011165c",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_New.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_New.json
@@ -191,9 +191,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_6b5d9610",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_for_specific_samples.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_for_specific_samples.json
@@ -190,9 +190,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_d27cb767",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_sample_data_analyst.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_sample_data_analyst.json
@@ -190,9 +190,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0f9e9e8e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_f528c2eb",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_tdp.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_remote_tdp.json
@@ -191,9 +191,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:948cf8d9d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_e5b4942b",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_sample_msgext_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_sample_msgext_local.json
@@ -297,9 +297,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_55a59346",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365.json
@@ -364,9 +364,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1908f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout: 60",
@@ -698,9 +696,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:5"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_AdminAccount.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_AdminAccount.json
@@ -359,9 +359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b2319197966271e"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout: 60",
@@ -672,9 +670,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:5"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_account_with_copilot_license.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_account_with_copilot_license.json
@@ -358,9 +358,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1312e8d8d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout: 60",
@@ -689,9 +687,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1392e8d8d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:5"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_account_with_same_account.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_account_with_same_account.json
@@ -357,9 +357,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1908f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout: 60",
@@ -670,9 +668,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:5"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_withoutCommand.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_withoutCommand.json
@@ -87,9 +87,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b1b21195977271a"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:3"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_github.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_github.json
@@ -205,9 +205,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:13288c9c968e8c8c"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_785cbf4c",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_only.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_only.json
@@ -322,9 +322,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay: 3"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_only_AdminAccount.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_only_AdminAccount.json
@@ -321,9 +321,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay: 3"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_only_with_copilot_account.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_only_with_copilot_account.json
@@ -322,9 +322,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay: 3"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_withoutCommand.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_withoutCommand.json
@@ -97,9 +97,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay: 3"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_withoutCommand_Admin.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_m365_withoutCommand_Admin.json
@@ -93,9 +93,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay: 3"

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__webpage_login_Azure_account.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__webpage_login_Azure_account.json
@@ -123,9 +123,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_763f5642",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__webpage_login_account.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__webpage_login_account.json
@@ -74,9 +74,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0f1e1e8e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_c5999cc0",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__webpage_login_account_Copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__webpage_login_account_Copilot.json
@@ -123,9 +123,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0f1e1e8e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_517b02c4",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group_copilot_f5_local_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group_copilot_f5_local_debug.json
@@ -145,9 +145,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1408f0d9d5e6cae4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_9ad2a2ba",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group_debug_in_teams_tdp.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group_debug_in_teams_tdp.json
@@ -185,9 +185,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_107216f3",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group_login_azure_only.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group_login_azure_only.json
@@ -441,9 +441,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout: 60",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group_login_input_password_only.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group_login_input_password_only.json
@@ -72,9 +72,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1308f0d9d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_83da76fe",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group_login_tdp_page.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group_login_tdp_page.json
@@ -188,9 +188,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:0b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_ea3a642c",

--- a/packages/tests/vscuse/vscode-test-cases/groups/group_openapp_fromtdp.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group_openapp_fromtdp.json
@@ -269,9 +269,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:6308f0d9d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_b74ebac4",

--- a/packages/tests/vscuse/vscode-test-cases/groups/groups__debug_in_remote_with_Copilot_account.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/groups__debug_in_remote_with_Copilot_account.json
@@ -239,9 +239,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout: 60"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API.json
@@ -103,7 +103,7 @@
         "x": 347,
         "y": 132
       },
-      "description": "Click the \"No Action\" option from the dropdown menu under \"Add an action to your declarative agent\" in the \"Create Declarative Agent\" window of Microsoft 365 Agents Toolkit.",
+      "description": "Click the \"Add an Action\" option from the dropdown menu under \"Add an action to your declarative agent\" in the \"Create Declarative Agent\" window of Microsoft 365 Agents Toolkit.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_API_Key.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_API_Key.json
@@ -95,7 +95,7 @@
         "x": 232,
         "y": 51
       },
-      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dialog at the top of the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the checkbox to select all operations in the \"Select Operation(s) Copilot Can Interact with\" dropdown in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -123,7 +123,7 @@
         "x": 797,
         "y": 49
       },
-      "description": "Click the blue \"Clear All\" button in the dropdown for operation selection within the \"Microsoft 365 Agents Toolkit\" extension in Visual Studio Code, to deselect all chosen APIs.",
+      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dropdown to confirm the operation selection in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_OAuth.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Basic_OAuth.json
@@ -99,7 +99,7 @@
         "x": 232,
         "y": 51
       },
-      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dialog at the top of the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the \"Select all\" checkbox at the top-left of the \"Select Operation(s) Copilot Can Interact with\" quick pick to select all listed API operations (checking the \"GET /repair\" operation), in the Microsoft 365 Agents Toolkit extension for Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -127,7 +127,7 @@
         "x": 797,
         "y": 49
       },
-      "description": "Click the blue \"Clear All\" button in the dropdown for operation selection within the \"Microsoft 365 Agents Toolkit\" extension in Visual Studio Code, to deselect all chosen APIs.",
+      "description": "Click the blue \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" quick pick to confirm the selected API operation(s), in the Microsoft 365 Agents Toolkit extension for Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -165,9 +165,7 @@
         "dhash:313:73:0:10:f0b09494b2717075"
       ],
       "postconditions": [],
-      "tags": [
-        "precondition:old"
-      ],
+      "tags": [],
       "screenshot": "step_b20287ae",
       "created_at": "2026-05-11T05:27:45.252075",
       "plan_id": "plan_7ca218e3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Bearer_token.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Add_Action_Import_Existing_API_Bearer_token.json
@@ -96,7 +96,7 @@
         "x": 232,
         "y": 51
       },
-      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dialog at the top of the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the checkbox to select all operations in the \"Select Operation(s) Copilot Can Interact with\" dropdown in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -124,7 +124,7 @@
         "x": 797,
         "y": 49
       },
-      "description": "Click the blue \"Clear All\" button in the dropdown for operation selection within the \"Microsoft 365 Agents Toolkit\" extension in Visual Studio Code, to deselect all chosen APIs.",
+      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dropdown to confirm the operation selection in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_MCP_Oauth_Remote.json
@@ -405,7 +405,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": ["dhash:512:384:0:20:f0b0949492b17075"],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_6ed8712c",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Add_Knowledge_Onedrive.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Add_Knowledge_Onedrive.json
@@ -335,9 +335,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition:old"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Local_Debug.json
@@ -322,9 +322,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_cf00d488",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_No_Action_Remote_Debug.json
@@ -115,7 +115,7 @@
         "x": 277,
         "y": 75
       },
-      "description": "Select the \"dev\" option in the \"Select an environment\" dropdown within Visual Studio Code.",
+      "description": "Click the \"Default folder\" dropdown in the \"Workspace Folder\" dialog to set the project root folder path (`/home/.vscode/AgentsToolkitProjects`).",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Oauth_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Oauth_js_Remote_Debug.json
@@ -82,7 +82,7 @@
         "x": 320,
         "y": 136
       },
-      "description": "Click the \"No Action\" option in the \"Add an action to your declarative agent\" dropdown menu within the \"Create Declarative Agent\" dialog in Microsoft Visual Studio Code.",
+      "description": "Click the \"Add an Action\" option in the \"Add an action to your declarative agent\" dropdown menu within the \"Create Declarative Agent\" dialog in Microsoft Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_Oauth_Without_Reference_Id.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Typespec_Oauth_Without_Reference_Id.json
@@ -420,7 +420,7 @@
         "x": 433,
         "y": 411
       },
-      "description": "Click the red plus (+) button inside the \"Message Copilot\" input box to start composing a new message in the chat within the M365 Copilot web application interface.",
+      "description": "Click the \"Message Copilot\" input box to start composing a new message in the chat within the M365 Copilot web application interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Featrue_Open_DeveloperPortal_Publish.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Featrue_Open_DeveloperPortal_Publish.json
@@ -445,9 +445,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout:60"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Add_App_With_Unsupported_Feature_From_TDP.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Add_App_With_Unsupported_Feature_From_TDP.json
@@ -217,9 +217,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_28d97d6c",
@@ -813,9 +811,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:6308f0d9d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_69dd8982",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -317,9 +317,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_copilot_license_disabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_copilot_license_disabled.json
@@ -317,9 +317,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Action_And_Capability_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Action_And_Capability_Remote_Debug.json
@@ -611,9 +611,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_88cddf83",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_MCP_Server.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_MCP_Server.json
@@ -627,9 +627,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:d0902223a3222421"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition:old"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Local_Env_Provision.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Local_Env_Provision.json
@@ -328,9 +328,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fbd1439e",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Manifest_File_Function_Manifest_Plugin_Support.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Manifest_File_Function_Manifest_Plugin_Support.json
@@ -216,7 +216,7 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press Enter to confirm the \"Enter OpenAPI Description Document Location\" input in the VS Code Microsoft 365 Agents Toolkit interface.",
+      "description": "Press the \"Enter\" key again to proceed to typing in the \"Enter OpenAPI Description Document Location\" input within the VS Code Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_Bearer_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_Bearer_Auth_Configurations.json
@@ -106,7 +106,7 @@
         "x": 232,
         "y": 51
       },
-      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dialog at the top of the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the checkbox to select all operations in the \"Select Operation(s) Copilot Can Interact with\" dropdown in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -134,7 +134,7 @@
         "x": 797,
         "y": 49
       },
-      "description": "Click the blue \"Clear All\" button in the dropdown for operation selection within the \"Microsoft 365 Agents Toolkit\" extension in Visual Studio Code, to deselect all chosen APIs.",
+      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dropdown to confirm the operation selection in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_Microsoft_Entra_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_Microsoft_Entra_Auth_Configurations.json
@@ -108,7 +108,7 @@
         "x": 232,
         "y": 51
       },
-      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dialog at the top of the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the checkbox to select all operations in the \"Select Operation(s) Copilot Can Interact with\" dropdown in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -137,7 +137,7 @@
         "x": 797,
         "y": 49
       },
-      "description": "Click the blue \"Clear All\" button in the dropdown for operation selection within the \"Microsoft 365 Agents Toolkit\" extension in Visual Studio Code, to deselect all chosen APIs.",
+      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dropdown to confirm the operation selection in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_OAuth_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_OAuth_Auth_Configurations.json
@@ -119,7 +119,7 @@
         "x": 232,
         "y": 51
       },
-      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dialog at the top of the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the checkbox to select all operations in the \"Select Operation(s) Copilot Can Interact with\" dropdown in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -148,7 +148,7 @@
         "x": 797,
         "y": 49
       },
-      "description": "Click the blue \"Clear All\" button in the dropdown for operation selection within the \"Microsoft 365 Agents Toolkit\" extension in Visual Studio Code, to deselect all chosen APIs.",
+      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dropdown to confirm the operation selection in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_PKCE_OAuth_Auth_Configurations.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_No_Action_Add_PKCE_OAuth_Auth_Configurations.json
@@ -117,7 +117,7 @@
         "x": 232,
         "y": 51
       },
-      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dialog at the top of the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the checkbox to select all operations in the \"Select Operation(s) Copilot Can Interact with\" dropdown in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -146,7 +146,7 @@
         "x": 797,
         "y": 49
       },
-      "description": "Click the blue \"Clear All\" button in the dropdown for operation selection within the \"Microsoft 365 Agents Toolkit\" extension in Visual Studio Code, to deselect all chosen APIs.",
+      "description": "Click the \"OK\" button in the \"Select Operation(s) Copilot Can Interact with\" dropdown to confirm the operation selection in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_AI_Search_without_AzureOpenAI_Keys.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_AI_Search_without_AzureOpenAI_Keys.json
@@ -62,7 +62,7 @@
         "x": 301,
         "y": 131
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the Microsoft 365 Agents Toolkit extension within Visual Studio Code, selecting the agent type for data-driven interactions.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -322,9 +322,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:d0932323383c202a"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_adac6ccc",
@@ -454,9 +452,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:d0832323383c202a"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_0c38e94d",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_AI_Search_without_OpenAI_Keys.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_AI_Search_without_OpenAI_Keys.json
@@ -58,7 +58,7 @@
         "x": 301,
         "y": 131
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the Microsoft 365 Agents Toolkit extension within Visual Studio Code, selecting the agent type for data-driven interactions.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -362,9 +362,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:d0832323383c202a"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_7259ef4d",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Custom_API_without_AzureOpenAI_Keys.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Custom_API_without_AzureOpenAI_Keys.json
@@ -63,7 +63,7 @@
         "x": 301,
         "y": 131
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the Microsoft 365 Agents Toolkit extension within Visual Studio Code, selecting the agent type for data-driven interactions.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -445,9 +445,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:d0932322a8616068"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_4c693ee5",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Custom_API_without_OpenAI_Keys.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_Custom_API_without_OpenAI_Keys.json
@@ -62,7 +62,7 @@
         "x": 301,
         "y": 131
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the Microsoft 365 Agents Toolkit extension within Visual Studio Code, selecting the agent type for data-driven interactions.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_bot_with_existing_AAD.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_LocalDebug_bot_with_existing_AAD.json
@@ -371,9 +371,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Open_DeveloperPortal_Publish.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Open_DeveloperPortal_Publish.json
@@ -445,9 +445,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "precondition_wait_timeout:60"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Publish_to_Teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Publish_to_Teams.json
@@ -572,9 +572,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Remove_App_From_Devportal_And_Reprovision.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Remove_App_From_Devportal_And_Reprovision.json
@@ -355,9 +355,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1818e0d8d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_20b064ec",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Report_Issue.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Report_Issue.json
@@ -591,9 +591,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b5a0c9a968e888c"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fc66dd5e",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Sign_Out.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Sign_Out.json
@@ -547,9 +547,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_ee23b803",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_ts_Local_Debug_With_Different_Account.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Simple_Bot_ts_Local_Debug_With_Different_Account.json
@@ -460,9 +460,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1392e8d8d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_2db18dfb",
@@ -858,9 +856,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1392e8d8d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_82d51d3a",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Update_App.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Update_App.json
@@ -405,9 +405,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b18e0d8d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_5c930fdc",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Verify_Project_Type_Selection_Shows_Only_DA_CEA_Teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Verify_Project_Type_Selection_Shows_Only_DA_CEA_Teams.json
@@ -204,9 +204,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_c2833360",
@@ -550,9 +548,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:6308f0d9d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_8e1d3ee7",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Verify_Sub_Options_On_App_Created_By_TDP.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Verify_Sub_Options_On_App_Created_By_TDP.json
@@ -221,9 +221,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_84b6ae98",
@@ -817,9 +815,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:6308f0d9d9e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_1644b51f",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature__Test_Account_AAD.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature__Test_Account_AAD.json
@@ -280,9 +280,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:0b2319195966271e"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay: 3"
@@ -492,9 +490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:132319197966271e"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_dfdb3c52",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Dice_Roller_in_meeting_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Dice_Roller_in_meeting_Local_Debug.json
@@ -474,9 +474,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1b08f0d9d1e6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [
         "delay:3"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_ProxyAgent_NodeJS_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_ProxyAgent_NodeJS_Local_Debug.json
@@ -240,9 +240,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1392e8d8d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_4ff23a8f",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_SSO_Enabled_Tab_via_APIM_Proxy_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_SSO_Enabled_Tab_via_APIM_Proxy_Local_Debug.json
@@ -437,9 +437,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1328f8d9d9f6e6e4"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_b80c48ae",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Teams_Center_Dashboard_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Teams_Center_Dashboard_Local_Debug.json
@@ -357,9 +357,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:1842d9d9d5e6c3e5"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_97aea02d",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Teams_Center_Dashboard_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Teams_Center_Dashboard_Remote_Debug.json
@@ -389,9 +389,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:08c2d9d9d5e6c3e5"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_8dbc6247",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Local_Debug.json
@@ -45,7 +45,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Playground_Debug.json
@@ -44,7 +44,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_js_Remote_Debug.json
@@ -47,7 +47,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Local_Debug.json
@@ -46,7 +46,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"General Teams Agent\" dropdown option in the \"Teams Agent or App Using Teams AI Library\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Playground_Debug.json
@@ -45,7 +45,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_py_Remote_Debug.json
@@ -49,7 +49,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Local_Debug.json
@@ -45,7 +45,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Playground_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Playground_Debug.json
@@ -44,7 +44,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_Azure_OpenAI_ts_Remote_Debug.json
@@ -47,7 +47,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Local_Debug.json
@@ -48,7 +48,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_js_Remote_Debug.json
@@ -51,7 +51,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Local_Debug.json
@@ -46,7 +46,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_py_Remote_Debug.json
@@ -51,7 +51,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"General Teams Agent\" dropdown option in the \"Teams Agent or App Using Teams AI Library\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Local_Debug.json
@@ -48,7 +48,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_AI_Search_OpenAI_ts_Remote_Debug.json
@@ -51,7 +51,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_Local_Debug.json
@@ -49,7 +49,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_js_PlayGround.json
@@ -48,7 +48,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"General Teams Agent\" dropdown option in the \"Teams Agent or App Using Teams AI Library\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -104,7 +104,7 @@
         "x": 457,
         "y": 73
       },
-      "description": "Click on the \"Enter OpenAPI Description Document Location\" text field within the pop-up window at the top of the Microsoft Visual Studio Code interface.",
+      "description": "Click on the \"Enter OpenAPI Document URL\" option within the \"OpenAPI Document\" pop-up window at the top of the Microsoft Visual Studio Code interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_Local_Debug.json
@@ -51,7 +51,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_py_PlayGround.json
@@ -49,7 +49,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -105,7 +105,7 @@
         "x": 457,
         "y": 73
       },
-      "description": "Click on the \"Enter OpenAPI Description Document Location\" text field within the pop-up window at the top of the Microsoft Visual Studio Code interface.",
+      "description": "Click on the \"Enter OpenAPI Document URL\" option within the \"OpenAPI Document\" pop-up window at the top of the Microsoft Visual Studio Code interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_Local_Debug.json
@@ -50,7 +50,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"General Teams Agent\" dropdown option in the \"Teams Agent or App Using Teams AI Library\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_PlayGround.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_Azure_OpenAI_ts_PlayGround.json
@@ -48,7 +48,7 @@
         "x": 410,
         "y": 127
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" menu.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Local_Debug.json
@@ -125,7 +125,7 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press the \"Enter\" key to confirm the selected file path in the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
+      "description": "Press the \"Enter\" key again after selecting \"Custom API Preview\" to proceed to the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_js_Remote_Debug.json
@@ -132,7 +132,7 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press the \"Enter\" key to confirm the selected file path in the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
+      "description": "Press the \"Enter\" key again after selecting \"Custom API Preview\" to proceed to the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Local_Debug.json
@@ -131,7 +131,7 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press the \"Enter\" key to confirm the selected file path in the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
+      "description": "Press the \"Enter\" key again after selecting \"Custom API Preview\" to proceed to the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_py_Remote_Debug.json
@@ -128,7 +128,7 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press the \"Enter\" key to confirm the selected file path in the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
+      "description": "Press the \"Enter\" key again after selecting \"Custom API Preview\" to proceed to the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Local_Debug.json
@@ -129,7 +129,7 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press the \"Enter\" key to confirm the selected file path in the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
+      "description": "Press the \"Enter\" key again after selecting \"Custom API Preview\" to proceed to the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Custom_API_OpenAI_ts_Remote_Debug.json
@@ -132,7 +132,7 @@
       "parameters": {
         "key": "enter"
       },
-      "description": "Press the \"Enter\" key to confirm the selected file path in the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
+      "description": "Press the \"Enter\" key again after selecting \"Custom API Preview\" to proceed to the \"Enter OpenAPI Description Document Location\" input field within the Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Copilot_Remote_Debug.json
@@ -53,7 +53,7 @@
         "x": 385,
         "y": 128
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option within the \"Teams Agent or App Using Microsoft Teams SDK\" selection popup in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_js_Remote_Debug.json
@@ -51,7 +51,7 @@
         "x": 385,
         "y": 128
       },
-      "description": "Click the \"General Teams Agent\" dropdown option within the \"Teams Agent or App Using Teams AI Library\" selection popup in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Local_Debug.json
@@ -46,7 +46,7 @@
         "x": 307,
         "y": 132
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Teams AI Library\" selection menu within the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Copilot_Remote_Debug.json
@@ -54,7 +54,7 @@
         "x": 385,
         "y": 128
       },
-      "description": "Click the \"General Teams Agent\" dropdown option within the \"Teams Agent or App Using Teams AI Library\" selection popup in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Local_Debug.json
@@ -45,7 +45,7 @@
         "x": 307,
         "y": 132
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" selection menu within the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_py_Remote_Debug.json
@@ -50,7 +50,7 @@
         "x": 307,
         "y": 132
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" selection menu within the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Copilot_Remote_Debug.json
@@ -53,7 +53,7 @@
         "x": 385,
         "y": 128
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option within the \"Teams Agent or App Using Microsoft Teams SDK\" selection popup in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_Azure_OpenAI_ts_Remote_Debug.json
@@ -51,7 +51,7 @@
         "x": 385,
         "y": 128
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option within the \"Teams Agent or App Using Microsoft Teams SDK\" selection popup in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_js_Remote_Debug.json
@@ -52,7 +52,7 @@
         "x": 385,
         "y": 128
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option within the \"Teams Agent or App Using Microsoft Teams SDK\" selection popup in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Local_Debug.json
@@ -47,7 +47,7 @@
         "x": 307,
         "y": 132
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option in the \"Teams Agent or App Using Microsoft Teams SDK\" selection menu within the Microsoft 365 Agents Toolkit interface in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_py_Remote_Debug.json
@@ -52,7 +52,7 @@
         "x": 385,
         "y": 128
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option within the \"Teams Agent or App Using Microsoft Teams SDK\" selection popup in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Agent_With_Data_Customize_OpenAI_ts_Remote_Debug.json
@@ -52,7 +52,7 @@
         "x": 385,
         "y": 128
       },
-      "description": "Click the \"Teams Agent with Data\" dropdown option within the \"Teams Agent or App Using Microsoft Teams SDK\" selection popup in Visual Studio Code.",
+      "description": "Click the \"Teams Agent with Data\" dropdown option.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Collaborator_Agent_debug_in_playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Collaborator_Agent_debug_in_playground.json
@@ -84,11 +84,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:290:52:16:5:2cd3d6d69633a844",
-        "dhash:290:52:96:5:000088544655758c",
-        "dhash:290:52:0:10:f0b0949492b17071"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_6063f1fc",
@@ -108,9 +104,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:e0b0949492b17071"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_a2796d72",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Collaborator_Agent_local_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Collaborator_Agent_local_debug.json
@@ -84,11 +84,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:333:48:16:5:09146e9c52521295",
-        "dhash:333:48:96:5:0112a6486a5c5ca1",
-        "dhash:333:48:0:10:e0b0949492b17071"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_46f750b2",
@@ -108,9 +104,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:f0b0949492b37271"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_288a8d0e",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Teams_Collaborator_Agent_remote_debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Teams_Collaborator_Agent_remote_debug.json
@@ -106,9 +106,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:f0b09494b2717075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_288a8d0e",


### PR DESCRIPTION
## What
Extracts **only** the packages/tests/vscuse/vscode-test-cases/**/*.json changes (test **plans** + **groups**) that have accumulated on qfai/split-vscuse-driver-model (#16437) into a standalone PR targeting dev.

131 JSON files changed, no other files touched (workflow files, config.yaml, and the local wheel from #16437 are intentionally excluded).

## Why
#16437's primary purpose is splitting the vscuse driver LLM from the product/test LLM. Alongside that, a series of test-plan housekeeping fixes accumulated on the same branch (step description corrections, restored steps that were incorrectly deleted, precondition cleanup for secret-typing steps, mislabeled-step fixes, etc.) — these are independently valuable and unrelated to the model-split change, so they're being split out here to land on dev on their own.

## Verification
- Content of every file in this PR is byte-identical to the corresponding file on qfai/split-vscuse-driver-model (verified via `git diff` — zero diff).
- Confirmed no overlap with files dev has independently changed since the branches' last common ancestor, so this should merge cleanly and cause no conflicts when qfai/split-vscuse-driver-model is later merged with dev.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>