### PR TITLE
ci(pr-vscuse-test): cap selected test plans at 256 to avoid GH Actions matrix limit

### DIFF
--- a/.github/workflows/pr-vscuse-test.yml
+++ b/.github/workflows/pr-vscuse-test.yml
@@ -14,6 +14,9 @@
 #   2. Gets the diff between the PR branch and the target branch
 #   3. Selects test plans — a changed test plan file is run as an "impacted" case;
 #      for product-code changes GitHub Copilot CLI (Claude Sonnet 4.6) picks relevant plans
+#      (the final list is capped at 256 entries — GitHub Actions' hard limit on the number
+#      of configurations a single job's `strategy.matrix` can expand to; see
+#      MAX_MATRIX_PLANS / cap_plans_json in the "Select test plans via AI" step)
 #   4. Posts a PR comment listing the selected plans
 #   5. Dispatches dev-smoke-test-pipeline.yml with those plans
 #   6. Resolves (edits) the PR comment with the final pass/fail result
@@ -302,6 +305,30 @@ jobs:
         run: |
           set -euo pipefail
 
+          # GitHub Actions hard-caps a single job's `strategy.matrix` at 256 generated
+          # configurations. dev-smoke-test-pipeline.yml forwards our test_plans CSV
+          # straight into ui-test-vscuse-template.yml's `strategy.matrix.test_plan`, so
+          # handing it more than 256 plans makes GitHub fail that job during matrix
+          # expansion -- before a single Case-* test even starts. This is not
+          # theoretical: run 30250346356 was manually dispatched with 270 plans and
+          # every Case-* job silently never ran (the run still showed a red ❌, but
+          # zero test cases actually executed). This workflow's own AI/impacted-plan
+          # selection normally stays well under the limit, but cap defensively
+          # wherever a plan list is about to become the final test_plans output, so a
+          # large "impacted files" or smoke-fallback list can never repeat that
+          # failure mode. Keep only the first MAX_MATRIX_PLANS entries.
+          MAX_MATRIX_PLANS=256
+          cap_plans_json() {
+            local plans_json="$1" count
+            count=$(echo "$plans_json" | jq 'length')
+            if [ "$count" -gt "$MAX_MATRIX_PLANS" ]; then
+              echo "::warning::Selected ${count} test plans, which exceeds the GitHub Actions matrix limit of ${MAX_MATRIX_PLANS} configurations; truncating to the first ${MAX_MATRIX_PLANS}." >&2
+              echo "$plans_json" | jq -c ".[0:${MAX_MATRIX_PLANS}]"
+            else
+              echo "$plans_json"
+            fi
+          }
+
           # List every available plan name (one per line)
           PLANS_TEXT=$(find packages/tests/vscuse/vscode-test-cases/plans \
             -maxdepth 1 -name "*.json" -exec basename {} .json \; | sort)
@@ -371,6 +398,7 @@ jobs:
           # steps are gated on has_code_files), so we must not invoke it here.
           if [ "${HAS_CODE_FILES:-true}" != "true" ]; then
             if [ "$HINT_MATCHED_COUNT" -gt 0 ]; then
+              HINT_MATCHED_PLANS=$(cap_plans_json "$HINT_MATCHED_PLANS")
               PLANS_CSV=$(echo "$HINT_MATCHED_PLANS" | jq -r 'join(",")')
               echo "test_plans=${PLANS_CSV}" >> "$GITHUB_OUTPUT"
               echo "reason=Selected ${HINT_MATCHED_COUNT} user-requested plan(s) from authoritative hint (no product code modified)." >> "$GITHUB_OUTPUT"
@@ -378,6 +406,7 @@ jobs:
               echo "is_fallback=false" >> "$GITHUB_OUTPUT"
               echo "Selected user-hinted plans: $PLANS_CSV"
             elif [ "$IMPACTED_COUNT" -gt 0 ]; then
+              IMPACTED_PLANS=$(cap_plans_json "$IMPACTED_PLANS")
               PLANS_CSV=$(echo "$IMPACTED_PLANS" | jq -r 'join(",")')
               echo "test_plans=${PLANS_CSV}" >> "$GITHUB_OUTPUT"
               echo "reason=Selected ${IMPACTED_COUNT} impacted test plan(s) changed in this PR (no product code modified)." >> "$GITHUB_OUTPUT"
@@ -386,6 +415,7 @@ jobs:
               echo "Selected impacted plans only: $PLANS_CSV"
             else
               SMOKE_PLANS=$(jq -c '[.smokeTestCases[]]' packages/tests/vscuse/smoking-test-cases.json)
+              SMOKE_PLANS=$(cap_plans_json "$SMOKE_PLANS")
               PLANS_CSV=$(echo "$SMOKE_PLANS" | jq -r 'join(",")')
               echo "test_plans=${PLANS_CSV}" >> "$GITHUB_OUTPUT"
               echo "reason=No runnable changed plans found; using smoke test cases as fallback." >> "$GITHUB_OUTPUT"
@@ -476,6 +506,7 @@ jobs:
             IS_FALLBACK="true"
           fi
 
+          VALID_PLANS=$(cap_plans_json "$VALID_PLANS")
           PLANS_CSV=$(echo "$VALID_PLANS" | jq -r 'join(",")')
           echo "test_plans=${PLANS_CSV}"    >> "$GITHUB_OUTPUT"
           echo "reason=${AI_REASON}"        >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What
`pr-vscuse-test.yml` selects a list of VscUse test plans (AI-picked, impacted-file, user-hint, or smoke-fallback) and forwards it as `test_plan` to `dev-smoke-test-pipeline.yml`, which forwards it again to `ui-test-vscuse-template.yml`'s `strategy.matrix.test_plan`.

## The limit
GitHub Actions hard-caps a single job's `strategy.matrix` at **256** generated configurations. If the forwarded plan list ever exceeds that, the downstream `main` (`Case-*`) job fails during **matrix expansion** — before any runner is even allocated, so **zero** test cases execute, yet the overall run still shows as failed.

This is not theoretical: [run 30250346356](https://github.com/OfficeDev/microsoft-365-agents-toolkit/actions/runs/30250346356) was manually dispatched with 270 plans and hit exactly this:
```
Strategy for job 'main' produced 270 configurations which exceeds the maximum of 256 configurations
```
The job list only showed `discover-test-plans` (success) and `report` (success, nothing to report) — no `Case-*` job ever appears, which makes the failure easy to misdiagnose as "everything passed, why is it red?".

## Fix
Add a `cap_plans_json` helper in `pr-vscuse-test.yml`'s "Select test plans via AI" step and call it at every point a plan list is finalized (user-hint, impacted-only, smoke-fallback, and the main AI+impacted path): if the list has more than 256 entries, keep only the first 256 and emit a `::warning::` annotation explaining the truncation.

This workflow's own selection normally stays well under the limit (1-5 AI picks, or a handful of impacted plans), so this is a defensive guard, not a behavior change for the common case.

## Verification
- `python -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly.
- Extracted the step's script and ran `bash -n` — no syntax errors.
- Unit-tested `cap_plans_json` standalone with 5 / 256 / 257 / 270-element arrays — truncates to exactly 256 only when `> 256`, keeps the first N entries, and the resulting CSV still joins correctly (256 items -> 255 commas).