### PR TITLE
docs(vscuse): fix misleading description of empty-area click in M365 login groups

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_account_with_copilot_license.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_account_with_copilot_license.json
@@ -449,7 +449,7 @@
         "x": 322,
         "y": 100
       },
-      "description": "Click the \"Sign in to Microsoft 365\" link in the ACCOUNTS section of the Microsoft 365 Agents Toolkit panel within Visual Studio Code.",
+      "description": "Click the right empty location of \"Sign in to Microsoft 365\" item in the ACCOUNTS section of the Microsoft 365 Agents Toolkit sidebar in Visual Studio Code to open the account sign-in dropdown.(Previously for clicking the \"Sign in to Microsoft 365\" button.)",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_account_with_same_account.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__login_azure_and_m365_account_with_same_account.json
@@ -448,7 +448,7 @@
         "x": 322,
         "y": 100
       },
-      "description": "Click the \"Sign in to Microsoft 365\" link in the ACCOUNTS section of the Microsoft 365 Agents Toolkit panel within Visual Studio Code.",
+      "description": "Click the right empty location of \"Sign in to Microsoft 365\" item in the ACCOUNTS section of the Microsoft 365 Agents Toolkit sidebar in Visual Studio Code to open the account sign-in dropdown.(Previously for clicking the \"Sign in to Microsoft 365\" button.)",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## Problem

While investigating why `DA_With_EK_Happy_Path` presses **F1 immediately after signing in**, I found that the step it runs just before that ‑ `step_448cbf32` ‑ does not do what its description says.

| | |
|---|---|
| **Step** | `step_448cbf32` (index 16 of `group__login_azure_and_m365_account_with_copilot_license.json`, i.e. `plan_b36c23b3`) |
| **Action** | `click (322, 100)` |
| **Description (before)** | *Click the "Sign in to Microsoft 365" link in the ACCOUNTS section…* |
| **Reality** | `(322, 100)` is **outside the sidebar** – the panel's right edge is at `x ≈ 305` – so the click lands on the empty editor background and hits nothing. |

Evidence:

* The pixel at `(322, 100)` in the step's own recorded baseline is `#1f1f1f` (flat editor background).
* Its first precondition is `dhash:322:100:16:5:0000000000000000` – an **all‑zero** hash means that 16 px window is perfectly uniform, i.e. empty area. For comparison, the real command‑palette target `step_26b0ae25 (322, 49)` has `dhash:322:49:16:5:00004036d9266969`.
* The only visible effect between this step's baseline and the next one is that the blue focus ring around the ACCOUNTS tree disappears – the click just moves focus out of the tree.

The actual Microsoft 365 sign‑in is performed by the steps that follow: `F1` → `Microsoft 365 Agents: Accounts` → `Enter` → click `(322, 49)`. That is why the plan appears to "press F1 right after logging in".

## Why this is only a description fix

The identical step exists in **three** sibling login groups, all with the same coordinates and the same all‑zero precondition:

| group | step | description |
|---|---|---|
| `group__login_azure_and_m365.json` | `step_71c576dc` | ✅ already corrected |
| `group__login_azure_and_m365_account_with_copilot_license.json` | `step_448cbf32` | ❌ still wrong |
| `group__login_azure_and_m365_account_with_same_account.json` | `step_4aefa89f` | ❌ still wrong |

`step_71c576dc` was corrected during the *2026‑07‑21 step‑description audit* (`cd59d2e0b1` → `afab8dce5b`) and a maintainer added the explanatory note:

> Click the right empty location of "Sign in to Microsoft 365" item … **(Previously for clicking the "Sign in to Microsoft 365" button.)**

So the behaviour is known and intentional – the step used to hit the button, the UI moved, and the F1 command‑palette path was added as the working route. The other two groups were simply **missed by that audit**, which is what makes the plans look broken when you read them.

## Change

Aligns `step_448cbf32` and `step_4aefa89f` with the already‑merged wording of `step_71c576dc`, so all three siblings are consistent.

**Description text only.** No coordinates, preconditions, tags, screenshots or step order were changed – 2 files, 2 lines.

## Affected plans (no behaviour change)

`DA_With_EK_Happy_Path`, `Feature_DA_Advanced_Personal_Scope_Provision_with_Copilot_License`, `Sample_Hello_World_Meeting_Local_Debug` (and the plans using the *same_account* group).

## Follow‑up worth considering (not in this PR)

`step_448cbf32` carries a **full‑screen** precondition (`dhash:322:100:0:10:…`). Because it is a no‑op click, the only thing it can contribute is a false failure: any change in the ACCOUNTS region (a different tenant account name, an extra environment‑warning row) breaks that hash and the step can precondition‑timeout and fail the whole case. Deleting the dead step in all three groups would be the more thorough fix.