### PR TITLE
refactor: update click input box description

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair.json
@@ -41,7 +41,7 @@
         "x": 350,
         "y": 373
       },
-      "description": "Click on the input box",
+      "description": "Click the input box in the M365 Copilot chat page.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair.json
@@ -41,7 +41,7 @@
         "x": 350,
         "y": 373
       },
-      "description": "Click on the blank area above the \"vscuse_app_${{var:app_name}}dev\" agent title in the Microsoft 365 Copilot chat interface.(Previously used for clicking the input box, but now used for precondition validation.)",
+      "description": "Click on the input box",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair_Oauth.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair_Oauth.json
@@ -41,7 +41,7 @@
         "x": 376,
         "y": 409
       },
-      "description": "Click on the input box",
+      "description": "Click the input box in the M365 Copilot chat page.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair_Oauth.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_DA_repair_Oauth.json
@@ -41,7 +41,7 @@
         "x": 376,
         "y": 409
       },
-      "description": "Click on the blank area of the chat pane, just below the \"${{var:app_name}}dev\" agent title and above the \"Created by\" line, in the M365 Copilot chat interface.(Previously used for clicking the input box, but now used for precondition validation.)",
+      "description": "Click on the input box",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_basic_ai_chat_bot_in_copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_basic_ai_chat_bot_in_copilot.json
@@ -38,7 +38,7 @@
         "x": 416,
         "y": 369
       },
-      "description": "Click on the agent title \"${{var:app_name}}dev\" heading in the M365 Copilot web application chat page.(Previously used for clicking the input box.)",
+      "description": "Click on the input box",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_basic_ai_chat_bot_in_copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_basic_ai_chat_bot_in_copilot.json
@@ -38,7 +38,7 @@
         "x": 416,
         "y": 369
       },
-      "description": "Click on the input box",
+      "description": "Click the input box in the M365 Copilot chat page.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_customize_AzureAI_in_copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_customize_AzureAI_in_copilot.json
@@ -38,7 +38,7 @@
         "x": 373,
         "y": 366
       },
-      "description": "Click the \"Message ${{var:app_name}}dev\" input box in the M365 Copilot web application, within the agent chat interface, focusing on the area where users enter text to start a conversation.(Previously used for clicking the input box.)",
+      "description": "Click on the input box",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__validation_customize_AzureAI_in_copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__validation_customize_AzureAI_in_copilot.json
@@ -38,7 +38,7 @@
         "x": 373,
         "y": 366
       },
-      "description": "Click on the input box",
+      "description": "Click the input box in the M365 Copilot chat page.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
This pull request updates several test case descriptions in the `vscuse/vscode-test-cases` suite to clarify the user action being tested. The descriptions for actions that previously referenced clicking on various areas of the Copilot chat interface are now simplified to consistently state "Click on the input box".

Test case description simplification:

* Updated step descriptions in the following test case files to "Click on the input box" for clarity and consistency:
  - `group__validation_DA_repair.json`
  - `group__validation_DA_repair_Oauth.json`
  - `group__validation_basic_ai_chat_bot_in_copilot.json`
  - `group__validation_customize_AzureAI_in_copilot.json`