### PR TITLE
fix: require explicit add-auth operation selection

### DIFF
--- a/packages/fx-core/src/question/other.ts
+++ b/packages/fx-core/src/question/other.ts
@@ -937,7 +937,7 @@ export function addAuthActionQuestion(): IQTreeNode {
               apis.push(...(runtime.run_for_functions as string[]));
             });
           const apisDedup = [...new Set(apis)];
-          if (apisDedup.length === 1 || (inputs.nonInteractive && apisDedup.length > 0)) {
+          if (apisDedup.length === 1) {
             inputs[QuestionNames.ApiOperation] = apisDedup;
             return false;
           }

--- a/packages/fx-core/tests/question/other.test.ts
+++ b/packages/fx-core/tests/question/other.test.ts
@@ -324,7 +324,7 @@ describe("addAuthActionQuestion", () => {
     }
   });
 
-  it("apiFromPluginManifestQuestion condition: should select all APIs non-interactively", async () => {
+  it("apiFromPluginManifestQuestion condition: should require selection for multiple APIs", async () => {
     const inputs: Inputs = {
       platform: Platform.CLI,
       nonInteractive: true,
@@ -358,8 +358,8 @@ describe("addAuthActionQuestion", () => {
 
     assert.isFalse(apiSpecResult);
     assert.equal(inputs[QuestionNames.ApiSpecLocation], "spec.yaml");
-    assert.isFalse(apiOperationResult);
-    assert.deepEqual(inputs[QuestionNames.ApiOperation], ["function1", "function2"]);
+    assert.isTrue(apiOperationResult);
+    assert.isUndefined(inputs[QuestionNames.ApiOperation]);
   });
 
   it("apiFromPluginManifestQuestion condition: should preserve explicit APIs", async () => {


### PR DESCRIPTION
## Summary
- remove the accidental non-interactive default that selected every API operation during `add auth`
- preserve the existing single-operation auto-selection and explicit operation behavior
- require normal selection handling when a plugin manifest exposes multiple operations

## Context
Follow-up to #16516, where the non-interactive default-to-all behavior was added unintentionally.

## Validation
- `pnpm exec vitest run tests/question/other.test.ts --config vitest.config.ts --maxWorkers=75% --reporter=dot` (58 passed)
- `npm run build` in `packages/fx-core`