### PR TITLE
Use Entra ID (AAD) auth for vscuse's own Azure OpenAI and Vision calls

### DIFF
--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -143,14 +143,24 @@ jobs:
     env:
       GH_APP_ID: ${{ secrets.GH_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      # --- Azure OpenAI used by the TEST CASES (scaffolded projects) -------------
+      # Key-based endpoint; consumed via ${{env:...}} / ${{secret:...}} placeholders in
+      # the plans and forwarded into the container through docker.environment.
       AZURE_OPENAI_ENDPOINT: ${{ vars.TEST_TENANT_AZURE_OPENAI_ENDPOINT }}
       AZURE_OPENAI_API_KEY: ${{ secrets.TEST_TENANT_AZURE_OPENAI_KEY }}
       AZURE_OPENAI_MODEL: ${{ vars.TEST_TENANT_AZURE_OPENAI_MODEL }}
       AZURE_OPENAI_API_VERSION: ${{ vars.TEST_TENANT_AZURE_OPENAI_API_VERSION }}
 
-      # Vision service
-      AZURE_VISION_ENDPOINT: ${{ vars.AZURE_VISION_ENDPOINT }}
-      AZURE_VISION_KEY: ${{ secrets.AZURE_VISION_KEY }}
+      # --- Azure OpenAI + Vision used by VSCUSE ITSELF ---------------------------
+      # Entra ID (AAD) auth only - no API keys. The token comes from the
+      # "Login to Azure" step below (DEVOPS_* federated credentials).
+      VSCUSE_AZURE_OPENAI_ENDPOINT: ${{ vars.VSCUSE_AZURE_OPENAI_ENDPOINT }}
+      VSCUSE_AZURE_OPENAI_MODEL: ${{ vars.VSCUSE_AZURE_OPENAI_MODEL }}
+      VSCUSE_AZURE_OPENAI_API_VERSION: ${{ vars.VSCUSE_AZURE_OPENAI_API_VERSION }}
+      VSCUSE_AZURE_VISION_ENDPOINT: ${{ vars.VSCUSE_AZURE_VISION_ENDPOINT }}
+
+      # Vision service is now AAD-only for vscuse (see VSCUSE_AZURE_VISION_ENDPOINT above);
+      # AZURE_VISION_ENDPOINT / AZURE_VISION_KEY are no longer needed.
 
       # AZURE AI search
       AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: "text-embedding-ada-002"
@@ -232,6 +242,17 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
+      # vscuse's own Azure OpenAI / Vision calls authenticate with Entra ID, so we must be
+      # logged in BEFORE "Run test". The service principal needs "Cognitive Services OpenAI
+      # User" on the vscuse AOAI resource and "Cognitive Services User" on the Vision one.
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{secrets.DEVOPS_CLIENT_ID}}
+          tenant-id: ${{secrets.DEVOPS_TENANT_ID}}
+          subscription-id: ${{secrets.DEVOPS_SUB_ID}}
+          enable-AzPSSession: true
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -263,12 +284,29 @@ jobs:
       - name: Verify Azure Configuration
         run: |
           echo "Verifying Azure configuration..."
+          # vscuse itself: Entra ID auth, endpoint only (no key).
+          if [ -z "$VSCUSE_AZURE_OPENAI_ENDPOINT" ]; then
+            echo "❌ VSCUSE_AZURE_OPENAI_ENDPOINT is not set"
+            exit 1
+          fi
+          if [ -z "$VSCUSE_AZURE_VISION_ENDPOINT" ]; then
+            echo "❌ VSCUSE_AZURE_VISION_ENDPOINT is not set"
+            exit 1
+          fi
+          if ! az account show > /dev/null 2>&1; then
+            echo "❌ Not logged in to Azure - Entra ID auth for vscuse will fail"
+            exit 1
+          fi
+          echo "✅ vscuse Azure OpenAI + Vision configured (Entra ID auth)"
+
+          # Test cases: key-based Azure OpenAI endpoint.
           if [ -z "$AZURE_OPENAI_ENDPOINT" ] || [ -z "$AZURE_OPENAI_API_KEY" ]; then
-            echo "❌ Azure OpenAI configuration missing"
+            echo "❌ Test-case Azure OpenAI configuration missing"
             exit 1
           else
-            echo "✅ Azure OpenAI configured"
+            echo "✅ Test-case Azure OpenAI configured (API key auth)"
           fi
+
           if [ -n "$AZURE_CLIENT_ID" ] && [ -n "$AZURE_CLIENT_SECRET" ] && [ -n "$AZURE_TENANT_ID" ]; then
             echo "✅ Azure Service Principal configured - M365 Toolkit authentication enabled"
           else

--- a/packages/tests/vscuse/vscode-test-cases/config.yaml
+++ b/packages/tests/vscuse/vscode-test-cases/config.yaml
@@ -1,14 +1,20 @@
+## Azure OpenAI / Vision used by VSCUSE ITSELF.
+## Entra ID (AAD) auth only - no API keys (team policy). The token comes from the
+## "Login to Azure" step in the workflow (azure/login@v2 with DEVOPS_* credentials).
+## Note this is a DIFFERENT endpoint from the key-based one the test cases use; the
+## latter is passed into the container through docker.environment below.
 azure_openai:
-  endpoint: "${AZURE_OPENAI_ENDPOINT}" # Required: Set via environment variable
-  api_key: "${AZURE_OPENAI_API_KEY}" # Required: Set via environment variable
-  api_version: "${AZURE_OPENAI_API_VERSION}" # Default: "2025-04-01-preview"
-  model: "${AZURE_OPENAI_MODEL}" # Default: "gpt-4.1"
+  endpoint: "${VSCUSE_AZURE_OPENAI_ENDPOINT}" # Required: Set via environment variable
+  api_version: "${VSCUSE_AZURE_OPENAI_API_VERSION}" # Default: "2025-04-01-preview"
+  model: "${VSCUSE_AZURE_OPENAI_MODEL}" # Default: "gpt-4.1"
   timeout: 60 # Default: 60 (seconds)
-  use_azure_credential: false # Default: false
+  use_azure_credential: true # Authenticate with Entra ID instead of an API key
+  credential_type: "cli" # Reuse the azure/login session (avoids the slow IMDS probe)
 
 azure_vision:
-  endpoint: "${AZURE_VISION_ENDPOINT}" # Required: Set via environment variable
-  api_key: "${AZURE_VISION_KEY}" # Required: Set via environment variable
+  endpoint: "${VSCUSE_AZURE_VISION_ENDPOINT}" # Required: Set via environment variable
+  use_azure_credential: true # Authenticate with Entra ID instead of an API key
+  credential_type: "cli"
 
 azure_service_principal:
   client_id: "${AZURE_CLIENT_ID}" # Required: Set via environment variable
@@ -30,6 +36,15 @@ docker:
   environment:
     TEAMSFX_TELEMETRY_TEST: "true" # Default: false (set to true to use VS Code Insider)
     NPM_CONFIG_REGISTRY: "${NPM_CONFIG_REGISTRY:https://registry.npmjs.org/}"
+
+    # Azure OpenAI for the TEST CASES (scaffolded projects). vscuse itself uses a
+    # different, AAD-only endpoint, so it no longer injects these automatically -
+    # they have to be declared explicitly here.
+    AZURE_OPENAI_ENDPOINT: "${AZURE_OPENAI_ENDPOINT}"
+    AZURE_OPENAI_API_KEY: "${AZURE_OPENAI_API_KEY}"
+    AZURE_OPENAI_MODEL: "${AZURE_OPENAI_MODEL}"
+    AZURE_OPENAI_API_VERSION: "${AZURE_OPENAI_API_VERSION}"
+
     AZURE_SEARCH_KEY: "${AZURE_SEARCH_KEY}"
     AZURE_SEARCH_ENDPOINT: "${AZURE_SEARCH_ENDPOINT}"
     AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: "${AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME}"


### PR DESCRIPTION
## What

Per team policy, all Azure OpenAI and Azure Vision calls made **by vscuse itself** must use Entra ID (AAD) auth instead of API keys. The **test cases** keep using a separate, key-based Azure OpenAI endpoint.

Companion to https://github.com/1openwindow/vsc-use/pull/31.

## The problem

Today `AZURE_OPENAI_ENDPOINT` / `AZURE_OPENAI_API_KEY` serve two very different consumers:

1. **vscuse itself** — via `packages/tests/vscuse/vscode-test-cases/config.yaml`
2. **the test cases** — via `${{env:AZURE_OPENAI_ENDPOINT}}` / `${{secret:AZURE_OPENAI_API_KEY}}` placeholders in the plans (e.g. `groups/group_fill_in_azure_key_env.json`), which get written into the scaffolded projects' `.env.*.user` files

Those two need to be split so vscuse can go AAD-only while test cases keep a key.

## Changes

### `.github/workflows/ui-test-vscuse-common.yml` (job `main`)

- Moved `azure/login@v2` (DEVOPS_* federated credentials) to run **right after checkout**, i.e. before `Run test`. The existing login before the blob upload is left untouched.
- Added a new block of job env vars for vscuse's own AAD endpoints:
  `VSCUSE_AZURE_OPENAI_ENDPOINT`, `VSCUSE_AZURE_OPENAI_MODEL`, `VSCUSE_AZURE_OPENAI_API_VERSION`, `VSCUSE_AZURE_VISION_ENDPOINT`.
- `AZURE_OPENAI_ENDPOINT` / `AZURE_OPENAI_API_KEY` / `AZURE_OPENAI_MODEL` / `AZURE_OPENAI_API_VERSION` are **unchanged** — they now serve only the test cases.
- Removed `AZURE_VISION_ENDPOINT` / `AZURE_VISION_KEY` (vscuse's Vision calls are AAD now).
- `Verify Azure Configuration` now checks both paths: vscuse endpoints + an `az account show` liveness check, and the key-based test-case pair.

### `packages/tests/vscuse/vscode-test-cases/config.yaml`

- `azure_openai` / `azure_vision` point at the `VSCUSE_*` endpoints with `use_azure_credential: true` and `credential_type: cli`.
  `cli` reuses the `azure/login` session; the `default` credential chain probes Environment → Workload Identity → Managed Identity (IMDS) first, which is slow and flaky on hosted runners.
- Added `AZURE_OPENAI_ENDPOINT` / `AZURE_OPENAI_API_KEY` / `AZURE_OPENAI_MODEL` / `AZURE_OPENAI_API_VERSION` under `docker.environment`.
  This is **required**: with `use_azure_credential: true`, vscuse stops auto-injecting `AZURE_OPENAI_*` into the container (an AAD-only endpoint has no key to hand out), so the key-based values must be declared explicitly.

## Prerequisites — please complete before merging

**1. New GitHub Actions variables** (environment `engineering`):

| Variable | Value |
| --- | --- |
| `VSCUSE_AZURE_OPENAI_ENDPOINT` | AAD-only Azure OpenAI endpoint for vscuse |
| `VSCUSE_AZURE_OPENAI_MODEL` | deployment name on that endpoint |
| `VSCUSE_AZURE_OPENAI_API_VERSION` | e.g. `2025-04-01-preview` |
| `VSCUSE_AZURE_VISION_ENDPOINT` | AAD-enabled Computer Vision endpoint |

**2. RBAC** for the `DEVOPS_CLIENT_ID` service principal:
- `Cognitive Services OpenAI User` on the vscuse Azure OpenAI resource
- `Cognitive Services User` on the Computer Vision resource

**3. Merge order** — 1openwindow/vsc-use#31 must be merged **and released** first, and this pipeline must pick up a vscuse wheel that contains it (`vscuse_version: latest`). Older wheels silently ignore `credential_type` and only honour `use_azure_credential` in one of four agents, so vscuse would fall back to key auth and fail.

## Can be retired afterwards

`secrets.AZURE_VISION_KEY`, `vars.AZURE_VISION_ENDPOINT`

Unchanged and still needed: `vars.TEST_TENANT_AZURE_OPENAI_ENDPOINT`, `secrets.TEST_TENANT_AZURE_OPENAI_KEY`, `vars.TEST_TENANT_AZURE_OPENAI_MODEL`, `vars.TEST_TENANT_AZURE_OPENAI_API_VERSION`.

## Validation

Loaded this exact `config.yaml` against the new vscuse build with representative env vars:

```
vscuse endpoint   = https://vscuse-aad.openai.azure.com/  | aad = True | cred = cli
vscuse vision     = https://vscuse-vision.cognitiveservices.azure.com/ | aad = True
container AOAI    = https://testcase.openai.azure.com/ <key> gpt-4.1 2024-10-21
```

i.e. vscuse resolves to the AAD endpoint, the container still gets the key-based one. `ConfigManager.validate()` passes with no Azure OpenAI API key present.
