### PR TITLE
fix(vscuse): preserve generated work item metadata

### DIFF
--- a/docs/03-specs/operations/product/compile-vscuse-case-bundles.md
+++ b/docs/03-specs/operations/product/compile-vscuse-case-bundles.md
@@ -160,6 +160,9 @@ cases:
 The example scenario ID identifies the target behavior as the case's primary validation goal;
 scaffold, login, provision, and deploy may be setup for that goal. The current compiler preserves
 this required ID in generated metadata but does not yet resolve it against the scenario documents.
+Each case separately declares the numeric Azure DevOps work items that own its imported GitHub
+test-case parents. These IDs populate the legacy VScUse `description.workitem` field and must not be
+replaced by the engineering Scenario ID.
 
 `bundleId` is intentionally absent. Its original purpose was to identify the source file and its
 generated outputs, but the repository-relative YAML path already provides that identity. Generated
@@ -178,6 +181,7 @@ only duplicate information.
 | `cases`                                                 | One or more explicit cases for the file's single scaffold template. V1 has no matrix expansion.                                                                                                                                       |
 | `case.id`                                               | Required and unique within the file. Combined with the resolved scaffold template for the generated plan name.                                                                                                                        |
 | `case.scenarioId`                                       | Required non-empty product/engineering Scenario ID; copied to generated metadata without current doc lookup.                                                                                                                          |
+| `case.workItemIds`                                      | Required non-empty list of unique positive integer Azure DevOps work item IDs; serialized as a comma-separated list in `plan_metadata.description.workitem`.                                                                          |
 | `case.steps`                                            | Required ordered references containing exactly one `scaffold`. Inline definitions and overrides are invalid.                                                                                                                          |
 | `case.gate`                                             | Optional execution gate: `pr`, `scheduled`, or `manual`; default is `pr`.                                                                                                                                                             |
 | `case.featureFlags`                                     | Optional non-empty list of unique case-local compatibility switches. These are merged with bundle-level defaults, and duplicate names across the two scopes are invalid.                                                              |
@@ -1042,7 +1046,8 @@ flowchart LR
 5. Resolve accounts, exact launch titles, open/check adapters, ARM input, and lifecycle operations
    through compiler-owned operation adapters. Authored open kind and destination select a compatible
    component for the current target state.
-6. Preserve the required non-empty `scenarioId` in generated metadata. Document lookup and
+6. Preserve the required non-empty `scenarioId` in the generated `scenario_id:*` metadata tag and
+   serialize `workItemIds` into the legacy `description.workitem` field. Document lookup and
    active/superseded identity validation are not implemented in V1.
 7. Compose each plan by instantiating case initialization once, the compiler-owned create command
    once before the scaffold answers, and quick-input components in resolved answer order. Then
@@ -1281,6 +1286,7 @@ coordinates, omit required prompt guards, or silently choose a nearby component.
 | VCB-120 | Given a `removeWorkspaceFile` operation, compilation emits one workspace mutation that deletes the authored project-relative file and fails when the path is absent, absolute, or escapes the project, so a case can prove that a later local debug recreates a file the template ships.                                                                                                                                                                                                                                                                                           |
 | VCB-121 | Given a `teams-collaborator-agent` scaffold, the authored selector path resolves `Teams Agents and Apps` then `Teams Collaborator Agent` followed by the Azure OpenAI key, endpoint, and deployment name inputs, and authors no LLM-service and no programming-language answer, because that template ships TypeScript only and reads Azure OpenAI settings directly.                                                                                                                                                                                                              |
 | VCB-122 | Given the Teams Collaborator Agent bundle, its remote Teams case selects `Launch Remote (Chrome)` and stops once the deployed app conversation opens, while its local Teams case selects `Debug in Teams (Chrome)` and asserts one reply in that personal conversation, where the agent answers without an at-mention.                                                                                                                                                                                                                                                             |
+| VCB-123 | Given a semantic case, it requires one or more unique positive integer Azure DevOps work item IDs, preserves its engineering Scenario ID in the `scenario_id:*` tag, and serializes only the numeric work item IDs into `plan_metadata.description.workitem`, so test-run synchronization can resolve imported GitHub test-case parents.                                                                                                                                                                                                                                           |
 
 ## Boundary
 

--- a/packages/tests/vscuse/vscode-test-cases/cases/basic-custom-engine-agent.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/basic-custom-engine-agent.yml
@@ -7,6 +7,7 @@ version: 1
 cases:
   - id: basic-cea-ts-azure-openai-remote-teams
     scenarioId: SCN-CREATE-BASIC-CEA-01
+    workItemIds: [33338525]
     steps:
       [
         scaffold-basic-cea-ts-azure-openai,
@@ -22,6 +23,7 @@ cases:
 
   - id: basic-cea-ts-azure-openai-local-teams
     scenarioId: SCN-CREATE-BASIC-CEA-01
+    workItemIds: [33338524]
     steps:
       [
         scaffold-basic-cea-ts-azure-openai,
@@ -34,6 +36,7 @@ cases:
 
   - id: basic-cea-ts-azure-openai-playground
     scenarioId: SCN-CREATE-BASIC-CEA-01
+    workItemIds: [36119770]
     steps:
       [
         scaffold-basic-cea-ts-azure-openai,
@@ -45,6 +48,7 @@ cases:
 
   - id: basic-cea-js-azure-openai-remote-teams
     scenarioId: SCN-CREATE-BASIC-CEA-03
+    workItemIds: [33338521]
     steps:
       [
         scaffold-basic-cea-js-azure-openai,
@@ -60,6 +64,7 @@ cases:
 
   - id: basic-cea-js-azure-openai-local-teams
     scenarioId: SCN-CREATE-BASIC-CEA-03
+    workItemIds: [33338520]
     steps:
       [
         scaffold-basic-cea-js-azure-openai,
@@ -72,6 +77,7 @@ cases:
 
   - id: basic-cea-js-azure-openai-playground
     scenarioId: SCN-CREATE-BASIC-CEA-03
+    workItemIds: [36119761]
     steps:
       [
         scaffold-basic-cea-js-azure-openai,
@@ -87,6 +93,7 @@ cases:
   # launch before that operation starts an app with no dependencies.
   - id: basic-cea-py-azure-openai-remote-teams
     scenarioId: SCN-CREATE-BASIC-CEA-04
+    workItemIds: [36162207]
     steps:
       [
         scaffold-basic-cea-py-azure-openai,
@@ -103,6 +110,7 @@ cases:
 
   - id: basic-cea-py-azure-openai-local-teams
     scenarioId: SCN-CREATE-BASIC-CEA-04
+    workItemIds: [36061767, 36176601]
     steps:
       [
         scaffold-basic-cea-py-azure-openai,
@@ -116,6 +124,7 @@ cases:
 
   - id: basic-cea-py-azure-openai-playground
     scenarioId: SCN-CREATE-BASIC-CEA-04
+    workItemIds: [36119764]
     steps:
       [
         scaffold-basic-cea-py-azure-openai,

--- a/packages/tests/vscuse/vscode-test-cases/cases/custom-copilot-rag-azure-ai-search.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/custom-copilot-rag-azure-ai-search.yml
@@ -6,6 +6,7 @@ version: 1
 cases:
   - id: rag-azure-ai-search-ts-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-AZURE-SEARCH-01
+    workItemIds: [27569074]
     steps:
       [
         scaffold-rag-search-ts-azure-openai,
@@ -20,6 +21,7 @@ cases:
 
   - id: rag-azure-ai-search-ts-openai-local-teams
     scenarioId: SCN-CREATE-RAG-AZURE-SEARCH-01
+    workItemIds: [28970306]
     steps:
       [
         scaffold-rag-search-ts-openai,
@@ -34,6 +36,7 @@ cases:
 
   - id: rag-azure-ai-search-js-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-AZURE-SEARCH-03
+    workItemIds: [36534512]
     steps:
       [
         scaffold-rag-search-js-azure-openai,
@@ -48,6 +51,7 @@ cases:
 
   - id: rag-azure-ai-search-js-openai-local-teams
     scenarioId: SCN-CREATE-RAG-AZURE-SEARCH-03
+    workItemIds: [28970334]
     steps:
       [
         scaffold-rag-search-js-openai,
@@ -62,6 +66,7 @@ cases:
 
   - id: rag-azure-ai-search-py-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-AZURE-SEARCH-04
+    workItemIds: [27454153]
     steps:
       [
         scaffold-rag-search-py-azure-openai,
@@ -77,6 +82,7 @@ cases:
 
   - id: rag-azure-ai-search-py-openai-local-teams
     scenarioId: SCN-CREATE-RAG-AZURE-SEARCH-04
+    workItemIds: [27454158]
     steps:
       [
         scaffold-rag-search-py-openai,

--- a/packages/tests/vscuse/vscode-test-cases/cases/custom-copilot-rag-custom-api.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/custom-copilot-rag-custom-api.yml
@@ -7,6 +7,7 @@ version: 1
 cases:
   - id: rag-custom-api-ts-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOM-API-01
+    workItemIds: [27588564]
     steps:
       [
         scaffold-rag-custom-api-ts-azure-openai,
@@ -19,6 +20,7 @@ cases:
 
   - id: rag-custom-api-ts-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOM-API-01
+    workItemIds: [27588580]
     steps:
       [
         scaffold-rag-custom-api-ts-openai,
@@ -32,6 +34,7 @@ cases:
 
   - id: rag-custom-api-js-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOM-API-04
+    workItemIds: [27588577]
     steps:
       [
         scaffold-rag-custom-api-js-azure-openai,
@@ -44,6 +47,7 @@ cases:
 
   - id: rag-custom-api-js-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOM-API-04
+    workItemIds: [27588587]
     steps:
       [
         scaffold-rag-custom-api-js-openai,
@@ -57,6 +61,7 @@ cases:
 
   - id: rag-custom-api-py-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOM-API-05
+    workItemIds: [28969537]
     steps:
       [
         scaffold-rag-custom-api-py-azure-openai,
@@ -70,6 +75,7 @@ cases:
 
   - id: rag-custom-api-py-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOM-API-05
+    workItemIds: [28969579]
     steps:
       [
         scaffold-rag-custom-api-py-openai,

--- a/packages/tests/vscuse/vscode-test-cases/cases/custom-copilot-rag-customize.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/custom-copilot-rag-customize.yml
@@ -7,6 +7,7 @@ version: 1
 cases:
   - id: rag-customize-ts-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOMIZE-01
+    workItemIds: [27569137]
     steps:
       [
         scaffold-rag-customize-ts-azure-openai,
@@ -19,6 +20,7 @@ cases:
 
   - id: rag-customize-ts-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOMIZE-01
+    workItemIds: [28869466]
     steps:
       [
         scaffold-rag-customize-ts-openai,
@@ -32,6 +34,7 @@ cases:
 
   - id: rag-customize-js-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOMIZE-03
+    workItemIds: [27569146]
     steps:
       [
         scaffold-rag-customize-js-azure-openai,
@@ -44,6 +47,7 @@ cases:
 
   - id: rag-customize-js-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOMIZE-03
+    workItemIds: [28869495]
     steps:
       [
         scaffold-rag-customize-js-openai,
@@ -57,6 +61,7 @@ cases:
 
   - id: rag-customize-py-azure-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOMIZE-04
+    workItemIds: [27551381]
     steps:
       [
         scaffold-rag-customize-py-azure-openai,
@@ -70,6 +75,7 @@ cases:
 
   - id: rag-customize-py-openai-local-teams
     scenarioId: SCN-CREATE-RAG-CUSTOMIZE-04
+    workItemIds: [27551384]
     steps:
       [
         scaffold-rag-customize-py-openai,
@@ -84,6 +90,7 @@ cases:
 
   - id: rag-customize-py-openai-local-copilot
     scenarioId: SCN-CREATE-RAG-CUSTOMIZE-04
+    workItemIds: [36031920]
     # The run workflow injects this before VS Code starts so scaffold renders
     # the Copilot profiles without mutating user settings or reloading.
     featureFlags:

--- a/packages/tests/vscuse/vscode-test-cases/cases/da-api-plugin-from-existing-api.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/da-api-plugin-from-existing-api.yml
@@ -3,6 +3,7 @@ version: 1
 cases:
   - id: da-api-plugin-from-existing-api-no-auth-remote-preview
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-EXISTING-API
+    workItemIds: [28941863]
     gate: manual
     steps:
       [
@@ -17,6 +18,7 @@ cases:
 
   - id: da-api-plugin-from-existing-api-api-key-remote-preview
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-EXISTING-API
+    workItemIds: [31434601]
     gate: manual
     steps:
       [
@@ -31,6 +33,7 @@ cases:
 
   - id: da-api-plugin-from-existing-api-bearer-remote-preview
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-EXISTING-API
+    workItemIds: [31434602]
     gate: manual
     steps:
       [
@@ -45,6 +48,7 @@ cases:
 
   - id: da-api-plugin-from-existing-api-oauth-remote-preview
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-EXISTING-API
+    workItemIds: [31434597]
     gate: manual
     steps:
       [

--- a/packages/tests/vscuse/vscode-test-cases/cases/da-api-plugin-from-scratch-bearer.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/da-api-plugin-from-scratch-bearer.yml
@@ -3,6 +3,7 @@ version: 1
 cases:
   - id: da-api-plugin-from-scratch-api-key-ts-local-copilot
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH
+    workItemIds: [34592925]
     gate: manual
     steps:
       [
@@ -17,6 +18,7 @@ cases:
 
   - id: da-api-plugin-from-scratch-api-key-js-local-copilot
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH
+    workItemIds: [34628854, 36176601]
     gate: manual
     steps:
       [

--- a/packages/tests/vscuse/vscode-test-cases/cases/da-api-plugin-from-scratch-oauth.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/da-api-plugin-from-scratch-oauth.yml
@@ -3,6 +3,7 @@ version: 1
 cases:
   - id: da-api-plugin-from-scratch-entra-ts-local-copilot
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH
+    workItemIds: [34594770]
     gate: manual
     steps:
       [
@@ -16,6 +17,7 @@ cases:
 
   - id: da-api-plugin-from-scratch-oauth-ts-local-copilot
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH
+    workItemIds: [34628898]
     gate: manual
     steps:
       [
@@ -29,6 +31,7 @@ cases:
 
   - id: da-api-plugin-from-scratch-oauth-js-local-copilot
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH
+    workItemIds: [34628898]
     gate: manual
     steps:
       [

--- a/packages/tests/vscuse/vscode-test-cases/cases/da-api-plugin-from-scratch.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/da-api-plugin-from-scratch.yml
@@ -3,6 +3,7 @@ version: 1
 cases:
   - id: da-api-plugin-from-scratch-ts
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH
+    workItemIds: [35692270]
     gate: manual
     steps:
       [
@@ -19,6 +20,7 @@ cases:
 
   - id: da-api-plugin-from-scratch-js
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH
+    workItemIds: [35719151]
     gate: manual
     steps:
       [
@@ -35,6 +37,7 @@ cases:
 
   - id: da-api-plugin-from-scratch-js-local-copilot
     scenarioId: SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH
+    workItemIds: [35692256]
     gate: manual
     steps:
       [

--- a/packages/tests/vscuse/vscode-test-cases/cases/da-mcp-server.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/da-mcp-server.yml
@@ -7,6 +7,7 @@ featureFlags:
 cases:
   - id: da-mcp-remote-none-preview
     scenarioId: SCN-DA-CREATE-WITH-MCP-SERVER
+    workItemIds: [36270854]
     steps:
       [
         scaffold-mcp-none,
@@ -20,6 +21,7 @@ cases:
 
   - id: da-mcp-remote-oauth-preview
     scenarioId: SCN-DA-CREATE-WITH-MCP-SERVER
+    workItemIds: [35613058]
     steps:
       [
         scaffold-mcp-oauth,
@@ -33,6 +35,7 @@ cases:
 
   - id: da-mcp-remote-entra-preview
     scenarioId: SCN-DA-CREATE-WITH-MCP-SERVER
+    workItemIds: [35613646]
     steps:
       [
         scaffold-mcp-entra,

--- a/packages/tests/vscuse/vscode-test-cases/cases/da-no-action.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/da-no-action.yml
@@ -3,6 +3,7 @@ version: 1
 cases:
   - id: da-no-action-remote-preview
     scenarioId: SCN-DA-CREATE-NO-ACTION
+    workItemIds: [28941585]
     steps:
       [
         scaffold-da-no-action,

--- a/packages/tests/vscuse/vscode-test-cases/cases/default-bot.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/default-bot.yml
@@ -6,6 +6,7 @@ version: 1
 cases:
   - id: simple-bot-ts-remote-teams
     scenarioId: SCN-CREATE-DEFAULT-BOT-01
+    workItemIds: [14134645]
     steps:
       [
         scaffold-simple-bot-ts,
@@ -21,6 +22,7 @@ cases:
 
   - id: simple-bot-ts-local-teams
     scenarioId: SCN-CREATE-DEFAULT-BOT-01
+    workItemIds: [9729308]
     steps:
       [
         scaffold-simple-bot-ts,
@@ -33,6 +35,7 @@ cases:
 
   - id: simple-bot-ts-playground
     scenarioId: SCN-CREATE-DEFAULT-BOT-01
+    workItemIds: [36232737, 15988344]
     steps:
       [
         scaffold-simple-bot-ts,
@@ -44,6 +47,7 @@ cases:
 
   - id: simple-bot-js-remote-teams
     scenarioId: SCN-CREATE-DEFAULT-BOT-03
+    workItemIds: [9729295]
     steps:
       [
         scaffold-simple-bot-js,
@@ -59,6 +63,7 @@ cases:
 
   - id: simple-bot-js-local-teams
     scenarioId: SCN-CREATE-DEFAULT-BOT-03
+    workItemIds: [11042961]
     steps:
       [
         scaffold-simple-bot-js,
@@ -71,6 +76,7 @@ cases:
 
   - id: simple-bot-js-playground
     scenarioId: SCN-CREATE-DEFAULT-BOT-03
+    workItemIds: [36232743, 15988344]
     steps:
       [
         scaffold-simple-bot-js,
@@ -82,6 +88,7 @@ cases:
 
   - id: simple-bot-py-remote-teams
     scenarioId: SCN-CREATE-DEFAULT-BOT-04
+    workItemIds: [36045666]
     steps:
       [
         scaffold-simple-bot-py,
@@ -98,6 +105,7 @@ cases:
 
   - id: simple-bot-py-local-teams
     scenarioId: SCN-CREATE-DEFAULT-BOT-04
+    workItemIds: [35636569]
     steps:
       [
         scaffold-simple-bot-py,
@@ -111,6 +119,7 @@ cases:
 
   - id: simple-bot-py-playground
     scenarioId: SCN-CREATE-DEFAULT-BOT-04
+    workItemIds: [36232730, 15988344]
     steps:
       [
         scaffold-simple-bot-py,

--- a/packages/tests/vscuse/vscode-test-cases/cases/default-message-extension.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/default-message-extension.yml
@@ -6,6 +6,7 @@ version: 1
 cases:
   - id: message-extension-ts-remote-teams
     scenarioId: SCN-CREATE-MESSAGE-EXTENSION-01
+    workItemIds: [35692309]
     steps:
       [
         scaffold-message-extension-ts,
@@ -20,6 +21,7 @@ cases:
 
   - id: message-extension-ts-local-teams
     scenarioId: SCN-CREATE-MESSAGE-EXTENSION-01
+    workItemIds: [34869342]
     steps:
       [
         scaffold-message-extension-ts,
@@ -31,11 +33,13 @@ cases:
 
   - id: message-extension-ts-playground
     scenarioId: SCN-CREATE-MESSAGE-EXTENSION-01
+    workItemIds: [27548742]
     steps:
       [scaffold-message-extension-ts, check-message-extension-ts, f5-playground]
 
   - id: message-extension-py-remote-teams
     scenarioId: SCN-CREATE-MESSAGE-EXTENSION-03
+    workItemIds: [35636525]
     steps:
       [
         scaffold-message-extension-py,
@@ -51,6 +55,7 @@ cases:
 
   - id: message-extension-py-local-teams
     scenarioId: SCN-CREATE-MESSAGE-EXTENSION-03
+    workItemIds: [35732768]
     steps:
       [
         scaffold-message-extension-py,
@@ -63,6 +68,7 @@ cases:
 
   - id: message-extension-py-playground
     scenarioId: SCN-CREATE-MESSAGE-EXTENSION-03
+    workItemIds: [35732768]
     steps:
       [
         scaffold-message-extension-py,

--- a/packages/tests/vscuse/vscode-test-cases/cases/general-teams-agent.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/general-teams-agent.yml
@@ -8,6 +8,7 @@ version: 1
 cases:
   - id: general-teams-ts-azure-openai-remote-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-01
+    workItemIds: [27042830]
     steps:
       [
         scaffold-general-ts-azure-openai,
@@ -23,6 +24,7 @@ cases:
 
   - id: general-teams-ts-azure-openai-local-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-01
+    workItemIds: [27042450]
     steps:
       [
         scaffold-general-ts-azure-openai,
@@ -35,6 +37,7 @@ cases:
 
   - id: general-teams-ts-azure-openai-playground
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-01
+    workItemIds: [36229816]
     steps:
       [
         scaffold-general-ts-azure-openai,
@@ -46,6 +49,7 @@ cases:
 
   - id: general-teams-ts-azure-openai-remote-copilot
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-01
+    workItemIds: [36033075]
     # The run workflow injects this before VS Code starts so scaffold renders
     # the Copilot profiles without mutating user settings or reloading.
     featureFlags:
@@ -65,6 +69,7 @@ cases:
 
   - id: general-teams-ts-azure-openai-local-copilot
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-01
+    workItemIds: [36033050]
     featureFlags:
       - TEAMSFX_CEA_ENABLED=true
     steps:
@@ -79,6 +84,7 @@ cases:
 
   - id: general-teams-js-azure-openai-remote-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-03
+    workItemIds: [27042828]
     steps:
       [
         scaffold-general-js-azure-openai,
@@ -94,6 +100,7 @@ cases:
 
   - id: general-teams-js-azure-openai-local-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-03
+    workItemIds: [27042416]
     steps:
       [
         scaffold-general-js-azure-openai,
@@ -106,6 +113,7 @@ cases:
 
   - id: general-teams-js-azure-openai-playground
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-03
+    workItemIds: [36217287]
     steps:
       [
         scaffold-general-js-azure-openai,
@@ -117,6 +125,7 @@ cases:
 
   - id: general-teams-py-azure-openai-remote-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-04
+    workItemIds: [27551399]
     steps:
       [
         scaffold-general-py-azure-openai,
@@ -133,6 +142,7 @@ cases:
 
   - id: general-teams-py-azure-openai-local-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-04
+    workItemIds: [27178027]
     steps:
       [
         scaffold-general-py-azure-openai,
@@ -146,6 +156,7 @@ cases:
 
   - id: general-teams-py-azure-openai-playground
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-04
+    workItemIds: [36229811]
     steps:
       [
         scaffold-general-py-azure-openai,
@@ -161,6 +172,7 @@ cases:
   # Azure OpenAI v1 endpoint and assert a real completion.
   - id: general-teams-ts-openai-remote-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-01
+    workItemIds: [27042831]
     steps:
       [
         scaffold-general-ts-openai,
@@ -175,6 +187,7 @@ cases:
 
   - id: general-teams-ts-openai-local-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-01
+    workItemIds: [27042451]
     steps:
       [
         scaffold-general-ts-openai,
@@ -188,6 +201,7 @@ cases:
 
   - id: general-teams-js-openai-remote-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-03
+    workItemIds: [27042829]
     steps:
       [
         scaffold-general-js-openai,
@@ -202,6 +216,7 @@ cases:
 
   - id: general-teams-js-openai-local-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-03
+    workItemIds: [27042433]
     steps:
       [
         scaffold-general-js-openai,
@@ -215,6 +230,7 @@ cases:
 
   - id: general-teams-py-openai-remote-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-04
+    workItemIds: [27551403]
     steps:
       [
         scaffold-general-py-openai,
@@ -230,6 +246,7 @@ cases:
 
   - id: general-teams-py-openai-local-teams
     scenarioId: SCN-CREATE-CUSTOM-COPILOT-BASIC-04
+    workItemIds: [27178071]
     steps:
       [
         scaffold-general-py-openai,

--- a/packages/tests/vscuse/vscode-test-cases/cases/non-sso-tab.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/non-sso-tab.yml
@@ -6,6 +6,7 @@ version: 1
 cases:
   - id: tab-ts-remote-teams
     scenarioId: SCN-CREATE-NON-SSO-TAB-01
+    workItemIds: [14134646, 15263834]
     steps:
       [
         scaffold-tab-ts,
@@ -21,6 +22,7 @@ cases:
 
   - id: tab-ts-local-teams
     scenarioId: SCN-CREATE-NON-SSO-TAB-01
+    workItemIds: [15276946, 15455338, 12615302]
     steps:
       [
         scaffold-tab-ts,
@@ -35,6 +37,7 @@ cases:
   # lifecycle recreating it is to delete the scaffolded copy first.
   - id: tab-ts-local-teams-env-recreated
     scenarioId: SCN-CREATE-NON-SSO-TAB-02
+    workItemIds: [17038910]
     steps:
       [
         scaffold-tab-ts,

--- a/packages/tests/vscuse/vscode-test-cases/cases/teams-collaborator-agent.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/teams-collaborator-agent.yml
@@ -8,6 +8,7 @@ version: 1
 cases:
   - id: collaborator-ts-azure-openai-remote-teams
     scenarioId: SCN-CREATE-COLLABORATOR-01
+    workItemIds: [35692291]
     steps:
       [
         scaffold-collaborator-ts,
@@ -22,6 +23,7 @@ cases:
 
   - id: collaborator-ts-azure-openai-local-teams
     scenarioId: SCN-CREATE-COLLABORATOR-01
+    workItemIds: [35527255]
     steps:
       [
         scaffold-collaborator-ts,

--- a/packages/tests/vscuse/vscode-test-cases/cases/weather-agent.yml
+++ b/packages/tests/vscuse/vscode-test-cases/cases/weather-agent.yml
@@ -9,6 +9,7 @@ version: 1
 cases:
   - id: weather-ts-azure-openai-remote-teams
     scenarioId: SCN-CREATE-WEATHER-01
+    workItemIds: [34648368]
     steps:
       [
         scaffold-weather-ts-azure-openai,
@@ -28,6 +29,7 @@ cases:
   # because the local run reads no Azure resources.
   - id: weather-ts-azure-openai-local-teams
     scenarioId: SCN-CREATE-WEATHER-01
+    workItemIds: [34648342]
     steps:
       [
         scaffold-weather-ts-azure-openai,
@@ -40,6 +42,7 @@ cases:
 
   - id: weather-js-azure-openai-remote-teams
     scenarioId: SCN-CREATE-WEATHER-01
+    workItemIds: [34648345]
     steps:
       [
         scaffold-weather-js-azure-openai,
@@ -55,6 +58,7 @@ cases:
 
   - id: weather-js-azure-openai-local-teams
     scenarioId: SCN-CREATE-WEATHER-01
+    workItemIds: [34648323]
     steps:
       [
         scaffold-weather-js-azure-openai,
@@ -74,6 +78,7 @@ cases:
   # name, and the different generated configuration that follows from it.
   - id: weather-ts-openai-remote-teams
     scenarioId: SCN-CREATE-WEATHER-03
+    workItemIds: [34648339]
     steps:
       [
         scaffold-weather-ts-openai,
@@ -88,6 +93,7 @@ cases:
 
   - id: weather-ts-openai-local-teams
     scenarioId: SCN-CREATE-WEATHER-03
+    workItemIds: [34648300]
     steps:
       [
         scaffold-weather-ts-openai,
@@ -101,6 +107,7 @@ cases:
 
   - id: weather-js-openai-remote-teams
     scenarioId: SCN-CREATE-WEATHER-03
+    workItemIds: [34648304]
     steps:
       [
         scaffold-weather-js-openai,
@@ -115,6 +122,7 @@ cases:
 
   - id: weather-js-openai-local-teams
     scenarioId: SCN-CREATE-WEATHER-03
+    workItemIds: [34648299]
     steps:
       [
         scaffold-weather-js-openai,
@@ -131,6 +139,7 @@ cases:
   # deployed first, unlike a declarative agent.
   - id: weather-ts-azure-openai-remote-copilot
     scenarioId: SCN-CREATE-WEATHER-01
+    workItemIds: [33338502]
     steps:
       [
         scaffold-weather-ts-azure-openai,
@@ -146,6 +155,7 @@ cases:
 
   - id: weather-ts-azure-openai-local-copilot
     scenarioId: SCN-CREATE-WEATHER-01
+    workItemIds: [33338504]
     steps:
       [
         scaffold-weather-ts-azure-openai,
@@ -161,6 +171,7 @@ cases:
   # completion from the scaffolded agent.
   - id: weather-ts-azure-openai-playground
     scenarioId: SCN-CREATE-WEATHER-01
+    workItemIds: [36230430]
     steps:
       [
         scaffold-weather-ts-azure-openai,
@@ -172,6 +183,7 @@ cases:
 
   - id: weather-js-azure-openai-playground
     scenarioId: SCN-CREATE-WEATHER-01
+    workItemIds: [36230411]
     steps:
       [
         scaffold-weather-js-azure-openai,

--- a/packages/tests/vscuse/vscode-test-cases/engine/compile-case-bundle.cjs
+++ b/packages/tests/vscuse/vscode-test-cases/engine/compile-case-bundle.cjs
@@ -61,7 +61,7 @@ function composeCase({ compileStep, expandedCase, sourcePath }) {
           name: expandedCase.caseId,
           description: {
             owner: "",
-            workitem: expandedCase.scenarioId,
+            workitem: expandedCase.workItemIds.join(","),
             other: "",
           },
           execution_order: steps.map(({ step_id }) => step_id),

--- a/packages/tests/vscuse/vscode-test-cases/engine/compile-case-bundle.test.cjs
+++ b/packages/tests/vscuse/vscode-test-cases/engine/compile-case-bundle.test.cjs
@@ -12,9 +12,11 @@ featureFlags:
 cases:
   - id: remote
     scenarioId: SCN-REMOTE
+    workItemIds: [1001, 1002]
     steps: [scaffold, deploy, deploy]
   - id: local
     scenarioId: SCN-LOCAL
+    workItemIds: [1003]
     gate: manual
     steps: [scaffold, target]
 

--- a/packages/tests/vscuse/vscode-test-cases/engine/expand-case-bundle.cjs
+++ b/packages/tests/vscuse/vscode-test-cases/engine/expand-case-bundle.cjs
@@ -66,6 +66,7 @@ function expandCaseBundle({ bundle, sourcePath }) {
       ]),
       gate: caseDefinition.gate ?? "pr",
       scenarioId: caseDefinition.scenarioId,
+      workItemIds: structuredClone(caseDefinition.workItemIds),
       steps,
       templateId: scaffolds[0]?.definition.with.template,
     });

--- a/packages/tests/vscuse/vscode-test-cases/engine/semantic-step-compiler.test.cjs
+++ b/packages/tests/vscuse/vscode-test-cases/engine/semantic-step-compiler.test.cjs
@@ -65,6 +65,83 @@ async function compileFixture(fileName, transform) {
   });
 }
 
+test("VCB-123: numeric work item IDs remain distinct from scenario metadata", () => {
+  const sourceText = `version: 1
+cases:
+  - id: remote
+    scenarioId: SCN-REMOTE
+    workItemIds: [1001, 1002]
+    steps: [scaffold]
+steps:
+  scaffold:
+    type: scaffold
+    with:
+      template: weather-agent
+      answers: []
+`;
+  const compileStep = () => ({
+    ok: true,
+    value: [
+      {
+        step_id: "step_scaffold",
+        agent: "assertion",
+        tool: "",
+        parameters: {},
+        description: "Compiled scaffold",
+        depends_on: [],
+        tags: [],
+      },
+    ],
+  });
+  const result = compileCaseBundle({
+    sourcePath: "cases/work-items.yml",
+    sourceText,
+    compileStep,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.value[0].plan.plan_metadata.description.workitem,
+    "1001,1002",
+  );
+  assert.equal(
+    result.value[0].plan.plan_metadata.tags.includes("scenario_id:SCN-REMOTE"),
+    true,
+  );
+
+  for (const invalidWorkItemIds of [
+    undefined,
+    "[]",
+    "[0]",
+    "[-1]",
+    "[1.5]",
+    "[9007199254740992]",
+    "[1001, 1001]",
+    '["1001"]',
+  ]) {
+    const invalid = compileCaseBundle({
+      sourcePath: "cases/work-items.yml",
+      sourceText: sourceText.replace(
+        "    workItemIds: [1001, 1002]\n",
+        invalidWorkItemIds === undefined
+          ? ""
+          : `    workItemIds: ${invalidWorkItemIds}\n`,
+      ),
+      compileStep,
+    });
+    const label = invalidWorkItemIds ?? "missing";
+    assert.equal(invalid.ok, false, label);
+    assert.ok(
+      invalid.diagnostics.some(
+        ({ code, yamlPath }) =>
+          code === "VCB_WORK_ITEM_IDS_INVALID" &&
+          yamlPath === "$.cases[0].workItemIds",
+      ),
+      label,
+    );
+  }
+});
+
 test("VCB-34: semantic compiler does not read external template contracts", async (context) => {
   const plansDirectory = await fs.mkdtemp(
     path.join(os.tmpdir(), "vscuse-contract-reads-"),
@@ -444,6 +521,7 @@ test("VCB-91: Teams Other scaffolds resolve the complete authored selector path"
 cases:
   - id: ${caseId}
     scenarioId: VCB-91
+    workItemIds: [1001]
     steps: [scaffold, check]
 steps:
   scaffold:
@@ -2167,6 +2245,7 @@ test("VCB-107: local user environment values update the fixed project file", asy
 cases:
   - id: local-user-environment
     scenarioId: VCB-107
+    workItemIds: [1001]
     steps: [scaffold, check, set-api-key]
 steps:
   scaffold:

--- a/packages/tests/vscuse/vscode-test-cases/engine/validate-case-bundle.cjs
+++ b/packages/tests/vscuse/vscode-test-cases/engine/validate-case-bundle.cjs
@@ -3,6 +3,7 @@ const { createDiagnostic } = require("./diagnostics.cjs");
 const allowedCaseFields = new Set([
   "id",
   "scenarioId",
+  "workItemIds",
   "featureFlags",
   "steps",
   "gate",
@@ -205,6 +206,24 @@ function validateCaseBundle({ bundle, sourcePath }) {
             sourcePath,
             `${yamlPath}.scenarioId`,
             "Each case must have a non-empty scenario ID.",
+          ),
+        );
+      }
+      if (
+        !Array.isArray(caseDefinition.workItemIds) ||
+        caseDefinition.workItemIds.length === 0 ||
+        caseDefinition.workItemIds.some(
+          (workItemId) => !Number.isSafeInteger(workItemId) || workItemId <= 0,
+        ) ||
+        new Set(caseDefinition.workItemIds).size !==
+          caseDefinition.workItemIds.length
+      ) {
+        diagnostics.push(
+          createDiagnostic(
+            "VCB_WORK_ITEM_IDS_INVALID",
+            sourcePath,
+            `${yamlPath}.workItemIds`,
+            "Each case must have unique positive integer work item IDs.",
           ),
         );
       }

--- a/packages/tests/vscuse/vscode-test-cases/engine/write-generated-plans.test.cjs
+++ b/packages/tests/vscuse/vscode-test-cases/engine/write-generated-plans.test.cjs
@@ -12,6 +12,7 @@ version: 1
 cases:
   - id: remote
     scenarioId: SCN-REMOTE
+    workItemIds: [1001]
     steps: [scaffold]
 steps:
   scaffold:
@@ -26,6 +27,7 @@ const twoCaseSourceText = sourceText.replace(
   `    steps: [scaffold]
   - id: local
     scenarioId: SCN-LOCAL
+    workItemIds: [1002]
     steps: [scaffold]
 steps:`,
 );

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-js-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-03",
+      "workitem": "33338520",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-playground.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-js-azure-openai-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-03",
+      "workitem": "36119761",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-03",
+      "workitem": "33338521",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-py-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-04",
+      "workitem": "36061767,36176601",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-playground.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-py-azure-openai-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-04",
+      "workitem": "36119764",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-py-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-04",
+      "workitem": "36162207",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-ts-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-01",
+      "workitem": "33338524",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-playground.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-ts-azure-openai-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-01",
+      "workitem": "36119770",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "basic-cea-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-BASIC-CEA-01",
+      "workitem": "33338525",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-js-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-03",
+      "workitem": "27042416",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-playground.json
@@ -12,7 +12,7 @@
     "name": "general-teams-js-azure-openai-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-03",
+      "workitem": "36217287",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-03",
+      "workitem": "27042828",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-js-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-03",
+      "workitem": "27042433",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-js-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-03",
+      "workitem": "27042829",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-py-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-04",
+      "workitem": "27178027",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-playground.json
@@ -12,7 +12,7 @@
     "name": "general-teams-py-azure-openai-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-04",
+      "workitem": "36229811",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-py-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-04",
+      "workitem": "27551399",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-py-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-04",
+      "workitem": "27178071",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-py-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-04",
+      "workitem": "27551403",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "general-teams-ts-azure-openai-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-01",
+      "workitem": "36033050",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-ts-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-01",
+      "workitem": "27042450",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-playground.json
@@ -12,7 +12,7 @@
     "name": "general-teams-ts-azure-openai-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-01",
+      "workitem": "36229816",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-remote-copilot.json
@@ -12,7 +12,7 @@
     "name": "general-teams-ts-azure-openai-remote-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-01",
+      "workitem": "36033075",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-01",
+      "workitem": "27042830",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-ts-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-01",
+      "workitem": "27042451",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "general-teams-ts-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-CUSTOM-COPILOT-BASIC-01",
+      "workitem": "27042831",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-js-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-js-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-azure-ai-search-js-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-AZURE-SEARCH-03",
+      "workitem": "36534512",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-js-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-js-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-azure-ai-search-js-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-AZURE-SEARCH-03",
+      "workitem": "28970334",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-py-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-py-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-azure-ai-search-py-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-AZURE-SEARCH-04",
+      "workitem": "27454153",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-py-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-py-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-azure-ai-search-py-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-AZURE-SEARCH-04",
+      "workitem": "27454158",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-ts-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-ts-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-azure-ai-search-ts-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-AZURE-SEARCH-01",
+      "workitem": "27569074",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-ts-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-ts-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-azure-ai-search-ts-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-AZURE-SEARCH-01",
+      "workitem": "28970306",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-js-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-js-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-custom-api-js-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOM-API-04",
+      "workitem": "27588577",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-js-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-js-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-custom-api-js-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOM-API-04",
+      "workitem": "27588587",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-py-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-py-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-custom-api-py-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOM-API-05",
+      "workitem": "28969537",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-py-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-py-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-custom-api-py-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOM-API-05",
+      "workitem": "28969579",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-ts-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-ts-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-custom-api-ts-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOM-API-01",
+      "workitem": "27588564",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-ts-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-ts-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-custom-api-ts-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOM-API-01",
+      "workitem": "27588580",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-customize-js-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOMIZE-03",
+      "workitem": "27569146",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-customize-js-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOMIZE-03",
+      "workitem": "28869495",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-customize-py-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOMIZE-04",
+      "workitem": "27551381",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-openai-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-openai-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "rag-customize-py-openai-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOMIZE-04",
+      "workitem": "36031920",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-customize-py-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOMIZE-04",
+      "workitem": "27551384",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-customize-ts-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOMIZE-01",
+      "workitem": "27569137",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "rag-customize-ts-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-RAG-CUSTOMIZE-01",
+      "workitem": "28869466",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-existing-api--da-api-plugin-from-existing-api-api-key-remote-preview.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-existing-api--da-api-plugin-from-existing-api-api-key-remote-preview.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-existing-api-api-key-remote-preview",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-EXISTING-API",
+      "workitem": "31434601",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-existing-api--da-api-plugin-from-existing-api-bearer-remote-preview.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-existing-api--da-api-plugin-from-existing-api-bearer-remote-preview.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-existing-api-bearer-remote-preview",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-EXISTING-API",
+      "workitem": "31434602",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-existing-api--da-api-plugin-from-existing-api-no-auth-remote-preview.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-existing-api--da-api-plugin-from-existing-api-no-auth-remote-preview.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-existing-api-no-auth-remote-preview",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-EXISTING-API",
+      "workitem": "28941863",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-existing-api--da-api-plugin-from-existing-api-oauth-remote-preview.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-existing-api--da-api-plugin-from-existing-api-oauth-remote-preview.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-existing-api-oauth-remote-preview",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-EXISTING-API",
+      "workitem": "31434597",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch--da-api-plugin-from-scratch-js-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch--da-api-plugin-from-scratch-js-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-scratch-js-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH",
+      "workitem": "35692256",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch--da-api-plugin-from-scratch-js.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch--da-api-plugin-from-scratch-js.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-scratch-js",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH",
+      "workitem": "35719151",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch--da-api-plugin-from-scratch-ts.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch--da-api-plugin-from-scratch-ts.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-scratch-ts",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH",
+      "workitem": "35692270",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-bearer--da-api-plugin-from-scratch-api-key-js-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-bearer--da-api-plugin-from-scratch-api-key-js-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-scratch-api-key-js-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH",
+      "workitem": "34628854,36176601",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-bearer--da-api-plugin-from-scratch-api-key-ts-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-bearer--da-api-plugin-from-scratch-api-key-ts-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-scratch-api-key-ts-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH",
+      "workitem": "34592925",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-oauth--da-api-plugin-from-scratch-entra-ts-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-oauth--da-api-plugin-from-scratch-entra-ts-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-scratch-entra-ts-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH",
+      "workitem": "34594770",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-oauth--da-api-plugin-from-scratch-oauth-js-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-oauth--da-api-plugin-from-scratch-oauth-js-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-scratch-oauth-js-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH",
+      "workitem": "34628898",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-oauth--da-api-plugin-from-scratch-oauth-ts-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-api-plugin-from-scratch-oauth--da-api-plugin-from-scratch-oauth-ts-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "da-api-plugin-from-scratch-oauth-ts-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-API-PLUGIN-FROM-SCRATCH",
+      "workitem": "34628898",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-mcp-server--da-mcp-remote-entra-preview.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-mcp-server--da-mcp-remote-entra-preview.json
@@ -12,7 +12,7 @@
     "name": "da-mcp-remote-entra-preview",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-WITH-MCP-SERVER",
+      "workitem": "35613646",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-mcp-server--da-mcp-remote-none-preview.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-mcp-server--da-mcp-remote-none-preview.json
@@ -12,7 +12,7 @@
     "name": "da-mcp-remote-none-preview",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-WITH-MCP-SERVER",
+      "workitem": "36270854",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-mcp-server--da-mcp-remote-oauth-preview.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-mcp-server--da-mcp-remote-oauth-preview.json
@@ -12,7 +12,7 @@
     "name": "da-mcp-remote-oauth-preview",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-WITH-MCP-SERVER",
+      "workitem": "35613058",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-no-action--da-no-action-remote-preview.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-no-action--da-no-action-remote-preview.json
@@ -12,7 +12,7 @@
     "name": "da-no-action-remote-preview",
     "description": {
       "owner": "",
-      "workitem": "SCN-DA-CREATE-NO-ACTION",
+      "workitem": "28941585",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-js-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-js-local-teams.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-js-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-03",
+      "workitem": "11042961",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-js-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-js-playground.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-js-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-03",
+      "workitem": "36232743,15988344",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-js-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-js-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-js-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-03",
+      "workitem": "9729295",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-py-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-py-local-teams.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-py-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-04",
+      "workitem": "35636569",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-py-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-py-playground.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-py-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-04",
+      "workitem": "36232730,15988344",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-py-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-py-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-py-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-04",
+      "workitem": "36045666",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-ts-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-ts-local-teams.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-ts-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-01",
+      "workitem": "9729308",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-ts-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-ts-playground.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-ts-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-01",
+      "workitem": "36232737,15988344",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-ts-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-ts-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "simple-bot-ts-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-DEFAULT-BOT-01",
+      "workitem": "14134645",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-py-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-py-local-teams.json
@@ -12,7 +12,7 @@
     "name": "message-extension-py-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-MESSAGE-EXTENSION-03",
+      "workitem": "35732768",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-py-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-py-playground.json
@@ -12,7 +12,7 @@
     "name": "message-extension-py-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-MESSAGE-EXTENSION-03",
+      "workitem": "35732768",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-py-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-py-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "message-extension-py-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-MESSAGE-EXTENSION-03",
+      "workitem": "35636525",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-ts-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-ts-local-teams.json
@@ -12,7 +12,7 @@
     "name": "message-extension-ts-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-MESSAGE-EXTENSION-01",
+      "workitem": "34869342",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-ts-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-ts-playground.json
@@ -12,7 +12,7 @@
     "name": "message-extension-ts-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-MESSAGE-EXTENSION-01",
+      "workitem": "27548742",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-ts-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-ts-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "message-extension-ts-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-MESSAGE-EXTENSION-01",
+      "workitem": "35692309",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/non-sso-tab--tab-ts-local-teams-env-recreated.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/non-sso-tab--tab-ts-local-teams-env-recreated.json
@@ -12,7 +12,7 @@
     "name": "tab-ts-local-teams-env-recreated",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-NON-SSO-TAB-02",
+      "workitem": "17038910",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/non-sso-tab--tab-ts-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/non-sso-tab--tab-ts-local-teams.json
@@ -12,7 +12,7 @@
     "name": "tab-ts-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-NON-SSO-TAB-01",
+      "workitem": "15276946,15455338,12615302",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/non-sso-tab--tab-ts-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/non-sso-tab--tab-ts-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "tab-ts-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-NON-SSO-TAB-01",
+      "workitem": "14134646,15263834",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/teams-collaborator-agent--collaborator-ts-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/teams-collaborator-agent--collaborator-ts-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "collaborator-ts-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-COLLABORATOR-01",
+      "workitem": "35527255",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/teams-collaborator-agent--collaborator-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/teams-collaborator-agent--collaborator-ts-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "collaborator-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-COLLABORATOR-01",
+      "workitem": "35692291",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "weather-js-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-01",
+      "workitem": "34648323",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-playground.json
@@ -12,7 +12,7 @@
     "name": "weather-js-azure-openai-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-01",
+      "workitem": "36230411",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "weather-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-01",
+      "workitem": "34648345",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "weather-js-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-03",
+      "workitem": "34648299",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "weather-js-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-03",
+      "workitem": "34648304",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-local-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-local-copilot.json
@@ -12,7 +12,7 @@
     "name": "weather-ts-azure-openai-local-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-01",
+      "workitem": "33338504",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "weather-ts-azure-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-01",
+      "workitem": "34648342",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-playground.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-playground.json
@@ -12,7 +12,7 @@
     "name": "weather-ts-azure-openai-playground",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-01",
+      "workitem": "36230430",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-remote-copilot.json
@@ -12,7 +12,7 @@
     "name": "weather-ts-azure-openai-remote-copilot",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-01",
+      "workitem": "33338502",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "weather-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-01",
+      "workitem": "34648368",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-openai-local-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-openai-local-teams.json
@@ -12,7 +12,7 @@
     "name": "weather-ts-openai-local-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-03",
+      "workitem": "34648300",
       "other": ""
     },
     "execution_order": [

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-openai-remote-teams.json
@@ -12,7 +12,7 @@
     "name": "weather-ts-openai-remote-teams",
     "description": {
       "owner": "",
-      "workitem": "SCN-CREATE-WEATHER-03",
+      "workitem": "34648339",
       "other": ""
     },
     "execution_order": [


### PR DESCRIPTION
## Summary

- add required numeric `workItemIds` to generated vscuse semantic cases while keeping `scenarioId` as scenario metadata
- serialize numeric work item IDs into `plan_metadata.description.workitem`
- validate work item IDs as non-empty, unique, positive safe integers and cover the contract with `VCB-123`
- regenerate all 93 manifest-owned plans with metadata-only changes

## Why

Generated plans previously wrote `SCN-*` scenario IDs into the legacy `workitem` field. The test-report sync resolves that field as Azure DevOps work item ownership, so the generated plan names could not be linked to their parent test-case issues. This contributes to the unmapped runs reported in OfficeDev/microsoft-365-agents-toolkit-test#25065.

Companion sync PR: OfficeDev/microsoft-365-agents-toolkit-test#25066.

## Validation

- `pnpm --dir packages/tests run generate:vscuse-cases`
- `pnpm --dir packages/tests run test:vscuse-engine` (159 passed)
- `pnpm exec prettier --check "packages/tests/vscuse/vscode-test-cases/engine/*.cjs" "packages/tests/vscuse/vscode-test-cases/cases/*.yml" "docs/03-specs/operations/product/compile-vscuse-case-bundles.md"`
- second generation pass: `No generated plan changes.`
- all 93 generated plan diffs are exactly one metadata line changed