### PR TITLE
refactor: set parent window when using WAM broker login

### DIFF
--- a/docs/02-architecture/adr/ADR-0021-wam-broker-dialog-parent-window.md
+++ b/docs/02-architecture/adr/ADR-0021-wam-broker-dialog-parent-window.md
@@ -1,0 +1,210 @@
+# ADR-0021 — Parent window for the WAM broker sign-in dialog
+
+- **Status:** Proposed
+- **Date:** 2026-08-04
+- **Source:** Investigation of [gim-home/wiqd#1884](https://github.com/gim-home/wiqd/issues/1884)
+  — "`wiqd auth login` hangs in the VS Code integrated terminal delegating to ATK interactive sign-in"
+- **Related:** [ADR-0003](ADR-0003-broker-gating.md) (broker gating policy),
+  [identity-and-login §1.3](../external-dependencies/identity-and-login.md#13-native-broker-wam)
+
+## Context
+
+When the CLI signs in on Windows with the native broker (WAM), it calls
+`acquireTokenInteractive` and MSAL hands off to the broker, which renders a
+native sign-in window out-of-process. Two problems follow from that hand-off.
+
+**The CLI prints nothing.** `loginWithBroker` only emits a message from inside
+the `openBrowser` callback, which MSAL never invokes when the broker handles
+the flow. The terminal stays silent for the whole interactive sign-in.
+
+**The dialog is not reliably reachable.** `InteractiveRequest.windowHandle` was
+not set, so `NativeBrokerPlugin` substituted `Buffer.from([0])` — a NULL owner —
+and the broker window was created unowned.
+
+Whether an unowned window surfaces depends on Windows' foreground-activation
+rules. A process may bring a window to the foreground only if it is the
+foreground process, was *started by* the foreground process, or received the
+last input event. Measured process trees:
+
+| Host | Process chain | Foreground rights | Unowned dialog |
+|---|---|---|---|
+| classic console | `node <- cmd` | granted — parent owns the foreground window | comes to front, behaves modally |
+| VS Code terminal | `node <- pwsh <- Code <- Code` | denied — parent owns no window | created behind, no activation |
+| via wiqd | `node(atk) <- node(wiqd) <- shell` | denied — parent is windowless | created behind, no activation |
+
+The reported bug is the combination: nothing printed, and a dialog the user
+cannot see. The CLI appears hung.
+
+## Options considered
+
+- **A — Print a hint message only.** Emit a line before `acquireTokenInteractive`
+  when the broker is available. Fixes the "no output" half everywhere, leaves
+  the dialog unreachable.
+- **B — Pass a parent window handle.** Resolve a real window and set
+  `windowHandle`, so the dialog is owned: pinned above its owner in z-order,
+  and the owner disabled while it is up.
+- **C — Create our own owner window.** A 1×1 offscreen top-level window inside
+  the CLI process. Works in every host, but requires a native addon with a
+  dedicated Win32 message-pump thread — a window with no pump gets ghosted and
+  the broker blocks on it.
+- **D — Disable the broker in console contexts.** Falls back to the existing
+  loopback auth-code flow, which already prints a URL and opens a browser.
+  Loses WAM's SSO and device-trust properties and may break Conditional Access
+  policies that require a broker.
+
+## Decision
+
+Adopt **B**. The CLI resolves a parent window handle and passes it as
+`InteractiveRequest.windowHandle`.
+
+`node.exe` owns no window of its own, so the handle must come from an ancestor.
+[`packages/cli/src/commonlib/windowHandle.ts`](../../../packages/cli/src/commonlib/windowHandle.ts)
+spawns a short PowerShell script that snapshots the process table once, walks up
+from the CLI process, and returns the first ancestor with a visible
+`MainWindowHandle`. The handle is converted to raw little-endian pointer bytes —
+the shape `@azure/msal-node-runtime` expects — and memoized for the process
+lifetime.
+
+The walk, rather than `GetConsoleWindow()`, because the two host families differ:
+
+- **ConPTY hosts** (VS Code, Windows Terminal): the shell is attached to a hidden
+  `PseudoConsoleWindow`, which `MainWindowHandle` skips because it is not
+  visible. The walk continues to the terminal host — `Code.exe`,
+  `WindowsTerminal.exe` — which owns the window the user actually sees.
+- **Classic conhost**: the shell itself reports the console window, so the walk
+  stops there.
+
+Being a ConPTY host is not sufficient — the terminal must also be an *ancestor*.
+"Windows Terminal" covers two different process topologies:
+
+- **WT launches the shell** (a profile tab, or `wt.exe <cmd>`): the shell is a
+  child of `WindowsTerminal.exe`, so the walk reaches it.
+- **Console handoff** (a standalone `cmd.exe` whose session `conhost.exe`
+  delegates to the configured `DelegationTerminal`): `WindowsTerminal.exe` is
+  COM-activated by the DCOM launcher, or is a pre-existing instance that is
+  reused. Either way it sits on a separate process branch, connected to the
+  client only by ConPTY pipes, which carry no parent/child relationship. The
+  walk cannot cross into it and climbs into `explorer` instead.
+
+There is no supported API to map a ConPTY client back to the terminal window
+rendering it, so the handoff case is accepted as unresolvable rather than
+approximated by heuristics (matching `WT_SESSION` against WT instances, or
+picking the foreground WT window, both misbehave with multiple windows or tabs).
+
+Two guards constrain the result:
+
+- The walk **stops at `explorer.exe`** and returns no handle. Explorer's
+  `MainWindowHandle` is whichever visible top-level window it happens to
+  enumerate first and varies across a session; a non-deterministic owner is
+  worse than none.
+- Any failure — non-Windows, no suitable ancestor, PowerShell error, timeout —
+  returns `undefined`, which restores the pre-existing NULL-owner behavior.
+
+On by default. `ATK_WAM_PARENT_WINDOW=off` disables it; `=debug` additionally
+appends the resolved handle and walk trail to `%TEMP%/atk-wam-parent.log`. The
+file trace exists because callers such as wiqd capture the CLI's stdout, which
+would otherwise swallow the diagnostic.
+
+## Evidence
+
+All measured on Windows 11 x64, `@azure/msal-node@5.4.0`,
+`@azure/msal-node-extensions@1.5.25`.
+
+| Host | Resolved walk | Handle | Outcome |
+|---|---|---|---|
+| VS Code, pwsh | `node <- pwsh <- Code <- Code` | `0x2f1130` `Chrome_WidgetWin_1` | dialog in front, blocks |
+| VS Code, cmd | `node <- cmd <- Code <- Code` | `0x2f1130` | dialog in front, blocks |
+| Windows Terminal tab, pwsh | `node <- pwsh <- WindowsTerminal` | `0xd30a02` `CASCADIA_HOSTING_WINDOW_CLASS` | dialog in front, blocks |
+| `wt.exe cmd` | `node <- cmd <- WindowsTerminal` | `0x1240546` | dialog in front, blocks |
+| standalone cmd (Windows Terminal defterm) | `node <- cmd <- explorer <- svchost <- services <- wininit` | none | no `WindowsTerminal` ancestor; walk stops at `explorer` and returns `undefined` |
+| forced `conhost.exe`, cmd | `node <- cmd` | `0x1612e0` `ConsoleWindowClass` | not a GUI window; see follow-ups |
+
+Supporting facts:
+
+- The console window is attributed to the shell process (`cmd.exe`), not to
+  `conhost.exe` — every `conhost` instance reports `MainWindowHandle = 0`.
+- The same `cmd.exe` reports a real `MainWindowHandle` under forced conhost and
+  `0` under defterm handoff. That difference distinguishes the last two rows
+  above and confirms the handoff actually occurred.
+- Explorer's `MainWindowHandle` was observed as a `ThumbnailDeviceHelperWnd`
+  (`0x8e0c5e`) — a shell helper window, which is why the walk now stops there
+  rather than accepting it. A `cmd.exe` started from a transient `explorer.exe`
+  launcher hits a windowless `explorer` and would otherwise climb into system
+  processes; one started from the Start menu or Run dialog has the shell
+  `explorer` as its parent and would otherwise return the helper window.
+- Resolution cost is ~700 ms on first call, 0 ms thereafter (memoized). A
+  per-process `Get-CimInstance` loop cost ~1700 ms; the single bulk query
+  replaced it.
+- The script takes no input and is passed as base64 UTF-16LE via
+  `-EncodedCommand`, so there is no interpolation or injection surface.
+- PowerShell emits CLIXML progress records on stderr; stderr is discarded to
+  keep them out of CLI output.
+
+## Consequences
+
+**Positive.** The dialog is owned by the terminal window in ConPTY hosts, so it
+is pinned above it and blocks it — the behavior users already get in a classic
+console. This covers the VS Code and wiqd cases in the originating issue. No
+native dependency is added, and every failure path degrades to today's
+behavior.
+
+**Negative.** Sign-in blocks for ~700 ms on the first call while PowerShell
+runs, with no output during that window. The resolution is heuristic — it
+depends on `MainWindowHandle` semantics and on process-tree shape, neither of
+which is contractual. It is Windows-only and adds a process spawn to the login
+path.
+
+**Neutral.** Owned windows are excluded from the taskbar by design, so parenting
+changes z-order and modality but cannot give the user a taskbar button or
+Alt-Tab entry to recover a lost dialog.
+
+**Unchanged for console handoff.** A standalone `cmd.exe` hosted by Windows
+Terminal through defterm keeps the NULL owner. That is not a regression: the
+shell is the foreground process and started the CLI, so the broker inherits the
+foreground grant and the dialog still opens in front. What is missing is the
+ongoing relationship — the dialog falls behind on the next click on the
+terminal, does not minimize or restore with it, and is not centered on it.
+
+## Follow-ups
+
+Not covered by this ADR; each needs its own decision or work item.
+
+1. **Hint message (option A) is still worth shipping.** Parenting does not fix
+   the "prints nothing" half of the issue, and it only helps on Windows with the
+   broker available. A localized line before `acquireTokenInteractive`, gated on
+   `isBrokerAvailable`, would cover every host and both the M365 and Azure paths.
+2. **Tests.** No unit tests exist for `windowHandle.ts`. Per the
+   `vibe-coding` skill this behavior change needs an Acceptance Criteria table
+   with tests derived 1:1. At minimum: non-Windows returns `undefined`, `off`
+   returns `undefined`, malformed script output returns `undefined`, a
+   PowerShell failure returns `undefined`, the buffer encoding is correct for
+   the pointer size, and the result is memoized.
+3. **Classic conhost is unguarded.** The walk stops at the shell's own
+   `ConsoleWindowClass` window there. That is not a normal GUI window and has no
+   application message pump. A forced-conhost session was the one configuration
+   observed to hang, though the cause was never isolated — the Explorer landing
+   is an equally plausible explanation and is now guarded. Guarding it properly
+   requires comparing against `GetConsoleWindow()`, which costs an `Add-Type`
+   compile (~0.5–1 s) on the synchronous login path.
+4. **The original hang has no confirmed root cause.** It was reproduced by A/B
+   (`off` cleared it) but never with a trace attached. If it recurs, the trace
+   file names the owner window.
+5. **Cost could move off the critical path.** The resolution could run
+   concurrently with MSAL setup rather than blocking, or be replaced by a
+   cheaper detection (`TERM_PROGRAM`, `WT_SESSION`) at the cost of robustness.
+6. **VS Code surface is unaffected.** The extension already runs in a process
+   with a real window; if it ever adopts the broker (see ADR-0003), it should
+   pass its own handle rather than reuse this walk.
+7. **Update dependent docs.** [ADR-0003](ADR-0003-broker-gating.md) should note
+   that CLI broker sign-in now parents its dialog, and
+   [identity-and-login §1.3](../external-dependencies/identity-and-login.md#13-native-broker-wam)
+   should gain `windowHandle` alongside the existing broker quirks.
+
+## Unrelated defect found during this work
+
+`CLILogProvider.setLogLevel()` in
+[`packages/cli/src/commonlib/log.ts`](../../../packages/cli/src/commonlib/log.ts)
+is dead code — the log level it sets is never consulted, so every
+`CliCodeLogInstance.debug()` and `.verbose()` call across the CLI silently
+discards its message. Only `necessaryLog()` bypasses the check. Pre-existing and
+out of scope here; it deserves its own issue.

--- a/docs/02-architecture/adr/ADR-0021-wam-broker-dialog-parent-window.md
+++ b/docs/02-architecture/adr/ADR-0021-wam-broker-dialog-parent-window.md
@@ -86,17 +86,29 @@ Being a ConPTY host is not sufficient — the terminal must also be an *ancestor
   client only by ConPTY pipes, which carry no parent/child relationship. The
   walk cannot cross into it and climbs into `explorer` instead.
 
-There is no supported API to map a ConPTY client back to the terminal window
-rendering it, so the handoff case is accepted as unresolvable rather than
-approximated by heuristics (matching `WT_SESSION` against WT instances, or
-picking the foreground WT window, both misbehave with multiple windows or tabs).
+A second family of hosts breaks the walk outright. Git Bash (MSYS) emulates
+`fork`/`exec` by spawning a fresh Win32 process and letting the original exit, so
+the Win32 parent chain above `sh` points at a PID that no longer exists. The
+observed trail is `node <- node <- sh <- (dead pid)` — the snapshot has no entry
+for the dead PID, the loop ends, and nothing is found. `GetConsoleWindow()` does
+not bridge either gap: it returns 0 under Git Bash and a hidden
+`PseudoConsoleWindow` elsewhere.
+
+When the walk yields nothing, the resolver falls back to
+`GetForegroundWindow()`. At sign-in time that is the terminal the user just typed
+into, and it was measured to return the same handle the walk produces in the
+hosts where both work. It is a fallback rather than the primary source because
+the user can switch windows during the ~700 ms resolution, and an unrelated
+application is a worse owner than a real ancestor. The P/Invoke it needs costs
+~500 ms to compile, so it is only paid on the path that already failed.
 
 Two guards constrain the result:
 
 - The walk **stops at `explorer.exe`** and returns no handle. Explorer's
   `MainWindowHandle` is whichever visible top-level window it happens to
   enumerate first and varies across a session; a non-deterministic owner is
-  worse than none.
+  worse than none. An `explorer`-owned foreground window is rejected for the
+  same reason.
 - Any failure — non-Windows, no suitable ancestor, PowerShell error, timeout —
   returns `undefined`, which restores the pre-existing NULL-owner behavior.
 
@@ -116,8 +128,10 @@ All measured on Windows 11 x64, `@azure/msal-node@5.4.0`,
 | VS Code, cmd | `node <- cmd <- Code <- Code` | `0x2f1130` | dialog in front, blocks |
 | Windows Terminal tab, pwsh | `node <- pwsh <- WindowsTerminal` | `0xd30a02` `CASCADIA_HOSTING_WINDOW_CLASS` | dialog in front, blocks |
 | `wt.exe cmd` | `node <- cmd <- WindowsTerminal` | `0x1240546` | dialog in front, blocks |
-| standalone cmd (Windows Terminal defterm) | `node <- cmd <- explorer <- svchost <- services <- wininit` | none | no `WindowsTerminal` ancestor; walk stops at `explorer` and returns `undefined` |
+| standalone cmd (Windows Terminal defterm) | `node <- cmd <- explorer <- svchost <- services <- wininit` | none from the walk | no `WindowsTerminal` ancestor; falls back to foreground |
+| VS Code, Git Bash, via wiqd | `node <- node <- sh <- (dead pid)` | none from the walk | MSYS severs the Win32 parent chain; falls back to foreground |
 | forced `conhost.exe`, cmd | `node <- cmd` | `0x1612e0` `ConsoleWindowClass` | not a GUI window; see follow-ups |
+| fallback branch, forced | `(999999) <- [foreground:Code(33156)]` | `0x2f1130` | same window the walk resolves when it works |
 
 Supporting facts:
 
@@ -132,9 +146,9 @@ Supporting facts:
   launcher hits a windowless `explorer` and would otherwise climb into system
   processes; one started from the Start menu or Run dialog has the shell
   `explorer` as its parent and would otherwise return the helper window.
-- Resolution cost is ~700 ms on first call, 0 ms thereafter (memoized). A
-  per-process `Get-CimInstance` loop cost ~1700 ms; the single bulk query
-  replaced it.
+- Resolution cost is ~700 ms on first call, 0 ms thereafter (memoized), rising to
+  ~980 ms when the fallback branch compiles its P/Invoke. A per-process
+  `Get-CimInstance` loop cost ~1700 ms; the single bulk query replaced it.
 - The script takes no input and is passed as base64 UTF-16LE via
   `-EncodedCommand`, so there is no interpolation or injection surface.
 - PowerShell emits CLIXML progress records on stderr; stderr is discarded to
@@ -158,12 +172,11 @@ path.
 changes z-order and modality but cannot give the user a taskbar button or
 Alt-Tab entry to recover a lost dialog.
 
-**Unchanged for console handoff.** A standalone `cmd.exe` hosted by Windows
-Terminal through defterm keeps the NULL owner. That is not a regression: the
-shell is the foreground process and started the CLI, so the broker inherits the
-foreground grant and the dialog still opens in front. What is missing is the
-ongoing relationship — the dialog falls behind on the next click on the
-terminal, does not minimize or restore with it, and is not centered on it.
+**Negative, from the fallback.** If the user switches windows while resolution
+runs, the dialog is parented to whatever is in the foreground at that moment,
+which disables that unrelated application until sign-in completes. The window is
+still reachable and the situation resolves itself, but it is a worse outcome than
+the walk succeeding. This risk did not exist before the fallback.
 
 ## Follow-ups
 

--- a/docs/02-architecture/adr/README.md
+++ b/docs/02-architecture/adr/README.md
@@ -39,6 +39,7 @@ decision. The format for a new ADR is defined inline below under
 | ADR-0018 | [`ScaffoldRuntime` + T1/T2/T3 test pyramid + design-first `descriptor.spec` gate (application of ADR-0013, not a competing tiering)](ADR-0018-scaffold-runtime-test-pyramid.md) | Accepted | [`scaffolding.create.proposal.md` §14](../scaffolding.create.proposal.md#14-adrs-this-proposal-will-be-decomposed-into) |
 | ADR-0019 | [Dual-stream scaffold telemetry (v3 verbatim + parallel `scaffold-v4-*` family)](ADR-0019-dual-stream-scaffold-telemetry.md) | Accepted | [`scaffolding.create.proposal.md` §14](../scaffolding.create.proposal.md#14-adrs-this-proposal-will-be-decomposed-into) |
 | ADR-0020 | [MCP server URL validity: when to check, and whether to block](ADR-0020-mcp-server-url-validity.md) | Accepted | [`mcp-remote-servers.md` §3](../external-dependencies/mcp-remote-servers.md#3-open-questions) |
+| ADR-0021 | [Parent window for the WAM broker sign-in dialog](ADR-0021-wam-broker-dialog-parent-window.md) | Proposed | [gim-home/wiqd#1884](https://github.com/gim-home/wiqd/issues/1884) |
 
 > **Reading order vs. numeric order.** The Index is in **numeric order** —
 > the immutable, reservation-ordered ADR id is the anchor for every forward

--- a/packages/cli/src/commonlib/codeFlowLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowLogin.ts
@@ -40,6 +40,7 @@ import { azureLoginMessage, env, m365LoginMessage, sendFileTimeout } from "./com
 import { getAccountByHomeId } from "./common/tokenCacheUtils";
 import { decodeClaimsChallenge } from "./common/utils";
 import CliCodeLogInstance from "./log";
+import { getParentWindowHandle } from "./windowHandle";
 
 export class ErrorMessage {
   static readonly loginFailureTitle = "LoginFail";
@@ -325,6 +326,9 @@ export class CodeFlowLogin {
       authority: authority,
       prompt: "select_account",
       claims: claim,
+      // Parents the native WAM dialog. Without it MSAL passes a NULL owner and the dialog can
+      // be created behind the terminal with no way for the user to reach it.
+      windowHandle: this.isBrokerAvailable ? getParentWindowHandle() : undefined,
       openBrowser: async (url: string) => {
         url += "#";
         if (this.accountName == "azure") {

--- a/packages/cli/src/commonlib/windowHandle.ts
+++ b/packages/cli/src/commonlib/windowHandle.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { execFileSync } from "child_process";
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+import { logger } from "./logger";
+
+/**
+ * Walks up the process tree and returns the `MainWindowHandle` of the first ancestor that has one.
+ *
+ * Why a walk rather than GetConsoleWindow(): under any ConPTY host GetConsoleWindow() returns a
+ * hidden `PseudoConsoleWindow`, which is useless as a dialog owner. The window the user actually
+ * sees belongs to the terminal host process, so we have to climb the ancestor chain to find it.
+ *
+ * Measured behavior per host (walk trail -> resolved owner):
+ * - VS Code integrated terminal: `node <- pwsh <- Code` -> the VS Code window.
+ * - Windows Terminal tab, or `wt.exe <cmd>`: `node <- cmd <- WindowsTerminal` -> the WT window.
+ *   WT spawned the shell, so it is a genuine ancestor.
+ * - Classic conhost (`conhost.exe cmd`): `node <- cmd` -> the console window itself, because
+ *   under conhost the console window is attributed to the client process.
+ * - Standalone `cmd.exe` handed off to WT by the default-terminal setting: `node <- cmd <-
+ *   explorer <- svchost <- ...`. WT is COM-activated on a separate process branch and is NOT an
+ *   ancestor, so no terminal window is reachable and the walk yields nothing. That is intended:
+ *   MSAL then uses a NULL owner, and the dialog still comes to the front via the foreground grant
+ *   the CLI process holds.
+ *
+ * The walk stops at `explorer` rather than continuing, because explorer's `MainWindowHandle` is an
+ * arbitrary shell window (observed: a `ThumbnailDeviceHelperWnd`) that would be a bogus owner.
+ *
+ * The script takes no input, so nothing is interpolated into the command line.
+ */
+const resolveWindowScript = [
+  "$ErrorActionPreference = 'SilentlyContinue'",
+  // Snapshot the whole process table once; per-process CIM queries are ~3x slower.
+  "$parent = @{}",
+  "Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId | ForEach-Object { $parent[[int]$_.ProcessId] = [int]$_.ParentProcessId }",
+  "$windows = @{}",
+  "$names = @{}",
+  "Get-Process | ForEach-Object { $names[[int]$_.Id] = $_.ProcessName; if ($_.MainWindowHandle -ne 0) { $windows[[int]$_.Id] = [int64]$_.MainWindowHandle } }",
+  // Start from the parent of this PowerShell process, i.e. the CLI process itself.
+  "$id = $parent[$PID]",
+  "$trail = @()",
+  "$found = 0",
+  "for ($i = 0; $i -lt 12 -and $id; $i++) {",
+  "  $name = $names[$id]",
+  "  $trail += ('{0}({1})' -f $name, $id)",
+  // Explorer's MainWindowHandle is an arbitrary shell window that varies over a session.
+  "  if ($name -eq 'explorer') { break }",
+  "  if ($windows.ContainsKey($id)) { $found = $windows[$id]; break }",
+  "  $id = $parent[$id]",
+  "}",
+  // Single line: "<handle>;<walk trail>"
+  "[Console]::Out.Write(\"$found;\" + ($trail -join ' <- '))",
+].join("\n");
+
+let cachedHandle: Buffer | undefined;
+let resolved = false;
+
+function mode(): string {
+  return (process.env.ATK_WAM_PARENT_WINDOW ?? "").trim().toLowerCase();
+}
+
+function pointerSize(): number {
+  return process.arch === "ia32" || process.arch === "arm" ? 4 : 8;
+}
+
+/**
+ * Logs to the CLI and, when ATK_WAM_PARENT_WINDOW=debug, also appends to a temp file.
+ * The file trace exists because a parent process (for example wiqd) may capture the CLI's
+ * stdout, which would otherwise swallow the diagnostic.
+ */
+function trace(message: string): void {
+  logger.debug(message);
+  if (mode() !== "debug") {
+    return;
+  }
+  try {
+    fs.appendFileSync(
+      path.join(os.tmpdir(), "atk-wam-parent.log"),
+      `${new Date().toISOString()} pid=${process.pid} ${message}${os.EOL}`
+    );
+  } catch {
+    // Diagnostics are best-effort.
+  }
+}
+
+function toHandleBuffer(handle: number): Buffer {
+  const size = pointerSize();
+  const buffer = Buffer.alloc(size);
+  if (size === 4) {
+    buffer.writeUInt32LE(handle);
+  } else {
+    buffer.writeBigUInt64LE(BigInt(handle));
+  }
+  return buffer;
+}
+
+/**
+ * Resolves a parent window handle for the WAM broker dialog, in the raw pointer-bytes format
+ * `@azure/msal-node-runtime` expects (the same shape Electron's `getNativeWindowHandle()` returns).
+ *
+ * What the owner buys: without it the dialog is an independent top-level window — it still opens
+ * in front (the broker inherits the CLI's foreground grant), but it falls behind the terminal on
+ * the next click, does not minimize/restore with it, and is not centered on it. With it, the
+ * dialog stays above the terminal window and tracks it.
+ *
+ * Set ATK_WAM_PARENT_WINDOW=off to disable, or =debug to also append the walk to a temp file.
+ *
+ * Returns undefined when disabled, on non-Windows platforms, when no suitable ancestor window
+ * exists, or when resolution fails for any reason. In that case MSAL falls back to a NULL owner,
+ * which is the behavior before this helper existed.
+ */
+export function getParentWindowHandle(): Buffer | undefined {
+  if (resolved) {
+    return cachedHandle;
+  }
+  resolved = true;
+
+  if (process.platform !== "win32") {
+    return undefined;
+  }
+  if (mode() === "off") {
+    return undefined;
+  }
+
+  try {
+    const encoded = Buffer.from(resolveWindowScript, "utf16le").toString("base64");
+    const output = execFileSync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
+      {
+        encoding: "utf8",
+        timeout: 15000,
+        windowsHide: true,
+        // PowerShell writes CLIXML progress records to stderr; keep them out of the CLI output.
+        stdio: ["ignore", "pipe", "ignore"],
+      }
+    );
+    const [handleText, walk] = output.trim().split(";");
+    const handle = Number.parseInt(handleText, 10);
+    if (!Number.isSafeInteger(handle) || handle <= 0) {
+      trace(`[Login] no visible ancestor window found, using default owner (walk: ${walk ?? ""})`);
+      return undefined;
+    }
+    trace(`[Login] using parent window handle 0x${handle.toString(16)} (walk: ${walk ?? ""})`);
+    cachedHandle = toHandleBuffer(handle);
+    return cachedHandle;
+  } catch (e: any) {
+    trace(`[Login] failed to resolve parent window handle: ${e.message}`);
+    return undefined;
+  }
+}

--- a/packages/cli/src/commonlib/windowHandle.ts
+++ b/packages/cli/src/commonlib/windowHandle.ts
@@ -21,13 +21,18 @@ import { logger } from "./logger";
  * - Classic conhost (`conhost.exe cmd`): `node <- cmd` -> the console window itself, because
  *   under conhost the console window is attributed to the client process.
  * - Standalone `cmd.exe` handed off to WT by the default-terminal setting: `node <- cmd <-
- *   explorer <- svchost <- ...`. WT is COM-activated on a separate process branch and is NOT an
- *   ancestor, so no terminal window is reachable and the walk yields nothing. That is intended:
- *   MSAL then uses a NULL owner, and the dialog still comes to the front via the foreground grant
- *   the CLI process holds.
+ *   explorer <- ...`. WT is COM-activated on a separate process branch and is NOT an ancestor.
+ * - Git Bash: `node <- sh <- (dead pid)`. MSYS emulates fork/exec by spawning a new Win32
+ *   process and letting the original exit, so the Win32 parent chain is severed above `sh`.
+ *
+ * The last two cases fall back to `GetForegroundWindow()`, which at sign-in time is the terminal
+ * the user just typed into. Measured to return the same handle the walk yields where both work.
+ * It is a fallback rather than the primary source because the user may switch windows while the
+ * ~700 ms resolution runs, and an unrelated app is a worse owner than the real ancestor.
  *
  * The walk stops at `explorer` rather than continuing, because explorer's `MainWindowHandle` is an
- * arbitrary shell window (observed: a `ThumbnailDeviceHelperWnd`) that would be a bogus owner.
+ * arbitrary shell window (observed: a `ThumbnailDeviceHelperWnd`) that would be a bogus owner. For
+ * the same reason an `explorer`-owned foreground window is rejected.
  *
  * The script takes no input, so nothing is interpolated into the command line.
  */
@@ -50,6 +55,19 @@ const resolveWindowScript = [
   "  if ($name -eq 'explorer') { break }",
   "  if ($windows.ContainsKey($id)) { $found = $windows[$id]; break }",
   "  $id = $parent[$id]",
+  "}",
+  // Fallback for the hosts where the walk cannot reach the terminal. The P/Invoke costs ~500 ms
+  // to compile, so it is only paid when the walk already failed.
+  "if ($found -eq 0) {",
+  '  $sig = \'[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow(); [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);\'',
+  "  $api = Add-Type -MemberDefinition $sig -Name AtkForeground -Namespace Atk -PassThru",
+  "  $fg = $api::GetForegroundWindow()",
+  "  if ($fg -ne [IntPtr]::Zero) {",
+  "    $fpid = 0",
+  "    [void]$api::GetWindowThreadProcessId($fg, [ref]$fpid)",
+  "    $fname = $names[[int]$fpid]",
+  "    if ($fname -and $fname -ne 'explorer') { $found = [int64]$fg; $trail += ('[foreground:{0}({1})]' -f $fname, $fpid) }",
+  "  }",
   "}",
   // Single line: "<handle>;<walk trail>"
   "[Console]::Out.Write(\"$found;\" + ($trail -join ' <- '))",
@@ -127,8 +145,15 @@ export function getParentWindowHandle(): Buffer | undefined {
 
   try {
     const encoded = Buffer.from(resolveWindowScript, "utf16le").toString("base64");
+    const powerShellPath = path.join(
+      process.env.SystemRoot ?? "C:\\Windows",
+      "System32",
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe"
+    );
     const output = execFileSync(
-      "powershell.exe",
+      powerShellPath,
       ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
       {
         encoding: "utf8",

--- a/packages/cli/tests/unit/commonlib/windowHandle.tests.ts
+++ b/packages/cli/tests/unit/commonlib/windowHandle.tests.ts
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as os from "os";
+import * as path from "path";
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
+
+const execFileSyncMock = vi.fn();
+const appendFileSyncMock = vi.fn();
+const debugMock = vi.fn();
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return {
+    ...actual,
+    execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+  };
+});
+
+vi.mock("fs-extra", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs-extra")>();
+  const mocked = {
+    ...actual,
+    appendFileSync: (...args: unknown[]) => appendFileSyncMock(...args),
+  };
+  return { ...mocked, default: mocked };
+});
+
+vi.mock("../../../src/commonlib/logger", () => ({
+  logger: { debug: (...args: unknown[]) => debugMock(...args) },
+}));
+
+async function importModule() {
+  return await import("../../../src/commonlib/windowHandle");
+}
+
+describe("windowHandle", () => {
+  const originalPlatform = process.platform;
+  const originalArch = process.arch;
+  const originalEnv = { ...process.env };
+
+  function setReadOnly(key: "platform" | "arch", value: string) {
+    Object.defineProperty(process, key, { value, configurable: true });
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    execFileSyncMock.mockReset();
+    appendFileSyncMock.mockReset();
+    debugMock.mockReset();
+    setReadOnly("platform", "win32");
+    setReadOnly("arch", "x64");
+    delete process.env.ATK_WAM_PARENT_WINDOW;
+  });
+
+  afterEach(() => {
+    setReadOnly("platform", originalPlatform);
+    setReadOnly("arch", originalArch);
+    process.env = { ...originalEnv };
+  });
+
+  it("returns undefined on non-Windows platforms without spawning PowerShell", async () => {
+    setReadOnly("platform", "darwin");
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isUndefined(getParentWindowHandle());
+    assert.equal(execFileSyncMock.mock.calls.length, 0);
+  });
+
+  it("returns undefined when ATK_WAM_PARENT_WINDOW is off", async () => {
+    process.env.ATK_WAM_PARENT_WINDOW = " OFF ";
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isUndefined(getParentWindowHandle());
+    assert.equal(execFileSyncMock.mock.calls.length, 0);
+  });
+
+  it("encodes the resolved handle as 8 pointer bytes on 64-bit", async () => {
+    execFileSyncMock.mockReturnValue("66048;node(1) <- Code(2)\n");
+    const { getParentWindowHandle } = await importModule();
+
+    const handle = getParentWindowHandle();
+
+    assert.isDefined(handle);
+    assert.equal(handle!.length, 8);
+    assert.equal(handle!.readBigUInt64LE(), BigInt(66048));
+    const [command, args] = execFileSyncMock.mock.calls[0];
+    assert.isTrue((command as string).endsWith(path.join("v1.0", "powershell.exe")));
+    assert.include(args as string[], "-EncodedCommand");
+  });
+
+  it("encodes the resolved handle as 4 pointer bytes on 32-bit", async () => {
+    setReadOnly("arch", "ia32");
+    execFileSyncMock.mockReturnValue("4096;node(1)");
+    const { getParentWindowHandle } = await importModule();
+
+    const handle = getParentWindowHandle();
+
+    assert.isDefined(handle);
+    assert.equal(handle!.length, 4);
+    assert.equal(handle!.readUInt32LE(), 4096);
+  });
+
+  it("resolves only once and reuses the cached handle", async () => {
+    execFileSyncMock.mockReturnValue("4096;node(1)");
+    const { getParentWindowHandle } = await importModule();
+
+    const first = getParentWindowHandle();
+    const second = getParentWindowHandle();
+
+    assert.strictEqual(first, second);
+    assert.equal(execFileSyncMock.mock.calls.length, 1);
+  });
+
+  it("returns undefined when no ancestor window is found and caches that result", async () => {
+    execFileSyncMock.mockReturnValue("0;node(1) <- sh(2)");
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isUndefined(getParentWindowHandle());
+    assert.isUndefined(getParentWindowHandle());
+    assert.equal(execFileSyncMock.mock.calls.length, 1);
+  });
+
+  it("returns undefined when the output is not a number and has no walk trail", async () => {
+    execFileSyncMock.mockReturnValue("not-a-handle");
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isUndefined(getParentWindowHandle());
+  });
+
+  it("resolves the handle when the output has no walk trail", async () => {
+    execFileSyncMock.mockReturnValue("4096");
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isDefined(getParentWindowHandle());
+  });
+
+  it("falls back to C:\\Windows when SystemRoot is not set", async () => {
+    delete process.env.SystemRoot;
+    execFileSyncMock.mockReturnValue("4096;node(1)");
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isDefined(getParentWindowHandle());
+    assert.equal(
+      execFileSyncMock.mock.calls[0][0],
+      path.join("C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+    );
+  });
+
+  it("returns undefined when PowerShell fails", async () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("spawn failed");
+    });
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isUndefined(getParentWindowHandle());
+    assert.include(debugMock.mock.calls[0][0] as string, "spawn failed");
+  });
+
+  it("appends the trace to a temp file in debug mode", async () => {
+    process.env.ATK_WAM_PARENT_WINDOW = "Debug";
+    execFileSyncMock.mockReturnValue("4096;node(1)");
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isDefined(getParentWindowHandle());
+    assert.equal(appendFileSyncMock.mock.calls.length, 1);
+    assert.equal(appendFileSyncMock.mock.calls[0][0], path.join(os.tmpdir(), "atk-wam-parent.log"));
+  });
+
+  it("ignores failures of the debug file trace", async () => {
+    process.env.ATK_WAM_PARENT_WINDOW = "debug";
+    appendFileSyncMock.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    execFileSyncMock.mockReturnValue("4096;node(1)");
+    const { getParentWindowHandle } = await importModule();
+
+    assert.isDefined(getParentWindowHandle());
+  });
+});


### PR DESCRIPTION
This pull request introduces support for parenting the WAM (Web Account Manager) broker sign-in dialog to the appropriate terminal window on Windows, improving the user experience during CLI authentication. The main change is to resolve and pass a real parent window handle to MSAL, ensuring the dialog appears in front of the correct window and behaves modally, rather than sometimes being hidden behind other windows.


Fix: https://github.com/gim-home/wiqd/issues/1884

I checked it across cmd, powershell, cmd in Terminal, powershell in Terminal, cmd in VS Code, powershell in VS Code, and git bash. All these work.
<img width="1050" height="612" alt="image" src="https://github.com/user-attachments/assets/6251e778-9695-426b-a3e6-859e60175a30" />
<img width="1117" height="624" alt="image" src="https://github.com/user-attachments/assets/54c0445f-071b-4406-ae71-974a0fb5c247" />
<img width="1371" height="919" alt="image" src="https://github.com/user-attachments/assets/8c3f0afc-5f07-4d59-8a42-262384b3dda2" />

