### PR TITLE
fix(vscuse): Auto-fix Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Remote_Debug

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_launch_remote_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_launch_remote_none_da.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 60,
       "precondition_retry_interval": 2
     },
-    "total_steps": 15,
+    "total_steps": 16,
     "created_at": "2026-04-21T01:53:19.064480",
     "name": "group  debug in copilot launch remote none da",
     "description": {
@@ -31,6 +31,7 @@
       "step_19ee7405",
       "step_77e6e5d9",
       "step_27dc9b90",
+      "step_reload_copilot",
       "step_add_app_dev_copilot",
       "step_8f5f8690"
     ],
@@ -356,6 +357,29 @@
       ],
       "screenshot": "step_27dc9b90",
       "created_at": "2026-04-21T03:01:47.071846",
+      "plan_id": "plan_c795f9af"
+    },
+    {
+      "step_id": "step_reload_copilot",
+      "agent": "interaction",
+      "tool": "keyboard_shortcut",
+      "parameters": {
+        "keys": "ctrl+r"
+      },
+      "description": "Reload the M365 Copilot browser page (Ctrl+R) to re-resolve the \"${{var:app_name}}dev\" agent deep link. When the launch opens the chat/entity1 deep link before the sideloaded agent title has propagated to the tenant catalog, M365 shows a dead-end \"This agent is not installed\" modal that only offers Close; reloading after the wait lets the now-propagated agent open its chat (or show the installable agent-store Add modal). Harmless if the agent already loaded.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay: 30",
+        "force_run:true"
+      ],
+      "screenshot": "",
+      "created_at": "2026-04-21T03:01:47.085177",
       "plan_id": "plan_c795f9af"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_launch_remote_none_da.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_copilot_launch_remote_none_da.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 60,
       "precondition_retry_interval": 2
     },
-    "total_steps": 14,
+    "total_steps": 15,
     "created_at": "2026-04-21T01:53:19.064480",
     "name": "group  debug in copilot launch remote none da",
     "description": {
@@ -31,6 +31,7 @@
       "step_19ee7405",
       "step_77e6e5d9",
       "step_27dc9b90",
+      "step_add_app_dev_copilot",
       "step_8f5f8690"
     ],
     "tags": [
@@ -355,6 +356,31 @@
       ],
       "screenshot": "step_27dc9b90",
       "created_at": "2026-04-21T03:01:47.071846",
+      "plan_id": "plan_c795f9af"
+    },
+    {
+      "step_id": "step_add_app_dev_copilot",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 373,
+        "y": 222
+      },
+      "description": "Click the \"Add\" button in the M365 Copilot agent-store install modal for ${{var:app_name}}dev to install the remote agent and dismiss the blocking modal, so the agent appears in the sidebar and the chat input becomes reachable. If the modal is not present (agent already added), this click is harmless.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay: 8",
+        "force_run:true"
+      ],
+      "screenshot": "",
+      "created_at": "2026-04-21T03:01:47.085177",
       "plan_id": "plan_c795f9af"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Remote_Debug.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 2,
+    "total_steps": 1,
     "created_at": "2026-05-11T06:58:57.669528",
     "name": "Basic Custom Engine Azure OpenAI js Copilot Remote Debug",
     "description": {
@@ -30,7 +30,6 @@
       "plan_r_0928_073729",
       "plan_r_0928_075846",
       "plan_c795f9af",
-      "step_add_app_copilot",
       "plan_568c0a08"
     ],
     "tags": [],
@@ -56,28 +55,6 @@
       "postconditions": [],
       "tags": [],
       "screenshot": "step_b703a796",
-      "created_at": "2026-05-11T06:58:57.763957",
-      "plan_id": "plan_b814ca64"
-    },
-    {
-      "step_id": "step_add_app_copilot",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 373,
-        "y": 222
-      },
-      "description": "Click the \"Add\" button in the M365 Copilot agent store install dialog (for ${{var:app_name}}dev) to install the agent and dismiss the modal, so the Copilot chat input becomes reachable. If the agent is already added and the chat is open, this clicks empty page area and is harmless.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "true",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "",
       "created_at": "2026-05-11T06:58:57.763957",
       "plan_id": "plan_b814ca64"
     }

--- a/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Remote_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Remote_Debug.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_count": 0
     },
-    "total_steps": 1,
+    "total_steps": 2,
     "created_at": "2026-05-11T06:58:57.669528",
     "name": "Basic Custom Engine Azure OpenAI js Copilot Remote Debug",
     "description": {
@@ -30,6 +30,7 @@
       "plan_r_0928_073729",
       "plan_r_0928_075846",
       "plan_c795f9af",
+      "step_add_app_copilot",
       "plan_568c0a08"
     ],
     "tags": [],
@@ -55,6 +56,28 @@
       "postconditions": [],
       "tags": [],
       "screenshot": "step_b703a796",
+      "created_at": "2026-05-11T06:58:57.763957",
+      "plan_id": "plan_b814ca64"
+    },
+    {
+      "step_id": "step_add_app_copilot",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 373,
+        "y": 222
+      },
+      "description": "Click the \"Add\" button in the M365 Copilot agent store install dialog (for ${{var:app_name}}dev) to install the agent and dismiss the modal, so the Copilot chat input becomes reachable. If the agent is already added and the chat is open, this clicks empty page area and is harmless.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "true",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
       "created_at": "2026-05-11T06:58:57.763957",
       "plan_id": "plan_b814ca64"
     }


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Remote_Debug`
**Status:** :white_check_mark: FIXED (attempt 3/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/e79b6476-5438-4e2d-bf82-019ecc3d8b4e/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/f5e0dd8b-8480-45bc-b5c4-edff0dda2b3c/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Added inline step step_add_app_copilot (click "Add" at 373,222) before the copil | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/a141aed5-7b22-41c5-ae1c-5a6f25db41f9/test_report.html) |
| 2 | Inserted an "Add" click step (373,222) inside group `plan_c795f9af` right before | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/70f3c09f-bf21-498f-a68f-0305b6b16ffd/test_report.html) |
| n/a | INVALID AI OUTPUT | :warning: Invalid AI output | — |
| 3 | In shared group `group__debug_in_copilot_launch_remote_none_da.json` (plan_c795f | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/f5e0dd8b-8480-45bc-b5c4-edff0dda2b3c/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Basic_Custom_Engine_Azure_OpenAI_js_Copilot_Remote_Debug.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `claude-opus-4.8`</sub>