### PR TITLE
refactor: support model response format in string or json

### DIFF
--- a/packages/fx-core/tests/v4/scenarios/createWeatherAgent.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createWeatherAgent.test.ts
@@ -12,6 +12,7 @@ import {
   readJsonObject,
   recordProperty,
   runV4Package,
+  text,
 } from "./helpers/scenarioHarness";
 
 /**
@@ -102,5 +103,17 @@ describe("SCN-TEAMS-CREATE-WEATHER-AGENT (v4, T3 InMemoryRuntime)", () => {
     assert.instanceOf(error, UserError);
     assert.strictEqual(error.name, REQUIRE_EMPTY_TARGET);
     assert.strictEqual(runtime.files.size, 0);
+  });
+
+  it("SCN-CREATE-WEATHER-07: generated agents normalize Adaptive Card content", async () => {
+    for (const language of ["typescript", "javascript"] as const) {
+      const { files } = await run(language);
+      const extension = language === "typescript" ? "ts" : "js";
+      const agentSource = text(files, `src/agent.${extension}`);
+
+      assert.include(agentSource, "content must be a JSON object, not a JSON-encoded string");
+      assert.include(agentSource, 'typeof llmResponseContent.content === "string"');
+      assert.include(agentSource, "content: adaptiveCardContent");
+    }
   });
 });

--- a/templates/v4/create/weather-agent/content/javascript/src/agent.js.tpl
+++ b/templates/v4/create/weather-agent/content/javascript/src/agent.js.tpl
@@ -89,7 +89,10 @@ Respond in JSON format with the following JSON schema, and do not use markdown i
 {
     "contentType": "'Text' or 'AdaptiveCard' only",
     "content": "{The content of the response, may be plain text, or JSON based adaptive card}"
-}`);
+}
+
+For Text responses, content must be a string.
+For AdaptiveCard responses, content must be a JSON object, not a JSON-encoded string.`);
 
 weatherAgent.onActivity(ActivityTypes.Message, async (context, state) => {
   if (supportsFilesWarning && !supportsFilesWarned) {
@@ -112,9 +115,13 @@ weatherAgent.onActivity(ActivityTypes.Message, async (context, state) => {
   if (llmResponseContent.contentType === "Text") {
     await context.sendActivity(llmResponseContent.content);
   } else if (llmResponseContent.contentType === "AdaptiveCard") {
+    const adaptiveCardContent =
+      typeof llmResponseContent.content === "string"
+        ? JSON.parse(llmResponseContent.content)
+        : llmResponseContent.content;
     const response = MessageFactory.attachment({
       contentType: "application/vnd.microsoft.card.adaptive",
-      content: llmResponseContent.content,
+      content: adaptiveCardContent,
     });
     await context.sendActivity(response);
   }

--- a/templates/v4/create/weather-agent/content/python/src/agent.py.tpl
+++ b/templates/v4/create/weather-agent/content/python/src/agent.py.tpl
@@ -131,7 +131,10 @@ Respond in JSON format with the following JSON schema, and do not use markdown i
 {
     "contentType": "'Text' or 'AdaptiveCard' only",
     "content": "{The content of the response, may be plain text, or JSON based adaptive card}"
-}"""
+}
+
+For Text responses, content must be a string.
+For AdaptiveCard responses, content must be a JSON object, not a JSON-encoded string."""
 )
 
 @weather_agent.activity(ActivityTypes.Message)
@@ -159,9 +162,12 @@ async def on_message(context: TurnContext, state: TurnState):
         if llm_response_content["contentType"] == "Text":
             await context.send_activity(llm_response_content["content"])
         elif llm_response_content["contentType"] == "AdaptiveCard":
+            adaptive_card_content = llm_response_content["content"]
+            if isinstance(adaptive_card_content, str):
+                adaptive_card_content = json.loads(adaptive_card_content)
             response = MessageFactory.attachment({
                 "contentType": "application/vnd.microsoft.card.adaptive",
-                "content": llm_response_content["content"],
+                "content": adaptive_card_content,
             })
             await context.send_activity(response)
     except (json.JSONDecodeError, KeyError) as e:

--- a/templates/v4/create/weather-agent/content/typescript/src/agent.ts.tpl
+++ b/templates/v4/create/weather-agent/content/typescript/src/agent.ts.tpl
@@ -58,10 +58,9 @@ weatherAgent.onConversationUpdate(
   }
 );
 
-interface WeatherForecastAgentResponse {
-  contentType: "Text" | "AdaptiveCard";
-  content: string;
-}
+type WeatherForecastAgentResponse =
+  | { contentType: "Text"; content: string }
+  | { contentType: "AdaptiveCard"; content: string | Record<string, unknown> };
 
 {{#useOpenAI}}
 const agentModel = new ChatOpenAI({
@@ -98,7 +97,10 @@ Respond in JSON format with the following JSON schema, and do not use markdown i
 {
     "contentType": "'Text' or 'AdaptiveCard' only",
     "content": "{The content of the response, may be plain text, or JSON based adaptive card}"
-}`);
+}
+
+For Text responses, content must be a string.
+For AdaptiveCard responses, content must be a JSON object, not a JSON-encoded string.`);
 
 weatherAgent.onActivity(ActivityTypes.Message, async (context, state) => {
   if (supportsFilesWarning && !supportsFilesWarned) {
@@ -121,9 +123,13 @@ weatherAgent.onActivity(ActivityTypes.Message, async (context, state) => {
   if (llmResponseContent.contentType === "Text") {
     await context.sendActivity(llmResponseContent.content);
   } else if (llmResponseContent.contentType === "AdaptiveCard") {
+    const adaptiveCardContent =
+      typeof llmResponseContent.content === "string"
+        ? JSON.parse(llmResponseContent.content)
+        : llmResponseContent.content;
     const response = MessageFactory.attachment({
       contentType: "application/vnd.microsoft.card.adaptive",
-      content: llmResponseContent.content,
+      content: adaptiveCardContent,
     });
     await context.sendActivity(response);
   }

--- a/templates/vsc/js/weather-agent/src/agent.js.tpl
+++ b/templates/vsc/js/weather-agent/src/agent.js.tpl
@@ -89,7 +89,10 @@ Respond in JSON format with the following JSON schema, and do not use markdown i
 {
     "contentType": "'Text' or 'AdaptiveCard' only",
     "content": "{The content of the response, may be plain text, or JSON based adaptive card}"
-}`);
+}
+
+For Text responses, content must be a string.
+For AdaptiveCard responses, content must be a JSON object, not a JSON-encoded string.`);
 
 weatherAgent.onActivity(ActivityTypes.Message, async (context, state) => {
   if (supportsFilesWarning && !supportsFilesWarned) {
@@ -112,9 +115,13 @@ weatherAgent.onActivity(ActivityTypes.Message, async (context, state) => {
   if (llmResponseContent.contentType === "Text") {
     await context.sendActivity(llmResponseContent.content);
   } else if (llmResponseContent.contentType === "AdaptiveCard") {
+    const adaptiveCardContent =
+      typeof llmResponseContent.content === "string"
+        ? JSON.parse(llmResponseContent.content)
+        : llmResponseContent.content;
     const response = MessageFactory.attachment({
       contentType: "application/vnd.microsoft.card.adaptive",
-      content: llmResponseContent.content,
+      content: adaptiveCardContent,
     });
     await context.sendActivity(response);
   }

--- a/templates/vsc/python/weather-agent/src/agent.py.tpl
+++ b/templates/vsc/python/weather-agent/src/agent.py.tpl
@@ -131,7 +131,10 @@ Respond in JSON format with the following JSON schema, and do not use markdown i
 {
     "contentType": "'Text' or 'AdaptiveCard' only",
     "content": "{The content of the response, may be plain text, or JSON based adaptive card}"
-}"""
+}
+
+For Text responses, content must be a string.
+For AdaptiveCard responses, content must be a JSON object, not a JSON-encoded string."""
 )
 
 @weather_agent.activity(ActivityTypes.Message)
@@ -159,9 +162,12 @@ async def on_message(context: TurnContext, state: TurnState):
         if llm_response_content["contentType"] == "Text":
             await context.send_activity(llm_response_content["content"])
         elif llm_response_content["contentType"] == "AdaptiveCard":
+            adaptive_card_content = llm_response_content["content"]
+            if isinstance(adaptive_card_content, str):
+                adaptive_card_content = json.loads(adaptive_card_content)
             response = MessageFactory.attachment({
                 "contentType": "application/vnd.microsoft.card.adaptive",
-                "content": llm_response_content["content"],
+                "content": adaptive_card_content,
             })
             await context.send_activity(response)
     except (json.JSONDecodeError, KeyError) as e:

--- a/templates/vsc/ts/weather-agent/src/agent.ts.tpl
+++ b/templates/vsc/ts/weather-agent/src/agent.ts.tpl
@@ -58,10 +58,9 @@ weatherAgent.onConversationUpdate(
   }
 );
 
-interface WeatherForecastAgentResponse {
-  contentType: "Text" | "AdaptiveCard";
-  content: string;
-}
+type WeatherForecastAgentResponse =
+  | { contentType: "Text"; content: string }
+  | { contentType: "AdaptiveCard"; content: string | Record<string, unknown> };
 
 {{#useOpenAI}}
 const agentModel = new ChatOpenAI({
@@ -98,7 +97,10 @@ Respond in JSON format with the following JSON schema, and do not use markdown i
 {
     "contentType": "'Text' or 'AdaptiveCard' only",
     "content": "{The content of the response, may be plain text, or JSON based adaptive card}"
-}`);
+}
+
+For Text responses, content must be a string.
+For AdaptiveCard responses, content must be a JSON object, not a JSON-encoded string.`);
 
 weatherAgent.onActivity(ActivityTypes.Message, async (context, state) => {
   if (supportsFilesWarning && !supportsFilesWarned) {
@@ -121,9 +123,13 @@ weatherAgent.onActivity(ActivityTypes.Message, async (context, state) => {
   if (llmResponseContent.contentType === "Text") {
     await context.sendActivity(llmResponseContent.content);
   } else if (llmResponseContent.contentType === "AdaptiveCard") {
+    const adaptiveCardContent =
+      typeof llmResponseContent.content === "string"
+        ? JSON.parse(llmResponseContent.content)
+        : llmResponseContent.content;
     const response = MessageFactory.attachment({
       contentType: "application/vnd.microsoft.card.adaptive",
-      content: llmResponseContent.content,
+      content: adaptiveCardContent,
     });
     await context.sendActivity(response);
   }


### PR DESCRIPTION
This pull request improves how Adaptive Card responses are handled in generated weather agent templates for JavaScript, TypeScript, and Python. It ensures that Adaptive Card content is always passed as a JSON object, not as a JSON-encoded string, which fixes issues with rendering adaptive cards. The changes also clarify the expected response format in the code comments and add a new test to verify this normalization behavior.