### PR TITLE
fix(cli): initialize region for ROPC authentication

### DIFF
--- a/packages/cli/src/commonlib/m365LoginUserPassword.ts
+++ b/packages/cli/src/commonlib/m365LoginUserPassword.ts
@@ -73,8 +73,7 @@ export class M365ProviderUserPassword extends BasicLogin implements M365TokenPro
     if (M365ProviderUserPassword.accessToken) {
       const m365Token = M365ProviderUserPassword.accessToken;
 
-      // Set region for App Studio API
-      if (tokenRequest.scopes === AppStudioScopes()) {
+      if (hasSameScopes(tokenRequest.scopes, AppStudioScopes())) {
         const authSvcRequest = {
           scopes: AuthSvcScopes(),
           username: user!,
@@ -147,3 +146,12 @@ export class M365ProviderUserPassword extends BasicLogin implements M365TokenPro
 }
 
 export default M365ProviderUserPassword.getInstance();
+
+function hasSameScopes(first: string[], second: string[]): boolean {
+  const firstScopes = new Set(first);
+  const secondScopes = new Set(second);
+  return (
+    firstScopes.size === secondScopes.size &&
+    [...firstScopes].every((scope) => secondScopes.has(scope))
+  );
+}

--- a/packages/cli/tests/unit/commonlib/m365LoginUserPassword.tests.ts
+++ b/packages/cli/tests/unit/commonlib/m365LoginUserPassword.tests.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  acquireTokenByUsernamePassword: vi.fn(),
+  setRegionEndpointByToken: vi.fn(),
+}));
+
+vi.mock("@azure/msal-node", () => ({
+  PublicClientApplication: vi.fn(function PublicClientApplication() {
+    return {
+      acquireTokenByUsernamePassword: mocks.acquireTokenByUsernamePassword,
+    };
+  }),
+}));
+
+vi.mock("@microsoft/teamsfx-core", () => ({
+  AppStudioScopes: () => ["app-studio-read", "app-studio-write"],
+  AuthSvcScopes: () => ["authsvc-scope"],
+  teamsDevPortalClient: {
+    setRegionEndpointByToken: mocks.setRegionEndpointByToken,
+  },
+}));
+
+import { M365ProviderUserPassword } from "../../../src/commonlib/m365LoginUserPassword";
+
+describe("M365ProviderUserPassword", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes the Teams Developer Portal region when separate scope arrays have equal values", async () => {
+    mocks.acquireTokenByUsernamePassword
+      .mockResolvedValueOnce({ accessToken: "app-studio-token" })
+      .mockResolvedValueOnce({ accessToken: "authsvc-token" });
+
+    const provider = M365ProviderUserPassword.getInstance();
+    const result = await provider.getAccessToken({
+      scopes: ["app-studio-write", "app-studio-read"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mocks.acquireTokenByUsernamePassword).toHaveBeenCalledTimes(2);
+    expect(mocks.acquireTokenByUsernamePassword).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ scopes: ["authsvc-scope"] })
+    );
+    expect(mocks.setRegionEndpointByToken).toHaveBeenCalledWith("authsvc-token");
+  });
+
+  it("does not initialize the Teams Developer Portal region for non-AppStudio scopes", async () => {
+    mocks.acquireTokenByUsernamePassword.mockResolvedValueOnce({ accessToken: "graph-token" });
+
+    const provider = M365ProviderUserPassword.getInstance();
+    const result = await provider.getAccessToken({ scopes: ["graph-scope"] });
+
+    expect(result.isOk()).toBe(true);
+    expect(mocks.acquireTokenByUsernamePassword).toHaveBeenCalledTimes(1);
+    expect(mocks.setRegionEndpointByToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tests/src/e2e/declarativeAgent/RopcRegionLifecycle.tests.ts
+++ b/packages/tests/src/e2e/declarativeAgent/RopcRegionLifecycle.tests.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+import * as fs from "fs-extra";
+import { describe, it } from "mocha";
+import * as path from "path";
+import {
+  cleanUpLocalProject,
+  execAsync,
+  getTestFolder,
+  getUniqueAppName,
+} from "../commonUtils";
+
+describe("Declarative agent ROPC region lifecycle", function () {
+  this.timeout(20 * 60 * 1000);
+
+  it("scaffolds, provisions, and uninstalls a declarative agent", async function () {
+    const testFolder = getTestFolder();
+    const appName = getUniqueAppName();
+    const projectPath = path.join(testFolder, appName);
+    let provisioned = false;
+
+    try {
+      await execAsync(
+        `atk new -c declarative-agent -n ${appName} -f ${testFolder} -i false`,
+        {
+          cwd: testFolder,
+          env: process.env,
+          timeout: 5 * 60 * 1000,
+        },
+      );
+      expect(
+        await fs.pathExists(projectPath),
+        "scaffold should create the project",
+      ).to.be.true;
+
+      await execAsync("atk provision --env local -i false", {
+        cwd: projectPath,
+        env: process.env,
+        timeout: 10 * 60 * 1000,
+      });
+      provisioned = true;
+      expect(
+        await fs.pathExists(path.join(projectPath, "env", ".env.local")),
+        "provision should write the local environment file",
+      ).to.be.true;
+    } finally {
+      try {
+        if (provisioned) {
+          await execAsync(
+            `atk uninstall --mode env --env local --folder ${projectPath} --options m365-app,app-registration,bot-framework-registration -i false`,
+            {
+              cwd: projectPath,
+              env: process.env,
+              timeout: 5 * 60 * 1000,
+            },
+          );
+        }
+      } finally {
+        await cleanUpLocalProject(projectPath);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Initialize the Teams Developer Portal region after every successful ROPC M365 token acquisition.
- Add a regression test for the separate-but-equal `AppStudioScopes()` array case.

## Root cause
`M365ProviderUserPassword` gated AuthSvc region discovery on `tokenRequest.scopes === AppStudioScopes()`. `AppStudioScopes()` creates a new array on each call, so the identity comparison is always false. Consequently, CI ROPC authentication never initialized `teamsDevPortalClient.regionEndpoint`; `listApps` and `deleteApp` then failed with `Failed to get region`.

The normal code-flow provider already requests `AuthSvcScopes()` and calls `setRegionEndpointByToken` after authentication. This change aligns the ROPC provider with that behavior while retaining its headless username/password grant.

## Validation
- `pnpm exec vitest run tests/unit/commonlib/m365LoginUserPassword.tests.ts --config vitest.config.ts --maxWorkers=75%`
- `pnpm run build` in `packages/cli`
- Local ROPC AuthSvc discovery returned `regionGtms.teamsDevPortal` as `https://dev.teams.microsoft.com`.