### PR TITLE
feat: enable RAI validation for builder API

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -898,6 +898,8 @@
   "error.teamsApp.createAppPackage.invalidFile": "%s is invalid, it should be in the same directory as manifest.json or a subdirectory of it.",
   "error.teamsApp.createAppPackage.packageSizeExceeded": "The generated app package (%s MB) exceeds the maximum allowed size of %s MB. Reduce the package contents before building.",
   "error.m365.packageService.packageSizeExceeded": "The app package (%s MB) exceeds the maximum supported size (%s MB). Reduce the package contents before uploading.",
+  "error.m365.packageService.validationFailed": "The app package failed RAI validation. Resolve the following issues and try again:\n%s",
+  "info.m365.packageService.raiValidationInProgress": "RAI validation is in progress. Waiting for completion...",
   "driver.botFramework.description": "creates or updates the bot registration on dev.botframework.com",
   "driver.botFramework.summary.create": "The bot registration has been created successfully (%s).",
   "driver.botFramework.summary.update": "The bot registration has been updated successfully (%s).",

--- a/packages/fx-core/src/common/treatmentVariables.ts
+++ b/packages/fx-core/src/common/treatmentVariables.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export const TreatmentVariables = {
+  VSCodeConfig: "vscode",
+  RaiValidation: "RaiValidation",
+} as const;

--- a/packages/fx-core/src/component/m365/errors.ts
+++ b/packages/fx-core/src/component/m365/errors.ts
@@ -17,3 +17,23 @@ export class NotExtendedToM365Error extends UserError {
     });
   }
 }
+
+export interface PackageValidationFailureReason {
+  errorCode: string;
+  errorDetail: string;
+}
+
+export class PackageValidationFailedError extends UserError {
+  constructor(source: string, failureReasons: PackageValidationFailureReason[]) {
+    const reasons = failureReasons
+      .map(({ errorCode, errorDetail }) => `${errorCode}: ${errorDetail}`)
+      .join("\n");
+    super({
+      source,
+      name: "PackageValidationFailed",
+      message: getDefaultString("error.m365.packageService.validationFailed", reasons),
+      displayMessage: getLocalizedString("error.m365.packageService.validationFailed", reasons),
+      helpLink: M365HelpLink,
+    });
+  }
+}

--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -279,11 +279,11 @@ export class PackageService {
       if (!statusId) {
         throw new Error("Missing statusId in package upload response.");
       }
-      this.logger?.debug(`Acquiring package with statusId: ${statusId as string} ...`);
+      this.logger?.debug(`Acquiring package with statusId: ${statusId} ...`);
 
       do {
         const statusResponse = await this.axiosInstance.get(
-          `/builder/v1/users/packages/status/${statusId as string}`,
+          `/builder/v1/users/packages/status/${statusId}`,
           {
             baseURL: serviceUrl,
             headers: { Authorization: `Bearer ${token}` },

--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -20,6 +20,7 @@ import stripBom from "strip-bom";
 import { getResourceServiceEndpoint, ResourceServiceType } from "../../common/constants";
 import { ErrorContextMW, TOOLS } from "../../common/globalVars";
 import { getDefaultString, getLocalizedString } from "../../common/localizeUtils";
+import { TreatmentVariables } from "../../common/treatmentVariables";
 import {
   Component,
   sendTelemetryErrorEvent,
@@ -33,7 +34,11 @@ import { assembleError } from "../../error/common";
 import { ErrorCategory } from "../../error/types";
 import { AppUser } from "../driver/teamsApp/interfaces/appdefinitions/appUser";
 import { advancedDASettingUrl, M365HelpLink } from "./constants";
-import { NotExtendedToM365Error } from "./errors";
+import {
+  NotExtendedToM365Error,
+  PackageValidationFailedError,
+  PackageValidationFailureReason,
+} from "./errors";
 import { M365AppDefinition, M365AppEntity } from "./interface";
 
 const M365ErrorSource = "M365";
@@ -53,6 +58,26 @@ export const AgentPermission = {
   owner: "Owner",
   type: "M365",
 };
+
+enum BuilderValidationStatus {
+  Pending = "pending",
+  Successful = "successful",
+  Failed = "failed",
+}
+
+interface BuilderPackageUploadResponse {
+  statusId?: string;
+}
+
+interface BuilderPackageStatusResponse {
+  titleId?: string;
+  appId?: string;
+  validationInfo?: {
+    completedDate?: string;
+    failureReasons?: PackageValidationFailureReason[];
+    status: BuilderValidationStatus;
+  };
+}
 
 // Call m365 service for package CRUD
 export class PackageService {
@@ -230,27 +255,30 @@ export class PackageService {
       this.logger?.debug(`"Uploading package with sideLoading V2 in ${appScope} scope ..."`);
       const uploadHeaders = content.getHeaders();
       uploadHeaders["Authorization"] = `Bearer ${token}`;
+      const forceRaiValidationEnabled = process.env.TEAMSFX_RAI_VALIDATION_ENABLED;
+      const isRaiValidationEnabled =
+        forceRaiValidationEnabled === undefined
+          ? ((await TOOLS.expServiceProvider?.getTreatmentVariableAsync<boolean>(
+              TreatmentVariables.VSCodeConfig,
+              TreatmentVariables.RaiValidation,
+              true
+            )) ?? false)
+          : forceRaiValidationEnabled === "true" || forceRaiValidationEnabled === "1";
       const uploadResponse = await this.withNetworkRetry(() =>
         this.axiosInstance.post("/builder/v1/users/packages", content, {
           baseURL: serviceUrl,
           headers: uploadHeaders,
           params: {
             scope: appScope,
-            shouldBlock: true,
+            ...(isRaiValidationEnabled && { isRAIValidationAsync: true }),
           },
         })
       );
 
-      if (uploadResponse.status === 200 || uploadResponse.status === 201) {
-        const titleId: string = uploadResponse.data.titlePreview.titleId;
-        const appId: string = uploadResponse.data.titlePreview.appId;
-        this.logger?.info(`TitleId: ${titleId}`);
-        this.logger?.info(`AppId: ${appId}`);
-        this.logger?.verbose("Sideloading done.");
-        return [titleId, appId];
+      const { statusId } = uploadResponse.data as BuilderPackageUploadResponse;
+      if (!statusId) {
+        throw new Error("Missing statusId in package upload response.");
       }
-
-      const statusId = uploadResponse.data.statusId;
       this.logger?.debug(`Acquiring package with statusId: ${statusId as string} ...`);
 
       do {
@@ -259,20 +287,60 @@ export class PackageService {
           {
             baseURL: serviceUrl,
             headers: { Authorization: `Bearer ${token}` },
+            ...(isRaiValidationEnabled && { params: { isRAIValidationAsync: true } }),
           }
         );
         const resCode = statusResponse.status;
         this.logger?.debug(`Package status: ${resCode} ...`);
-        if (resCode === 200) {
-          const titleId: string = statusResponse.data.titleId;
-          const appId: string = statusResponse.data.appId;
+
+        if (!isRaiValidationEnabled) {
+          if (resCode === 200) {
+            const titleId: string = statusResponse.data.titleId;
+            const appId: string = statusResponse.data.appId;
+            this.logger?.info(`TitleId: ${titleId}`);
+            this.logger?.info(`AppId: ${appId}`);
+            this.logger?.verbose("Sideloading done.");
+            return [titleId, appId];
+          }
+          await waitSeconds(7);
+          continue;
+        }
+
+        const statusResult = statusResponse.data as BuilderPackageStatusResponse;
+        const validationInfo = statusResult?.validationInfo;
+        if (
+          !validationInfo ||
+          (validationInfo.status === BuilderValidationStatus.Pending &&
+            (resCode === 202 || resCode === 200))
+        ) {
+          this.logger?.info(getLocalizedString("info.m365.packageService.raiValidationInProgress"));
+          await waitSeconds(7);
+          continue;
+        }
+
+        if (resCode === 200 && validationInfo?.status === BuilderValidationStatus.Successful) {
+          const { titleId, appId } = statusResult;
+          if (!titleId || !appId) {
+            throw new Error("Missing titleId or appId in successful package status response.");
+          }
           this.logger?.info(`TitleId: ${titleId}`);
           this.logger?.info(`AppId: ${appId}`);
           this.logger?.verbose("Sideloading done.");
           return [titleId, appId];
-        } else {
-          await waitSeconds(7);
         }
+
+        if (resCode === 200 && validationInfo?.status === BuilderValidationStatus.Failed) {
+          const validationError = new PackageValidationFailedError(
+            M365ErrorSource,
+            validationInfo.failureReasons ?? []
+          );
+          this.logger?.error(validationError.displayMessage ?? validationError.message);
+          throw validationError;
+        }
+
+        throw new Error(
+          `Unexpected package status response: HTTP ${resCode}, validation status ${validationInfo?.status}.`
+        );
       } while (true);
     } catch (error: any) {
       if (error.response) {

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -353,6 +353,7 @@ describe("Package Service", () => {
       data: {
         titleId: "test-title-id-builder-api",
         appId: "test-app-id-builder-api",
+        validationInfo: { status: "successful", completedDate: "2026-08-06T20:53:30.5267304Z" },
       },
     };
     axiosGetResponses["/marketplace/v1/users/titles/test-title-id-builder-api/sharingInfo"] = {
@@ -482,12 +483,11 @@ describe("Package Service", () => {
     };
     axiosPostResponses["/builder/v1/users/packages"] = {
       status: 200,
-      data: {
-        titlePreview: {
-          titleId: "test-title-id",
-          appId: "test-app-id",
-        },
-      },
+      data: { statusId: "test-status-id-builder-api" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: { titleId: "test-title-id", appId: "test-app-id" },
     };
 
     const postStub = vi.spyOn(testAxiosInstance, "post");
@@ -505,13 +505,12 @@ describe("Package Service", () => {
     chai.assert.isDefined(builderRequest);
     chai.assert.deepEqual(builderRequest?.[2]?.params, {
       scope: AppScope.Tenant,
-      shouldBlock: true,
     });
     chai.assert.equal(builderRequest?.[2]?.headers?.Authorization, "Bearer test-token");
     chai.assert.isFalse(postStub.mock.calls.some(([url]) => url === "/dev/v1/users/packages"));
   });
 
-  it("sideLoadingV2 returns immediately when shouldBlock response is 200", async () => {
+  it("sideLoadingV2 polls status after a 200 upload response", async () => {
     axiosGetResponses["/config/v1/environment"] = {
       data: {
         titlesServiceUrl: "https://test-url",
@@ -519,12 +518,11 @@ describe("Package Service", () => {
     };
     axiosPostResponses["/builder/v1/users/packages"] = {
       status: 200,
-      data: {
-        titlePreview: {
-          titleId: "test-title-id-blocked",
-          appId: "test-app-id-blocked",
-        },
-      },
+      data: { statusId: "test-status-id-blocked" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-blocked"] = {
+      status: 200,
+      data: { titleId: "test-title-id-blocked", appId: "test-app-id-blocked" },
     };
 
     const packageService = new PackageService("https://test-endpoint", logger);
@@ -548,7 +546,7 @@ describe("Package Service", () => {
     expect(verboseStub).toHaveBeenCalledWith("Sideloading done.");
   });
 
-  it("sideLoadingV2 returns immediately when shouldBlock response is 201", async () => {
+  it("sideLoadingV2 polls status after a 201 upload response", async () => {
     axiosGetResponses["/config/v1/environment"] = {
       data: {
         titlesServiceUrl: "https://test-url",
@@ -556,12 +554,11 @@ describe("Package Service", () => {
     };
     axiosPostResponses["/builder/v1/users/packages"] = {
       status: 201,
-      data: {
-        titlePreview: {
-          titleId: "test-title-id-created",
-          appId: "test-app-id-created",
-        },
-      },
+      data: { statusId: "test-status-id-created" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-created"] = {
+      status: 200,
+      data: { titleId: "test-title-id-created", appId: "test-app-id-created" },
     };
 
     const packageService = new PackageService("https://test-endpoint", logger);
@@ -580,36 +577,43 @@ describe("Package Service", () => {
     chai.assert.equal(result[1], "test-app-id-created");
   });
 
-  it("sideload builder status api with 202 on first try and 200 on second try", async () => {
-    axiosPostResponses["/builder/v1/users/packages"] = {
-      data: {
-        statusId: "test-status-id-builder-api",
-        titlePreview: {
-          titleId: "test-title-id-preview-builder-api",
-        },
+  it("waits for RAI validation after upload", async () => {
+    setTools({
+      expServiceProvider: {
+        getTreatmentVariableAsync: vi.fn().mockResolvedValue(true),
       },
+    } as any);
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      status: 200,
+      data: { statusId: "test-status-id-builder-api" },
     };
     let statusCallCount = 0;
-    vi.spyOn(testAxiosInstance, "get").mockImplementation((url: string): any => {
+    const getStub = vi.spyOn(testAxiosInstance, "get").mockImplementation((url: string): any => {
       if (url === "/builder/v1/users/packages/status/test-status-id-builder-api") {
         statusCallCount++;
         if (statusCallCount === 1) {
-          return Promise.resolve({ status: 202 });
+          return Promise.resolve({
+            status: 202,
+            data: { validationInfo: { status: "pending" } },
+          });
+        }
+        if (statusCallCount === 2) {
+          return Promise.resolve({
+            status: 200,
+            data: { validationInfo: { status: "pending" } },
+          });
         }
         return Promise.resolve({
           status: 200,
           data: {
             titleId: "test-title-id-builder-api",
             appId: "test-app-id-builder-api",
+            validationInfo: { status: "successful", completedDate: "2026-08-06T20:53:30.5267304Z" },
           },
         });
       }
       if (url === "/config/v1/environment") {
-        return Promise.resolve({
-          data: {
-            titlesServiceUrl: "https://test-url",
-          },
-        });
+        return Promise.resolve({ data: { titlesServiceUrl: "https://test-url" } });
       }
       return Promise.resolve({});
     });
@@ -617,27 +621,69 @@ describe("Package Service", () => {
     const packageService = new PackageService("https://test-endpoint", logger);
     vi.spyOn(packageService, "getManifestFromZip" as keyof PackageService).mockReturnValue({
       copilotAgents: {
-        declarativeAgents: [
-          {
-            id: "declarativeAgent",
-            file: "declarativeAgent.json",
-          },
-        ],
+        declarativeAgents: [{ id: "declarativeAgent", file: "declarativeAgent.json" }],
       },
     } as any);
-    let actualError: Error | undefined;
-    try {
-      const result = await packageService.sideLoading("test-token", "test-path");
-      chai.assert.equal(result[0], "test-title-id-builder-api");
-      chai.assert.equal(result[1], "test-app-id-builder-api");
-    } catch (error: any) {
-      actualError = error;
-    }
 
-    chai.assert.isUndefined(actualError);
+    const result = await packageService.sideLoading("test-token", "test-path");
+
+    chai.assert.deepEqual(result, ["test-title-id-builder-api", "test-app-id-builder-api", ""]);
+    chai.assert.equal(statusCallCount, 3);
+    const statusRequest = getStub.mock.calls.find(
+      ([url]) => url === "/builder/v1/users/packages/status/test-status-id-builder-api"
+    );
+    expect(statusRequest?.[1]?.params).toEqual({ isRAIValidationAsync: true });
+    expect(vi.mocked(commonUtils.waitSeconds)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(commonUtils.waitSeconds)).toHaveBeenCalledWith(7);
+  });
+
+  it("surfaces RAI validation failure reasons", async () => {
+    setTools({
+      expServiceProvider: {
+        getTreatmentVariableAsync: vi.fn().mockResolvedValue(true),
+      },
+    } as any);
+    axiosGetResponses["/config/v1/environment"] = {
+      data: { titlesServiceUrl: "https://test-url" },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      status: 200,
+      data: { statusId: "test-status-id-builder-api" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: {
+        validationInfo: {
+          status: "failed",
+          failureReasons: [
+            {
+              errorCode: "RAIViolation",
+              errorDetail: "Detected offensive content in agent description.",
+            },
+          ],
+        },
+      },
+    };
+    const errorStub = vi.spyOn(logger, "error").mockReturnValue();
+    const packageService = new PackageService("https://test-endpoint", logger);
+    await expect(
+      packageService.sideLoadingV2("test-token", "test-path", AppScope.Personal)
+    ).rejects.toMatchObject({
+      name: "PackageValidationFailed",
+      message: expect.stringContaining("RAIViolation"),
+      displayMessage: expect.stringContaining("Detected offensive content in agent description."),
+    });
+    expect(errorStub).toHaveBeenCalledWith(
+      expect.stringContaining("Resolve the following issues and try again")
+    );
+    expect(errorStub).toHaveBeenCalledWith(expect.stringContaining("RAIViolation"));
+    expect(errorStub).toHaveBeenCalledWith(
+      expect.stringContaining("Detected offensive content in agent description.")
+    );
   });
 
   it("sideloading throws error in get status", async () => {
+    setTools({} as any);
     axiosGetResponses["/config/v1/environment"] = {
       data: {
         titlesServiceUrl: "https://test-url",
@@ -645,11 +691,9 @@ describe("Package Service", () => {
     };
 
     axiosPostResponses["/builder/v1/users/packages"] = {
+      status: 202,
       data: {
         statusId: "test-status-id-builder-api",
-        titlePreview: {
-          titleId: "test-title-id-preview-builder-api",
-        },
       },
     };
     let actualError: Error | undefined;
@@ -671,6 +715,7 @@ describe("Package Service", () => {
     }
     chai.assert.isDefined(actualError);
 
+    setTools({} as any);
     const expectedError = new Error("test-status") as any;
     expectedError.response = {
       data: {
@@ -1929,9 +1974,13 @@ describe("Package Service", () => {
 
   it("withNetworkRetry works for sideLoadingV2 upload", async () => {
     let postCallCount = 0;
-    vi.spyOn(testAxiosInstance, "get").mockImplementation(() => {
+    vi.spyOn(testAxiosInstance, "get").mockImplementation((url: string) => {
+      if (url === "/config/v1/environment") {
+        return Promise.resolve({ data: { titlesServiceUrl: "https://test-url" } });
+      }
       return Promise.resolve({
-        data: { titlesServiceUrl: "https://test-url" },
+        status: 200,
+        data: { titleId: "retry-title-id", appId: "retry-app-id" },
       });
     });
     vi.spyOn(testAxiosInstance, "post").mockImplementation((url: string) => {
@@ -1944,12 +1993,7 @@ describe("Package Service", () => {
         }
         return Promise.resolve({
           status: 200,
-          data: {
-            titlePreview: {
-              titleId: "retry-title-id",
-              appId: "retry-app-id",
-            },
-          },
+          data: { statusId: "retry-status-id" },
         });
       }
       return Promise.reject(new Error("unexpected url"));
@@ -1982,6 +2026,12 @@ describe("Package Service", () => {
           data: { titlesServiceUrl: "https://test-url" },
         });
       }
+      if (url === "/builder/v1/users/packages/status/retry-builder-status-id") {
+        return Promise.resolve({
+          status: 200,
+          data: { titleId: "retry-builder-title-id", appId: "retry-builder-app-id" },
+        });
+      }
       return Promise.reject(new Error("unexpected get url"));
     });
     vi.spyOn(testAxiosInstance, "post").mockImplementation((url: string) => {
@@ -1994,12 +2044,7 @@ describe("Package Service", () => {
         }
         return Promise.resolve({
           status: 200,
-          data: {
-            titlePreview: {
-              titleId: "retry-builder-title-id",
-              appId: "retry-builder-app-id",
-            },
-          },
+          data: { statusId: "retry-builder-status-id" },
         });
       }
       return Promise.reject(new Error("unexpected url"));
@@ -2083,12 +2128,12 @@ describe("Package Service", () => {
     };
     axiosPostResponses["/builder/v1/users/packages"] = {
       status: 201,
-      data: {
-        titlePreview: {
-          titleId: "test-title-id",
-          appId: "test-app-id",
-        },
-      },
+      data: { statusId: "test-status-id-builder-api" },
+    };
+
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: { titleId: "test-title-id", appId: "test-app-id" },
     };
 
     const packageService = new PackageService("https://test-endpoint", logger);
@@ -2106,12 +2151,11 @@ describe("Package Service", () => {
     };
     axiosPostResponses["/builder/v1/users/packages"] = {
       status: 201,
-      data: {
-        titlePreview: {
-          titleId: "test-title-id",
-          appId: "test-app-id",
-        },
-      },
+      data: { statusId: "test-status-id-builder-api" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: { titleId: "test-title-id", appId: "test-app-id" },
     };
     axiosGetResponses["/marketplace/v1/users/titles/test-title-id/sharingInfo"] = {
       status: 200,
@@ -2135,12 +2179,12 @@ describe("Package Service", () => {
     };
     axiosPostResponses["/builder/v1/users/packages"] = {
       status: 201,
-      data: {
-        titlePreview: {
-          titleId: "test-title-id",
-          appId: "test-app-id",
-        },
-      },
+      data: { statusId: "test-status-id-builder-api" },
+    };
+
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: { titleId: "test-title-id", appId: "test-app-id" },
     };
 
     const packageService = new PackageService("https://test-endpoint", logger);
@@ -2158,12 +2202,12 @@ describe("Package Service", () => {
     };
     axiosPostResponses["/builder/v1/users/packages"] = {
       status: 201,
-      data: {
-        titlePreview: {
-          titleId: "test-title-id",
-          appId: "test-app-id",
-        },
-      },
+      data: { statusId: "test-status-id-builder-api" },
+    };
+
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: { titleId: "test-title-id", appId: "test-app-id" },
     };
 
     const packageService = new PackageService("https://test-endpoint", logger);

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -66,6 +66,8 @@ describe("Package Service", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete process.env.TEAMSFX_RAI_VALIDATION_ENABLED;
+    delete process.env.TEAMSFX_RAI_VALIDATION_FORCE_FAILED;
   });
 
   beforeEach(() => {
@@ -637,6 +639,77 @@ describe("Package Service", () => {
     expect(vi.mocked(commonUtils.waitSeconds)).toHaveBeenCalledWith(7);
   });
 
+  it("uses environment override to enable RAI validation", async () => {
+    process.env.TEAMSFX_RAI_VALIDATION_ENABLED = "true";
+    const getTreatmentVariableAsync = vi.fn();
+    setTools({ expServiceProvider: { getTreatmentVariableAsync } } as any);
+    axiosGetResponses["/config/v1/environment"] = {
+      data: { titlesServiceUrl: "https://test-url" },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      data: { statusId: "test-status-id-builder-api" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: {
+        titleId: "test-title-id-builder-api",
+        appId: "test-app-id-builder-api",
+        validationInfo: { status: "successful" },
+      },
+    };
+    const postStub = vi.spyOn(testAxiosInstance, "post");
+    const getStub = vi.spyOn(testAxiosInstance, "get");
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    await packageService.sideLoadingV2("test-token", "test-path", AppScope.Personal);
+
+    expect(getTreatmentVariableAsync).not.toHaveBeenCalled();
+    expect(
+      postStub.mock.calls.find(([url]) => url === "/builder/v1/users/packages")?.[2]?.params
+    ).toEqual({
+      scope: AppScope.Personal,
+      isRAIValidationAsync: true,
+    });
+    expect(
+      getStub.mock.calls.find(
+        ([url]) => url === "/builder/v1/users/packages/status/test-status-id-builder-api"
+      )?.[1]?.params
+    ).toEqual({ isRAIValidationAsync: true });
+  });
+
+  it("uses environment override to disable RAI validation", async () => {
+    process.env.TEAMSFX_RAI_VALIDATION_ENABLED = "false";
+    const getTreatmentVariableAsync = vi.fn().mockResolvedValue(true);
+    setTools({ expServiceProvider: { getTreatmentVariableAsync } } as any);
+    axiosGetResponses["/config/v1/environment"] = {
+      data: { titlesServiceUrl: "https://test-url" },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      data: { statusId: "test-status-id-builder-api" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: { titleId: "test-title-id-builder-api", appId: "test-app-id-builder-api" },
+    };
+    const postStub = vi.spyOn(testAxiosInstance, "post");
+    const getStub = vi.spyOn(testAxiosInstance, "get");
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    await packageService.sideLoadingV2("test-token", "test-path", AppScope.Personal);
+
+    expect(getTreatmentVariableAsync).not.toHaveBeenCalled();
+    expect(
+      postStub.mock.calls.find(([url]) => url === "/builder/v1/users/packages")?.[2]?.params
+    ).toEqual({
+      scope: AppScope.Personal,
+    });
+    expect(
+      getStub.mock.calls.find(
+        ([url]) => url === "/builder/v1/users/packages/status/test-status-id-builder-api"
+      )?.[1]?.params
+    ).toBeUndefined();
+  });
+
   it("surfaces RAI validation failure reasons", async () => {
     setTools({
       expServiceProvider: {
@@ -679,6 +752,94 @@ describe("Package Service", () => {
     expect(errorStub).toHaveBeenCalledWith(expect.stringContaining("RAIViolation"));
     expect(errorStub).toHaveBeenCalledWith(
       expect.stringContaining("Detected offensive content in agent description.")
+    );
+  });
+
+  it("waits for missing RAI validation information", async () => {
+    process.env.TEAMSFX_RAI_VALIDATION_ENABLED = "true";
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      data: { statusId: "test-status-id-builder-api" },
+    };
+    let statusCallCount = 0;
+    vi.spyOn(testAxiosInstance, "get").mockImplementation((url: string): any => {
+      if (url === "/config/v1/environment") {
+        return Promise.resolve({ data: { titlesServiceUrl: "https://test-url" } });
+      }
+      statusCallCount++;
+      return Promise.resolve(
+        statusCallCount === 1
+          ? { status: 202, data: {} }
+          : {
+              status: 200,
+              data: {
+                titleId: "test-title-id-builder-api",
+                appId: "test-app-id-builder-api",
+                validationInfo: { status: "successful" },
+              },
+            }
+      );
+    });
+    const infoStub = vi.spyOn(logger, "info").mockReturnValue();
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    const result = await packageService.sideLoadingV2("test-token", "test-path", AppScope.Personal);
+
+    chai.assert.deepEqual(result, ["test-title-id-builder-api", "test-app-id-builder-api"]);
+    expect(vi.mocked(commonUtils.waitSeconds)).toHaveBeenCalledWith(7);
+    expect(infoStub).toHaveBeenCalledWith(
+      "RAI validation is in progress. Waiting for completion..."
+    );
+  });
+
+  it("throws when package upload has no status ID", async () => {
+    axiosGetResponses["/config/v1/environment"] = {
+      data: { titlesServiceUrl: "https://test-url" },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = { data: {} };
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    await expect(
+      packageService.sideLoadingV2("test-token", "test-path", AppScope.Personal)
+    ).rejects.toThrow("Missing statusId in package upload response.");
+  });
+
+  it("throws for successful RAI validation without app IDs", async () => {
+    process.env.TEAMSFX_RAI_VALIDATION_ENABLED = "true";
+    axiosGetResponses["/config/v1/environment"] = {
+      data: { titlesServiceUrl: "https://test-url" },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      data: { statusId: "test-status-id-builder-api" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 200,
+      data: { validationInfo: { status: "successful" } },
+    };
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    await expect(
+      packageService.sideLoadingV2("test-token", "test-path", AppScope.Personal)
+    ).rejects.toThrow("Missing titleId or appId in successful package status response.");
+  });
+
+  it("throws for unexpected RAI validation status responses", async () => {
+    process.env.TEAMSFX_RAI_VALIDATION_ENABLED = "true";
+    axiosGetResponses["/config/v1/environment"] = {
+      data: { titlesServiceUrl: "https://test-url" },
+    };
+    axiosPostResponses["/builder/v1/users/packages"] = {
+      data: { statusId: "test-status-id-builder-api" },
+    };
+    axiosGetResponses["/builder/v1/users/packages/status/test-status-id-builder-api"] = {
+      status: 202,
+      data: { validationInfo: { status: "successful" } },
+    };
+
+    const packageService = new PackageService("https://test-endpoint", logger);
+    await expect(
+      packageService.sideLoadingV2("test-token", "test-path", AppScope.Personal)
+    ).rejects.toThrow(
+      "Unexpected package status response: HTTP 202, validation status successful."
     );
   });
 


### PR DESCRIPTION
https://github.com/OfficeDev/microsoft-365-agents-toolkit-test/issues/26356

https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/39221336/

Use env variable: "TEAMSFX_RAI_VALIDATION_ENABLED": "true" to enable

<img width="1251" height="85" alt="image" src="https://github.com/user-attachments/assets/b3be1860-b019-420b-9b2d-3442c3fde193" />
<img width="1572" height="117" alt="image" src="https://github.com/user-attachments/assets/39dce851-397d-428b-8438-59da92b7df45" />
<img width="455" height="132" alt="image" src="https://github.com/user-attachments/assets/5dc5acc1-a812-40f6-ae59-3a2906314c53" />

