### PR TITLE
feat(manifest): throw typed SchemaFetchError with cause on schema fetch failure

### DIFF
--- a/packages/manifest/src/SchemaFetchError.ts
+++ b/packages/manifest/src/SchemaFetchError.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Error thrown when a manifest schema cannot be fetched or parsed from its URL.
+ *
+ * @remarks
+ * The originating error (network failure, `response.text()` rejection, JSON
+ * parse error, etc.) is preserved on {@link SchemaFetchError.cause} so callers
+ * can branch on the failure type instead of matching against the message string.
+ * The message keeps the historical `Failed to get manifest at url ... due to: ...`
+ * shape for backward compatibility.
+ */
+export class SchemaFetchError extends Error {
+  /** The schema URL that failed to load. */
+  public readonly schemaUrl: string;
+
+  constructor(schemaUrl: string, cause?: unknown) {
+    const reason = cause instanceof Error ? cause.message : "unknown error";
+    super(`Failed to get manifest at url ${schemaUrl} due to: ${reason}`, { cause });
+    this.name = "SchemaFetchError";
+    this.schemaUrl = schemaUrl;
+  }
+}

--- a/packages/manifest/src/generated-types/index.ts
+++ b/packages/manifest/src/generated-types/index.ts
@@ -7,6 +7,7 @@ import Ajv2020 from "ajv/dist/2020";
 import fs from "fs-extra";
 import fetch from "../fetchHelper";
 import path from "path";
+import { SchemaFetchError } from "../SchemaFetchError";
 import stripBom from "strip-bom";
 import * as DeclarativeAgentManifestV1D0 from "./copilot/declarative-agent/DeclarativeAgentManifestV1D0";
 import * as DeclarativeAgentManifestV1D2 from "./copilot/declarative-agent/DeclarativeAgentManifestV1D2";
@@ -460,11 +461,7 @@ export class AppManifestUtils {
       const cleanedText = text.replace(/\\a/g, "\\u0007").replace(/\\v/g, "\\u000b");
       result = JSON.parse(cleanedText) as JSONSchemaType<AppManifest>;
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        throw new Error(`Failed to get manifest at url ${schemaUrl} due to: ${e.message}`);
-      } else {
-        throw new Error(`Failed to get manifest at url ${schemaUrl} due to: unknown error`);
-      }
+      throw new SchemaFetchError(schemaUrl, e);
     }
     return result;
   }

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -17,8 +17,10 @@ import {
 } from "./generated-types";
 import { TeamsAppManifest } from "./manifest";
 import { PluginManifestSchema } from "./pluginManifest";
+import { SchemaFetchError } from "./SchemaFetchError";
 
 export * from "./declarativeCopilotManifest";
+export * from "./SchemaFetchError";
 export * from "./generated-types";
 export * from "./manifest";
 export * from "./pluginManifest";
@@ -89,11 +91,8 @@ export class ManifestUtil {
    * @returns An empty array if it passes validation, or an array of error string otherwise.
    */
   static validateManifestAgainstSchema<
-    T extends
-      | Manifest
-      | DeclarativeCopilotManifestSchema
-      | PluginManifestSchema
-      | TeamsManifest = TeamsAppManifest,
+    T extends Manifest | DeclarativeCopilotManifestSchema | PluginManifestSchema | TeamsManifest =
+      TeamsAppManifest,
   >(manifest: T, schema: JSONSchemaType<T>): Promise<string[]> {
     let validate;
     if (schema.$schema?.includes("2020-12")) {
@@ -134,11 +133,8 @@ export class ManifestUtil {
    * @returns
    */
   static async fetchSchema<
-    T extends
-      | Manifest
-      | DeclarativeCopilotManifestSchema
-      | PluginManifestSchema
-      | TeamsManifest = TeamsAppManifest,
+    T extends Manifest | DeclarativeCopilotManifestSchema | PluginManifestSchema | TeamsManifest =
+      TeamsAppManifest,
   >(manifest: T): Promise<JSONSchemaType<T>> {
     const schemaUrl = ((manifest as any).$schema || (manifest as any).schema) as string;
     if (!schemaUrl) {
@@ -152,11 +148,7 @@ export class ManifestUtil {
       const cleanedText = text.replace(/\\a/g, "\\x07");
       result = JSON.parse(cleanedText) as JSONSchemaType<T>;
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        throw new Error(`Failed to get manifest at url ${schemaUrl} due to: ${e.message}`);
-      } else {
-        throw new Error(`Failed to get manifest at url ${schemaUrl} due to: unknown error`);
-      }
+      throw new SchemaFetchError(schemaUrl, e);
     }
     return result;
   }
@@ -172,11 +164,8 @@ export class ManifestUtil {
    * @returns An empty array if schema validation passes, or an array of error string otherwise.
    */
   static async validateManifest<
-    T extends
-      | Manifest
-      | DeclarativeCopilotManifestSchema
-      | PluginManifestSchema
-      | TeamsManifest = TeamsAppManifest,
+    T extends Manifest | DeclarativeCopilotManifestSchema | PluginManifestSchema | TeamsManifest =
+      TeamsAppManifest,
   >(manifest: T): Promise<string[]> {
     const schema = await this.fetchSchema(manifest);
     return ManifestUtil.validateManifestAgainstSchema(manifest, schema);

--- a/packages/manifest/test/AppManifestUtils.test.ts
+++ b/packages/manifest/test/AppManifestUtils.test.ts
@@ -3,6 +3,7 @@ import "mocha";
 import fs from "fs-extra";
 import sinon from "sinon";
 import { AppManifestUtils } from "../src";
+import { SchemaFetchError } from "../src";
 import * as fetchHelper from "../src/fetchHelper";
 
 describe("AppManifestUtils", async () => {
@@ -81,6 +82,41 @@ describe("AppManifestUtils", async () => {
       );
       assert.isTrue(fetchStub.calledOnce);
       assert.isTrue(mockResponse.text.calledOnce);
+    });
+    it("should throw SchemaFetchError preserving the cause when fetch fails", async () => {
+      sandbox.stub(fs, "pathExists").resolves(false);
+      const fetchError = new Error("Network error");
+      sandbox.stub(fetchHelper, "default").rejects(fetchError);
+
+      try {
+        await AppManifestUtils.fetchSchema("https://abc.schema.json");
+        assert.fail("Expected error not thrown");
+      } catch (error: unknown) {
+        assert.instanceOf(error, SchemaFetchError);
+        const schemaFetchError = error as SchemaFetchError;
+        assert.strictEqual(schemaFetchError.schemaUrl, "https://abc.schema.json");
+        assert.strictEqual(schemaFetchError.cause, fetchError);
+        assert.strictEqual(
+          schemaFetchError.message,
+          "Failed to get manifest at url https://abc.schema.json due to: Network error"
+        );
+      }
+    });
+    it("should throw SchemaFetchError with unknown-error message for non-Error cause", async () => {
+      sandbox.stub(fs, "pathExists").resolves(false);
+      sandbox.stub(fetchHelper, "default").callsFake(() => Promise.reject("string error"));
+
+      try {
+        await AppManifestUtils.fetchSchema("https://abc.schema.json");
+        assert.fail("Expected error not thrown");
+      } catch (error: unknown) {
+        assert.instanceOf(error, SchemaFetchError);
+        assert.strictEqual((error as SchemaFetchError).cause, "string error");
+        assert.strictEqual(
+          (error as SchemaFetchError).message,
+          "Failed to get manifest at url https://abc.schema.json due to: unknown error"
+        );
+      }
     });
   });
 

--- a/packages/manifest/test/index.test.ts
+++ b/packages/manifest/test/index.test.ts
@@ -4,7 +4,13 @@ import fs from "fs-extra";
 import "mocha";
 import * as path from "path";
 import sinon from "sinon";
-import { AppManifestUtils, ManifestUtil, TeamsAppManifest, TeamsManifestConverter } from "../src";
+import {
+  AppManifestUtils,
+  ManifestUtil,
+  SchemaFetchError,
+  TeamsAppManifest,
+  TeamsManifestConverter,
+} from "../src";
 
 chai.use(chaiAsPromised);
 
@@ -236,6 +242,23 @@ describe("ManifestUtil", () => {
           .to.equal(
             "Failed to get manifest at url https://example.com/invalid-schema.json due to: Network error"
           );
+      }
+    });
+
+    it("should throw a typed SchemaFetchError preserving the cause", async () => {
+      const fetchError = new Error("Network error");
+      sandbox.stub(mockFetch, "default").rejects(fetchError);
+
+      const manifest = { $schema: "https://example.com/invalid-schema.json" } as TeamsAppManifest;
+
+      try {
+        await ManifestUtil.fetchSchema(manifest);
+        chai.assert.fail("Expected error not thrown");
+      } catch (error: unknown) {
+        chai.expect(error).to.be.instanceOf(SchemaFetchError);
+        const schemaFetchError = error as SchemaFetchError;
+        chai.expect(schemaFetchError.schemaUrl).to.equal("https://example.com/invalid-schema.json");
+        chai.expect(schemaFetchError.cause).to.equal(fetchError);
       }
     });
 


### PR DESCRIPTION
## Problem

`AppManifestUtils.fetchSchema` (and the deprecated `ManifestUtil.fetchSchema`) previously threw a plain `Error` with a hardcoded message prefix `Failed to get manifest at url <url> due to: <reason>`. Consumers that needed to react specifically to a schema-fetch failure had no reliable way to do so — they were forced to string-match on that message prefix, and the underlying cause (network failure, `response.text()` rejection, JSON parse error) was flattened into a string and lost.

## Change

Introduce a typed `SchemaFetchError` (exported from `@microsoft/app-manifest`) and throw it from both `fetchSchema` implementations:

- Extends `Error`, `name = "SchemaFetchError"`.
- Exposes the originating error via the standard `cause` property so callers can branch on the real failure type instead of parsing a message.
- Exposes `schemaUrl` for the URL that failed to load.
- **Backward compatible:** the `message` keeps the exact historical `Failed to get manifest at url <url> due to: <reason>` shape, so existing string-matching consumers and tests are unaffected.

This lets downstream callers do `error instanceof SchemaFetchError` / inspect `error.cause` instead of the brittle message heuristic.

## Tests

- `test/AppManifestUtils.test.ts`: new cases asserting `SchemaFetchError` is thrown, `cause` is preserved for `Error` rejections, `schemaUrl` is set, and the `unknown error` message is produced for non-`Error` causes.
- `test/index.test.ts`: new case asserting the deprecated `ManifestUtil.fetchSchema` throws a typed `SchemaFetchError` preserving `cause`; existing message-equality tests remain green.
- `npm run build` and the affected test files pass (29 passing); `npm run lint` reports 0 errors.