### PR TITLE
ci(vscuse): shuffle template plans and run 50 at a time

### DIFF
--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -54,6 +54,11 @@ on:
         required: false
         type: number
         default: 80
+      max_parallel:
+        description: "Maximum number of per-plan matrix jobs to run concurrently."
+        required: false
+        type: number
+        default: 100
       no_failed_step_text:
         required: false
         type: string
@@ -104,12 +109,15 @@ jobs:
           INPUT_TEST_PLAN: ${{ inputs.test_plan }}
         run: |
           if [ -z "$INPUT_TEST_PLAN" ]; then
-            # Use caller-supplied find predicate to enumerate default plans
-            plans=$(eval "find packages/tests/vscuse/vscode-test-cases/plans/ -maxdepth 1 -type f $PLAN_FIND_ARGS -exec basename {} .json \;" | jq -R -s -c 'split("\n")[:-1]')
+            # Use caller-supplied find predicate to enumerate default plans.
+            # Shuffle so that similarly named plans (e.g. Teams_*, DA_*) are spread
+            # across parallel batches instead of all landing in the same one, which
+            # reduces contention on the shared test tenant / Azure resources.
+            plans=$(eval "find packages/tests/vscuse/vscode-test-cases/plans/ -maxdepth 1 -type f $PLAN_FIND_ARGS -exec basename {} .json \;" | shuf | jq -R -s -c 'split("\n")[:-1]')
             echo "plans=$plans" >> $GITHUB_OUTPUT
             echo "Found test plans: $plans"
           else
-            input_plans=$(echo "$INPUT_TEST_PLAN" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R -s -c 'split("\n")[:-1]')
+            input_plans=$(echo "$INPUT_TEST_PLAN" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | shuf | jq -R -s -c 'split("\n")[:-1]')
             echo "plans=$input_plans" >> $GITHUB_OUTPUT
             echo "Using input test plans: $input_plans"
           fi
@@ -124,7 +132,7 @@ jobs:
       matrix:
         test_plan: ${{ fromJson(needs.discover-test-plans.outputs.test-plans) }}
       fail-fast: false
-      max-parallel: 100
+      max-parallel: ${{ inputs.max_parallel }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ui-test-vscuse-template.yml
+++ b/.github/workflows/ui-test-vscuse-template.yml
@@ -66,6 +66,7 @@ jobs:
       # Pipeline-specific knobs
       plan_find_args: '-name "*.json" ! -name "Feature_*" ! -name "Sample_*"'
       main_timeout_minutes: 50
+      max_parallel: 50
       no_failed_step_text: " "
       filter_no_errors_found: true
       email_subject_suffix: "[Templates]"


### PR DESCRIPTION
## Why

In the `uitest-vscuse-template` nightly, similarly named template plans (`Teams_*`, `DA_*`, `Basic_*`, ...) were adjacent in the `find` output that builds the matrix. GitHub Actions fills parallel slots in array order, so with `max-parallel: 100` and ~193 template plans, each wave was dominated by one plan family all hitting the shared test tenant and the same Azure resource types at once. That contention makes cases flaky and forces retries.

## What

Two small changes to the shared reusable workflow and the template caller:

- **De-cluster the run order.** In `ui-test-vscuse-common.yml`, the `discover-test-plans` job now pipes the plan list through `shuf` (both the default `find`-based discovery and the user-supplied `test_plan` path) before emitting the matrix array, so like-named plans spread across waves instead of piling into one.
- **Run 50 at a time.** Added a `max_parallel` input to the reusable workflow (default `100`, so `features`/`samples` callers are unchanged) and wired `strategy.max-parallel` to it. `ui-test-vscuse-template.yml` passes `max_parallel: 50`, giving ~4 mixed waves of 50 instead of 2 clustered waves of 100.

## Notes for reviewers

- The shuffle lives in the shared discover job, so it also reorders the `features`/`samples` callers. That is order-only and harmless: every matrix job, artifact, and report lookup is keyed by plan name, never by index.
- Shuffle is non-deterministic per run by design, but stable within a run: retries go through `rerun-failed-jobs`, which does not re-run the already-succeeded `discover-test-plans` job, so the chosen order persists across attempts.
- Confirmed `max-parallel: ${{ inputs.max_parallel }}` is a supported pattern for a `workflow_call` number input, and validated the `shuf | jq -R -s -c 'split("\n")[:-1]'` pipeline still yields a valid shuffled JSON array.