### PR TITLE
fix(vscuse): provide fake OpenAI API key

### DIFF
--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -203,6 +203,7 @@ jobs:
       # same fake key the existing UI tests use. Cases using this path must not
       # assert a real model completion.
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'fake' }}
+      FAKE_OPENAI_API_KEY: "faked_openapi_key"
 
       # SQL server
       SQL_USER: ${{ secrets.SQL_USER }}


### PR DESCRIPTION
## Summary
- provide the non-secret `FAKE_OPENAI_API_KEY` compatibility value to vscuse workflow jobs
- unblock generated OpenAI cases that reference `${{secret:FAKE_OPENAI_API_KEY}}`

## Validation
- `pnpm exec prettier --check ".github/workflows/ui-test-vscuse-common.yml"`
- `git diff --check`
- verified the failing plan's required variable is present in the shared workflow environment