### PR TITLE
fix(vscuse): Auto-fix DA_Regenrate_Action

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
@@ -65,7 +65,7 @@
       "parameters": {
         "text": "https://raw.githubusercontent.com/SLdragon/example-openapi-spec/refs/heads/main/petstore-official.yaml"
       },
-      "description": "Type 'https://raw.githubusercontent.com/SLdragon/example-openapi-spec/refs/heads/main/petstore-official.yaml' into the \"Enter OpenAPI Description Document URL\" input box in the popup dialog in Visual Studio Code’s Microsoft 365 Agents Toolkit interface.",
+      "description": "Type 'https://raw.githubusercontent.com/SLdragon/example-openapi-spec/refs/heads/main/petstore-official.yaml' into the \"Enter OpenAPI Description Document URL\" input box in the popup dialog in Visual Studio Code\u2019s Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -177,7 +177,7 @@
       "parameters": {
         "keys": "ctrl+z"
       },
-      "description": "Undo the last action in the Visual Studio Code “Select Operation” input field (in the Microsoft 365 Agents Toolkit extension) using keyboard shortcut: Ctrl+Z.",
+      "description": "Undo the last action in the Visual Studio Code \u201cSelect Operation\u201d input field (in the Microsoft 365 Agents Toolkit extension) using keyboard shortcut: Ctrl+Z.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -199,7 +199,7 @@
       "parameters": {
         "keys": "ctrl+z"
       },
-      "description": "Undo the selection of the API endpoint “GET /store/order/{orderId}” in the Visual Studio Code “Select Operation” input dropdown by pressing the keyboard shortcut Ctrl+Z.",
+      "description": "Undo the selection of the API endpoint \u201cGET /store/order/{orderId}\u201d in the Visual Studio Code \u201cSelect Operation\u201d input dropdown by pressing the keyboard shortcut Ctrl+Z.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -645,11 +645,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:235:258:16:5:545454a4b4804840",
-        "dhash:235:258:96:5:7d6d6e6d76667c7d",
-        "dhash:235:258:0:10:64c4c04523626421"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_2991de14",

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
@@ -647,7 +647,9 @@
       "depends_on": [],
       "preconditions": [],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "delay:5"
+      ],
       "screenshot": "step_2991de14",
       "created_at": "2026-05-11T05:57:45.132251",
       "plan_id": "plan_5bbb0081"

--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
@@ -645,7 +645,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:235:258:16:5:0c64c48494242820",
+        "dhash:235:258:96:5:9d6d6d7c7d6d667d",
+        "dhash:235:258:0:10:64444044236a6421"
+      ],
       "postconditions": [],
       "tags": [
         "delay:5"


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `DA_Regenrate_Action`
**Status:** :white_check_mark: FIXED (attempt 2/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/b4781822-3c3c-49ff-a51a-3557d12c7d8d/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/3e0031df-e544-4f2d-addc-c439bcc078a6/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Removed stale dhash preconditions from step_2991de14 (the "GET /pet/findByStatus | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/7470d6fe-7b6e-4353-aae7-3ddda356d128/test_report.html) |
| 2 | Added a `delay:5` tag to step_2991de14 so it waits for the "Select operation(s)" | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/3e0031df-e544-4f2d-addc-c439bcc078a6/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/DA_Regenrate_Action.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../vscode-test-cases/plans/DA_Regenrate_Action.json   | 18 ++++++++++--------
 1 file changed, 10 insertions(+), 8 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json b/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
index 586153b..570e049 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/DA_Regenrate_Action.json
@@ -65,7 +65,7 @@
       "parameters": {
         "text": "https://raw.githubusercontent.com/SLdragon/example-openapi-spec/refs/heads/main/petstore-official.yaml"
       },
-      "description": "Type 'https://raw.githubusercontent.com/SLdragon/example-openapi-spec/refs/heads/main/petstore-official.yaml' into the \"Enter OpenAPI Description Document URL\" input box in the popup dialog in Visual Studio Code’s Microsoft 365 Agents Toolkit interface.",
+      "description": "Type 'https://raw.githubusercontent.com/SLdragon/example-openapi-spec/refs/heads/main/petstore-official.yaml' into the \"Enter OpenAPI Description Document URL\" input box in the popup dialog in Visual Studio Code\u2019s Microsoft 365 Agents Toolkit interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -177,7 +177,7 @@
       "parameters": {
         "keys": "ctrl+z"
       },
-      "description": "Undo the last action in the Visual Studio Code “Select Operation” input field (in the Microsoft 365 Agents Toolkit extension) using keyboard shortcut: Ctrl+Z.",
+      "description": "Undo the last action in the Visual Studio Code \u201cSelect Operation\u201d input field (in the Microsoft 365 Agents Toolkit extension) using keyboard shortcut: Ctrl+Z.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -199,7 +199,7 @@
       "parameters": {
         "keys": "ctrl+z"
       },
-      "description": "Undo the selection of the API endpoint “GET /store/order/{orderId}” in the Visual Studio Code “Select Operation” input dropdown by pressing the keyboard shortcut Ctrl+Z.",
+      "description": "Undo the selection of the API endpoint \u201cGET /store/order/{orderId}\u201d in the Visual Studio Code \u201cSelect Operation\u201d input dropdown by pressing the keyboard shortcut Ctrl+Z.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -646,12 +646,14 @@
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:235:258:16:5:545454a4b4804840",
-        "dhash:235:258:96:5:7d6d6e6d76667c7d",
-        "dhash:235:258:0:10:64c4c04523626421"
+        "dhash:235:258:16:5:0c64c48494242820",
+        "dhash:235:258:96:5:9d6d6d7c7d6d667d",
+        "dhash:235:258:0:10:64444044236a6421"
       ],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "delay:5"
+      ],
       "screenshot": "step_2991de14",
       "created_at": "2026-05-11T05:57:45.132251",
       "plan_id": "plan_5bbb0081"
@@ -810,4 +812,4 @@
     "step_c4ce1938": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDB
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>