### PR TITLE
test(vscuse): update step_53ed5a31 description

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_openai_bot_in_Copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_openai_bot_in_Copilot.json
@@ -39,7 +39,7 @@
         "x": 340,
         "y": 373
       },
-      "description": "Click the app title \"${{var:app_name}}dev\" at the top of the M365 Copilot (web app) chat interface.(Previsously used for clicking the input box, but now used for precondition validation.)",
+      "description": "click message input box prepare for tying",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## Summary

Updates the `description` of `step_53ed5a31` in `group__validation_openai_bot_in_Copilot.json`.

**Before:**
> Click the app title "${{var:app_name}}dev" at the top of the M365 Copilot (web app) chat interface.(Previsously used for clicking the input box, but now used for precondition validation.)

**After:**
> click message input box prepare for tying

## Notes
- Only the `description` field of the step was changed; step parameters, preconditions, and screenshot references are untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>