### PR TITLE
build(release): update package RC versions

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-api",
-  "version": "0.23.17",
+  "version": "0.23.17-rc.0",
   "description": "teamsfx framework api",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-api",
-  "version": "0.23.17-rc.0",
+  "version": "0.24.1-rc.0",
   "description": "teamsfx framework api",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/m365agentstoolkit-cli",
-  "version": "1.1.14",
+  "version": "1.1.14-rc.0",
   "author": "Microsoft Corporation",
   "description": "Microsoft 365 Agents Toolkit CLI",
   "license": "MIT",

--- a/packages/eslint-plugin-teamsfx/package.json
+++ b/packages/eslint-plugin-teamsfx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/eslint-plugin-teamsfx",
-  "version": "0.0.14",
+  "version": "0.0.14-rc.0",
   "description": "eslint for teamsfx",
   "keywords": [
     "eslint",

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-core",
-  "version": "3.0.16",
+  "version": "3.0.16-rc.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-core",
-  "version": "3.0.16-rc.0",
+  "version": "3.1.1-rc.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -1,6 +1,6 @@
 {
-    "version": "~6.14",
-    "localVersion": "6.14.0",
+    "version": "0.0.0-rc",
+    "localVersion": "6.14.0-rc.0",
     "tagPrefix": "templates@",
     "v4tagPrefix": "templates-v4@",
     "vstagPrefix": "templates-vs@",

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/app-manifest",
-  "version": "1.0.9-rc.0",
+  "version": "1.1.1-rc.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/app-manifest",
-  "version": "1.0.9",
+  "version": "1.0.9-rc.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/packages/metrics-ts/package.json
+++ b/packages/metrics-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/metrics-ts",
-  "version": "0.0.11",
+  "version": "0.0.11-rc.0",
   "description": "Add metrics without intruding source code",
   "keywords": [
     "Metrics"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-server",
-  "version": "2.0.32",
+  "version": "2.0.32-rc.0",
   "author": "Microsoft Corporation",
   "description": "",
   "license": "MIT",

--- a/packages/spec-parser/package.json
+++ b/packages/spec-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/m365-spec-parser",
-  "version": "0.2.16",
+  "version": "0.2.16-rc.0",
   "description": "OpenAPI specification files Parser for M365 Apps",
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.esm2017.js",

--- a/packages/spec-parser/package.json
+++ b/packages/spec-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/m365-spec-parser",
-  "version": "0.2.16-rc.0",
+  "version": "0.3.1-rc.0",
   "description": "OpenAPI specification files Parser for M365 Apps",
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.esm2017.js",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-test",
-  "version": "0.1.21",
+  "version": "0.1.21-rc.0",
   "description": "A UI Test Project of Teams Toolkit Extension",
   "private": true,
   "author": "Microsoft Corporation",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ms-teams-vscode-extension",
   "displayName": "Microsoft 365 Agents Toolkit",
   "description": "Create, debug, and deploy agents with Microsoft 365 Agents Toolkit",
-  "version": "6.14.0",
+  "version": "6.14.0-rc.0",
   "publisher": "TeamsDevApp",
   "author": "Microsoft Corporation",
   "private": true,

--- a/packages/vscode-ui/package.json
+++ b/packages/vscode-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/vscode-ui",
-  "version": "1.0.19",
+  "version": "1.0.19-rc.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "templates",
-  "version": "6.14.0",
+  "version": "6.14.0-rc.0",
   "private": "true",
   "license": "MIT",
   "vsversion": "18.6.0",


### PR DESCRIPTION
## Summary
- restore the release branch package and template metadata to RC versions
- update the API, core, manifest, and spec-parser packages to their next RC versions

## Validation
- package JSON parsing and exact version assertions
- `pnpm exec prettier --check packages/api/package.json packages/fx-core/package.json packages/manifest/package.json packages/spec-parser/package.json`
- `git diff --check origin/release/6.14...HEAD`