### PR TITLE
fix(fx-core): align the MCP url validation and warning delivery onto v4

### DIFF
--- a/docs/01-product/scenarios/da/add-mcp-action-to-da.html
+++ b/docs/01-product/scenarios/da/add-mcp-action-to-da.html
@@ -212,7 +212,7 @@
     <section class="scenario-flow" aria-labelledby="provenance-heading">
       <div class="section-head"><h2 id="provenance-heading">Provenance</h2></div>
       <p>Scenario contract: <code>da/add-mcp-action-to-da.md</code>. Scaffold catalog kind: <code>modify</code>.</p>
-      <p class="fingerprint">Current fingerprints: semantic c7788f2243940e9f83a42d6343b0c88f92d248a0c35b83b83e6a41609c175709; presentation 0e3ea01b405baa97d0caa2521c7ab02ff703ed751fbbdb811eb202d65d3f6ea5</p>
+      <p class="fingerprint">Current fingerprints: semantic 30fc7ef7f883f05f92581295ba1299eab270edbf44eae79db27063058b039225; presentation 0e3ea01b405baa97d0caa2521c7ab02ff703ed751fbbdb811eb202d65d3f6ea5</p>
     </section>
   </main>
   <footer>Generated review projection. Scenario behavior remains in <code>add-mcp-action-to-da.md</code>.</footer>

--- a/docs/01-product/scenarios/da/add-mcp-action-to-da.md
+++ b/docs/01-product/scenarios/da/add-mcp-action-to-da.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-20T00:00:00Z
-- Last updated: 2026-07-17T00:00:00Z
+- Last updated: 2026-07-29T00:00:00Z
 - Status: implemented
 - PM owner: summzhan
 - Engineer owner: HuihuiWu-Microsoft, Alive-Fish
@@ -51,7 +51,7 @@ When `TEAMSFX_MCP_FOR_DA_DT=false`, VS Code keeps the compatibility handoff: it 
 
 - Entry: an existing DA project is available and the developer starts `Add action`.
 - Action source: the developer selects `Start with a MCP server`.
-- Server URL: the developer enters a valid remote MCP server URL unless the surface already supplied it.
+- Server URL: the developer enters a remote MCP server URL unless the surface already supplied it. The URL is checked as it is entered, by the same rule as create: a value that is not an absolute `http(s)` address, or one the server answers with 404 to an MCP `initialize` request, is rejected on the question.
 - Authentication: `OAuth (with static registration)`, `Entra SSO`, and `None` are available on the dynamic path. `OAuth (with dynamic registration)` is available only when DT and DCR are both true.
 - Static OAuth and Entra SSO: shipped v3 asks for the required client ID, the OAuth client secret, and optional OAuth scopes during add, then persists environment references. The v4 preview writes registration wiring without credential values and asks for missing values during provision.
 - Dynamic OAuth: add injects `dcr/register`. Unresolved authorization discovery produces a warning and a well-known URL placeholder that must be repaired before provision.
@@ -59,7 +59,7 @@ When `TEAMSFX_MCP_FOR_DA_DT=false`, VS Code keeps the compatibility handoff: it 
 - Confirmation: VS Code dynamic mode writes after the final required answer. CLI interactive retains the standard modification confirmation; cancellation writes nothing.
 - Idempotent re-run: adding the same URL and auth mode does not duplicate the action, lifecycle registration, or environment placeholder.
 - Deferred update: changing the auth mode for an already-added same-host server is not guaranteed by this scenario.
-- Validation: missing or invalid URL, invalid project or manifest path, and unsupported auth values are recoverable before mutation.
+- Validation: a missing URL, a URL that is not an absolute `http(s)` address or that answers 404 to the MCP `initialize` request, an invalid project or manifest path, and unsupported auth values are recoverable before mutation.
 
 ## User-visible outputs
 
@@ -76,6 +76,7 @@ When `TEAMSFX_MCP_FOR_DA_DT=false`, VS Code keeps the compatibility handoff: it 
 - The dynamic flow asks for action source, conditional MCP server URL, and authentication type. Shipped v3 also asks the conditional credential follow-ups for static OAuth and Entra SSO; the generated v4 preview walk omits them.
 - VS Code reports that the action was added after successful inline mutation. CLI uses its normal success output after confirmation or non-interactive completion.
 - Dynamic OAuth discovery fallback warns that the generated well-known URL placeholder must be repaired before provision.
+- Add has no scaffolding summary, so a lifecycle action left holding auth placeholders is raised as a warning notification naming the file to repair.
 
 ### Error and recovery messages
 
@@ -92,6 +93,7 @@ When `TEAMSFX_MCP_FOR_DA_DT=false`, VS Code keeps the compatibility handoff: it 
 ### External side effects
 
 - Dynamic add does not fetch MCP tools.
+- Entering the server URL sends an unauthenticated MCP `initialize` request to it to establish whether an MCP endpoint is there.
 - Auth wiring may probe authorization discovery endpoints. OAuth configuration creation and DCR execution occur during provision.
 - DT-off Fetch Tools may contact the selected MCP server when the developer invokes that follow-up scenario.
 
@@ -177,6 +179,6 @@ scaffolding:
         mcpServerUrl: https://example.com/mcp
         authType: none
   reviewedFingerprints:
-    semantic: c7788f2243940e9f83a42d6343b0c88f92d248a0c35b83b83e6a41609c175709
+    semantic: 30fc7ef7f883f05f92581295ba1299eab270edbf44eae79db27063058b039225
     presentation: 0e3ea01b405baa97d0caa2521c7ab02ff703ed751fbbdb811eb202d65d3f6ea5
 ```

--- a/docs/01-product/scenarios/da/create-da-with-mcp-server-superseded-20260717.html
+++ b/docs/01-product/scenarios/da/create-da-with-mcp-server-superseded-20260717.html
@@ -82,7 +82,7 @@
     <section class="scenario-flow" aria-labelledby="provenance-heading">
       <div class="section-head"><h2 id="provenance-heading">Provenance</h2></div>
       <p>Scenario contract: <code>da/create-da-with-mcp-server-superseded-20260717.md</code>. Scaffold catalog kind: <code>create</code>.</p>
-      <p class="fingerprint">Current fingerprints: semantic 996636cce995c01e0d0015ad010edc0dfe39fe2a901653725e268814e7163dd0; presentation 0b9d545e3dc0be33894ba1de544106c0e699616b30aada0fe1930362bf283709</p>
+      <p class="fingerprint">Current fingerprints: semantic db63725e483298552c0a55069932bba9418c30214e7f2341c412c02d900bcd7a; presentation 0b9d545e3dc0be33894ba1de544106c0e699616b30aada0fe1930362bf283709</p>
     </section>
   </main>
   <footer>Generated review projection. Scenario behavior remains in <code>create-da-with-mcp-server-superseded-20260717.md</code>.</footer>

--- a/docs/01-product/scenarios/da/create-da-with-mcp-server-superseded-20260720.html
+++ b/docs/01-product/scenarios/da/create-da-with-mcp-server-superseded-20260720.html
@@ -435,7 +435,7 @@
     <section class="scenario-flow" aria-labelledby="provenance-heading">
       <div class="section-head"><h2 id="provenance-heading">Provenance</h2></div>
       <p>Scenario contract: <code>da/create-da-with-mcp-server-superseded-20260720.md</code>. Scaffold catalog kind: <code>create</code>.</p>
-      <p class="fingerprint">Current fingerprints: semantic ce306745747b6901aec8ec6c20020627b56990c45e75fe87c87b426785f0065a; presentation 6fd81458e6ccea7b1855cbb5a8a5698fb81e8224c046483748adadcf7c5a0622</p>
+      <p class="fingerprint">Current fingerprints: semantic fe2d4b51d713e03ae3acdf3dc633bdbb24c1dc0a44808992462cccb87f81dba9; presentation 6fd81458e6ccea7b1855cbb5a8a5698fb81e8224c046483748adadcf7c5a0622</p>
     </section>
   </main>
   <footer>Generated review projection. Scenario behavior remains in <code>create-da-with-mcp-server-superseded-20260720.md</code>.</footer>

--- a/docs/01-product/scenarios/da/create-da-with-mcp-server.html
+++ b/docs/01-product/scenarios/da/create-da-with-mcp-server.html
@@ -447,7 +447,7 @@
     <section class="scenario-flow" aria-labelledby="provenance-heading">
       <div class="section-head"><h2 id="provenance-heading">Provenance</h2></div>
       <p>Scenario contract: <code>da/create-da-with-mcp-server.md</code>. Scaffold catalog kind: <code>create</code>.</p>
-      <p class="fingerprint">Current fingerprints: semantic ce306745747b6901aec8ec6c20020627b56990c45e75fe87c87b426785f0065a; presentation 6fd81458e6ccea7b1855cbb5a8a5698fb81e8224c046483748adadcf7c5a0622</p>
+      <p class="fingerprint">Current fingerprints: semantic fe2d4b51d713e03ae3acdf3dc633bdbb24c1dc0a44808992462cccb87f81dba9; presentation 6fd81458e6ccea7b1855cbb5a8a5698fb81e8224c046483748adadcf7c5a0622</p>
     </section>
   </main>
   <footer>Generated review projection. Scenario behavior remains in <code>create-da-with-mcp-server.md</code>.</footer>

--- a/docs/01-product/scenarios/da/create-da-with-mcp-server.md
+++ b/docs/01-product/scenarios/da/create-da-with-mcp-server.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-07-20T09:29:44Z
-- Last updated: 2026-07-21T01:53:25Z
+- Last updated: 2026-07-29T00:00:00Z
 - Status: approved
 - PM owner: summzhan
 - Engineer owner: HuihuiWu-Microsoft, Alive-Fish
@@ -53,13 +53,14 @@ While `TEAMSFX_MCP_FOR_DA_DT` still exists, setting it to `false` selects the co
 - Entry: the developer starts project creation and chooses `Declarative Agent` -> `Add an Action` -> `Start with a MCP server`.
 - Server source: when local discovery is available, the developer chooses `Local MCP server` or `Remote MCP server`; otherwise the flow continues with remote.
 - Local: the developer selects one or more discovered local servers. The flow skips URL, authentication, and credential questions.
-- Remote: the developer enters a valid MCP server URL and selects an authentication type.
+- Remote: the developer enters an MCP server URL and selects an authentication type. The URL is checked as it is entered: a value that is not an absolute `http(s)` address, or one the server answers with 404 to an MCP `initialize` request, is rejected on the question.
 - Remote auth: `OAuth (with static registration)`, `Entra SSO`, and `None` are always available on the dynamic route. `OAuth (with dynamic registration)` is available only when both DT and DCR are true.
 - Static OAuth: immediately after auth selection, the flow asks for a required OAuth client ID, a required masked client secret, and optional space-separated scopes, in that order.
 - Entra SSO: immediately after auth selection, the flow asks only for a required Microsoft Entra Application (Client) ID.
 - Dynamic OAuth and None: the flow asks no client ID, client secret, or scopes question and continues to project location and application name.
 - Dynamic OAuth: scaffolding injects `dcr/register`. If authorization discovery cannot be resolved, the generated action contains the documented well-known URL placeholder and the developer receives a warning to repair it before provision.
-- Validation: an empty required credential, invalid URL, invalid app name or location, unsupported auth value, or missing required non-interactive input keeps the flow recoverable and does not accept partial output.
+- Static OAuth: scaffolding injects `oauth/register`. If the server advertises no OAuth endpoints, the generated action contains authorization and token URL placeholders and the developer receives the same repair warning.
+- Validation: an empty required credential, a server URL that is not an absolute `http(s)` address or that answers 404 to the MCP `initialize` request, an invalid app name or location, an unsupported auth value, or a missing required non-interactive input keeps the flow recoverable and does not accept partial output.
 - Cancellation: cancelling before generation leaves no partially scaffolded project and persists no credential value.
 
 ## User-visible outputs
@@ -78,6 +79,7 @@ While `TEAMSFX_MCP_FOR_DA_DT` still exists, setting it to `false` selects the co
 - The guided flow shows the DA template choices, MCP source, conditional local selection or remote URL, auth type, required credential follow-ups, project location, and app name.
 - The client secret is masked while entered and is never included in generated review artifacts, warnings, or logs.
 - Dynamic OAuth discovery fallback produces a warning identifying the manual repair needed before provision.
+- A server URL that answers the `initialize` request like something other than an MCP endpoint, without answering 404, produces an advisory warning after scaffolding. Generation still succeeds.
 - Successful generation opens or reports the generated project through the normal surface behavior.
 
 ### Error and recovery messages
@@ -97,6 +99,7 @@ While `TEAMSFX_MCP_FOR_DA_DT` still exists, setting it to `false` selects the co
 ### External side effects
 
 - Local selection reads the discovered local MCP server catalog.
+- Entering the remote URL sends an unauthenticated MCP `initialize` request to it to establish whether an MCP endpoint is there.
 - Remote auth wiring may probe authorization discovery endpoints while generating the lifecycle action. OAuth configuration creation and DCR execution occur during provision, not scaffolding.
 
 ## Flow
@@ -214,6 +217,6 @@ scaffolding:
         oauthClientSecret:
           state: non-empty
   reviewedFingerprints:
-    semantic: ce306745747b6901aec8ec6c20020627b56990c45e75fe87c87b426785f0065a
+    semantic: fe2d4b51d713e03ae3acdf3dc633bdbb24c1dc0a44808992462cccb87f81dba9
     presentation: 6fd81458e6ccea7b1855cbb5a8a5698fb81e8224c046483748adadcf7c5a0622
 ```

--- a/packages/fx-core/src/component/generator/generatorAction.ts
+++ b/packages/fx-core/src/component/generator/generatorAction.ts
@@ -5,7 +5,7 @@ import AdmZip from "adm-zip";
 import fs from "fs-extra";
 import path from "path";
 
-import { LogProvider, Platform } from "@microsoft/teamsfx-api";
+import { LogProvider, Platform, Warning } from "@microsoft/teamsfx-api";
 
 import { SampleUrlInfo } from "../../common/samples";
 import { getTemplatesFolder } from "../../folder";
@@ -32,6 +32,8 @@ export interface GeneratorContext {
   sampleInfo?: SampleUrlInfo;
   fallback?: boolean;
   outputs?: string[];
+  /** Warnings raised while generating, for the caller to put on `CreateProjectResult`. */
+  warnings?: Warning[];
 
   filterFn?: (name: string) => boolean;
   fileNameReplaceFn?: (name: string, data: Buffer) => string;

--- a/packages/fx-core/src/component/generator/v4TemplateBridge.ts
+++ b/packages/fx-core/src/component/generator/v4TemplateBridge.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SystemError, UserError } from "@microsoft/teamsfx-api";
+import { SystemError, UserError, Warning } from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
 import { merge } from "lodash";
 import path from "path";
@@ -267,6 +267,10 @@ export async function scaffoldDeclarativeFromV4Channel(
   }
 
   const existing = await listExistingRelativeFiles(context.destination);
+  // Warnings raised by the pipeline are both logged and handed back on the context, so the
+  // caller can put them on `CreateProjectResult.warnings` — that is what feeds the scaffolding
+  // summary and the surfaces' post-create notifications.
+  const warnings: Warning[] = [];
   const result = await scaffold(
     {
       descriptor: loaded.value.descriptor,
@@ -276,14 +280,16 @@ export async function scaffoldDeclarativeFromV4Channel(
       callerFloor,
       targetDir: { path: context.destination, existing },
     },
-    createRealRuntime(context.destination, flagReader, stepRegistry, (message) =>
-      context.logProvider.warning(message)
-    )
+    createRealRuntime(context.destination, flagReader, stepRegistry, (warning) => {
+      warnings.push(warning);
+      context.logProvider.warning(warning.content);
+    })
   );
   if (result.isErr()) {
     throw result.error;
   }
 
   context.outputs = result.value.written;
+  context.warnings = warnings;
   return source;
 }

--- a/packages/fx-core/src/component/utils/mcpAuthScaffolder.ts
+++ b/packages/fx-core/src/component/utils/mcpAuthScaffolder.ts
@@ -110,6 +110,16 @@ export function isMCPScaffoldWarning(warning: { type: string }): boolean {
   return warning.type.startsWith("mcp");
 }
 
+/**
+ * The subset of MCP scaffolding warnings that mean the generated `m365agents.yml` still holds a
+ * placeholder and therefore cannot provision. Surfaces single these out for a blocking-looking
+ * notification instead of a summary line.
+ */
+export const MCP_AUTH_PLACEHOLDER_WARNING_TYPES = [
+  "mcpAuthDcrWellKnownUrlPlaceholder",
+  "mcpAuthOAuthUrlPlaceholder",
+];
+
 export interface InjectMCPAuthActionResult {
   /** True when `oauth-dynamic` was injected with the placeholder URL because
    * `endpoints.wellKnownUrl` was missing. */

--- a/packages/fx-core/src/core/FxCore.declarativeAgent.ts
+++ b/packages/fx-core/src/core/FxCore.declarativeAgent.ts
@@ -50,6 +50,7 @@ import {
 import { QuestionMW } from "../component/middleware/questionMW";
 import { outputScaffoldingWarningMessage } from "../component/utils/common";
 import {
+  MCP_AUTH_PLACEHOLDER_WARNING_TYPES,
   ResolvedMCPAuthEndpoints,
   deriveMCPManifestOAuth,
   injectMCPAuthActionToYml,
@@ -108,6 +109,14 @@ async function scaffoldAddMcpServerFromV4(
     );
     if (source.warning) {
       TOOLS.logProvider.warning(source.warning);
+    }
+    // Like the shipped add-action flow, this path has no scaffolding summary to fall back on,
+    // so an m365agents.yml left with auth placeholders has to be said out loud — otherwise
+    // provision fails later with an opaque error.
+    for (const warning of context.warnings ?? []) {
+      if (MCP_AUTH_PLACEHOLDER_WARNING_TYPES.includes(warning.type)) {
+        void TOOLS.ui.showMessage("warn", warning.content, false);
+      }
     }
   } catch (error) {
     return err(assembleError(error));

--- a/packages/fx-core/src/core/createFrontDoorAdapters.ts
+++ b/packages/fx-core/src/core/createFrontDoorAdapters.ts
@@ -151,6 +151,11 @@ export async function scaffoldV4(
   sendSuccessEvent(TelemetryEvent.GenerateTemplate, telemetryProps);
 
   const result: CreateProjectResult = { projectPath };
+  // The scaffolding summary and the surfaces' post-create notifications read these; dropping
+  // them here is what would make a placeholder-bearing m365agents.yml fail silently later.
+  if (generatorContext.warnings?.length) {
+    result.warnings = generatorContext.warnings;
+  }
   const ymlPath = pathUtils.getYmlFilePath(projectPath, "dev");
   if (ymlPath && (await fs.pathExists(ymlPath))) {
     const ensureRes = await coordinator.ensureTrackingId(projectPath, inputs.projectId);

--- a/packages/fx-core/src/index.ts
+++ b/packages/fx-core/src/index.ts
@@ -124,6 +124,7 @@ export {
   MCPEndpointStatus,
   probeMCPServerAuth,
 } from "./component/utils/mcpToolFetcher";
+export { MCP_AUTH_PLACEHOLDER_WARNING_TYPES } from "./component/utils/mcpAuthScaffolder";
 export { ODRTool, ODRServer, ODRProvider } from "./component/utils/odrProvider";
 export { pathUtils } from "./component/utils/pathUtils";
 export { newResourceGroupOption, resourceGroupHelper } from "./component/utils/ResourceGroupHelper";

--- a/packages/fx-core/src/v4/mcp/mcpAuthScaffold.ts
+++ b/packages/fx-core/src/v4/mcp/mcpAuthScaffold.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FxError, SystemError } from "@microsoft/teamsfx-api";
+import { FxError, SystemError, Warning } from "@microsoft/teamsfx-api";
 import { Result, err, ok } from "neverthrow";
 import { getLocalizedString } from "../../common/localizeUtils";
 import { ResolvedMCPAuthEndpoints, injectMcpAuthActionYaml } from "./mcpAuthAction";
@@ -67,13 +67,27 @@ function mcpAuthIdentifiers(mcpServerUrl: string): {
 async function resolveEndpoints(
   authType: string,
   mcpServerUrl: string,
-  warn?: (message: string) => void
+  warn?: (warning: Warning) => void
 ): Promise<ResolvedMCPAuthEndpoints> {
   if (authType !== "oauth" && authType !== "oauth-dynamic") {
     return {};
   }
   try {
     const probe = await mcpAuthScaffoldDeps.probeMCPServerAuth(mcpServerUrl);
+    // A mistyped server URL would otherwise leave no trace: endpoint discovery falls back to
+    // the host and happily returns its authorization server, so the scaffold looks complete.
+    // Advisory, so it covers every `notEndpoint` shape — not just the 404 that blocks at input
+    // time (ADR-0020).
+    if (probe.endpointStatus === "notEndpoint") {
+      warn?.({
+        type: "mcpServerUrlNotAnEndpoint",
+        content: getLocalizedString(
+          "core.MCPForDA.mcpServerUrlNotAnEndpoint",
+          mcpServerUrl,
+          String(probe.responseStatus)
+        ),
+      });
+    }
     const metadata = await mcpAuthScaffoldDeps.resolveMCPOAuthMetadata(
       probe.authMetadataUrl,
       undefined,
@@ -86,7 +100,10 @@ async function resolveEndpoints(
       wellKnownUrl: metadata.wellKnownUrl,
     };
   } catch (error) {
-    warn?.(getLocalizedString("core.MCPForDA.mcpAuthMetadataMissingError", errorMessage(error)));
+    warn?.({
+      type: "mcpAuthMetadataError",
+      content: getLocalizedString("core.MCPForDA.mcpAuthMetadataMissingError", errorMessage(error)),
+    });
     return {};
   }
 }
@@ -141,10 +158,16 @@ export async function injectMcpAuthAction(
     return err(injectResult.error);
   }
   if (injectResult.value.wellKnownUrlPlaceholderUsed) {
-    ctx.warn?.(getLocalizedString("core.MCPForDA.mcpAuthDcrPlaceholderWarning"));
+    ctx.warn?.({
+      type: "mcpAuthDcrWellKnownUrlPlaceholder",
+      content: getLocalizedString("core.MCPForDA.mcpAuthDcrPlaceholderWarning"),
+    });
   }
   if (injectResult.value.oauthUrlPlaceholderUsed) {
-    ctx.warn?.(getLocalizedString("core.MCPForDA.mcpAuthOAuthPlaceholderWarning"));
+    ctx.warn?.({
+      type: "mcpAuthOAuthUrlPlaceholder",
+      content: getLocalizedString("core.MCPForDA.mcpAuthOAuthPlaceholderWarning"),
+    });
   }
   ctx.write(args.ymlPath, Buffer.from(injectResult.value.yaml, "utf8"));
   return ok(undefined);

--- a/packages/fx-core/src/v4/pipeline/runScaffoldPipeline.ts
+++ b/packages/fx-core/src/v4/pipeline/runScaffoldPipeline.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FxError, SystemError, UserError } from "@microsoft/teamsfx-api";
+import { FxError, SystemError, UserError, Warning } from "@microsoft/teamsfx-api";
 import { Result, err, ok } from "neverthrow";
 import { ConditionalExpression, evaluateConditionalWhen } from "../expression/evaluateExpression";
 import { RenderVars, TemplateFileEntry } from "../model/dataModel";
@@ -19,6 +19,9 @@ const TPL_SUFFIX = ".tpl";
 function skipWarning(path: string): string {
   return getLocalizedString("core.v4.scaffold.existingFileSkipped", path);
 }
+
+/** `Warning.type` for a render path left untouched because the target already had that file. */
+export const EXISTING_FILE_SKIPPED_WARNING = "v4ExistingFileSkipped";
 
 /** A resolved step parameter value. */
 export type ParamValue = string | boolean | string[];
@@ -97,8 +100,12 @@ export interface StepContext {
   manifestWrapper(kind: string): ManifestWrapper;
   /** Read current bytes at a target path, or `undefined` when absent. */
   read(path: string): Buffer | undefined;
-  /** Emit a localized, user-visible warning without failing the pipeline. */
-  warn?(message: string): void;
+  /**
+   * Emit a localized, user-visible warning without failing the pipeline. The `type` is what
+   * lets a surface decide what to do with it (summary line, notification, log only), so it
+   * travels with the message instead of being dropped at the boundary.
+   */
+  warn?(warning: Warning): void;
 }
 
 /** An engine-registered, whitelist-dispatched post-render step. */
@@ -117,7 +124,7 @@ export interface PipelineRuntimePort {
   evalWhen(expr: string, renderVars: RenderVars): Result<boolean, FxError>;
   render(mustache: string, renderVars: RenderVars): Result<string, FxError>;
   manifestWrapper(kind: string): ManifestWrapper;
-  warn?(message: string): void;
+  warn?(warning: Warning): void;
   write(path: string, data: Buffer): void;
   writeEnvironment(
     environment: string,
@@ -289,7 +296,7 @@ export async function runScaffoldPipeline(
       if (targetDir.existing.includes(writePath)) {
         const warning = skipWarning(writePath);
         skipped.push({ path: writePath, warning });
-        port.warn?.(warning);
+        port.warn?.({ type: EXISTING_FILE_SKIPPED_WARNING, content: warning });
         continue;
       }
       const renderedBody = port.render(entry.data.toString("utf8"), renderVars); // AC-18
@@ -311,7 +318,7 @@ export async function runScaffoldPipeline(
       if (targetDir.existing.includes(writePath)) {
         const warning = skipWarning(writePath);
         skipped.push({ path: writePath, warning });
-        port.warn?.(warning);
+        port.warn?.({ type: EXISTING_FILE_SKIPPED_WARNING, content: warning });
         continue;
       }
       port.write(writePath, entry.data);

--- a/packages/fx-core/src/v4/runtime/realRuntime.ts
+++ b/packages/fx-core/src/v4/runtime/realRuntime.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SystemError } from "@microsoft/teamsfx-api";
+import { SystemError, Warning } from "@microsoft/teamsfx-api";
 import * as fs from "fs-extra";
 import * as path from "path";
 import { envUtil } from "../../component/utils/envUtil";
@@ -53,7 +53,7 @@ export function createRealRuntime(
   rootDir: string,
   flagReader?: (name: string) => boolean,
   stepRegistry?: StepRegistry,
-  warningSink?: (message: string) => void
+  warningSink?: (warning: Warning) => void
 ): RealRuntime {
   const exprPort: ExpressionRuntimePort = createExpressionPort(flagReader);
   const sink: FileSink = {

--- a/packages/fx-core/src/v4/runtime/runtimeRegistry.ts
+++ b/packages/fx-core/src/v4/runtime/runtimeRegistry.ts
@@ -6,6 +6,7 @@ import {
   FxError,
   SystemError,
   TeamsManifestWrapper,
+  Warning,
 } from "@microsoft/teamsfx-api";
 import { Result, err, ok } from "neverthrow";
 import path from "path";
@@ -278,7 +279,7 @@ export function buildPipelinePort(
   sink: FileSink,
   environmentWriter: EnvironmentWriter,
   stepRegistry: StepRegistry = STEP_REGISTRY,
-  warningSink?: (message: string) => void
+  warningSink?: (warning: Warning) => void
 ): PipelineRuntimePort {
   return {
     pipelineRegistry: (name: string): Orchestration | undefined =>

--- a/packages/fx-core/src/v4/runtime/steps/openApi.ts
+++ b/packages/fx-core/src/v4/runtime/steps/openApi.ts
@@ -492,7 +492,7 @@ export const openApiGenerateTeamsAiCustomApiFiles: RegisteredStep = {
           openapiSpecFileName
         );
         for (const warning of warnings) {
-          ctx.warn?.(warning.content);
+          ctx.warn?.({ type: String(warning.type), content: warning.content });
         }
 
         await writeTempTreeToContext(tempRoot, ctx);

--- a/packages/fx-core/src/v4/validation/capabilityCatalog.ts
+++ b/packages/fx-core/src/v4/validation/capabilityCatalog.ts
@@ -34,6 +34,7 @@ const CAPABILITY_FLOORS: Record<CapabilityKind, ReadonlyMap<string, string>> = {
     ["mcp.oauthClientIdRequired", "6.11.0"],
     ["mcp.oauthClientSecretRequired", "6.11.0"],
     ["mcp.entraClientIdRequired", "6.11.0"],
+    ["mcp.serverUrl", "6.11.0"],
   ]),
 };
 

--- a/packages/fx-core/src/v4/validators/createInputValidators.ts
+++ b/packages/fx-core/src/v4/validators/createInputValidators.ts
@@ -9,6 +9,7 @@ import {
   mcpOauthClientIdRequiredValidator,
   mcpOauthClientSecretRequiredValidator,
 } from "./mcpCredentialValidators";
+import { mcpServerUrlValidator } from "./mcpServerUrlValidator";
 
 export const uriValidator: Validator = (value: string): string | undefined => {
   try {
@@ -76,5 +77,6 @@ export function createDefaultCreateInputValidators(): Record<string, Validator> 
     "mcp.oauthClientIdRequired": mcpOauthClientIdRequiredValidator,
     "mcp.oauthClientSecretRequired": mcpOauthClientSecretRequiredValidator,
     "mcp.entraClientIdRequired": mcpEntraClientIdRequiredValidator,
+    "mcp.serverUrl": mcpServerUrlValidator,
   };
 }

--- a/packages/fx-core/src/v4/validators/mcpServerUrlValidator.ts
+++ b/packages/fx-core/src/v4/validators/mcpServerUrlValidator.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Validator } from "../collectInputs/collectInputs";
+import { validateMCPServerUrl } from "../../question/scaffold/vsc/teamsProjectTypeNode";
+
+/**
+ * ADR-0020: reject an MCP server URL that cannot be one — no scheme, or a 404 from the probe.
+ *
+ * Delegates to the same check the shipped question tree runs so both engines refuse exactly the
+ * same URLs; a second copy of the rule here would let the two drift apart silently.
+ */
+export const mcpServerUrlValidator: Validator = (value: string): Promise<string | undefined> =>
+  validateMCPServerUrl(value);

--- a/packages/fx-core/tests/component/generator/v4TemplateBridge.test.ts
+++ b/packages/fx-core/tests/component/generator/v4TemplateBridge.test.ts
@@ -608,6 +608,11 @@ describe("v4TemplateBridge.scaffoldDeclarativeFromV4Channel", () => {
     // the action is still injected, with placeholders the developer must replace
     assert.include(warning.mock.calls[1][0], "authorizationUrl");
     assert.include(warning.mock.calls[1][0], "tokenUrl");
+    // and the typed warnings come back on the context so the caller can put them on the result
+    assert.deepEqual(
+      (ctx.warnings ?? []).map((entry) => entry.type),
+      ["mcpAuthMetadataError", "mcpAuthOAuthUrlPlaceholder"]
+    );
     assert.include(
       (await fs.readFile(path.join(tmpDir, "m365agents.yml"))).toString(),
       "oauth/register"

--- a/packages/fx-core/tests/core/createFrontDoorAdapters.test.ts
+++ b/packages/fx-core/tests/core/createFrontDoorAdapters.test.ts
@@ -267,6 +267,48 @@ describe("createFrontDoorAdapters", () => {
       assert.equal(warning.mock.calls[0][0], "Using bundled template fallback.");
     });
 
+    it("carries the pipeline warnings onto the create result", async () => {
+      vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockImplementation(
+        async (context) => {
+          context.warnings = [{ type: "mcpAuthOAuthUrlPlaceholder", content: "repair the urls" }];
+          return TEMPLATE_SOURCE;
+        }
+      );
+      vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue(undefined);
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        [QuestionNames.Folder]: "/tmp",
+        [QuestionNames.AppName]: "MyApp",
+      };
+
+      const res = await scaffoldV4(inputs, v4Target, {});
+
+      assert.isTrue(res.isOk());
+      assert.deepEqual(res._unsafeUnwrap().warnings, [
+        { type: "mcpAuthOAuthUrlPlaceholder", content: "repair the urls" },
+      ]);
+    });
+
+    it("leaves the create result without warnings when the pipeline raised none", async () => {
+      vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockImplementation(
+        async (context) => {
+          context.warnings = [];
+          return TEMPLATE_SOURCE;
+        }
+      );
+      vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue(undefined);
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        [QuestionNames.Folder]: "/tmp",
+        [QuestionNames.AppName]: "MyApp",
+      };
+
+      const res = await scaffoldV4(inputs, v4Target, {});
+
+      assert.isTrue(res.isOk());
+      assert.isUndefined(res._unsafeUnwrap().warnings);
+    });
+
     it("returns the tracking id error when ensureTrackingId fails", async () => {
       vi.spyOn(scaffoldV4Deps, "scaffoldDeclarativeFromV4Channel").mockResolvedValue(
         TEMPLATE_SOURCE

--- a/packages/fx-core/tests/v4/pipeline/runScaffoldPipeline.test.ts
+++ b/packages/fx-core/tests/v4/pipeline/runScaffoldPipeline.test.ts
@@ -137,7 +137,7 @@ function makePort(opts: { pipelines?: string[]; steps?: Record<string, Registere
     },
     render: (mustache, vars) => renderMustache(mustache, vars),
     manifestWrapper: () => wrapper,
-    warn: (message) => warnings.push(message),
+    warn: (warning) => warnings.push(warning.content),
     write: (path, data) => {
       writes.set(path, data);
     },

--- a/packages/fx-core/tests/v4/runtime/steps/mcpAuth.test.ts
+++ b/packages/fx-core/tests/v4/runtime/steps/mcpAuth.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SystemError } from "@microsoft/teamsfx-api";
+import { SystemError, Warning } from "@microsoft/teamsfx-api";
 import { err } from "neverthrow";
 import {
   STEP_INJECT_YML_ACTION,
@@ -20,10 +20,10 @@ function makeCtx(initial: Record<string, string> = {}): {
   ctx: StepContext;
   files: Map<string, Buffer>;
   secretEnvironmentVariables: Map<string, Map<string, string>>;
-  warnings: string[];
+  warnings: Warning[];
 } {
   const runtime = createInMemoryRuntime();
-  const warnings: string[] = [];
+  const warnings: Warning[] = [];
   for (const [path, body] of Object.entries(initial)) {
     runtime.files.set(path, Buffer.from(body, "utf8"));
   }
@@ -34,7 +34,7 @@ function makeCtx(initial: Record<string, string> = {}): {
       writeEnvironment: runtime.port.writeEnvironment,
       manifestWrapper: () => NOOP_MANIFEST_WRAPPER,
     },
-    { warn: (message: string) => warnings.push(message) }
+    { warn: (warning: Warning) => warnings.push(warning) }
   );
   return {
     ctx,
@@ -72,6 +72,7 @@ describe("mcp-auth steps (v4)", () => {
     vi.spyOn(mcpAuthScaffoldDeps, "probeMCPServerAuth").mockResolvedValue({
       requiresAuth: true,
       authMetadataUrl: "https://auth.example.com/.well-known/oauth-protected-resource",
+      endpointStatus: "confirmed",
     });
     vi.spyOn(mcpAuthScaffoldDeps, "resolveMCPOAuthMetadata").mockResolvedValue({
       authorizationUrl: "https://auth.example.com/authorize",
@@ -188,10 +189,12 @@ describe("mcp-auth steps (v4)", () => {
 
       assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
       assert.lengthOf(warnings, 2);
-      assert.include(warnings[0], "metadata unavailable");
+      assert.strictEqual(warnings[0].type, "mcpAuthMetadataError");
+      assert.include(warnings[0].content, "metadata unavailable");
       // the action is still injected, with placeholders the developer must replace
-      assert.include(warnings[1], "authorizationUrl");
-      assert.include(warnings[1], "tokenUrl");
+      assert.strictEqual(warnings[1].type, "mcpAuthOAuthUrlPlaceholder");
+      assert.include(warnings[1].content, "authorizationUrl");
+      assert.include(warnings[1].content, "tokenUrl");
     });
 
     it("warns when oauth-dynamic requires manual replacement of the well-known URL", async () => {
@@ -207,8 +210,30 @@ describe("mcp-auth steps (v4)", () => {
 
       assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
       assert.lengthOf(warnings, 2);
-      assert.include(warnings[0], "metadata unavailable");
-      assert.include(warnings[1], "wellKnownAuthorizationServer");
+      assert.include(warnings[0].content, "metadata unavailable");
+      assert.strictEqual(warnings[1].type, "mcpAuthDcrWellKnownUrlPlaceholder");
+      assert.include(warnings[1].content, "wellKnownAuthorizationServer");
+    });
+
+    it("warns when the server URL answered like something that is not an MCP endpoint", async () => {
+      vi.mocked(mcpAuthScaffoldDeps.probeMCPServerAuth).mockResolvedValue({
+        requiresAuth: false,
+        endpointStatus: "notEndpoint",
+        responseStatus: 403,
+      });
+      const { ctx, warnings } = makeCtx({ "m365agents.yml": PROVISION_YML });
+
+      const res = await mcpAuthInjectYmlAction.apply(
+        { ymlPath: "m365agents.yml", authType: "oauth", mcpServerUrl: SERVER_URL },
+        ctx
+      );
+
+      assert.isTrue(res.isOk(), res.isErr() ? res.error.message : "expected ok");
+      // advisory only — the action is still injected with the endpoints that did resolve
+      assert.lengthOf(warnings, 1);
+      assert.strictEqual(warnings[0].type, "mcpServerUrlNotAnEndpoint");
+      assert.include(warnings[0].content, SERVER_URL);
+      assert.include(warnings[0].content, "403");
     });
 
     it("is idempotent — a re-run does not duplicate the registration action", async () => {

--- a/packages/fx-core/tests/v4/runtime/steps/openApi.test.ts
+++ b/packages/fx-core/tests/v4/runtime/steps/openApi.test.ts
@@ -323,7 +323,7 @@ describe("OpenAPI runtime steps (v4)", () => {
       "src/app/app.ts": "// Replace with function definition code\n",
       "src/app/handlers.ts": "// Replace with function handler code\n{{OPENAPI_SPEC_PATH}}",
     });
-    state.ctx.warn = (message) => warnings.push(message);
+    state.ctx.warn = (warning) => warnings.push(warning.content);
 
     const result = await openApiGenerateTeamsAiCustomApiFiles.apply(
       {
@@ -353,7 +353,7 @@ describe("OpenAPI runtime steps (v4)", () => {
       "src/app/app.ts": "// Replace with function definition code\n",
       "src/app/handlers.ts": "// Replace with function handler code\n{{OPENAPI_SPEC_PATH}}",
     });
-    state.ctx.warn = (message) => warnings.push(message);
+    state.ctx.warn = (warning) => warnings.push(warning.content);
 
     const result = await openApiGenerateTeamsAiCustomApiFiles.apply(
       {

--- a/packages/fx-core/tests/v4/scenarios/addMcpServerEntry.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/addMcpServerEntry.test.ts
@@ -10,11 +10,20 @@ import { FeatureFlags, featureFlagManager } from "../../../src/common/featureFla
 import { setTools } from "../../../src/common/globalVars";
 import { copilotGptManifestUtils } from "../../../src/component/driver/teamsApp/utils/CopilotGptManifestUtils";
 import { manifestUtils } from "../../../src/component/driver/teamsApp/utils/ManifestUtils";
+import { scaffoldDeclarativeFromV4Channel } from "../../../src/component/generator/v4TemplateBridge";
 import { fxCoreDeclarativeAgentDeps } from "../../../src/core/FxCore.declarativeAgent";
 import { QuestionNames } from "../../../src/question";
 import { ActionStartOptions } from "../../../src/question/constants";
 import { addPluginQuestionNode } from "../../../src/question/other";
 import { MockTools } from "../../core/utils";
+
+// The entry imports the channel scaffold as a binding, so the module has to be mocked to drive
+// the warnings it hands back on the generator context.
+vi.mock("../../../src/component/generator/v4TemplateBridge", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/component/generator/v4TemplateBridge")>();
+  return { ...actual, scaffoldDeclarativeFromV4Channel: vi.fn() };
+});
 
 /**
  * T3 scenario tier: the real MCP add-action entry and its legacy question adapter.
@@ -172,6 +181,31 @@ describe("SCN-DA-ADD-MCP-ACTION-TO-DA (v4 entry, T3)", () => {
     }
     assert.equal(modifyFrontDoorStub.mock.calls.length, 3);
     assert.equal(scaffoldStub.mock.calls.length, 0);
+  });
+
+  it("raises only the placeholder warnings from the v4 add scaffold as notifications", async () => {
+    vi.mocked(scaffoldDeclarativeFromV4Channel).mockImplementation(async (context) => {
+      context.warnings = [
+        { type: "mcpServerUrlNotAnEndpoint", content: "advisory only" },
+        { type: "mcpAuthOAuthUrlPlaceholder", content: "repair the oauth urls" },
+      ];
+      return { origin: "bundled", version: "1.0.0", digest: "sha256:test", location: "test" };
+    });
+    const showMessage = vi.spyOn(tools.ui, "showMessage");
+
+    const result = await fxCoreDeclarativeAgentDeps.scaffoldAddMcpServerFromV4({
+      templateId: "add-mcp-server",
+      projectPath: path.join(os.tmpdir(), "scenario-add-mcp-placeholder-warning"),
+      teamsManifestPath: "appPackage/manifest.json",
+      appName: "My MCP App",
+      mcpServerUrl: "https://example.com/mcp",
+      authType: "oauth",
+    });
+
+    assert.isTrue(result.isOk());
+    const warned = showMessage.mock.calls.filter((call) => call[0] === "warn");
+    assert.equal(warned.length, 1);
+    assert.equal(warned[0][1], "repair the oauth urls");
   });
 
   it("SCN-ADD-MCP-12: v4 add questions collect auth type but defer credentials", () => {

--- a/packages/fx-core/tests/v4/scenarios/createMcpServerStatic.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createMcpServerStatic.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { assert } from "chai";
+import { afterEach, beforeEach, vi } from "vitest";
 import {
   FxError,
   InputTextConfig,
@@ -27,6 +28,7 @@ import {
   runV4Package,
   V4ScenarioOutcome,
 } from "./helpers/scenarioHarness";
+import { teamsProjectTypeDeps } from "../../../src/question/scaffold/vsc/teamsProjectTypeNode";
 
 /**
  * T3 scenario tier for the DT-off v4 static MCP create package.
@@ -136,6 +138,18 @@ async function run(
 }
 
 describe("SCN-DA-CREATE-WITH-MCP-SERVER (DT-off, v4, T3 InMemoryRuntime)", () => {
+  beforeEach(() => {
+    // The server-URL question probes the server (ADR-0020); keep these tests offline.
+    vi.spyOn(teamsProjectTypeDeps, "probeMCPServerAuth").mockResolvedValue({
+      requiresAuth: false,
+      endpointStatus: "confirmed",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("SCN-CREATE-MCP-STATIC-01: static MCP scaffold writes mcp-tools-1.json", async () => {
     const { files, outcome } = await run(["search", "calendar"]);
     assert.include(outcome.written, "appPackage/ai-plugin.json");

--- a/packages/fx-core/tests/v4/surface/createInputs.test.ts
+++ b/packages/fx-core/tests/v4/surface/createInputs.test.ts
@@ -36,7 +36,8 @@ import {
   runCreateInputs,
   runCreateInputsWalk,
 } from "../../../src/v4/surface/createInputs";
-import { assert } from "vitest";
+import { assert, vi } from "vitest";
+import { teamsProjectTypeDeps } from "../../../src/question/scaffold/vsc/teamsProjectTypeNode";
 
 /**
  * Tests for docs/03-specs/operations/scaffolding/collect-create-inputs.md.
@@ -575,6 +576,10 @@ describe("runCreateInputs (collect-create-inputs)", () => {
   });
 
   it("CCI-01: remote-only provider auto-skips mcpServerType, asks url + authType=none", async () => {
+    // The server-URL question probes the server (ADR-0020); keep this test offline.
+    const probe = vi
+      .spyOn(teamsProjectTypeDeps, "probeMCPServerAuth")
+      .mockResolvedValue({ requiresAuth: false, endpointStatus: "confirmed" });
     const ui = new ScriptedUserInteraction({
       text: { mcpServerUrl: "https://api.example.com/mcp" },
       select: { authType: "none" },
@@ -605,8 +610,9 @@ describe("runCreateInputs (collect-create-inputs)", () => {
     if (validation === undefined) {
       assert.fail("expected MCP server URL prompt validation");
     }
-    assert.equal(await validation("not a uri"), "must be a valid URI");
+    assert.include(await validation("not a uri"), "absolute URL");
     assert.isUndefined(await validation("https://api.example.com/mcp"));
+    probe.mockRestore();
   });
 
   it("CCI-17: openapi.operations provider lists operations from the selected OpenAPI document", async () => {

--- a/packages/fx-core/tests/v4/validators/createInputValidators.test.ts
+++ b/packages/fx-core/tests/v4/validators/createInputValidators.test.ts
@@ -16,6 +16,7 @@ describe("create input validators (collect-inputs INV-3b)", () => {
       "mcp.oauthClientIdRequired",
       "mcp.oauthClientSecretRequired",
       "mcp.entraClientIdRequired",
+      "mcp.serverUrl",
     ]);
     assert.isUndefined(await validators.uri("https://example.com/mcp", {}));
     assert.equal(await validators.uri("not a uri", {}), "must be a valid URI");

--- a/packages/fx-core/tests/v4/validators/mcpServerUrlValidator.test.ts
+++ b/packages/fx-core/tests/v4/validators/mcpServerUrlValidator.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { afterEach, assert, vi } from "vitest";
+import { mcpServerUrlValidator } from "../../../src/v4/validators/mcpServerUrlValidator";
+import { teamsProjectTypeDeps } from "../../../src/question/scaffold/vsc/teamsProjectTypeNode";
+
+/**
+ * ADR-0020 decision F, applied at the v4 extension point: a 404 blocks, the weaker negative
+ * shapes and an undetermined probe do not.
+ */
+describe("mcp.serverUrl validator (ADR-0020)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects a value that cannot be an absolute http(s) URL without probing", async () => {
+    const probe = vi.spyOn(teamsProjectTypeDeps, "probeMCPServerAuth");
+
+    assert.include((await mcpServerUrlValidator("not a uri", {})) ?? "", "absolute URL");
+    assert.include(
+      (await mcpServerUrlValidator("ftp://example.com/mcp", {})) ?? "",
+      "absolute URL"
+    );
+    assert.strictEqual(probe.mock.calls.length, 0);
+  });
+
+  it("rejects a 404 — the one answer no valid MCP endpoint was measured giving", async () => {
+    vi.spyOn(teamsProjectTypeDeps, "probeMCPServerAuth").mockResolvedValue({
+      requiresAuth: false,
+      endpointStatus: "notEndpoint",
+      responseStatus: 404,
+    });
+
+    assert.include(
+      (await mcpServerUrlValidator("https://example.com/mcp", {})) ?? "",
+      "Couldn't reach an MCP server at this URL"
+    );
+  });
+
+  it("accepts the weaker negative shapes and an undetermined probe", async () => {
+    const probe = vi.spyOn(teamsProjectTypeDeps, "probeMCPServerAuth");
+
+    probe.mockResolvedValue({
+      requiresAuth: false,
+      endpointStatus: "notEndpoint",
+      responseStatus: 403,
+    });
+    assert.isUndefined(await mcpServerUrlValidator("https://example.com/mcp", {}));
+
+    probe.mockResolvedValue({ requiresAuth: false, endpointStatus: "undetermined" });
+    assert.isUndefined(await mcpServerUrlValidator("https://example.com/mcp", {}));
+
+    probe.mockResolvedValue({ requiresAuth: true, endpointStatus: "confirmed" });
+    assert.isUndefined(await mcpServerUrlValidator("https://example.com/mcp", {}));
+  });
+});

--- a/packages/vscode-extension/src/utils/autoOpenHelper.ts
+++ b/packages/vscode-extension/src/utils/autoOpenHelper.ts
@@ -17,6 +17,7 @@ import {
   generateScaffoldingSummary,
   JSONSyntaxError,
   manifestUtils,
+  MCP_AUTH_PLACEHOLDER_WARNING_TYPES,
   outputScaffoldingWarningMessage,
   pathUtils,
   pluginManifestUtils,
@@ -267,16 +268,6 @@ export async function ShowScaffoldingWarningSummary(
     ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.ShowScaffoldingWarningSummaryError, error);
   }
 }
-
-/**
- * `Warning.type` values reported when MCP auth endpoint discovery failed and the scaffolder
- * fell back to fill-in placeholders in `m365agents.yml`. The other MCP warnings are advisory
- * and stay in the output channel.
- */
-const MCP_AUTH_PLACEHOLDER_WARNING_TYPES = [
-  "mcpAuthDcrWellKnownUrlPlaceholder",
-  "mcpAuthOAuthUrlPlaceholder",
-];
 
 /**
  * Whether the scaffolded project needs a manual edit before any lifecycle can succeed, given

--- a/templates/v4/create/da/mcp-server-static/questions.json
+++ b/templates/v4/create/da/mcp-server-static/questions.json
@@ -6,7 +6,7 @@
       "type": "text",
       "title": "MCP Server URL",
       "keyPrefix": "core.createProjectQuestion.mcpForDa.ServerUrl",
-      "validation": "uri"
+      "validation": "mcp.serverUrl"
     },
     {
       "name": "mcpToolsFilePath",

--- a/templates/v4/create/da/mcp-server/questions.json
+++ b/templates/v4/create/da/mcp-server/questions.json
@@ -17,7 +17,7 @@
       "title": "MCP Server URL",
       "keyPrefix": "core.createProjectQuestion.mcpForDa.ServerUrl",
       "condition": { "expr": "mcpServerType == 'remote'" },
-      "validation": "uri"
+      "validation": "mcp.serverUrl"
     },
     {
       "name": "selectedLocalServers",

--- a/templates/v4/modify/add-mcp-server/descriptor.json
+++ b/templates/v4/modify/add-mcp-server/descriptor.json
@@ -4,7 +4,7 @@
   "name": "Add MCP Server Action",
   "kind": "modify",
   "languages": ["common"],
-  "minEngineVersion": "5.20.0",
+  "minEngineVersion": "6.11.0",
   "spec": "docs/03-specs/scenarios/da/add-mcp-server.md",
   "requiresNetwork": false,
 

--- a/templates/v4/modify/add-mcp-server/questions.json
+++ b/templates/v4/modify/add-mcp-server/questions.json
@@ -7,7 +7,7 @@
       "title": "MCP Server URL",
       "keyPrefix": "template.mcpAddServer.mcpServerUrl",
       "condition": { "expr": "mcpServerUrl == null" },
-      "validation": "uri"
+      "validation": "mcp.serverUrl"
     },
     {
       "name": "authType",


### PR DESCRIPTION
Follow-up to #16458, which fixed MCP OAuth discovery and made its failures visible — but only on the v3 code paths. Scaffolding the same declarative agent through the v4 engine still produced an unprovisionable project silently. Three gaps, same invariant restored: ATK never silently produces an unprovisionable auth configuration.

## 1. The v4 question walk did not validate the MCP server url

The v4 templates asked for the url under `"validation": "uri"`, which only checks that the value parses. #16458 gave the shipped question tree a real check — reject anything that is not an absolute http(s) url, and reject a 404 from the MCP `initialize` probe, the one answer ADR-0020 found no valid endpoint ever gives. So a url the v3 walk refuses outright was scaffolded by v4 without a word.

Adds `mcp.serverUrl`, a named validator that delegates to `validateMCPServerUrl` rather than restating the rule, so the two engines cannot drift apart. The three MCP question sets point at it, and `add-mcp-server`'s `minEngineVersion` rises to the floor the new validator sits at.

## 2. The v4 path discarded the endpoint verdict

`resolveEndpoints` threw away `probe.endpointStatus`, so the advisory for a url that answered like something other than an MCP endpoint never fired on the v4 path. It now fires, matching v3.

This is the case that leaves no other trace: a mistyped url — most often the host without the trailing `/mcp` — still resolves *the host's* authorization server through the discovery fallback, so the scaffold looks complete.

## 3. v4 warnings never reached the surfaces

The v4 pipeline's warn channel took a bare string and handed it to `logProvider.warning`, so a warning ended its life in the output channel. Every consumer added by #16458 — the scaffolding summary allowlist, the VS Code placeholder notification — keys off `Warning.type`, and the type was dropped at that boundary. A v4-scaffolded project whose `m365agents.yml` holds auth placeholders therefore said nothing at all, and the first thing the toolkit suggested was the provision those placeholders guarantee will fail.

The channel is now typed as `Warning` end to end — step context, runtime port, real runtime sink — and the collected warnings come back on `GeneratorContext`, the way that bridge already returns `outputs`, for `scaffoldV4` to put on `CreateProjectResult.warnings`. The type travels with the message instead of a surface having to guess it from the wording. This is generic engine plumbing, not an MCP branch in the engine.

`MCP_AUTH_PLACEHOLDER_WARNING_TYPES` — the list meaning "this project cannot provision as scaffolded" — moves out of the VS Code extension into core, so the extension notification and `scaffoldAddMcpServerFromV4` read the same list instead of two copies drifting apart.

## Verification

- fx-core: full suite `291 passed | 1 skipped (292 files)` / `5294 passed | 35 skipped | 1 todo`, against a `290 (291 files)` / `5282` baseline — the delta is this PR's added tests, no regressions.
- fx-core `npm run build` clean; `vscode-extension` `tsc --noEmit` clean and `autoOpenHelper` `24 passed`.
- New focused test at the extension point (`tests/v4/validators/mcpServerUrlValidator.test.ts`) covers the scheme rejection, the blocking 404, and the shapes ADR-0020 says must *not* block: 403, `undetermined`, and `confirmed`.

One incidental fix: the added probe made several v4 scenario tests reach the real network, because they answer the url question with real addresses. Those now stub `probeMCPServerAuth`.
