### PR TITLE
feat(fx-core): add cancellable typed authoring APIs

### DIFF
--- a/packages/fx-core/src/common/cancellation.ts
+++ b/packages/fx-core/src/common/cancellation.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Inputs } from "@microsoft/teamsfx-api";
+import { UserCancelError } from "../error";
+
+type CancellableInputs = Inputs & { abortSignal?: AbortSignal };
+
+export function getAbortSignal(inputs: Inputs): AbortSignal | undefined {
+  return (inputs as CancellableInputs).abortSignal;
+}
+
+/** Stops a cooperatively cancellable FxCore operation at a safe boundary. */
+export function throwIfAborted(inputs: Inputs): void {
+  if (getAbortSignal(inputs)?.aborted) {
+    throw new UserCancelError("FxCoreClient");
+  }
+}

--- a/packages/fx-core/src/common/mcpToolFetcher.ts
+++ b/packages/fx-core/src/common/mcpToolFetcher.ts
@@ -21,11 +21,15 @@ export interface MCPFetchResult {
 }
 
 /** Fetch MCP tool definitions from a remote MCP server. */
-export async function fetchMCPTools(serverUrl: string): Promise<MCPFetchResult> {
+export async function fetchMCPTools(
+  serverUrl: string,
+  signal?: AbortSignal
+): Promise<MCPFetchResult> {
   let authMetadataUrl: string | undefined;
   try {
-    await axios.get(serverUrl, { timeout: 10000 });
+    await axios.get(serverUrl, { timeout: 10000, signal });
   } catch (error: any) {
+    signal?.throwIfAborted();
     if (error?.response?.status === 401 || error?.status === 401) {
       const wwwAuth = error?.response?.headers?.["www-authenticate"];
       if (wwwAuth) {
@@ -52,7 +56,9 @@ export async function fetchMCPTools(serverUrl: string): Promise<MCPFetchResult> 
 
     try {
       await client.connect(transport);
+      signal?.throwIfAborted();
       const result = await client.listTools();
+      signal?.throwIfAborted();
       const tools: MCPTool[] = result.tools.map((tool: any) => ({
         ...tool,
         description: tool.description ?? "",
@@ -62,6 +68,7 @@ export async function fetchMCPTools(serverUrl: string): Promise<MCPFetchResult> 
       await client.close();
     }
   } catch (error: any) {
+    signal?.throwIfAborted();
     try {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore - dynamic import of MCP SDK subpath
@@ -75,7 +82,9 @@ export async function fetchMCPTools(serverUrl: string): Promise<MCPFetchResult> 
 
       try {
         await client.connect(transport);
+        signal?.throwIfAborted();
         const result = await client.listTools();
+        signal?.throwIfAborted();
         const tools: MCPTool[] = result.tools.map((tool: any) => ({
           ...tool,
           description: tool.description ?? "",
@@ -85,6 +94,7 @@ export async function fetchMCPTools(serverUrl: string): Promise<MCPFetchResult> 
         await client.close();
       }
     } catch {
+      signal?.throwIfAborted();
       if (
         error?.message?.includes("401") ||
         error?.message?.includes("Unauthorized") ||
@@ -194,15 +204,22 @@ export interface MCPAuthProbeResult {
  * server announces where its messages go. Anything else — the stream ending, an error, a
  * stream that just keeps talking, a server that never answers — means no such announcement.
  */
-function announcesLegacyMessageEndpoint(stream: Readable): Promise<boolean> {
+function announcesLegacyMessageEndpoint(stream: Readable, signal?: AbortSignal): Promise<boolean> {
   return new Promise((resolve) => {
     let buffered = "";
     const settle = (found: boolean) => {
       clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
       stream.destroy();
       resolve(found);
     };
+    const onAbort = () => settle(false);
     const timer = setTimeout(() => settle(false), LEGACY_SSE_TIMEOUT_MS);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      settle(false);
+      return;
+    }
     stream.on("data", (chunk: Buffer | string) => {
       buffered += chunk.toString();
       if (/^event:\s*endpoint\s*$/m.test(buffered)) {
@@ -226,27 +243,34 @@ function announcesLegacyMessageEndpoint(stream: Readable): Promise<boolean> {
  * own disambiguation is to open an SSE stream with GET: an HTTP+SSE server replies
  * `text/event-stream` and names its message endpoint in the first event.
  */
-async function servesLegacySSETransport(serverUrl: string): Promise<boolean> {
+async function servesLegacySSETransport(serverUrl: string, signal?: AbortSignal): Promise<boolean> {
   try {
     const response = await axios.get(serverUrl, {
       timeout: LEGACY_SSE_TIMEOUT_MS,
       responseType: "stream",
       headers: { Accept: "text/event-stream" },
+      signal,
     });
     const contentType = String(response.headers?.["content-type"] ?? "");
     if (!contentType.includes("text/event-stream")) {
       response.data?.destroy?.();
       return false;
     }
-    return await announcesLegacyMessageEndpoint(response.data);
+    const announcesEndpoint = await announcesLegacyMessageEndpoint(response.data, signal);
+    signal?.throwIfAborted();
+    return announcesEndpoint;
   } catch {
+    signal?.throwIfAborted();
     // A GET that fails says only that the old transport is not there either.
     return false;
   }
 }
 
 /** Probe an MCP streamable-HTTP endpoint for an OAuth challenge and for the URL's validity. */
-export async function probeMCPServerAuth(serverUrl: string): Promise<MCPAuthProbeResult> {
+export async function probeMCPServerAuth(
+  serverUrl: string,
+  signal?: AbortSignal
+): Promise<MCPAuthProbeResult> {
   const initializeBody = {
     jsonrpc: "2.0",
     id: 1,
@@ -264,11 +288,13 @@ export async function probeMCPServerAuth(serverUrl: string): Promise<MCPAuthProb
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
       },
+      signal,
     });
     return carriesJSONRPCEnvelope(response.data)
       ? { requiresAuth: false, endpointStatus: "confirmed" }
       : { requiresAuth: false, endpointStatus: "notEndpoint", responseStatus: response.status };
   } catch (error: any) {
+    signal?.throwIfAborted();
     const status: unknown = error?.response?.status ?? error?.status;
     if (status === 401) {
       // Only something that means to be a protected resource issues an OAuth challenge, so a
@@ -286,7 +312,7 @@ export async function probeMCPServerAuth(serverUrl: string): Promise<MCPAuthProb
     if (typeof status === "number" && NOT_AN_ENDPOINT_STATUSES.includes(status)) {
       // The spec reads a 4xx here as "this may be the old transport", not as "wrong URL", so
       // the verdict is not settled until HTTP+SSE has been ruled out.
-      return (await servesLegacySSETransport(serverUrl))
+      return (await servesLegacySSETransport(serverUrl, signal))
         ? { requiresAuth: false, endpointStatus: "confirmed" }
         : { requiresAuth: false, endpointStatus: "notEndpoint", responseStatus: status };
     }

--- a/packages/fx-core/src/component/middleware/questionMW.ts
+++ b/packages/fx-core/src/component/middleware/questionMW.ts
@@ -3,6 +3,7 @@
 
 import { HookContext, Middleware, NextFunction } from "@feathersjs/hooks/lib";
 import { Inputs, err } from "@microsoft/teamsfx-api";
+import { throwIfAborted } from "../../common/cancellation";
 import { TOOLS } from "../../common/globalVars";
 import { QuestionNodes, questionNodes } from "../../question";
 import { traverse } from "../../ui/visitor";
@@ -10,11 +11,13 @@ import { traverse } from "../../ui/visitor";
 export function QuestionMW(key: keyof QuestionNodes, fromAction = false): Middleware {
   return async (ctx: HookContext, next: NextFunction) => {
     const inputs = ctx.arguments[0] as Inputs;
+    throwIfAborted(inputs);
     if (fromAction) {
       inputs.outputEnvVarNames = ctx.arguments[2];
     }
     const node = questionNodes[key](inputs.platform);
     const askQuestionRes = await traverse(node, inputs, TOOLS.ui, TOOLS.telemetryReporter);
+    throwIfAborted(inputs);
     if (askQuestionRes.isErr()) {
       if (fromAction) {
         ctx.result = {

--- a/packages/fx-core/src/core/FxCore.declarativeAgent.ts
+++ b/packages/fx-core/src/core/FxCore.declarativeAgent.ts
@@ -21,6 +21,7 @@ import {
 import fs from "fs-extra";
 import * as path from "path";
 import { listAPIInfo } from "../common/daSpecParser";
+import { getAbortSignal, throwIfAborted } from "../common/cancellation";
 import { FeatureFlags, featureFlagManager } from "../common/featureFlags";
 import { ErrorContextMW, TOOLS, createContext } from "../common/globalVars";
 import { getDefaultString, getLocalizedString } from "../common/localizeUtils";
@@ -649,6 +650,7 @@ export class FxCoreDeclarativeAgentPart {
         path.join(appPackageFolder, DefaultApiSpecFolderName)
       );
 
+      throwIfAborted(inputs);
       const generateRes = await openApiSpecHelperModule.generateFromApiSpec(
         specParser,
         teamsManifestPath,
@@ -771,7 +773,7 @@ export class FxCoreDeclarativeAgentPart {
           if (needsMetadataProbe && !inputs[QuestionNames.MCPForDAAuthMetadataUrl]) {
             try {
               const { probeMCPServerAuth } = await import("../component/utils/mcpToolFetcher");
-              const authProbe = await probeMCPServerAuth(mcpServerUrl);
+              const authProbe = await probeMCPServerAuth(mcpServerUrl, getAbortSignal(inputs));
               if (authProbe.authMetadataUrl) {
                 inputs[QuestionNames.MCPForDAAuthMetadataUrl] = authProbe.authMetadataUrl;
               }
@@ -809,6 +811,9 @@ export class FxCoreDeclarativeAgentPart {
               ),
             });
           }
+          // Everything below updates project files. Once this gate passes, finish the
+          // mutation sequence so cancellation cannot leave half-written auth configuration.
+          throwIfAborted(inputs);
           try {
             const ymlPath = pathUtils.getYmlFilePath(inputs.projectPath);
             if (ymlPath) {
@@ -914,7 +919,7 @@ export class FxCoreDeclarativeAgentPart {
         ) {
           try {
             const { probeMCPServerAuth } = await import("../component/utils/mcpToolFetcher");
-            const authProbe = await probeMCPServerAuth(mcpServerUrl);
+            const authProbe = await probeMCPServerAuth(mcpServerUrl, getAbortSignal(inputs));
             if (authProbe.requiresAuth) {
               inputs[QuestionNames.MCPForDAAuth] = "OAuthPluginVault";
               if (authProbe.authMetadataUrl) {
@@ -931,7 +936,7 @@ export class FxCoreDeclarativeAgentPart {
         if ((!currentTools || currentTools.length === 0) && mcpServerUrl) {
           try {
             const { fetchMCPTools } = await import("../component/utils/mcpToolFetcher");
-            const result = await fetchMCPTools(mcpServerUrl);
+            const result = await fetchMCPTools(mcpServerUrl, getAbortSignal(inputs));
             if (!result.requiresAuth && result.tools.length > 0) {
               inputs[QuestionNames.MCPForDAAvailableTools] = result.tools;
               if (!inputs[QuestionNames.MCPForDAPreFetchTools]) {
@@ -972,6 +977,8 @@ export class FxCoreDeclarativeAgentPart {
             });
           }
         }
+
+        throwIfAborted(inputs);
 
         // If no tools available (auth required or fetch failed), skip creating plugin - just warn
         const mcpTools = inputs[QuestionNames.MCPForDAAvailableTools];
@@ -1219,7 +1226,6 @@ export class FxCoreDeclarativeAgentPart {
         mcpConfig = { servers: {} };
       }
     }
-
     // Ensure unique server entry name to avoid overwriting an existing one.
     let uniqueName = serverName;
     let suffix = 1;
@@ -1231,6 +1237,7 @@ export class FxCoreDeclarativeAgentPart {
       url: mcpServerUrl,
     };
 
+    throwIfAborted(inputs);
     await fs.ensureDir(mcpConfigDir);
     await fs.writeJSON(mcpConfigPath, mcpConfig, { spaces: 2 });
 

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -52,6 +52,7 @@ import { Container } from "typedi";
 import { pathToFileURL } from "url";
 import { teamsDevPortalClient } from "../client/teamsDevPortalClient";
 import { ApiKeyParameters, AuthParameters } from "../common/authInterface";
+import { throwIfAborted } from "../common/cancellation";
 import {
   AppStudioScopes,
   MosServiceScope,
@@ -231,7 +232,7 @@ export class FxCore extends FxCoreOpenPluginPart {
   }
 
   private getAbortSignal(inputs: Inputs): AbortSignal | undefined {
-    return inputs.abortSignal as AbortSignal | undefined;
+    return inputs.abortSignal;
   }
 
   /**
@@ -2388,6 +2389,7 @@ export class FxCore extends FxCoreOpenPluginPart {
       true,
       getLocalizedString("core.addSkill.continue")
     );
+    throwIfAborted(inputs);
     if (confirmRes.isErr()) {
       return err(confirmRes.error);
     } else if (confirmRes.value !== getLocalizedString("core.addSkill.continue")) {
@@ -2961,6 +2963,7 @@ export class FxCore extends FxCoreOpenPluginPart {
 
       // Update openapi spec
       const specParser = new SpecParser(apiSpecPath, getParserOptions(ProjectType.Copilot, true));
+      throwIfAborted(inputs);
       await specParser.addAuthScheme(authName, authType, authParameters);
 
       let authTypeScheme;

--- a/packages/fx-core/src/core/FxCoreClient.ts
+++ b/packages/fx-core/src/core/FxCoreClient.ts
@@ -20,7 +20,7 @@ import { teamsappMgr } from "../component/driver/teamsApp/teamsappMgr";
 import { PackageService } from "../component/m365/packageService";
 import { envUtil } from "../component/utils/envUtil";
 import { UserCancelError, assembleError } from "../error";
-import { UninstallInputs } from "../question";
+import { AddAuthActionInputs, AddPluginInputs, AddSkillInputs, UninstallInputs } from "../question";
 import { FxCore } from "./FxCore";
 
 /** Execution controls shared by every first-class fx-core client operation. */
@@ -70,104 +70,26 @@ export type FxCoreLaunchInfoResult = Record<string, unknown>;
 
 export type FxCoreProvisionInputs = InputsWithProjectPath & { env: string };
 
-interface FxCoreAddPluginBaseInputs extends InputsWithProjectPath {
-  "manifest-path": string;
-}
-
 /** Inputs for adding an OpenAPI or MCP action to an existing project. */
-export type FxCoreAddPluginInputs =
-  | (FxCoreAddPluginBaseInputs & {
-      "api-plugin-type": "api-spec";
-      "api-operation"?: string[];
-    } & (
-        | {
-            "openapi-spec-type": "enter-url" | "open-file";
-            "openapi-spec-location": string;
-          }
-        | {
-            "openapi-spec-type": "search-api";
-            "search-openapi-spec-query": string;
-            "select-openapi-spec": string;
-          }
-      ))
-  | (FxCoreAddPluginBaseInputs & {
-      "api-plugin-type": "mcp";
-      "mcp-da-server-url": string;
-      "mcp-tools-file-path"?: string;
-    } & (
-        | { "mcp-da-auth-type": "none" | "oauth-dynamic" }
-        | {
-            "mcp-da-auth-type": "entra-sso";
-            "mcp-da-client-id": string;
-          }
-        | {
-            "mcp-da-auth-type": "oauth";
-            "mcp-da-client-id": string;
-            "mcp-da-client-secret": string;
-            "mcp-da-scopes"?: string;
-          }
-      ));
-
-interface FxCoreAddSkillBaseInputs extends InputsWithProjectPath {
-  "manifest-path": string;
-  "expose-to-copilot"?: "yes" | "no";
-}
+export type FxCoreAddPluginInputs = AddPluginInputs &
+  InputsWithProjectPath & {
+    "manifest-path": string;
+    "api-plugin-type": "api-spec" | "mcp";
+  };
 
 /** Inputs for creating or importing an agent skill. */
-export type FxCoreAddSkillInputs = FxCoreAddSkillBaseInputs &
-  (
-    | {
-        "skill-name": string;
-        "skill-description": string;
-        "skill-source-type"?: "new";
-        "skill-from"?: never;
-        "skill-from-zip-file"?: never;
-      }
-    | {
-        "skill-from": string;
-        "skill-source-type"?: never;
-        "skill-name"?: never;
-        "skill-description"?: never;
-        "skill-from-zip-file"?: never;
-      }
-    | {
-        "skill-from-zip-file": string;
-        "skill-source-type": "existing";
-        "skill-name"?: never;
-        "skill-description"?: never;
-        "skill-from"?: never;
-      }
-  );
-
-interface FxCoreAddAuthBaseInputs extends InputsWithProjectPath {
-  "plugin-manifest-path": string;
-  "auth-name": string;
-  "openapi-spec-location"?: string;
-  "api-operation"?: string[];
-}
+export type FxCoreAddSkillInputs = AddSkillInputs &
+  InputsWithProjectPath & {
+    "manifest-path": string;
+    "expose-to-copilot"?: "yes" | "no";
+  };
 
 /** Inputs for adding an authentication configuration to a plugin. */
-export type FxCoreAddAuthActionInputs = FxCoreAddAuthBaseInputs &
-  (
-    | { "api-auth": "bearer-token" }
-    | {
-        "api-auth": "api-key";
-        "api-key-in": "header" | "query";
-        "api-key-name": string;
-      }
-    | {
-        "api-auth": "oauth";
-        "oauth-authorization-url": string;
-        "oauth-token-url": string;
-        "oauth-scope": string;
-        "oauth-refresh-url"?: string;
-        "oauth-pkce"?: "true" | "false";
-      }
-    | {
-        "api-auth": "microsoft-entra";
-        "oauth-scope": string;
-      }
-  );
+export type FxCoreAddAuthActionInputs = AddAuthActionInputs &
+  InputsWithProjectPath & {
+    "plugin-manifest-path": string;
+    "auth-name": string;
+  };
 
 /**
  * Stable, typed lifecycle boundary for in-process consumers.

--- a/packages/fx-core/src/core/FxCoreClient.ts
+++ b/packages/fx-core/src/core/FxCoreClient.ts
@@ -3,6 +3,7 @@
 
 import {
   FxError,
+  Inputs,
   InputsWithProjectPath,
   Result,
   TeamsAppInputs,
@@ -69,6 +70,105 @@ export type FxCoreLaunchInfoResult = Record<string, unknown>;
 
 export type FxCoreProvisionInputs = InputsWithProjectPath & { env: string };
 
+interface FxCoreAddPluginBaseInputs extends InputsWithProjectPath {
+  "manifest-path": string;
+}
+
+/** Inputs for adding an OpenAPI or MCP action to an existing project. */
+export type FxCoreAddPluginInputs =
+  | (FxCoreAddPluginBaseInputs & {
+      "api-plugin-type": "api-spec";
+      "api-operation"?: string[];
+    } & (
+        | {
+            "openapi-spec-type": "enter-url" | "open-file";
+            "openapi-spec-location": string;
+          }
+        | {
+            "openapi-spec-type": "search-api";
+            "search-openapi-spec-query": string;
+            "select-openapi-spec": string;
+          }
+      ))
+  | (FxCoreAddPluginBaseInputs & {
+      "api-plugin-type": "mcp";
+      "mcp-da-server-url": string;
+      "mcp-tools-file-path"?: string;
+    } & (
+        | { "mcp-da-auth-type": "none" | "oauth-dynamic" }
+        | {
+            "mcp-da-auth-type": "entra-sso";
+            "mcp-da-client-id": string;
+          }
+        | {
+            "mcp-da-auth-type": "oauth";
+            "mcp-da-client-id": string;
+            "mcp-da-client-secret": string;
+            "mcp-da-scopes"?: string;
+          }
+      ));
+
+interface FxCoreAddSkillBaseInputs extends InputsWithProjectPath {
+  "manifest-path": string;
+  "expose-to-copilot"?: "yes" | "no";
+}
+
+/** Inputs for creating or importing an agent skill. */
+export type FxCoreAddSkillInputs = FxCoreAddSkillBaseInputs &
+  (
+    | {
+        "skill-name": string;
+        "skill-description": string;
+        "skill-source-type"?: "new";
+        "skill-from"?: never;
+        "skill-from-zip-file"?: never;
+      }
+    | {
+        "skill-from": string;
+        "skill-source-type"?: never;
+        "skill-name"?: never;
+        "skill-description"?: never;
+        "skill-from-zip-file"?: never;
+      }
+    | {
+        "skill-from-zip-file": string;
+        "skill-source-type": "existing";
+        "skill-name"?: never;
+        "skill-description"?: never;
+        "skill-from"?: never;
+      }
+  );
+
+interface FxCoreAddAuthBaseInputs extends InputsWithProjectPath {
+  "plugin-manifest-path": string;
+  "auth-name": string;
+  "openapi-spec-location"?: string;
+  "api-operation"?: string[];
+}
+
+/** Inputs for adding an authentication configuration to a plugin. */
+export type FxCoreAddAuthActionInputs = FxCoreAddAuthBaseInputs &
+  (
+    | { "api-auth": "bearer-token" }
+    | {
+        "api-auth": "api-key";
+        "api-key-in": "header" | "query";
+        "api-key-name": string;
+      }
+    | {
+        "api-auth": "oauth";
+        "oauth-authorization-url": string;
+        "oauth-token-url": string;
+        "oauth-scope": string;
+        "oauth-refresh-url"?: string;
+        "oauth-pkce"?: "true" | "false";
+      }
+    | {
+        "api-auth": "microsoft-entra";
+        "oauth-scope": string;
+      }
+  );
+
 /**
  * Stable, typed lifecycle boundary for in-process consumers.
  *
@@ -76,6 +176,18 @@ export type FxCoreProvisionInputs = InputsWithProjectPath & { env: string };
  * are successful domain outcomes from validate(), with valid set to false.
  */
 export interface IFxCoreClient {
+  addPlugin(
+    inputs: FxCoreAddPluginInputs,
+    options?: FxCoreExecutionOptions
+  ): Promise<Result<undefined, FxError>>;
+  addSkill(
+    inputs: FxCoreAddSkillInputs,
+    options?: FxCoreExecutionOptions
+  ): Promise<Result<undefined, FxError>>;
+  addAuthAction(
+    inputs: FxCoreAddAuthActionInputs,
+    options?: FxCoreExecutionOptions
+  ): Promise<Result<undefined, FxError>>;
   provision(
     inputs: FxCoreProvisionInputs,
     options?: FxCoreExecutionOptions
@@ -108,6 +220,27 @@ export class FxCoreClient implements IFxCoreClient {
 
   public constructor(private readonly tools: Tools) {
     this.core = new FxCore(tools);
+  }
+
+  public async addPlugin(
+    inputs: FxCoreAddPluginInputs,
+    options?: FxCoreExecutionOptions
+  ): Promise<Result<undefined, FxError>> {
+    return this.runAdd(inputs, options, (clientInputs) => this.core.addPlugin(clientInputs));
+  }
+
+  public async addSkill(
+    inputs: FxCoreAddSkillInputs,
+    options?: FxCoreExecutionOptions
+  ): Promise<Result<undefined, FxError>> {
+    return this.runAdd(inputs, options, (clientInputs) => this.core.addSkill(clientInputs));
+  }
+
+  public async addAuthAction(
+    inputs: FxCoreAddAuthActionInputs,
+    options?: FxCoreExecutionOptions
+  ): Promise<Result<undefined, FxError>> {
+    return this.runAdd(inputs, options, (clientInputs) => this.core.addAuthAction(clientInputs));
   }
 
   public async provision(
@@ -238,6 +371,18 @@ export class FxCoreClient implements IFxCoreClient {
 
   private withSignal<T extends Record<string, unknown>>(inputs: T, signal?: AbortSignal): T {
     return { ...inputs, abortSignal: signal };
+  }
+
+  private async runAdd<TInputs extends Inputs, TResult>(
+    inputs: TInputs,
+    options: FxCoreExecutionOptions | undefined,
+    operation: (clientInputs: TInputs) => Promise<Result<TResult, FxError>>
+  ): Promise<Result<undefined, FxError>> {
+    const cancelled = this.cancelled<undefined>(options?.signal);
+    if (cancelled) return cancelled;
+    const result = await operation(this.withSignal(inputs, options?.signal));
+    if (result.isErr()) return err(result.error);
+    return ok(undefined);
   }
 
   private cancelled<T>(signal?: AbortSignal): Result<T, FxError> | undefined {

--- a/packages/fx-core/tests/component/utils/mcpToolFetcher.test.ts
+++ b/packages/fx-core/tests/component/utils/mcpToolFetcher.test.ts
@@ -59,6 +59,15 @@ describe("mcpToolFetcher", () => {
   });
 
   describe("fetchMCPTools", () => {
+    it("should forward the abort signal to the initial request", async () => {
+      const getStub = vi.spyOn(axios, "get").mockResolvedValue({ status: 200 });
+      const controller = new AbortController();
+
+      await fetchMCPTools("https://example.com/mcp", controller.signal);
+
+      assert.strictEqual(getStub.mock.calls[0][1]?.signal, controller.signal);
+    });
+
     it("should return requiresAuth=true when server returns 401", async () => {
       vi.spyOn(axios, "get").mockRejectedValue({
         response: {
@@ -275,6 +284,18 @@ describe("mcpToolFetcher", () => {
   });
 
   describe("probeMCPServerAuth", () => {
+    it("should forward the abort signal to the initialize request", async () => {
+      const postStub = vi.spyOn(axios, "post").mockResolvedValue({
+        status: 200,
+        data: { jsonrpc: "2.0", id: 1, result: {} },
+      });
+      const controller = new AbortController();
+
+      await probeMCPServerAuth("https://example.com/mcp", controller.signal);
+
+      assert.strictEqual(postStub.mock.calls[0][2]?.signal, controller.signal);
+    });
+
     it("should confirm the endpoint when a 200 carries a JSON-RPC envelope", async () => {
       vi.spyOn(axios, "post").mockResolvedValue({
         status: 200,

--- a/packages/fx-core/tests/core/FxCoreClient.test.ts
+++ b/packages/fx-core/tests/core/FxCoreClient.test.ts
@@ -16,6 +16,134 @@ describe("FxCoreClient", () => {
     vi.restoreAllMocks();
   });
 
+  it("addOperations_PreAbortedSignal_DoNotInvokeEngine", async () => {
+    const addPluginSpy = vi.spyOn(FxCore.prototype, "addPlugin");
+    const addSkillSpy = vi.spyOn(FxCore.prototype, "addSkill");
+    const addAuthActionSpy = vi.spyOn(FxCore.prototype, "addAuthAction");
+    const controller = new AbortController();
+    controller.abort();
+    const client = new FxCoreClient(new MockTools());
+    const addPluginInputs = {
+      platform: Platform.CLI,
+      projectPath: "project",
+      "manifest-path": "project/appPackage/manifest.json",
+      "api-plugin-type": "api-spec" as const,
+      "openapi-spec-type": "open-file" as const,
+      "openapi-spec-location": "openapi.yaml",
+    };
+    const addSkillInputs = {
+      platform: Platform.CLI,
+      projectPath: "project",
+      "manifest-path": "project/appPackage/manifest.json",
+      "skill-name": "weather",
+      "skill-description": "Weather instructions",
+    };
+    const addAuthInputs = {
+      platform: Platform.CLI,
+      projectPath: "project",
+      "plugin-manifest-path": "project/appPackage/ai-plugin.json",
+      "auth-name": "apiAuth",
+      "api-auth": "bearer-token" as const,
+    };
+
+    const results = await Promise.all([
+      client.addPlugin(addPluginInputs, { signal: controller.signal }),
+      client.addSkill(addSkillInputs, { signal: controller.signal }),
+      client.addAuthAction(addAuthInputs, { signal: controller.signal }),
+    ]);
+
+    results.forEach((result) => {
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.name).toBe("UserCancel");
+    });
+    expect(addPluginSpy).not.toHaveBeenCalled();
+    expect(addSkillSpy).not.toHaveBeenCalled();
+    expect(addAuthActionSpy).not.toHaveBeenCalled();
+  });
+
+  it("addOperations_ActiveSignal_IsForwardedToEveryEngineInput", async () => {
+    const addPluginSpy = vi.spyOn(FxCore.prototype, "addPlugin").mockResolvedValue(ok(undefined));
+    const addSkillSpy = vi.spyOn(FxCore.prototype, "addSkill").mockResolvedValue(ok(undefined));
+    const addAuthActionSpy = vi
+      .spyOn(FxCore.prototype, "addAuthAction")
+      .mockResolvedValue(ok(undefined));
+    const controller = new AbortController();
+    const client = new FxCoreClient(new MockTools());
+    const addPluginInputs = {
+      platform: Platform.CLI,
+      projectPath: "project",
+      "manifest-path": "project/appPackage/manifest.json",
+      "api-plugin-type": "api-spec" as const,
+      "openapi-spec-type": "open-file" as const,
+      "openapi-spec-location": "openapi.yaml",
+    };
+    const addSkillInputs = {
+      platform: Platform.CLI,
+      projectPath: "project",
+      "manifest-path": "project/appPackage/manifest.json",
+      "skill-from": "skills/weather",
+    };
+    const addAuthInputs = {
+      platform: Platform.CLI,
+      projectPath: "project",
+      "plugin-manifest-path": "project/appPackage/ai-plugin.json",
+      "auth-name": "apiAuth",
+      "api-auth": "api-key" as const,
+      "api-key-in": "header" as const,
+      "api-key-name": "x-api-key",
+    };
+
+    const results = await Promise.all([
+      client.addPlugin(addPluginInputs, { signal: controller.signal }),
+      client.addSkill(addSkillInputs, { signal: controller.signal }),
+      client.addAuthAction(addAuthInputs, { signal: controller.signal }),
+    ]);
+
+    results.forEach((result) => expect(result.isOk()).toBe(true));
+    [addPluginSpy, addSkillSpy, addAuthActionSpy].forEach((spy) => {
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: controller.signal }));
+    });
+  });
+
+  it("addPlugin_AbortedAfterCommitStarts_ReturnsEngineResult", async () => {
+    const controller = new AbortController();
+    vi.spyOn(FxCore.prototype, "addPlugin").mockImplementation(async () => {
+      controller.abort();
+      return ok(undefined);
+    });
+    const client = new FxCoreClient(new MockTools());
+
+    const result = await client.addPlugin(
+      {
+        platform: Platform.CLI,
+        projectPath: "project",
+        "manifest-path": "project/appPackage/manifest.json",
+        "api-plugin-type": "api-spec",
+        "openapi-spec-type": "open-file",
+        "openapi-spec-location": "openapi.yaml",
+      },
+      { signal: controller.signal }
+    );
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("addAuthAction_EngineFailure_ReturnsOriginalError", async () => {
+    const expectedError = new UserCancelError("test");
+    vi.spyOn(FxCore.prototype, "addAuthAction").mockResolvedValue(err(expectedError));
+    const client = new FxCoreClient(new MockTools());
+
+    const result = await client.addAuthAction({
+      platform: Platform.CLI,
+      projectPath: "project",
+      "plugin-manifest-path": "project/appPackage/ai-plugin.json",
+      "auth-name": "apiAuth",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error).toBe(expectedError);
+  });
+
   it("provision_PreAbortedSignal_DoesNotInvokeEngine", async () => {
     const provisionSpy = vi.spyOn(FxCore.prototype, "provisionResources");
     const controller = new AbortController();


### PR DESCRIPTION
## Summary

Adds typed, cancellable authoring operations to `FxCoreClient` so in-process consumers can add actions, skills, and authentication without constructing untyped `Inputs` dictionaries or calling the legacy `FxCore` surface directly.

## Changes

- Adds typed `FxCoreClient` methods:
  - `addPlugin()`
  - `addSkill()`
  - `addAuthAction()`
- Exports corresponding input contracts derived from the existing generated question input types:
  - `FxCoreAddPluginInputs`
  - `FxCoreAddSkillInputs`
  - `FxCoreAddAuthActionInputs`
- Supports cancellation through `FxCoreExecutionOptions.signal`.
- Returns `UserCancel` immediately when an operation receives an already-aborted signal.
- Propagates active abort signals through question traversal and MCP HTTP operations.
- Checks cancellation at safe pre-mutation boundaries to avoid leaving partially written project configuration.
- Preserves successful engine results once a mutation has started instead of converting completed work into cancellation.
- Keeps the shared `@microsoft/teamsfx-api` `Inputs` contract unchanged.
- Adds tests covering input forwarding, cancellation, engine errors, and MCP signal propagation.

## Compatibility

This is an additive change:

- Existing `FxCore` methods remain unchanged.
- Existing `FxCoreClient` lifecycle APIs remain unchanged.
- Consumers that do not provide an `AbortSignal` retain the existing behavior.

## Validation

- Focused `FxCoreClient` unit tests: **18 passed**
- TypeScript compilation: **passed**
- Repository unit-test workflow: **passed**
- Formatting checks: **passed**
