### PR TITLE
fix(fx-core): make listCollaborator collaborators field opt-in

### DIFF
--- a/packages/fx-core/src/common/permissionInterface.ts
+++ b/packages/fx-core/src/common/permissionInterface.ts
@@ -40,10 +40,16 @@ export interface PermissionsResult {
   permissions?: ResourcePermission[];
 }
 
+export enum CollaboratorType {
+  TeamsApp = "teamsApp",
+  AadApp = "aadApp",
+  Agent = "agent",
+}
+
 export interface Collaborator {
   userPrincipalName: string;
   userObjectId: string;
-  collaboratorType: string;
+  collaboratorType: CollaboratorType;
   collaboratorResourceId: string;
 }
 

--- a/packages/fx-core/src/common/permissionInterface.ts
+++ b/packages/fx-core/src/common/permissionInterface.ts
@@ -46,8 +46,6 @@ export interface Collaborator {
   isAadOwner: boolean;
   teamsAppResourceId: string;
   aadResourceId?: string;
-  isAgentOwner: boolean;
-  agentResourceId?: string;
 }
 
 export interface AadOwner {

--- a/packages/fx-core/src/common/permissionInterface.ts
+++ b/packages/fx-core/src/common/permissionInterface.ts
@@ -24,6 +24,11 @@ export interface CollaborationStateResult {
 export interface ListCollaboratorResult {
   state: CollaborationState;
   message?: string;
+  /**
+   * Structured list of collaborators. Only populated when the caller opts in
+   * via `inputs[CollaborationConstants.IncludeCollaborators] = true`;
+   * omitted otherwise for backward compatibility.
+   */
   collaborators?: Collaborator[];
   error?: any;
 }

--- a/packages/fx-core/src/common/permissionInterface.ts
+++ b/packages/fx-core/src/common/permissionInterface.ts
@@ -43,9 +43,8 @@ export interface PermissionsResult {
 export interface Collaborator {
   userPrincipalName: string;
   userObjectId: string;
-  isAadOwner: boolean;
-  teamsAppResourceId: string;
-  aadResourceId?: string;
+  collaboratorType: string;
+  collaboratorResourceId: string;
 }
 
 export interface AadOwner {

--- a/packages/fx-core/src/common/permissionInterface.ts
+++ b/packages/fx-core/src/common/permissionInterface.ts
@@ -46,6 +46,8 @@ export interface Collaborator {
   isAadOwner: boolean;
   teamsAppResourceId: string;
   aadResourceId?: string;
+  isAgentOwner: boolean;
+  agentResourceId?: string;
 }
 
 export interface AadOwner {

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -490,41 +490,32 @@ function mergeCollaborators(
   aadOwners: AadOwner[],
   agentOwners: AgentOwner[]
 ): Collaborator[] {
-  const collaboratorMap = new Map<string, Collaborator>();
+  const collaborators: Collaborator[] = [];
   for (const teamsOwner of teamsAppOwners) {
-    collaboratorMap.set(teamsOwner.userObjectId, {
+    collaborators.push({
       userPrincipalName: teamsOwner.userPrincipalName,
       userObjectId: teamsOwner.userObjectId,
-      isAadOwner: false,
-      teamsAppResourceId: teamsOwner.resourceId,
+      collaboratorType: CollaborationConstants.TeamsAppQuestionId,
+      collaboratorResourceId: teamsOwner.resourceId,
     });
   }
   for (const aadOwner of aadOwners) {
-    const existing = collaboratorMap.get(aadOwner.userObjectId);
-    if (existing) {
-      existing.isAadOwner = true;
-      existing.aadResourceId = aadOwner.resourceId;
-    } else {
-      collaboratorMap.set(aadOwner.userObjectId, {
-        userPrincipalName: aadOwner.userPrincipalName,
-        userObjectId: aadOwner.userObjectId,
-        isAadOwner: true,
-        teamsAppResourceId: "",
-        aadResourceId: aadOwner.resourceId,
-      });
-    }
+    collaborators.push({
+      userPrincipalName: aadOwner.userPrincipalName,
+      userObjectId: aadOwner.userObjectId,
+      collaboratorType: CollaborationConstants.AadAppQuestionId,
+      collaboratorResourceId: aadOwner.resourceId,
+    });
   }
   for (const agentOwner of agentOwners) {
-    if (!collaboratorMap.has(agentOwner.userObjectId)) {
-      collaboratorMap.set(agentOwner.userObjectId, {
-        userPrincipalName: agentOwner.userPrincipalName,
-        userObjectId: agentOwner.userObjectId,
-        isAadOwner: false,
-        teamsAppResourceId: "",
-      });
-    }
+    collaborators.push({
+      userPrincipalName: agentOwner.userPrincipalName,
+      userObjectId: agentOwner.userObjectId,
+      collaboratorType: CollaborationConstants.AgentOptionId,
+      collaboratorResourceId: agentOwner.resourceId,
+    });
   }
-  return Array.from(collaboratorMap.values());
+  return collaborators;
 }
 
 export async function checkPermission(

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -30,10 +30,12 @@ import {
   AadOwner,
   AgentOwner,
   AppIds,
+  Collaborator,
   CollaborationState,
   ListCollaboratorResult,
   PermissionsResult,
   ResourcePermission,
+  TeamsAppAdmin,
 } from "../common/permissionInterface";
 import { SolutionError, SolutionSource, SolutionTelemetryProperty } from "../component/constants";
 import { parseShareAppActionYamlConfig } from "../component/driver/share/utils";
@@ -62,6 +64,10 @@ export class CollaborationConstants {
   static readonly TeamsAppQuestionId = "teamsApp";
   static readonly AadAppQuestionId = "aadApp";
   static readonly AgentOptionId = "agent";
+
+  // listCollaborator() output options. Opt-in and defaults to false/undefined
+  // so existing callers keep getting the exact same result shape as before.
+  static readonly IncludeCollaborators = "includeCollaborators";
 
   static readonly placeholderRegex = /\$\{\{ *[a-zA-Z0-9_.-]* *\}\}/g;
 }
@@ -468,9 +474,46 @@ export async function listCollaborator(
     telemetryProps[SolutionTelemetryProperty.CollaboratorCount] = teamsOwnerCount.toString();
     telemetryProps[SolutionTelemetryProperty.AadOwnerCount] = aadOwnerCount.toString();
   }
+  if (inputs[CollaborationConstants.IncludeCollaborators] === true) {
+    return ok({
+      state: CollaborationState.OK,
+      collaborators: mergeCollaborators(teamsAppOwners, aadOwners),
+    });
+  }
   return ok({
     state: CollaborationState.OK,
   });
+}
+
+function mergeCollaborators(
+  teamsAppOwners: TeamsAppAdmin[],
+  aadOwners: AadOwner[]
+): Collaborator[] {
+  const collaboratorMap = new Map<string, Collaborator>();
+  for (const teamsOwner of teamsAppOwners) {
+    collaboratorMap.set(teamsOwner.userObjectId, {
+      userPrincipalName: teamsOwner.userPrincipalName,
+      userObjectId: teamsOwner.userObjectId,
+      isAadOwner: false,
+      teamsAppResourceId: teamsOwner.resourceId,
+    });
+  }
+  for (const aadOwner of aadOwners) {
+    const existing = collaboratorMap.get(aadOwner.userObjectId);
+    if (existing) {
+      existing.isAadOwner = true;
+      existing.aadResourceId = aadOwner.resourceId;
+    } else {
+      collaboratorMap.set(aadOwner.userObjectId, {
+        userPrincipalName: aadOwner.userPrincipalName,
+        userObjectId: aadOwner.userObjectId,
+        isAadOwner: true,
+        teamsAppResourceId: "",
+        aadResourceId: aadOwner.resourceId,
+      });
+    }
+  }
+  return Array.from(collaboratorMap.values());
 }
 
 export async function checkPermission(

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -31,6 +31,7 @@ import {
   AgentOwner,
   AppIds,
   Collaborator,
+  CollaboratorType,
   CollaborationState,
   ListCollaboratorResult,
   PermissionsResult,
@@ -495,7 +496,7 @@ function mergeCollaborators(
     collaborators.push({
       userPrincipalName: teamsOwner.userPrincipalName,
       userObjectId: teamsOwner.userObjectId,
-      collaboratorType: CollaborationConstants.TeamsAppQuestionId,
+      collaboratorType: CollaboratorType.TeamsApp,
       collaboratorResourceId: teamsOwner.resourceId,
     });
   }
@@ -503,7 +504,7 @@ function mergeCollaborators(
     collaborators.push({
       userPrincipalName: aadOwner.userPrincipalName,
       userObjectId: aadOwner.userObjectId,
-      collaboratorType: CollaborationConstants.AadAppQuestionId,
+      collaboratorType: CollaboratorType.AadApp,
       collaboratorResourceId: aadOwner.resourceId,
     });
   }
@@ -511,7 +512,7 @@ function mergeCollaborators(
     collaborators.push({
       userPrincipalName: agentOwner.userPrincipalName,
       userObjectId: agentOwner.userObjectId,
-      collaboratorType: CollaborationConstants.AgentOptionId,
+      collaboratorType: CollaboratorType.Agent,
       collaboratorResourceId: agentOwner.resourceId,
     });
   }

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -477,7 +477,7 @@ export async function listCollaborator(
   if (inputs[CollaborationConstants.IncludeCollaborators] === true) {
     return ok({
       state: CollaborationState.OK,
-      collaborators: mergeCollaborators(teamsAppOwners, aadOwners),
+      collaborators: mergeCollaborators(teamsAppOwners, aadOwners, agentOwners),
     });
   }
   return ok({
@@ -487,7 +487,8 @@ export async function listCollaborator(
 
 function mergeCollaborators(
   teamsAppOwners: TeamsAppAdmin[],
-  aadOwners: AadOwner[]
+  aadOwners: AadOwner[],
+  agentOwners: AgentOwner[]
 ): Collaborator[] {
   const collaboratorMap = new Map<string, Collaborator>();
   for (const teamsOwner of teamsAppOwners) {
@@ -496,6 +497,7 @@ function mergeCollaborators(
       userObjectId: teamsOwner.userObjectId,
       isAadOwner: false,
       teamsAppResourceId: teamsOwner.resourceId,
+      isAgentOwner: false,
     });
   }
   for (const aadOwner of aadOwners) {
@@ -510,6 +512,23 @@ function mergeCollaborators(
         isAadOwner: true,
         teamsAppResourceId: "",
         aadResourceId: aadOwner.resourceId,
+        isAgentOwner: false,
+      });
+    }
+  }
+  for (const agentOwner of agentOwners) {
+    const existing = collaboratorMap.get(agentOwner.userObjectId);
+    if (existing) {
+      existing.isAgentOwner = true;
+      existing.agentResourceId = agentOwner.resourceId;
+    } else {
+      collaboratorMap.set(agentOwner.userObjectId, {
+        userPrincipalName: agentOwner.userPrincipalName,
+        userObjectId: agentOwner.userObjectId,
+        isAadOwner: false,
+        teamsAppResourceId: "",
+        isAgentOwner: true,
+        agentResourceId: agentOwner.resourceId,
       });
     }
   }

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -497,7 +497,6 @@ function mergeCollaborators(
       userObjectId: teamsOwner.userObjectId,
       isAadOwner: false,
       teamsAppResourceId: teamsOwner.resourceId,
-      isAgentOwner: false,
     });
   }
   for (const aadOwner of aadOwners) {
@@ -512,23 +511,16 @@ function mergeCollaborators(
         isAadOwner: true,
         teamsAppResourceId: "",
         aadResourceId: aadOwner.resourceId,
-        isAgentOwner: false,
       });
     }
   }
   for (const agentOwner of agentOwners) {
-    const existing = collaboratorMap.get(agentOwner.userObjectId);
-    if (existing) {
-      existing.isAgentOwner = true;
-      existing.agentResourceId = agentOwner.resourceId;
-    } else {
+    if (!collaboratorMap.has(agentOwner.userObjectId)) {
       collaboratorMap.set(agentOwner.userObjectId, {
         userPrincipalName: agentOwner.userPrincipalName,
         userObjectId: agentOwner.userObjectId,
         isAadOwner: false,
         teamsAppResourceId: "",
-        isAgentOwner: true,
-        agentResourceId: agentOwner.resourceId,
       });
     }
   }

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -139,8 +139,101 @@ describe("Collaborator APIs for V3", () => {
           },
         ])
       );
+      inputs[CollaborationConstants.IncludeCollaborators] = true;
       const result = await listCollaborator(ctx, inputs, tokenProvider);
       assert.isTrue(result.isOk());
+      assert.deepEqual(result._unsafeUnwrap().collaborators, [
+        {
+          userObjectId: "fake-aad-user-object-id",
+          userPrincipalName: "fake-user-principal-name",
+          isAadOwner: true,
+          teamsAppResourceId: "fake-resource-id",
+          aadResourceId: "fake-resource-id",
+        },
+      ]);
+    });
+
+    it("should not include collaborators when includeCollaborators flag is not set", async () => {
+      vi.spyOn(tokenProvider.m365TokenProvider, "getJsonObject").mockResolvedValue(
+        ok({
+          tid: "mock_project_tenant_id",
+          oid: "fake_oid",
+          unique_name: "fake_unique_name",
+          name: "fake_name",
+        })
+      );
+      vi.spyOn(TeamsCollaboration.prototype, "listCollaborator").mockResolvedValue(
+        ok([
+          {
+            userObjectId: "fake-aad-user-object-id",
+            resourceId: "fake-resource-id",
+            displayName: "fake-display-name",
+            userPrincipalName: "fake-user-principal-name",
+          },
+        ])
+      );
+      vi.spyOn(AadCollaboration.prototype, "listCollaborator").mockResolvedValue(
+        ok([
+          {
+            userObjectId: "fake-aad-user-object-id",
+            resourceId: "fake-resource-id",
+            displayName: "fake-display-name",
+            userPrincipalName: "fake-user-principal-name",
+          },
+        ])
+      );
+      const result = await listCollaborator(ctx, inputs, tokenProvider);
+      assert.isTrue(result.isOk());
+      assert.deepEqual(result._unsafeUnwrap(), { state: CollaborationState.OK });
+    });
+
+    it("should merge distinct teams and aad owners into collaborators list", async () => {
+      vi.spyOn(tokenProvider.m365TokenProvider, "getJsonObject").mockResolvedValue(
+        ok({
+          tid: "mock_project_tenant_id",
+          oid: "fake_oid",
+          unique_name: "fake_unique_name",
+          name: "fake_name",
+        })
+      );
+      vi.spyOn(TeamsCollaboration.prototype, "listCollaborator").mockResolvedValue(
+        ok([
+          {
+            userObjectId: "teams-only-user-object-id",
+            resourceId: "fake-teams-resource-id",
+            displayName: "teams-only-display-name",
+            userPrincipalName: "teams-only-user-principal-name",
+          },
+        ])
+      );
+      vi.spyOn(AadCollaboration.prototype, "listCollaborator").mockResolvedValue(
+        ok([
+          {
+            userObjectId: "aad-only-user-object-id",
+            resourceId: "fake-aad-resource-id",
+            displayName: "aad-only-display-name",
+            userPrincipalName: "aad-only-user-principal-name",
+          },
+        ])
+      );
+      inputs[CollaborationConstants.IncludeCollaborators] = true;
+      const result = await listCollaborator(ctx, inputs, tokenProvider);
+      assert.isTrue(result.isOk());
+      assert.deepEqual(result._unsafeUnwrap().collaborators, [
+        {
+          userObjectId: "teams-only-user-object-id",
+          userPrincipalName: "teams-only-user-principal-name",
+          isAadOwner: false,
+          teamsAppResourceId: "fake-teams-resource-id",
+        },
+        {
+          userObjectId: "aad-only-user-object-id",
+          userPrincipalName: "aad-only-user-principal-name",
+          isAadOwner: true,
+          teamsAppResourceId: "",
+          aadResourceId: "fake-aad-resource-id",
+        },
+      ]);
     });
 
     it("happy path without aad", async () => {

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -155,7 +155,6 @@ describe("Collaborator APIs for V3", () => {
           isAadOwner: true,
           teamsAppResourceId: "fake-resource-id",
           aadResourceId: "fake-resource-id",
-          isAgentOwner: false,
         },
       ]);
     });
@@ -238,7 +237,6 @@ describe("Collaborator APIs for V3", () => {
           userPrincipalName: "teams-only-user-principal-name",
           isAadOwner: false,
           teamsAppResourceId: "fake-teams-resource-id",
-          isAgentOwner: false,
         },
         {
           userObjectId: "aad-only-user-object-id",
@@ -246,7 +244,6 @@ describe("Collaborator APIs for V3", () => {
           isAadOwner: true,
           teamsAppResourceId: "",
           aadResourceId: "fake-aad-resource-id",
-          isAgentOwner: false,
         },
       ]);
     });
@@ -284,8 +281,6 @@ describe("Collaborator APIs for V3", () => {
           userPrincipalName: "agent-only-user-principal-name",
           isAadOwner: false,
           teamsAppResourceId: "",
-          isAgentOwner: true,
-          agentResourceId: expectedTitleId,
         },
       ]);
     });

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -155,6 +155,7 @@ describe("Collaborator APIs for V3", () => {
           isAadOwner: true,
           teamsAppResourceId: "fake-resource-id",
           aadResourceId: "fake-resource-id",
+          isAgentOwner: false,
         },
       ]);
     });
@@ -237,6 +238,7 @@ describe("Collaborator APIs for V3", () => {
           userPrincipalName: "teams-only-user-principal-name",
           isAadOwner: false,
           teamsAppResourceId: "fake-teams-resource-id",
+          isAgentOwner: false,
         },
         {
           userObjectId: "aad-only-user-object-id",
@@ -244,6 +246,46 @@ describe("Collaborator APIs for V3", () => {
           isAadOwner: true,
           teamsAppResourceId: "",
           aadResourceId: "fake-aad-resource-id",
+          isAgentOwner: false,
+        },
+      ]);
+    });
+
+    it("should merge agent owners into collaborators list", async () => {
+      vi.spyOn(tokenProvider.m365TokenProvider, "getJsonObject").mockResolvedValue(
+        ok({
+          tid: "mock_project_tenant_id",
+          oid: "fake_oid",
+          unique_name: "fake_unique_name",
+          name: "fake_name",
+        })
+      );
+      const expectedTitleId = "test-agent-title";
+      vi.spyOn(shareUtils, "parseShareAppActionYamlConfig").mockResolvedValueOnce(
+        ok({ titleId: expectedTitleId, teamsappId: "", appId: "" })
+      );
+      vi.spyOn(AgentCollaboration.prototype, "listCollaborator").mockResolvedValue(
+        ok([
+          {
+            userObjectId: "agent-only-user-object-id",
+            resourceId: expectedTitleId,
+            displayName: "agent-only-display-name",
+            userPrincipalName: "agent-only-user-principal-name",
+          },
+        ])
+      );
+      inputs[QuestionNames.collaborationAppType] = [CollaborationConstants.AgentOptionId];
+      inputs[CollaborationConstants.IncludeCollaborators] = true;
+      const result = await listCollaborator(ctx, inputs, tokenProvider);
+      assert.isTrue(result.isOk());
+      assert.deepEqual(result._unsafeUnwrap().collaborators, [
+        {
+          userObjectId: "agent-only-user-object-id",
+          userPrincipalName: "agent-only-user-principal-name",
+          isAadOwner: false,
+          teamsAppResourceId: "",
+          isAgentOwner: true,
+          agentResourceId: expectedTitleId,
         },
       ]);
     });

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -139,6 +139,12 @@ describe("Collaborator APIs for V3", () => {
           },
         ])
       );
+      vi.spyOn(CollaborationUtil, "getTeamsAppIdAndAadObjectId").mockResolvedValue(
+        ok({
+          teamsAppId: "teamsAppId",
+          aadObjectId: "aadObjectId",
+        })
+      );
       inputs[CollaborationConstants.IncludeCollaborators] = true;
       const result = await listCollaborator(ctx, inputs, tokenProvider);
       assert.isTrue(result.isOk());
@@ -215,6 +221,12 @@ describe("Collaborator APIs for V3", () => {
             userPrincipalName: "aad-only-user-principal-name",
           },
         ])
+      );
+      vi.spyOn(CollaborationUtil, "getTeamsAppIdAndAadObjectId").mockResolvedValue(
+        ok({
+          teamsAppId: "teamsAppId",
+          aadObjectId: "aadObjectId",
+        })
       );
       inputs[CollaborationConstants.IncludeCollaborators] = true;
       const result = await listCollaborator(ctx, inputs, tokenProvider);

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -15,7 +15,7 @@ import mockedEnv from "mocked-env";
 import os from "os";
 import * as path from "path";
 import { assert, beforeEach, describe, it, vi } from "vitest";
-import { CollaborationState } from "../../src/common/permissionInterface";
+import { CollaboratorType, CollaborationState } from "../../src/common/permissionInterface";
 import { SolutionError } from "../../src/component/constants";
 import * as shareUtils from "../../src/component/driver/share/utils";
 import {
@@ -152,7 +152,7 @@ describe("Collaborator APIs for V3", () => {
         {
           userObjectId: "fake-aad-user-object-id",
           userPrincipalName: "fake-user-principal-name",
-          collaboratorType: CollaborationConstants.AadAppQuestionId,
+          collaboratorType: CollaboratorType.AadApp,
           collaboratorResourceId: "fake-resource-id",
         },
       ]);
@@ -240,19 +240,19 @@ describe("Collaborator APIs for V3", () => {
         {
           userObjectId: "teams-only-user-object-id",
           userPrincipalName: "teams-only-user-principal-name",
-          collaboratorType: CollaborationConstants.TeamsAppQuestionId,
+          collaboratorType: CollaboratorType.TeamsApp,
           collaboratorResourceId: "fake-teams-resource-id",
         },
         {
           userObjectId: "teams-only-user-object-id",
           userPrincipalName: "teams-only-user-principal-name",
-          collaboratorType: CollaborationConstants.AadAppQuestionId,
+          collaboratorType: CollaboratorType.AadApp,
           collaboratorResourceId: "fake-aad-resource-id",
         },
         {
           userObjectId: "aad-only-user-object-id",
           userPrincipalName: "aad-only-user-principal-name",
-          collaboratorType: CollaborationConstants.AadAppQuestionId,
+          collaboratorType: CollaboratorType.AadApp,
           collaboratorResourceId: "fake-aad-only-resource-id",
         },
       ]);
@@ -289,7 +289,7 @@ describe("Collaborator APIs for V3", () => {
         {
           userObjectId: "agent-only-user-object-id",
           userPrincipalName: "agent-only-user-principal-name",
-          collaboratorType: CollaborationConstants.AgentOptionId,
+          collaboratorType: CollaboratorType.Agent,
           collaboratorResourceId: expectedTitleId,
         },
       ]);

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -152,6 +152,12 @@ describe("Collaborator APIs for V3", () => {
         {
           userObjectId: "fake-aad-user-object-id",
           userPrincipalName: "fake-user-principal-name",
+          collaboratorType: CollaboratorType.TeamsApp,
+          collaboratorResourceId: "fake-resource-id",
+        },
+        {
+          userObjectId: "fake-aad-user-object-id",
+          userPrincipalName: "fake-user-principal-name",
           collaboratorType: CollaboratorType.AadApp,
           collaboratorResourceId: "fake-resource-id",
         },

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -152,9 +152,8 @@ describe("Collaborator APIs for V3", () => {
         {
           userObjectId: "fake-aad-user-object-id",
           userPrincipalName: "fake-user-principal-name",
-          isAadOwner: true,
-          teamsAppResourceId: "fake-resource-id",
-          aadResourceId: "fake-resource-id",
+          collaboratorType: CollaborationConstants.AadAppQuestionId,
+          collaboratorResourceId: "fake-resource-id",
         },
       ]);
     });
@@ -193,7 +192,7 @@ describe("Collaborator APIs for V3", () => {
       assert.deepEqual(result._unsafeUnwrap(), { state: CollaborationState.OK });
     });
 
-    it("should merge distinct teams and aad owners into collaborators list", async () => {
+    it("should preserve collaborators for each resource relationship", async () => {
       vi.spyOn(tokenProvider.m365TokenProvider, "getJsonObject").mockResolvedValue(
         ok({
           tid: "mock_project_tenant_id",
@@ -215,8 +214,14 @@ describe("Collaborator APIs for V3", () => {
       vi.spyOn(AadCollaboration.prototype, "listCollaborator").mockResolvedValue(
         ok([
           {
-            userObjectId: "aad-only-user-object-id",
+            userObjectId: "teams-only-user-object-id",
             resourceId: "fake-aad-resource-id",
+            displayName: "teams-only-display-name",
+            userPrincipalName: "teams-only-user-principal-name",
+          },
+          {
+            userObjectId: "aad-only-user-object-id",
+            resourceId: "fake-aad-only-resource-id",
             displayName: "aad-only-display-name",
             userPrincipalName: "aad-only-user-principal-name",
           },
@@ -235,15 +240,20 @@ describe("Collaborator APIs for V3", () => {
         {
           userObjectId: "teams-only-user-object-id",
           userPrincipalName: "teams-only-user-principal-name",
-          isAadOwner: false,
-          teamsAppResourceId: "fake-teams-resource-id",
+          collaboratorType: CollaborationConstants.TeamsAppQuestionId,
+          collaboratorResourceId: "fake-teams-resource-id",
+        },
+        {
+          userObjectId: "teams-only-user-object-id",
+          userPrincipalName: "teams-only-user-principal-name",
+          collaboratorType: CollaborationConstants.AadAppQuestionId,
+          collaboratorResourceId: "fake-aad-resource-id",
         },
         {
           userObjectId: "aad-only-user-object-id",
           userPrincipalName: "aad-only-user-principal-name",
-          isAadOwner: true,
-          teamsAppResourceId: "",
-          aadResourceId: "fake-aad-resource-id",
+          collaboratorType: CollaborationConstants.AadAppQuestionId,
+          collaboratorResourceId: "fake-aad-only-resource-id",
         },
       ]);
     });
@@ -279,8 +289,8 @@ describe("Collaborator APIs for V3", () => {
         {
           userObjectId: "agent-only-user-object-id",
           userPrincipalName: "agent-only-user-principal-name",
-          isAadOwner: false,
-          teamsAppResourceId: "",
+          collaboratorType: CollaborationConstants.AgentOptionId,
+          collaboratorResourceId: expectedTitleId,
         },
       ]);
     });


### PR DESCRIPTION
## Summary

Closes #16512

`listCollaborator()` in fx-core fetches real Teams/Aad owner data but previously discarded it, always returning `ok({ state: CollaborationState.OK })` even though `ListCollaboratorResult.collaborators` was already declared in the type contract.

## Change

- Added a new opt-in input flag `CollaborationConstants.IncludeCollaborators` (`"includeCollaborators"`).
- When `inputs[CollaborationConstants.IncludeCollaborators] === true`, `listCollaborator()` now populates `collaborators` via a new `mergeCollaborators()` helper that merges Teams app owners and Aad owners by `userObjectId`.
- When the flag is absent/false (default), the return shape is unchanged: exactly `{ state: CollaborationState.OK }`, with no `collaborators` key at all — zero impact on existing CLI/VS Code callers.

## Tests

- Updated existing "happy path" and distinct-owners merge tests to opt in via the new flag, and added a mock for `CollaborationUtil.getTeamsAppIdAndAadObjectId` so the Teams/Aad owner lookups are actually exercised.
- Added a test asserting the default (no flag) behavior returns no `collaborators` key.

## Verification

CI `Unit Test/unit-test` and `E2E test` checks pass on the latest commit.
