### PR TITLE
build(api): bump package version to 0.24.1

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-api",
-  "version": "0.23.17",
+  "version": "0.24.1",
   "description": "teamsfx framework api",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Summary
- bump `@microsoft/teamsfx-api` from version `0.23.17` to `0.24.1`

## Test Plan
- `pnpm --filter @microsoft/teamsfx-api lint` (0 errors; 71 existing warnings)
- `pnpm --filter @microsoft/teamsfx-api build`
- `pnpm --filter @microsoft/teamsfx-api test:unit` (8 passing)
- `git diff --check release/6.14...HEAD`