### PR TITLE
fix(vscuse): Auto-fix basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
@@ -3830,7 +3830,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion a visible Visual Studio Code notification contains actions in deploy stage executed successfully.",
+      "description": "@assertion a visible Visual Studio Code notification explicitly contains the text actions in deploy stage executed successfully. A provision-stage success notification or a Deploy progress notification does not satisfy this assertion; keep waiting until the deploy-stage success notification is visible.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams`
**Status:** :white_check_mark: FIXED (attempt 1/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/6343bcea-0df3-4fcd-89c7-4b54cd1b4879/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/7b2094c8-063e-4510-ba09-aa4d82827e61/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Tightened the deploy-success assertion so stale provision or in-progress notific | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/7b2094c8-063e-4510-ba09-aa4d82827e61/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
...sic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
index 80fbebb..41737c4 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
@@ -3830,7 +3830,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion a visible Visual Studio Code notification contains actions in deploy stage executed successfully.",
+      "description": "@assertion a visible Visual Studio Code notification explicitly contains the text actions in deploy stage executed successfully. A provision-stage success notification or a Deploy progress notification does not satisfy this assertion; keep waiting until the deploy-stage success notification is visible.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>