### PR TITLE
fix(vscuse): verify image feature flag hook for 6.14

### DIFF
--- a/.github/workflows/vscuse-atk-docker-build.yml
+++ b/.github/workflows/vscuse-atk-docker-build.yml
@@ -1,37 +1,36 @@
 name: Build VscUse ATK Docker Image
 
 on:
-
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag for the Docker image'
+        description: "Tag for the Docker image"
         required: false
-        default: 'latest'
+        default: "latest"
       base_image_tag:
-        description: 'Tag of the base image (ghcr.io/microsoft/vscuse-base) to build from'
+        description: "Tag of the base image (ghcr.io/microsoft/vscuse-base) to build from"
         required: false
-        default: 'latest'
+        default: "latest"
       node_version:
-        description: 'Override the Node.js version baked into the image.'
+        description: "Override the Node.js version baked into the image."
         required: false
-        default: '22'
+        default: "22"
       no_cache:
-        description: 'Build without cache'
+        description: "Build without cache"
         type: boolean
         default: false
       run_id:
-        description: 'Specific ATK workflow run ID to download VSIX from'
+        description: "Specific ATK workflow run ID to download VSIX from"
         required: false
 
       run_test_cases:
-        description: 'Whether to trigger UI test after build'
+        description: "Whether to trigger UI test after build"
         type: boolean
         default: false
       source_ref:
-        description: 'Source branch this build belongs to. Used only to group concurrency so a re-dispatch for the same branch cancels the stale build. Leave empty for release/manual builds.'
+        description: "Source branch this build belongs to. Used to checkout the Docker context and group concurrency. Leave empty for release/manual builds."
         required: false
-        default: ''
+        default: ""
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: officedev/vscuse-atk-vscode
@@ -65,6 +64,25 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_ref || github.ref }}
+
+      - name: Resolve image source
+        id: source
+        env:
+          REQUESTED_SOURCE_REF: ${{ github.event.inputs.source_ref || github.ref_name }}
+        run: |
+          source_ref="${REQUESTED_SOURCE_REF#refs/heads/}"
+          source_ref="${source_ref#refs/tags/}"
+          source_sha=$(git rev-parse HEAD)
+          source_sha_short="${source_sha:0:7}"
+          if [ -z "$source_ref" ]; then
+            echo "Unable to resolve the checked-out source ref."
+            exit 1
+          fi
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "source_sha_short=$source_sha_short" >> "$GITHUB_OUTPUT"
 
       - name: Download latest M365 Agent Toolkit
         id: m365_download
@@ -137,13 +155,15 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=raw,value=${{ steps.source.outputs.source_ref }}
+            type=raw,value=${{ steps.source.outputs.source_ref }}-${{ steps.source.outputs.source_sha_short }}
             type=raw,value=${{ github.event.inputs.tag || 'latest' }}
             type=raw,value=teamsfx-${{ steps.m365_download.outputs.teamsfx_run_id }},enable=${{ steps.m365_download.outputs.teamsfx_run_id != '' }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.source.outputs.source_sha }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: ./packages/tests/vscuse/docker/vscuse-atk
@@ -157,6 +177,26 @@ jobs:
           cache-from: ${{ github.event.inputs.no_cache != 'true' && 'type=gha' || '' }}
           cache-to: ${{ github.event.inputs.no_cache != 'true' && 'type=gha,mode=max' || '' }}
           no-cache: ${{ github.event.inputs.no_cache == 'true' }}
+
+      - name: Verify published image
+        run: |
+          image="${REGISTRY}/${IMAGE_NAME}@${{ steps.build.outputs.digest }}"
+          docker pull "$image"
+
+          actual_revision=$(docker image inspect "$image" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')
+          if [ "$actual_revision" != "${{ steps.source.outputs.source_sha }}" ]; then
+            echo "Expected OCI revision ${{ steps.source.outputs.source_sha }}, got $actual_revision."
+            exit 1
+          fi
+
+          actual_entrypoint=$(docker image inspect "$image" --format '{{ join .Config.Entrypoint " " }}')
+          if [ "$actual_entrypoint" != "/usr/local/bin/vscuse-atk-entrypoint.sh" ]; then
+            echo "Unexpected image entrypoint: $actual_entrypoint"
+            exit 1
+          fi
+
+          docker run --rm --entrypoint /bin/sh "$image" -c \
+            'test -x /usr/local/bin/vscuse-atk-entrypoint.sh && test -f /usr/local/lib/vscuse-atk/sync-vscode-feature-flags.cjs'
 
       - name: Image summary
         if: success()

--- a/packages/tests/vscuse/docker/vscuse-atk/Dockerfile
+++ b/packages/tests/vscuse/docker/vscuse-atk/Dockerfile
@@ -190,5 +190,12 @@ RUN mkdir -p /home/vscode/.vscode/extensions /home/vscode/.vscode-insiders/exten
 # Merge ATK-specific editor settings into base image settings.json/setting.json
 RUN node -e "const fs=require('fs');const path=require('path');const userSettingsPath='/app/vscode-setting/setting.json';let updates={};if(fs.existsSync(userSettingsPath)&&fs.statSync(userSettingsPath).isFile()){try{const raw=fs.readFileSync(userSettingsPath,'utf8').trim();updates=raw?JSON.parse(raw):{};}catch(error){console.warn('Invalid JSON in '+userSettingsPath+', skip merge.');process.exit(0);}}else{console.log('No /app/vscode-setting/setting.json found, skip merge.');process.exit(0);}const candidates=['/home/vscode/.config/Code/User/settings.json','/tmp/vscode-settings/settings.json','/settings/setting.json','/settings/settings.json','/home/vscode/settings/setting.json','/home/vscode/settings/settings.json'];if(fs.existsSync('/settings')&&fs.statSync('/settings').isDirectory()){for(const name of fs.readdirSync('/settings')){if(/^settings?\\.json$/i.test(name)){candidates.push(path.join('/settings',name));}}}const files=[...new Set(candidates)].filter((file)=>fs.existsSync(file)&&fs.statSync(file).isFile());for(const file of files){let current={};try{const raw=fs.readFileSync(file,'utf8').trim();current=raw?JSON.parse(raw):{};}catch(error){console.warn('Skip non-JSON settings file: '+file);continue;}const merged={...current,...updates};fs.writeFileSync(file,JSON.stringify(merged,null,2)+'\\n','utf8');console.log('Updated '+file);}if(files.length===0){console.log('No target settings.json or setting.json found in base image.');}"
 
+COPY sync-vscode-feature-flags.cjs /usr/local/lib/vscuse-atk/sync-vscode-feature-flags.cjs
+COPY vscuse-atk-entrypoint.sh /usr/local/bin/vscuse-atk-entrypoint.sh
+RUN chmod +x /usr/local/bin/vscuse-atk-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/vscuse-atk-entrypoint.sh"]
+CMD ["/app/start.sh"]
+
 LABEL org.opencontainers.image.description="VscUse ATK Profile - Microsoft 365 Agent Toolkit"
 LABEL org.opencontainers.image.profile="atk"

--- a/packages/tests/vscuse/docker/vscuse-atk/sync-vscode-feature-flags.cjs
+++ b/packages/tests/vscuse/docker/vscuse-atk/sync-vscode-feature-flags.cjs
@@ -1,0 +1,61 @@
+const fs = require("node:fs");
+
+const ceaEnvironmentName = "TEAMSFX_CEA_ENABLED";
+const ceaSettingName = "M365AgentsToolkit.enableLaunchAgentForTeamsInCopilot";
+const defaultSettingsPaths = [
+  "/tmp/vscode-settings/settings.json",
+  "/home/vscode/.config/Code/User/settings.json",
+];
+
+function syncVscodeFeatureFlags({
+  environment = process.env,
+  settingsPaths = defaultSettingsPaths,
+} = {}) {
+  const ceaValue = environment[ceaEnvironmentName];
+  if (ceaValue === undefined) {
+    return [];
+  }
+  if (ceaValue !== "true" && ceaValue !== "false") {
+    throw new Error(`${ceaEnvironmentName} must be true or false`);
+  }
+
+  const updatedPaths = [];
+  for (const settingsPath of settingsPaths) {
+    let settingsText;
+    try {
+      settingsText = fs.readFileSync(settingsPath, "utf8");
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+
+    const settings = JSON.parse(settingsText);
+    if (
+      settings === null ||
+      Array.isArray(settings) ||
+      typeof settings !== "object"
+    ) {
+      throw new Error(`VS Code settings must be an object: ${settingsPath}`);
+    }
+    settings[ceaSettingName] = ceaValue === "true";
+    fs.writeFileSync(
+      settingsPath,
+      `${JSON.stringify(settings, null, 2)}\n`,
+      "utf8",
+    );
+    updatedPaths.push(settingsPath);
+  }
+
+  if (updatedPaths.length === 0) {
+    throw new Error("No seeded VS Code settings file was found");
+  }
+  return updatedPaths;
+}
+
+if (require.main === module) {
+  syncVscodeFeatureFlags();
+}
+
+module.exports = { syncVscodeFeatureFlags };

--- a/packages/tests/vscuse/docker/vscuse-atk/vscuse-atk-entrypoint.sh
+++ b/packages/tests/vscuse/docker/vscuse-atk/vscuse-atk-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node /usr/local/lib/vscuse-atk/sync-vscode-feature-flags.cjs
+exec /usr/local/bin/entrypoint.sh "$@"


### PR DESCRIPTION
## Summary

- keep this draft PR limited to the `release/6.14` image build path
- check out the requested `source_ref` before building the Docker context
- derive image source-ref/source-SHA tags and OCI revision from the actual checkout
- include the feature-flag startup hook in the image and verify the published image by digest

## Scope

This PR is intentionally not intended for merge. It exists to build and inspect the `release/6.14` Docker image and contains only the minimum image path:

- `.github/workflows/vscuse-atk-docker-build.yml`
- `packages/tests/vscuse/docker/vscuse-atk/Dockerfile`
- `packages/tests/vscuse/docker/vscuse-atk/sync-vscode-feature-flags.cjs`
- `packages/tests/vscuse/docker/vscuse-atk/vscuse-atk-entrypoint.sh`

No vscuse cases, generated plans, specifications, or test files are included.

## Validation

- feature-flag synchronization smoke test passed
- Docker BuildKit `--check` passed with no warnings
- workflow and JavaScript files pass Prettier
- editor diagnostics and `git diff --check` pass

## Related

- Workflow and image-hook changes from #16590
- Target: `release/6.14`