### PR TITLE
fix(vscuse): Auto-fix da-no-action--da-no-action-add-openapi-action

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/components/quick-input/add-da-action-select-all.json.tpl
+++ b/packages/tests/vscuse/vscode-test-cases/components/quick-input/add-da-action-select-all.json.tpl
@@ -10,7 +10,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the Select Operation(s) Copilot Can Interact with multi-select prompt is visible with the Toggle all checkboxes control.",
+      "description": "@assertion the Select Operation(s) Copilot Can Interact with multi-select prompt is visible, and the square checkbox immediately to the left of the input box is the control for toggling all operation checkboxes.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/da-no-action--da-no-action-add-openapi-action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-no-action--da-no-action-add-openapi-action.json
@@ -1245,7 +1245,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the Select Operation(s) Copilot Can Interact with multi-select prompt is visible with the Toggle all checkboxes control.",
+      "description": "@assertion the Select Operation(s) Copilot Can Interact with multi-select prompt is visible, and the square checkbox immediately to the left of the input box is the control for toggling all operation checkboxes.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `da-no-action--da-no-action-add-openapi-action`
**Status:** :white_check_mark: FIXED (attempt 1/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/7598ece3-0ba8-4ea0-89f3-839a1f84a895/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/4c4d2aba-f376-4daa-a128-128b5f3e34bb/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Updated step 54 to recognize the toggle-all checkbox immediately left of the inp | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/4c4d2aba-f376-4daa-a128-128b5f3e34bb/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/da-no-action--da-no-action-add-openapi-action.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../plans/da-no-action--da-no-action-add-openapi-action.json            | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/da-no-action--da-no-action-add-openapi-action.json b/packages/tests/vscuse/vscode-test-cases/plans/da-no-action--da-no-action-add-openapi-action.json
index 6c1dc16..58daa6e 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/da-no-action--da-no-action-add-openapi-action.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/da-no-action--da-no-action-add-openapi-action.json
@@ -1245,7 +1245,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the Select Operation(s) Copilot Can Interact with multi-select prompt is visible with the Toggle all checkboxes control.",
+      "description": "@assertion the Select Operation(s) Copilot Can Interact with multi-select prompt is visible, and the square checkbox immediately to the left of the input box is the control for toggling all operation checkboxes.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>