### PR TITLE
fix: point clean job at the atktesting07 tenant id

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -129,15 +129,16 @@ jobs:
     env:
       CLEAN_CLIENT_ID: ${{ vars.TEST_TENANT_CLEAN_CLIENT_ID }}
       CLEAN_CLIENT_SECRET: ${{ secrets.TEST_TENANT_CLEAN_CLIENT_SECRET }}
-      CLEAN_TENANT_ID: ${{ secrets.TEST_TENANT_CLEAN_TENANT_ID }}
+      CLEAN_TENANT_ID: ${{ vars.TEST_TENANT_CLEAN_TENANT_ID }}
       AZURE_TENANT_ID: ${{ secrets.TEST_TENANT_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.TEST_TENANT_SUBSCRIPTION_ID }}
       AZURE_ACCOUNT_NAME: ${{ secrets.TEST_TENANT_AZURE_ACCOUNT_NAME }}
       AZURE_ACCOUNT_PASSWORD: ${{ secrets.TEST_TENANT_AZURE_ACCOUNT_PASSWORD }}
+      # M365_ACCOUNT_NAME is overwritten per matrix leg with test001..test020
+      # (vars.M365_USERNAMES), so this password must be valid for those accounts.
       M365_ACCOUNT_PASSWORD: ${{ secrets.TEST_TENANT_M365_ACCOUNT_ADMIN_PASSWORD }}
       M365_DISPLAY_NAME: "test"
       MAIL_API_KEY: ${{ secrets.MAIL_API_KEY }}
-      TEST_TENANT_M365_ACCOUNT_NAME: ${{ secrets.TEST_TENANT_M365_ACCOUNT_ADMIN_ACCOUNT }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build-clean-matrix.outputs.matrix) }}


### PR DESCRIPTION
## Problem

The daily resource-cleanup job in `rerun.yml` (jobs `build-clean-matrix` -> `clean`, crons `30 10 * * *` and `0 1 * * *`) has **failed on every scheduled run since 2026-07-28 19:17 UTC+8** - 7 consecutive failures, each dying after ~3 min instead of the normal 12-22 min.

```
AADSTS50020: User account '...@atktesting07.onmicrosoft.com' ... does not exist in
tenant 'ATK Testing 06' ... subError: 'external_account_not_found'
```

| run | created (UTC) | result |
|---|---|---|
| 30320503281 | 2026-07-28 01:31 | :white_check_mark: success (12 min) - last good |
| 30354198630 | 2026-07-28 11:17 | :x: failure (3 min) |
| 30414331885 | 2026-07-29 01:31 | :x: failure |
| 30447069750 | 2026-07-29 11:18 | :x: failure |
| 30505874201 | 2026-07-30 01:31 | :x: failure |
| 30537888735 | 2026-07-30 11:16 | :x: failure |
| 30596580922 | 2026-07-31 01:31 | :x: failure |

## Root cause

The `atktesting06` -> `atktesting07` cutover (2026-07-28 09:12-09:13 UTC) rotated 11 variables and 11 secrets. It rotated the **variable** `TEST_TENANT_CLEAN_TENANT_ID`, but not the identically-named **secret**.

GitHub lets a secret and a variable share a name, so nothing surfaced the drift. This job held the **only** `secrets.TEST_TENANT_CLEAN_TENANT_ID` reference in the repository; the other eight references were already `vars.` and kept working:

| form | where | status |
|---|---|---|
| `secrets.` | `rerun.yml:132` | :x: stale (atktesting06) |
| `vars.` | `e2e-test-same-tenant.yml` :54 :57 :123 :126 :234 :237 | :white_check_mark: |
| `vars.` | `eval-microsoft-365-agents-toolkit.yml` :52 :56 | :white_check_mark: |

It also slipped through because every other `TEST_TENANT_*` secret is shared with `ui-test-vscuse-common.yml` and therefore exercised daily; this one is exclusive to `rerun.yml`.

## Blast radius

`GraphApiCleanHelper.create()` is the only statement in `clean.ts` `main()` outside a `try/catch`. It throws, `main().catch` calls `process.exit(-1)`, and **nothing downstream runs**. So for three days none of the following was cleaned, on any of the 20 matrix accounts: Entra app registrations (+ deleted-items purge), enterprise applications (+ purge), installed Teams apps, Developer Portal apps and API key registrations, `fxui*`/`vs*` Azure resource groups, SharePoint app packages, dev tunnels, M365 Titles acquisitions.

## Changes

**1. `CLEAN_TENANT_ID`: `secrets.` -> `vars.`**

A tenant id is not a secret - it is resolvable by anyone from the public OIDC discovery endpoint, and this repo already stores it as a plain variable in eight other places. Reading the variable fixes the outage and collapses the duplicate source of truth, so the next tenant rotation is a single edit that cannot drift.

**2. Drop the orphaned `TEST_TENANT_M365_ACCOUNT_NAME` env var**

It was added by #15062 for a real reason. `strategy.matrix` cannot reference the `secrets` context, so the hardcoded matrix carried a sentinel and the step resolved it:

```yaml
- { name: "M365_USERNAME_With_Copilot", value: "USE_ENV_TEST_TENANT" }
```
```bash
if [[ "$MATRIX_VALUE" == "USE_ENV_TEST_TENANT" ]]; then
  echo "M365_ACCOUNT_NAME=$TEST_TENANT_M365_ACCOUNT_NAME" >> $GITHUB_ENV
else
  echo "M365_ACCOUNT_NAME=$MATRIX_VALUE" >> $GITHUB_ENV
fi
```

That was the indirection for pulling in the Copilot test account, whose name was held in a secret. #15329 replaced the hardcoded matrix with `build-clean-matrix` reading `vars.M365_USERNAMES` - a variable, which the matrix *can* read directly - and deleted both the sentinel and the branch, but left this `env:` line behind. `git log -S` over the whole history shows nothing under `packages/` has ever read it, `USE_ENV_TEST_TENANT` no longer exists anywhere in the repo, and the line currently resolves to an empty string anyway because `secrets.TEST_TENANT_M365_ACCOUNT_ADMIN_ACCOUNT` does not exist (the secrets API returns 404 for it; only the variable does).

**3. A comment on `M365_ACCOUNT_PASSWORD` (no behaviour change)**

The value stays on `secrets.TEST_TENANT_M365_ACCOUNT_ADMIN_PASSWORD`, as set by #15329. The comment records the non-obvious constraint that `M365_ACCOUNT_NAME` is overwritten per matrix leg with `test001..test020` from `vars.M365_USERNAMES`, so whatever this secret holds has to be a valid password for **those** accounts - it is an ROPC username/password pair, and the account name rather than the password is what carries permissions. This has worked since February, which means the two password secrets held the same value in `atktesting06`; they were set separately during the cutover (09:13:15 vs 09:13:17), so if the first run after this fix reports `AADSTS50126` the follow-up is to switch this line to `secrets.TEST_TENANT_M365_ACCOUNT_PASSWORD` - the pairing `ui-test-vscuse-common.yml` uses for the same account pool.

## Verification

- `git grep secrets.TEST_TENANT_CLEAN_TENANT_ID` -> **0 hits** after this change (was exactly 1, repo-wide over all tracked files).
- `vars.TEST_TENANT_CLEAN_TENANT_ID` matches the tenant id published at `login.microsoftonline.com/atktesting07.onmicrosoft.com/v2.0/.well-known/openid-configuration`; the stale secret's value corresponded to `atktesting06`.
- `git log -S TEST_TENANT_M365_ACCOUNT_NAME -- packages/` -> **no commits**, i.e. no code has ever read it.
- No references in `microsoft-365-agents-toolkit-test`, and `rerun.yml` declares no `environment:`, so there is no environment-scoped or org-level shadow.
- Reviewed the last successful run (job 90155216660): 517 failures were HTTP 404 - the 20 matrix legs race each other over the same tenant-wide object list - and the only three 403s were Azure-managed AI Foundry service principals, which cannot be deleted through Graph by any role. No `Authorization_RequestDenied` anywhere, i.e. no evidence the cleanup identity is short on permissions.
- `yaml.safe_load` on the result confirms the `clean` job env block parses and no longer contains the dropped key.

## Not touched

`TEST_CLEAN_TENANT_ID` (no second `TENANT_`, last updated 2024-05-06) is a **different** secret used ~20 times across 13 workflows for `MAIL_TENANT_ID` / `DEVTUNNEL_TENANT_ID` / `M365_TENANT_ID`. It belongs to an older tenant lineage and is deliberately left alone, despite `ui-test.yml:184` mapping it onto the same `CLEAN_TENANT_ID` env var name.

`CLEAN_CLIENT_SECRET`, `MAIL_API_KEY` and `M365_DISPLAY_NAME` are also unread by `clean.ts` and are candidates for a later tidy-up, but they are left alone here to keep this change scoped to the outage.

## Validation after merge

Success criterion is the scheduled `clean` job returning to a 12-22 min duration ending in `Clean Job Done.`. It can also be triggered manually:

```
gh workflow run rerun.yml --ref dev -f run_id=<any completed run id> -f max_attempts=1 -f clean_up=true
```

Please avoid manual runs while `ui-test` / `uitest-vscuse-*` runs are in flight: the resource-group sweep matches on `name.includes("fxui"|"vs")` with no age filter and only excludes today's `fxui<UTC-month><UTC-day>` prefix, so it can delete resource groups belonging to a live test.