### PR TITLE
fix(share): honor inputs.env when resolving agent share configuration

### DIFF
--- a/packages/fx-core/src/component/driver/share/utils.ts
+++ b/packages/fx-core/src/component/driver/share/utils.ts
@@ -18,9 +18,10 @@ import { Constants } from "../teamsApp/constants";
 
 // Read m365agents.yaml and get the value of shared title id, and shared app id
 export async function parseShareAppActionYamlConfig(
-  projectPath: string
+  projectPath: string,
+  env = "dev"
 ): Promise<Result<{ teamsappId: string; titleId: string; appId: string }, FxError>> {
-  const templatePath = pathUtils.getYmlFilePath(projectPath, "dev") as string;
+  const templatePath = pathUtils.getYmlFilePath(projectPath, env) as string;
   const maybeProjectModel = await metadataUtil.parse(templatePath);
   if (maybeProjectModel.isErr()) {
     return err(maybeProjectModel.error);
@@ -67,7 +68,7 @@ export async function parseShareAppActionYamlConfig(
     );
   }
 
-  const readEnvRes = await envUtil.readEnv(projectPath, "dev");
+  const readEnvRes = await envUtil.readEnv(projectPath, env);
   if (readEnvRes.isErr()) {
     return err(readEnvRes.error);
   }

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -949,7 +949,10 @@ export class FxCore extends FxCoreOpenPluginPart {
     if (!emails || emails.length === 0) {
       return err(new MissingRequiredInputError("emails", "FxCore"));
     }
-    const parseRes = await shareUtils.parseShareAppActionYamlConfig(inputs.projectPath!);
+    const parseRes = await shareUtils.parseShareAppActionYamlConfig(
+      inputs.projectPath!,
+      inputs.env
+    );
     if (parseRes.isErr()) {
       return err(parseRes.error);
     }
@@ -1046,7 +1049,10 @@ export class FxCore extends FxCoreOpenPluginPart {
         return err(new InputValidationError("emails", "Too many emails"));
       }
     }
-    const parseRes = await shareUtils.parseShareAppActionYamlConfig(inputs.projectPath!);
+    const parseRes = await shareUtils.parseShareAppActionYamlConfig(
+      inputs.projectPath!,
+      inputs.env
+    );
     if (parseRes.isErr()) {
       return err(parseRes.error);
     }

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -321,7 +321,7 @@ export async function listCollaborator(
     inputs[QuestionNames.collaborationAppType] &&
     inputs[QuestionNames.collaborationAppType].indexOf(CollaborationConstants.AgentOptionId) > -1
   ) {
-    const parseRes = await parseShareAppActionYamlConfig(inputs.projectPath);
+    const parseRes = await parseShareAppActionYamlConfig(inputs.projectPath, inputs.env);
     if (parseRes.isErr()) {
       return err(parseRes.error);
     }
@@ -678,7 +678,7 @@ export async function grantPermission(
       inputs[QuestionNames.collaborationAppType] &&
       inputs[QuestionNames.collaborationAppType].indexOf(CollaborationConstants.AgentOptionId) > -1
     ) {
-      const parseRes = await parseShareAppActionYamlConfig(inputs.projectPath);
+      const parseRes = await parseShareAppActionYamlConfig(inputs.projectPath, inputs.env);
       if (parseRes.isErr()) {
         return err(parseRes.error);
       }

--- a/packages/fx-core/src/question/share.ts
+++ b/packages/fx-core/src/question/share.ts
@@ -152,7 +152,10 @@ export function selectUsersToRemoveSharedAccess(): MultiSelectQuestion {
         throw tokenRes.error;
       }
       const token = tokenRes.value;
-      const configRes = await shareUtils.parseShareAppActionYamlConfig(inputs.projectPath);
+      const configRes = await shareUtils.parseShareAppActionYamlConfig(
+        inputs.projectPath,
+        inputs.env
+      );
       if (configRes.isErr()) {
         throw configRes.error;
       }

--- a/packages/fx-core/tests/component/driver/share/utils.test.ts
+++ b/packages/fx-core/tests/component/driver/share/utils.test.ts
@@ -43,9 +43,11 @@ describe("parseShareAppActionYamlConfig", () => {
     vi.restoreAllMocks();
   });
 
-  it("should return manifestId, sharedTitleId, and sharedAppId when config is valid", async () => {
+  it("should use the specified environment when config is valid", async () => {
     const mockZipPath = createMockZipFile();
-    vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue("mockTemplatePath");
+    const getYmlFilePathSpy = vi
+      .spyOn(pathUtils, "getYmlFilePath")
+      .mockReturnValue("mockTemplatePath");
     vi.spyOn(metadataUtil, "parse").mockResolvedValue(
       ok({
         deploy: {
@@ -62,13 +64,15 @@ describe("parseShareAppActionYamlConfig", () => {
         },
       } as any)
     );
-    vi.spyOn(envUtil, "readEnv").mockResolvedValue(ok({}));
+    const readEnvSpy = vi.spyOn(envUtil, "readEnv").mockResolvedValue(ok({}));
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
     process.env["parseShareAppActionYamlConfigMockTitleIdName"] = "mockTitleId";
     process.env["parseShareAppActionYamlConfigMockAppIdName"] = "mockAppId";
-    const result = await parseShareAppActionYamlConfig("mockProjectPath");
+    const result = await parseShareAppActionYamlConfig("mockProjectPath", "prod");
 
     chai.assert.isTrue(result.isOk());
+    chai.assert.deepEqual(getYmlFilePathSpy.mock.calls[0], ["mockProjectPath", "prod"]);
+    chai.assert.deepEqual(readEnvSpy.mock.calls[0], ["mockProjectPath", "prod"]);
     if (result.isOk()) {
       chai.assert.deepEqual(result.value, {
         teamsappId: "mockManifestId",
@@ -77,8 +81,8 @@ describe("parseShareAppActionYamlConfig", () => {
       });
     }
 
-    process.env["parseShareAppActionYamlConfigMockTitleIdName"] = undefined;
-    process.env["parseShareAppActionYamlConfigMockAppIdName"] = undefined;
+    delete process.env["parseShareAppActionYamlConfigMockTitleIdName"];
+    delete process.env["parseShareAppActionYamlConfigMockAppIdName"];
   });
 
   it("should return error when yaml config is invalid", async () => {

--- a/packages/fx-core/tests/core/FxCore.share.test.ts
+++ b/packages/fx-core/tests/core/FxCore.share.test.ts
@@ -67,7 +67,7 @@ describe("FxCore.shareApplication", () => {
     it("share happy path", async () => {
       const shareWithTenantStub = coreSpy("shareWithTenant").mockResolvedValue(ok(undefined));
 
-      coreSpy("parseShareAppActionYamlConfig").mockResolvedValue(
+      const parseShareConfigStub = coreSpy("parseShareAppActionYamlConfig").mockResolvedValue(
         ok({ teamsappId: "mockAppId", titleId: "mockTitleId", appId: "mockAppId" })
       );
       vi.spyOn(metadataUtil, "parse").mockResolvedValue(ok(mockProjectModel));
@@ -93,6 +93,7 @@ describe("FxCore.shareApplication", () => {
       const inputs: Inputs = {
         platform: Platform.VSCode,
         projectPath: ".",
+        env: "prod",
         [QuestionNames.ShareOperation]: ShareOperationOption.ShareWithUsers,
         [QuestionNames.ShareScope]: ShareScopeOption.ShareAppWithTenantUsers,
       };
@@ -100,6 +101,7 @@ describe("FxCore.shareApplication", () => {
       const res = await runShareApplicationRaw(fxCore, inputs);
       chai.assert.isTrue(res.isOk());
       chai.assert.equal(shareWithTenantStub.mock.calls.length, 1);
+      chai.assert.deepEqual(parseShareConfigStub.mock.calls[0], [".", "prod"]);
     });
   });
 

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -274,9 +274,11 @@ describe("Collaborator APIs for V3", () => {
         })
       );
       const expectedTitleId = "test-agent-title";
-      vi.spyOn(shareUtils, "parseShareAppActionYamlConfig").mockResolvedValueOnce(
-        ok({ titleId: expectedTitleId, teamsappId: "", appId: "" })
-      );
+      const parseShareConfigSpy = vi
+        .spyOn(shareUtils, "parseShareAppActionYamlConfig")
+        .mockResolvedValueOnce(
+          ok({ titleId: expectedTitleId, teamsappId: "", appId: "" })
+        );
       vi.spyOn(AgentCollaboration.prototype, "listCollaborator").mockResolvedValue(
         ok([
           {
@@ -287,10 +289,12 @@ describe("Collaborator APIs for V3", () => {
           },
         ])
       );
+      inputs.env = "prod";
       inputs[QuestionNames.collaborationAppType] = [CollaborationConstants.AgentOptionId];
       inputs[CollaborationConstants.IncludeCollaborators] = true;
       const result = await listCollaborator(ctx, inputs, tokenProvider);
       assert.isTrue(result.isOk());
+      assert.deepEqual(parseShareConfigSpy.mock.calls[0], [inputs.projectPath, "prod"]);
       assert.deepEqual(result._unsafeUnwrap().collaborators, [
         {
           userObjectId: "agent-only-user-object-id",
@@ -736,11 +740,12 @@ describe("Collaborator APIs for V3", () => {
       const expectedTitleId = "test-agent-title";
       inputs.email = "your_collaborator@yourcompany.com";
       inputs.platform = Platform.CLI;
+      inputs.env = "prod";
       inputs[QuestionNames.collaborationAppType] = [CollaborationConstants.AgentOptionId];
 
-      vi.spyOn(shareUtils, "parseShareAppActionYamlConfig").mockResolvedValueOnce(
-        ok({ titleId: expectedTitleId, teamsappId: "", appId: "" })
-      );
+      const parseShareConfigSpy = vi
+        .spyOn(shareUtils, "parseShareAppActionYamlConfig")
+        .mockResolvedValueOnce(ok({ titleId: expectedTitleId, teamsappId: "", appId: "" }));
       vi.spyOn(AgentCollaboration.prototype, "grantPermission").mockResolvedValue(
         ok([
           {
@@ -754,6 +759,7 @@ describe("Collaborator APIs for V3", () => {
 
       const result = await grantPermission(ctx, inputs, tokenProvider);
       assert.isTrue(result.isOk());
+      assert.deepEqual(parseShareConfigSpy.mock.calls[0], [inputs.projectPath, "prod"]);
       if (result.isOk()) {
         const agentPermission = result.value.permissions?.find((p) => p.name === "agent_app");
         assert.isDefined(agentPermission);

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -276,9 +276,7 @@ describe("Collaborator APIs for V3", () => {
       const expectedTitleId = "test-agent-title";
       const parseShareConfigSpy = vi
         .spyOn(shareUtils, "parseShareAppActionYamlConfig")
-        .mockResolvedValueOnce(
-          ok({ titleId: expectedTitleId, teamsappId: "", appId: "" })
-        );
+        .mockResolvedValueOnce(ok({ titleId: expectedTitleId, teamsappId: "", appId: "" }));
       vi.spyOn(AgentCollaboration.prototype, "listCollaborator").mockResolvedValue(
         ok([
           {


### PR DESCRIPTION
## Summary

- allow the share configuration parser to resolve the YAML and environment file for the requested environment
- propagate `inputs.env` through share, remove-access, collaborator, and remove-user question flows
- preserve the existing `process.env` precedence and the default `dev` behavior
- add regression coverage for non-dev environment propagation

## Testing

- `git diff --cached --check`
- Unit tests were not run because workspace dependencies, including Vitest, are not installed in this environment.

Closes #16611