### PR TITLE
fix(scaffolding): pass authorization to Python basic CEA

### DIFF
--- a/docs/03-specs/operations/product/compile-vscuse-case-bundles.md
+++ b/docs/03-specs/operations/product/compile-vscuse-case-bundles.md
@@ -381,6 +381,14 @@ duplicated as case step references. A profile without lifecycle prelaunch tasks 
 explicit preceding lifecycle definitions, such as `provision` or `deploy`, required by its semantic
 adapter.
 
+A remote target whose adapter declares deployed-runtime readiness waits for the generated project's
+`BOT_ENDPOINT` to accept an unauthenticated HTTPS POST at `/api/messages` before starting its browser
+profile. The probe parses `env/.env.dev` without executing it, requires the generated Azure App
+Service origin, never prints the endpoint, and accepts the bot route's expected `400`, `401`, `403`,
+or `415` response as evidence that the application process owns the route. Other responses and
+connection failures remain retryable readiness failures. Profiles without that explicit adapter,
+including local targets, tabs, and declarative-agent previews, do not receive the probe.
+
 `open` is a separate convergent operation over the current target. `kind` identifies whether the
 surface activates an `app` or an `agent`; `destination` identifies whether success must produce
 `chat-ready` or `page-ready`. A target profile registers one activation adapter per destination it
@@ -1356,6 +1364,7 @@ coordinates, omit required prompt guards, or silently choose a nearby component.
 | VCB-161 | Given the Weather Agent TypeScript and JavaScript OpenAI Playground cases, each endpoint redirect uses a `playgroundEnvironment` operation that adds `OPENAI_BASE_URL` to the `envs` mapping in `m365agents.playground.yml` which writes `.localConfigs.playground`; the generated mutation must not target `m365agents.local.yml`, because the Playground launch does not consume `.localConfigs`.                                                                                                                                                                                                                                                                                                                                                                  |
 | VCB-162 | Given a checked `da/no-action` project, `workflowVersion.with.version: v1.9`, a preceding Microsoft 365 login, and `share` with the specified-users scope and an environment-backed email, compilation replaces and verifies only the top-level `m365agents.yml` version, executes the complete Share question flow without coordinates, and asserts the unsupported-workflow-version notification. The generated manual case authors `projectType`, `daTemplate`, `workspaceFolder`, and `appName` in the prompt order required by `da/no-action`, and replaces `DA_Error_Message_of_Legacy_Projects.json`; it preserves the current VSIX-to-engine compatibility contract but does not install or restart historical extension versions.                           |
 | VCB-163 | Given the invalid-character app-name attempt has returned through Workspace Folder and the overlength attempt begins, its opening visual assertion describes only the currently visible Application Name prompt and readiness for text input; it does not require the current screenshot to prove the preceding invalid-character correction history.                                                                                                                                                                                                                                                                                                                                                                                                                |
+| VCB-164 | Given a remote target whose semantic adapter explicitly declares deployed-runtime readiness, compilation emits a CodeAgent probe before the target command that parses `BOT_ENDPOINT` from `env/.env.dev` without shell evaluation, requires the generated Azure App Service HTTPS origin, sends an empty unauthenticated POST to `/api/messages` without logging the endpoint, retries connection failures and responses other than `400`, `401`, `403`, or `415` for up to 600 seconds, and accepts one of those expected bot-route responses as proof that the application process owns the route. Targets without that explicit adapter receive no probe.                                                                                                        |
 
 ## Boundary
 
@@ -1369,5 +1378,7 @@ coordinates, omit required prompt guards, or silently choose a nearby component.
 - Defining credentials in source control.
 - Installing, activating, or restarting historical extension versions to reproduce their complete
   generated project output.
+- Sending a Bot Framework activity or validating downstream model/service health as part of remote
+  runtime readiness.
 - Proving internal capability or tool invocation through traces, network interception, citations,
   or action-card structure in the V1 `chat` check.

--- a/docs/03-specs/scenarios/teams/create-basic-custom-engine-agent.md
+++ b/docs/03-specs/scenarios/teams/create-basic-custom-engine-agent.md
@@ -4,14 +4,15 @@
 
 ## Acceptance Criteria
 
-| ID | Runtime | Purpose | Gate | Harness | Scenario | Expected result |
-| --- | --- | --- | --- | --- | --- | --- |
-| SCN-CREATE-BASIC-CEA-01 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the TypeScript basic custom engine agent template. | The scaffold writes the TypeScript agent app files. |
-| SCN-CREATE-BASIC-CEA-02 | L1 | scenario | per-PR | InMemoryRuntime | Render a TypeScript basic custom engine agent with app name `My Agent App`. | Package and manifest app-name fields are rendered from caller floor values. |
-| SCN-CREATE-BASIC-CEA-03 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the JavaScript basic custom engine agent template. | The scaffold selects the JavaScript subtree and writes JavaScript entry files. |
-| SCN-CREATE-BASIC-CEA-04 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the Python basic custom engine agent template. | The scaffold selects the Python subtree and omits Node package files. |
-| SCN-CREATE-BASIC-CEA-05 | L1 | scenario | per-PR | InMemoryRuntime | Run the scaffold pipeline. | The only pipeline step is `require-empty-target`. |
-| SCN-CREATE-BASIC-CEA-06 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold into a target that already contains a file. | The scaffold fails with `REQUIRE_EMPTY_TARGET` before writing files. |
+| ID                      | Runtime | Purpose       | Gate   | Harness                  | Scenario                                                                    | Expected result                                                                                                      |
+| ----------------------- | ------- | ------------- | ------ | ------------------------ | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| SCN-CREATE-BASIC-CEA-01 | L1      | scenario      | per-PR | InMemoryRuntime          | Scaffold the TypeScript basic custom engine agent template.                 | The scaffold writes the TypeScript agent app files.                                                                  |
+| SCN-CREATE-BASIC-CEA-02 | L1      | scenario      | per-PR | InMemoryRuntime          | Render a TypeScript basic custom engine agent with app name `My Agent App`. | Package and manifest app-name fields are rendered from caller floor values.                                          |
+| SCN-CREATE-BASIC-CEA-03 | L1      | scenario      | per-PR | InMemoryRuntime          | Scaffold the JavaScript basic custom engine agent template.                 | The scaffold selects the JavaScript subtree and writes JavaScript entry files.                                       |
+| SCN-CREATE-BASIC-CEA-04 | L1      | scenario      | per-PR | InMemoryRuntime          | Scaffold the Python basic custom engine agent template.                     | The scaffold selects the Python subtree and omits Node package files.                                                |
+| SCN-CREATE-BASIC-CEA-05 | L1      | scenario      | per-PR | InMemoryRuntime          | Run the scaffold pipeline.                                                  | The only pipeline step is `require-empty-target`.                                                                    |
+| SCN-CREATE-BASIC-CEA-06 | L1      | scenario      | per-PR | InMemoryRuntime          | Scaffold into a target that already contains a file.                        | The scaffold fails with `REQUIRE_EMPTY_TARGET` before writing files.                                                 |
+| SCN-CREATE-BASIC-CEA-07 | L1      | compatibility | per-PR | CompatibilityDiffHarness | Compare the v3 and rendered v4 Python `AgentApplication` construction.      | V4 supplies the same MSAL connection manager as v3 so the Agents SDK receives its required authorization dependency. |
 
 ## Flow
 
@@ -26,10 +27,11 @@ flowchart TD
 ## Boundary
 
 - This scenario covers v4 package rendering for a new basic custom engine agent project.
-- It does not provision Azure, register a bot, or run CLI/VS Code end-to-end scaffolding.
+- It does not provision Azure, register a bot, or run CLI/VS Code end-to-end scaffolding; AC-07 compares the Python template construction statically.
 
 ## Invariants
 
 - The v4 create route must not fall back to the v3 `DefaultTemplateGenerator`.
 - The package must render only the selected language subtree.
 - The package must reject non-empty targets before writing output.
+- The Python template must preserve the v3 `AgentApplication` authorization wiring.

--- a/packages/fx-core/tests/v4/scenarios/createBasicCustomEngineAgent.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createBasicCustomEngineAgent.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as fs from "fs";
+import * as path from "path";
 import { UserError } from "@microsoft/teamsfx-api";
 import { assert } from "vitest";
 import { REQUIRE_EMPTY_TARGET } from "../../../src/v4/pipeline/runScaffoldPipeline";
@@ -11,6 +13,7 @@ import {
   readJsonObject,
   recordProperty,
   runV4Package,
+  text,
 } from "./helpers/scenarioHarness";
 
 /**
@@ -18,7 +21,7 @@ import {
  * `InMemoryRuntime`.
  *
  * Spec: docs/03-specs/scenarios/teams/create-basic-custom-engine-agent.md
- * (SCN-CREATE-BASIC-CEA-01..06)
+ * (SCN-CREATE-BASIC-CEA-01..07)
  */
 
 const templatePackage = loadV4Package("create", "basic-custom-engine-agent");
@@ -26,6 +29,12 @@ const appName = "My Agent App";
 
 async function run(language: "typescript" | "javascript" | "python" = "typescript") {
   return runV4Package(templatePackage, { callerFloor: { appName, language } });
+}
+
+function agentApplicationArguments(source: string): string {
+  const match = source.match(/AgentApplication\[TurnState\]\(\s*([\s\S]*?)\n\)/);
+  assert.isNotNull(match, "Python agent must construct AgentApplication[TurnState]");
+  return (match?.[1] ?? "").replace(/\s+/g, " ").trim();
 }
 
 describe("SCN-TEAMS-CREATE-BASIC-CUSTOM-ENGINE-AGENT (v4, T3 InMemoryRuntime)", () => {
@@ -89,5 +98,17 @@ describe("SCN-TEAMS-CREATE-BASIC-CUSTOM-ENGINE-AGENT (v4, T3 InMemoryRuntime)", 
     assert.instanceOf(error, UserError);
     assert.strictEqual(error.name, REQUIRE_EMPTY_TARGET);
     assert.strictEqual(runtime.files.size, 0);
+  });
+
+  it("SCN-CREATE-BASIC-CEA-07: Python preserves v3 AgentApplication authorization wiring", async () => {
+    const v3AgentPath = path.resolve(
+      templatePackage.packageDir,
+      "../../../vsc/python/basic-custom-engine-agent/src/agent.py.tpl"
+    );
+    const v3Arguments = agentApplicationArguments(fs.readFileSync(v3AgentPath, "utf8"));
+    const { files } = await run("python");
+
+    assert.include(v3Arguments, "connection_manager=connection_manager");
+    assert.strictEqual(agentApplicationArguments(text(files, "src/agent.py")), v3Arguments);
   });
 });

--- a/packages/tests/vscuse/vscode-test-cases/components/workspace/assert-deployed-runtime-ready.json.tpl
+++ b/packages/tests/vscuse/vscode-test-cases/components/workspace/assert-deployed-runtime-ready.json.tpl
@@ -1,0 +1,30 @@
+{
+  "component": {
+    "version": 1,
+    "id": "assertDeployedRuntimeReady",
+    "parameters": ["instanceSuffix"]
+  },
+  "steps": [
+    {
+      "step_id": "step_assertDeployedRuntimeReady_{{text:instanceSuffix}}",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    }
+  ]
+}

--- a/packages/tests/vscuse/vscode-test-cases/engine/semantic-step-compiler.cjs
+++ b/packages/tests/vscuse/vscode-test-cases/engine/semantic-step-compiler.cjs
@@ -476,6 +476,9 @@ const targetAdapters = {
     },
     readySubject: teamsAppDetailsSubject,
     requires: ["login:azure", "login:m365", "provision", "deploy"],
+    runtimeReadiness: {
+      component: "workspace/assert-deployed-runtime-ready.json.tpl",
+    },
   },
   // The v4 TypeScript Bot and Message Extension templates title the same
   // remote Teams launch `View Remote App in Teams (Chrome)`, and so does the Tab
@@ -496,6 +499,10 @@ const targetAdapters = {
     },
     readySubject: teamsAppDetailsSubject,
     requires: ["login:azure", "login:m365", "provision", "deploy"],
+    runtimeReadiness: {
+      component: "workspace/assert-deployed-runtime-ready.json.tpl",
+      templates: ["default-bot", "default-message-extension"],
+    },
   },
   // The Python templates and the Teams Collaborator Agent TypeScript template
   // name the same remote Teams launch `Launch Remote (Chrome)`, without the `in
@@ -517,6 +524,9 @@ const targetAdapters = {
     },
     readySubject: teamsAppDetailsSubject,
     requires: ["login:azure", "login:m365", "provision", "deploy"],
+    runtimeReadiness: {
+      component: "workspace/assert-deployed-runtime-ready.json.tpl",
+    },
   },
   "Preview in Copilot (Chrome)": {
     browserAuthentication: {
@@ -550,6 +560,9 @@ const targetAdapters = {
     },
     readySubject: copilotAgentSubject,
     requires: ["login:azure", "login:m365", "provision", "deploy"],
+    runtimeReadiness: {
+      component: "workspace/assert-deployed-runtime-ready.json.tpl",
+    },
   },
   // General Teams Agent templates expose the same custom-engine Copilot flow
   // without the preview prefix.
@@ -565,6 +578,9 @@ const targetAdapters = {
     },
     readySubject: copilotAgentSubject,
     requires: ["login:azure", "login:m365", "provision", "deploy"],
+    runtimeReadiness: {
+      component: "workspace/assert-deployed-runtime-ready.json.tpl",
+    },
   },
   // The local debug profiles below carry a preLaunchTask chain that validates
   // prerequisites, registers the app, starts the tunnel, and runs the local
@@ -2137,7 +2153,19 @@ function createSemanticStepCompiler() {
     }
 
     const output = [];
-    let error = append(
+    let error;
+    if (
+      profile.runtimeReadiness !== undefined &&
+      (profile.runtimeReadiness.templates === undefined ||
+        profile.runtimeReadiness.templates.includes(state.template))
+    ) {
+      error = append(
+        output,
+        render(state, profile.runtimeReadiness.component, {}),
+      );
+      if (error) return error;
+    }
+    error = append(
       output,
       render(state, "command-palette/execute-command.json.tpl", {
         commandTitle: commandTitles.target,

--- a/packages/tests/vscuse/vscode-test-cases/engine/semantic-step-compiler.test.cjs
+++ b/packages/tests/vscuse/vscode-test-cases/engine/semantic-step-compiler.test.cjs
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
 const fsSync = require("node:fs");
 const fs = require("node:fs/promises");
 const os = require("node:os");
@@ -1969,6 +1970,106 @@ test("VCB-71: the Python remote Teams target opens the app through the Teams add
   assert.equal(
     plan.steps.some((step) => step.step_id.startsWith("step_addAndOpenApp_")),
     true,
+  );
+});
+
+test("VCB-164: a remote bot target waits for its deployed runtime before launch", async () => {
+  const result = await compileFixture(
+    "basic-custom-engine-agent.yml",
+    (sourceText) => sourceText,
+  );
+
+  const defaultBotResult = await compileFixture(
+    "default-bot.yml",
+    (sourceText) => sourceText,
+  );
+  const tabResult = await compileFixture(
+    "non-sso-tab.yml",
+    (sourceText) => sourceText,
+  );
+
+  assert.equal(result.ok, true, result.diagnostics?.[0]?.code);
+  assert.equal(
+    defaultBotResult.ok,
+    true,
+    defaultBotResult.diagnostics?.[0]?.code,
+  );
+  assert.equal(tabResult.ok, true, tabResult.diagnostics?.[0]?.code);
+  const remotePlan = result.value.find(
+    (generated) =>
+      generated.caseId === "basic-cea-py-azure-openai-remote-teams",
+  ).plan;
+  const localPlan = result.value.find(
+    (generated) => generated.caseId === "basic-cea-py-azure-openai-local-teams",
+  ).plan;
+  const defaultBotPlan = defaultBotResult.value.find(
+    (generated) => generated.caseId === "simple-bot-ts-remote-teams",
+  ).plan;
+  const tabPlan = tabResult.value.find(
+    (generated) => generated.caseId === "tab-ts-remote-teams",
+  ).plan;
+  const probeIndex = remotePlan.steps.findIndex((step) =>
+    step.step_id.startsWith("step_assertDeployedRuntimeReady_"),
+  );
+  const targetIndex = remotePlan.steps.findIndex(
+    (step) =>
+      step.tool === "type_text" &&
+      step.parameters.text === "Debug: Select and Start Debugging",
+  );
+
+  assert.notEqual(probeIndex, -1);
+  assert.equal(probeIndex < targetIndex, true);
+  assert.equal(remotePlan.steps[probeIndex].agent, "code");
+  assert.equal(
+    remotePlan.steps[probeIndex].tags.includes("step_retry_timeout:600"),
+    true,
+  );
+  const sample = remotePlan.steps[probeIndex].parameters.sample;
+  assert.match(sample, /parsed\.scheme != \"https\"/);
+  assert.match(sample, /\.azurewebsites\.net/);
+  assert.match(sample, /method=\"POST\"/);
+  assert.match(sample, /status not in \{400, 401, 403, 415\}/);
+  assert.doesNotMatch(sample, /print\(/);
+  const scriptMatch = sample.match(/python3 - <<'PY'\n([\s\S]+)\nPY\n```$/);
+  assert.notEqual(scriptMatch, null);
+  const projectDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), "vscuse-runtime-readiness-"),
+  );
+  try {
+    await fs.mkdir(path.join(projectDirectory, "env"));
+    await fs.writeFile(
+      path.join(projectDirectory, "env", ".env.dev"),
+      "BOT_ENDPOINT=https://ready.azurewebsites.net:secret\n",
+      "utf8",
+    );
+    const execution = spawnSync("python3", ["-c", scriptMatch[1]], {
+      encoding: "utf8",
+      env: { ...process.env, PROJECT_DIR: projectDirectory },
+    });
+
+    assert.notEqual(execution.status, 0);
+    assert.match(execution.stderr, /The deployed bot endpoint is invalid/);
+    assert.doesNotMatch(execution.stderr, /secret/);
+  } finally {
+    await fs.rm(projectDirectory, { force: true, recursive: true });
+  }
+  assert.equal(
+    defaultBotPlan.steps.some((step) =>
+      step.step_id.startsWith("step_assertDeployedRuntimeReady_"),
+    ),
+    true,
+  );
+  assert.equal(
+    localPlan.steps.some((step) =>
+      step.step_id.startsWith("step_assertDeployedRuntimeReady_"),
+    ),
+    false,
+  );
+  assert.equal(
+    tabPlan.steps.some((step) =>
+      step.step_id.startsWith("step_assertDeployedRuntimeReady_"),
+    ),
+    false,
   );
 });
 

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 163,
+    "total_steps": 164,
     "name": "basic-cea-js-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -154,25 +154,26 @@
       "step_clickPrimaryAction_assertDialog_c0de2a626_6_4",
       "step_clickPrimaryAction_click_c0de2a626_6_4",
       "step_assertNotificationContains_assert_c0de2a626_6_5",
-      "step_executeCommand_open_c0de2a626_7_1",
-      "step_executeCommand_assertPalette_c0de2a626_7_1",
-      "step_executeCommand_filter_c0de2a626_7_1",
-      "step_executeCommand_assertCommand_c0de2a626_7_1",
-      "step_executeCommand_execute_c0de2a626_7_1",
-      "step_filterOption_filter_c0de2a626_7_2",
-      "step_filterOption_assertOption_c0de2a626_7_2",
-      "step_filterOption_confirm_c0de2a626_7_2",
-      "step_browserM365SignIn_assertAccount_c0de2a626_7_3",
-      "step_browserM365SignIn_focusAccount_c0de2a626_7_3",
-      "step_browserM365SignIn_enterAccount_c0de2a626_7_3",
-      "step_browserM365SignIn_submitAccount_c0de2a626_7_3",
-      "step_browserM365SignIn_assertPassword_c0de2a626_7_3",
-      "step_browserM365SignIn_enterPassword_c0de2a626_7_3",
-      "step_browserM365SignIn_submitPassword_c0de2a626_7_3",
-      "step_browserM365SignIn_assertStaySignedIn_c0de2a626_7_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c0de2a626_7_3",
-      "step_assertReady_assertReady_c0de2a626_7_4",
-      "step_zoomOut_zoomOut_c0de2a626_7_5",
+      "step_assertDeployedRuntimeReady_c0de2a626_7_1",
+      "step_executeCommand_open_c0de2a626_7_2",
+      "step_executeCommand_assertPalette_c0de2a626_7_2",
+      "step_executeCommand_filter_c0de2a626_7_2",
+      "step_executeCommand_assertCommand_c0de2a626_7_2",
+      "step_executeCommand_execute_c0de2a626_7_2",
+      "step_filterOption_filter_c0de2a626_7_3",
+      "step_filterOption_assertOption_c0de2a626_7_3",
+      "step_filterOption_confirm_c0de2a626_7_3",
+      "step_browserM365SignIn_assertAccount_c0de2a626_7_4",
+      "step_browserM365SignIn_focusAccount_c0de2a626_7_4",
+      "step_browserM365SignIn_enterAccount_c0de2a626_7_4",
+      "step_browserM365SignIn_submitAccount_c0de2a626_7_4",
+      "step_browserM365SignIn_assertPassword_c0de2a626_7_4",
+      "step_browserM365SignIn_enterPassword_c0de2a626_7_4",
+      "step_browserM365SignIn_submitPassword_c0de2a626_7_4",
+      "step_browserM365SignIn_assertStaySignedIn_c0de2a626_7_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c0de2a626_7_4",
+      "step_assertReady_assertReady_c0de2a626_7_5",
+      "step_zoomOut_zoomOut_c0de2a626_7_6",
       "step_sendCopilotMessage_assertInput_c0de2a626_9_1",
       "step_sendCopilotMessage_focusInput_c0de2a626_9_1",
       "step_sendCopilotMessage_type_c0de2a626_9_1",
@@ -3279,7 +3280,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c0de2a626_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c0de2a626_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c0de2a626_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c0de2a626_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3291,7 +3315,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c0de2a626_6_5"
+        "step_assertDeployedRuntimeReady_c0de2a626_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3301,7 +3325,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c0de2a626_7_1",
+      "step_id": "step_executeCommand_assertPalette_c0de2a626_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3311,7 +3335,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c0de2a626_7_1"
+        "step_executeCommand_open_c0de2a626_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3322,7 +3346,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c0de2a626_7_1",
+      "step_id": "step_executeCommand_filter_c0de2a626_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3334,7 +3358,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c0de2a626_7_1"
+        "step_executeCommand_assertPalette_c0de2a626_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3344,7 +3368,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c0de2a626_7_1",
+      "step_id": "step_executeCommand_assertCommand_c0de2a626_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3354,7 +3378,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c0de2a626_7_1"
+        "step_executeCommand_filter_c0de2a626_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3365,7 +3389,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c0de2a626_7_1",
+      "step_id": "step_executeCommand_execute_c0de2a626_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3377,7 +3401,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c0de2a626_7_1"
+        "step_executeCommand_assertCommand_c0de2a626_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3387,7 +3411,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c0de2a626_7_2",
+      "step_id": "step_filterOption_filter_c0de2a626_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3399,7 +3423,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c0de2a626_7_1"
+        "step_executeCommand_execute_c0de2a626_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3409,7 +3433,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c0de2a626_7_2",
+      "step_id": "step_filterOption_assertOption_c0de2a626_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3419,7 +3443,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c0de2a626_7_2"
+        "step_filterOption_filter_c0de2a626_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3430,7 +3454,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c0de2a626_7_2",
+      "step_id": "step_filterOption_confirm_c0de2a626_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3442,7 +3466,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c0de2a626_7_2"
+        "step_filterOption_assertOption_c0de2a626_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3452,7 +3476,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c0de2a626_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3462,7 +3486,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c0de2a626_7_2"
+        "step_filterOption_confirm_c0de2a626_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3473,7 +3497,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c0de2a626_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3487,7 +3511,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c0de2a626_7_3"
+        "step_browserM365SignIn_assertAccount_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c0de2a626_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3509,7 +3533,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c0de2a626_7_3"
+        "step_browserM365SignIn_focusAccount_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3519,7 +3543,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c0de2a626_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3531,7 +3555,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c0de2a626_7_3"
+        "step_browserM365SignIn_enterAccount_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3541,7 +3565,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c0de2a626_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3551,7 +3575,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c0de2a626_7_3"
+        "step_browserM365SignIn_submitAccount_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3562,7 +3586,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c0de2a626_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3574,7 +3598,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c0de2a626_7_3"
+        "step_browserM365SignIn_assertPassword_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3584,7 +3608,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c0de2a626_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3596,7 +3620,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c0de2a626_7_3"
+        "step_browserM365SignIn_enterPassword_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3606,7 +3630,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c0de2a626_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3616,7 +3640,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c0de2a626_7_3"
+        "step_browserM365SignIn_submitPassword_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3627,7 +3651,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c0de2a626_7_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c0de2a626_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3639,7 +3663,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c0de2a626_7_3"
+        "step_browserM365SignIn_assertStaySignedIn_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3650,7 +3674,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c0de2a626_7_4",
+      "step_id": "step_assertReady_assertReady_c0de2a626_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3660,7 +3684,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c0de2a626_7_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c0de2a626_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3671,7 +3695,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c0de2a626_7_5",
+      "step_id": "step_zoomOut_zoomOut_c0de2a626_7_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3683,7 +3707,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c0de2a626_7_4"
+        "step_assertReady_assertReady_c0de2a626_7_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3703,7 +3727,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c0de2a626_7_5"
+        "step_zoomOut_zoomOut_c0de2a626_7_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 163,
+    "total_steps": 164,
     "name": "basic-cea-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -154,21 +154,22 @@
       "step_clickPrimaryAction_assertDialog_cc59f0e87_6_4",
       "step_clickPrimaryAction_click_cc59f0e87_6_4",
       "step_assertNotificationContains_assert_cc59f0e87_6_5",
-      "step_executeCommand_open_cc59f0e87_7_1",
-      "step_executeCommand_assertPalette_cc59f0e87_7_1",
-      "step_executeCommand_filter_cc59f0e87_7_1",
-      "step_executeCommand_assertCommand_cc59f0e87_7_1",
-      "step_executeCommand_execute_cc59f0e87_7_1",
-      "step_filterOption_filter_cc59f0e87_7_2",
-      "step_filterOption_assertOption_cc59f0e87_7_2",
-      "step_filterOption_confirm_cc59f0e87_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_cc59f0e87_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_cc59f0e87_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_cc59f0e87_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_cc59f0e87_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cc59f0e87_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cc59f0e87_7_3",
-      "step_assertReady_assertReady_cc59f0e87_7_4",
+      "step_assertDeployedRuntimeReady_cc59f0e87_7_1",
+      "step_executeCommand_open_cc59f0e87_7_2",
+      "step_executeCommand_assertPalette_cc59f0e87_7_2",
+      "step_executeCommand_filter_cc59f0e87_7_2",
+      "step_executeCommand_assertCommand_cc59f0e87_7_2",
+      "step_executeCommand_execute_cc59f0e87_7_2",
+      "step_filterOption_filter_cc59f0e87_7_3",
+      "step_filterOption_assertOption_cc59f0e87_7_3",
+      "step_filterOption_confirm_cc59f0e87_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_cc59f0e87_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_cc59f0e87_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_cc59f0e87_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_cc59f0e87_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cc59f0e87_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cc59f0e87_7_4",
+      "step_assertReady_assertReady_cc59f0e87_7_5",
       "step_addAndOpenApp_assertAdd_cc59f0e87_8_1",
       "step_addAndOpenApp_add_cc59f0e87_8_1",
       "step_addAndOpenApp_assertAdded_cc59f0e87_8_1",
@@ -3279,7 +3280,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cc59f0e87_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_cc59f0e87_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cc59f0e87_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cc59f0e87_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3291,7 +3315,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cc59f0e87_6_5"
+        "step_assertDeployedRuntimeReady_cc59f0e87_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3301,7 +3325,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cc59f0e87_7_1",
+      "step_id": "step_executeCommand_assertPalette_cc59f0e87_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3311,7 +3335,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cc59f0e87_7_1"
+        "step_executeCommand_open_cc59f0e87_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3322,7 +3346,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cc59f0e87_7_1",
+      "step_id": "step_executeCommand_filter_cc59f0e87_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3334,7 +3358,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cc59f0e87_7_1"
+        "step_executeCommand_assertPalette_cc59f0e87_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3344,7 +3368,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cc59f0e87_7_1",
+      "step_id": "step_executeCommand_assertCommand_cc59f0e87_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3354,7 +3378,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cc59f0e87_7_1"
+        "step_executeCommand_filter_cc59f0e87_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3365,7 +3389,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cc59f0e87_7_1",
+      "step_id": "step_executeCommand_execute_cc59f0e87_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3377,7 +3401,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cc59f0e87_7_1"
+        "step_executeCommand_assertCommand_cc59f0e87_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3387,7 +3411,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cc59f0e87_7_2",
+      "step_id": "step_filterOption_filter_cc59f0e87_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3399,7 +3423,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cc59f0e87_7_1"
+        "step_executeCommand_execute_cc59f0e87_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3409,7 +3433,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cc59f0e87_7_2",
+      "step_id": "step_filterOption_assertOption_cc59f0e87_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3419,7 +3443,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cc59f0e87_7_2"
+        "step_filterOption_filter_cc59f0e87_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3430,7 +3454,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cc59f0e87_7_2",
+      "step_id": "step_filterOption_confirm_cc59f0e87_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3442,7 +3466,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cc59f0e87_7_2"
+        "step_filterOption_assertOption_cc59f0e87_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3452,7 +3476,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cc59f0e87_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cc59f0e87_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3462,7 +3486,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cc59f0e87_7_2"
+        "step_filterOption_confirm_cc59f0e87_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3473,7 +3497,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cc59f0e87_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cc59f0e87_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3487,7 +3511,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cc59f0e87_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_cc59f0e87_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cc59f0e87_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cc59f0e87_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3509,7 +3533,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cc59f0e87_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_cc59f0e87_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3519,7 +3543,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cc59f0e87_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cc59f0e87_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3531,7 +3555,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cc59f0e87_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_cc59f0e87_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3541,7 +3565,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cc59f0e87_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cc59f0e87_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3551,7 +3575,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cc59f0e87_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_cc59f0e87_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3562,7 +3586,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cc59f0e87_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cc59f0e87_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3574,7 +3598,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cc59f0e87_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cc59f0e87_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3585,7 +3609,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cc59f0e87_7_4",
+      "step_id": "step_assertReady_assertReady_cc59f0e87_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3595,7 +3619,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cc59f0e87_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cc59f0e87_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3616,7 +3640,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cc59f0e87_7_4"
+        "step_assertReady_assertReady_cc59f0e87_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 158,
+    "total_steps": 159,
     "name": "basic-cea-js-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -150,25 +150,26 @@
       "step_clickPrimaryAction_assertDialog_ccb34ef44_8_4",
       "step_clickPrimaryAction_click_ccb34ef44_8_4",
       "step_assertNotificationContains_assert_ccb34ef44_8_5",
-      "step_executeCommand_open_ccb34ef44_9_1",
-      "step_executeCommand_assertPalette_ccb34ef44_9_1",
-      "step_executeCommand_filter_ccb34ef44_9_1",
-      "step_executeCommand_assertCommand_ccb34ef44_9_1",
-      "step_executeCommand_execute_ccb34ef44_9_1",
-      "step_filterOption_filter_ccb34ef44_9_2",
-      "step_filterOption_assertOption_ccb34ef44_9_2",
-      "step_filterOption_confirm_ccb34ef44_9_2",
-      "step_browserM365SignIn_assertAccount_ccb34ef44_9_3",
-      "step_browserM365SignIn_focusAccount_ccb34ef44_9_3",
-      "step_browserM365SignIn_enterAccount_ccb34ef44_9_3",
-      "step_browserM365SignIn_submitAccount_ccb34ef44_9_3",
-      "step_browserM365SignIn_assertPassword_ccb34ef44_9_3",
-      "step_browserM365SignIn_enterPassword_ccb34ef44_9_3",
-      "step_browserM365SignIn_submitPassword_ccb34ef44_9_3",
-      "step_browserM365SignIn_assertStaySignedIn_ccb34ef44_9_3",
-      "step_browserM365SignIn_confirmStaySignedIn_ccb34ef44_9_3",
-      "step_assertReady_assertReady_ccb34ef44_9_4",
-      "step_zoomOut_zoomOut_ccb34ef44_9_5",
+      "step_assertDeployedRuntimeReady_ccb34ef44_9_1",
+      "step_executeCommand_open_ccb34ef44_9_2",
+      "step_executeCommand_assertPalette_ccb34ef44_9_2",
+      "step_executeCommand_filter_ccb34ef44_9_2",
+      "step_executeCommand_assertCommand_ccb34ef44_9_2",
+      "step_executeCommand_execute_ccb34ef44_9_2",
+      "step_filterOption_filter_ccb34ef44_9_3",
+      "step_filterOption_assertOption_ccb34ef44_9_3",
+      "step_filterOption_confirm_ccb34ef44_9_3",
+      "step_browserM365SignIn_assertAccount_ccb34ef44_9_4",
+      "step_browserM365SignIn_focusAccount_ccb34ef44_9_4",
+      "step_browserM365SignIn_enterAccount_ccb34ef44_9_4",
+      "step_browserM365SignIn_submitAccount_ccb34ef44_9_4",
+      "step_browserM365SignIn_assertPassword_ccb34ef44_9_4",
+      "step_browserM365SignIn_enterPassword_ccb34ef44_9_4",
+      "step_browserM365SignIn_submitPassword_ccb34ef44_9_4",
+      "step_browserM365SignIn_assertStaySignedIn_ccb34ef44_9_4",
+      "step_browserM365SignIn_confirmStaySignedIn_ccb34ef44_9_4",
+      "step_assertReady_assertReady_ccb34ef44_9_5",
+      "step_zoomOut_zoomOut_ccb34ef44_9_6",
       "step_sendCopilotMessage_assertInput_ccb34ef44_11_1",
       "step_sendCopilotMessage_focusInput_ccb34ef44_11_1",
       "step_sendCopilotMessage_type_ccb34ef44_11_1",
@@ -3190,7 +3191,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_ccb34ef44_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_ccb34ef44_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_ccb34ef44_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_ccb34ef44_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3202,7 +3226,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_ccb34ef44_8_5"
+        "step_assertDeployedRuntimeReady_ccb34ef44_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3212,7 +3236,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_ccb34ef44_9_1",
+      "step_id": "step_executeCommand_assertPalette_ccb34ef44_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3222,7 +3246,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_ccb34ef44_9_1"
+        "step_executeCommand_open_ccb34ef44_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3233,7 +3257,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_ccb34ef44_9_1",
+      "step_id": "step_executeCommand_filter_ccb34ef44_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3245,7 +3269,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_ccb34ef44_9_1"
+        "step_executeCommand_assertPalette_ccb34ef44_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3255,7 +3279,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_ccb34ef44_9_1",
+      "step_id": "step_executeCommand_assertCommand_ccb34ef44_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3265,7 +3289,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_ccb34ef44_9_1"
+        "step_executeCommand_filter_ccb34ef44_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3276,7 +3300,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_ccb34ef44_9_1",
+      "step_id": "step_executeCommand_execute_ccb34ef44_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3288,7 +3312,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_ccb34ef44_9_1"
+        "step_executeCommand_assertCommand_ccb34ef44_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3298,7 +3322,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_ccb34ef44_9_2",
+      "step_id": "step_filterOption_filter_ccb34ef44_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3310,7 +3334,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_ccb34ef44_9_1"
+        "step_executeCommand_execute_ccb34ef44_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3320,7 +3344,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_ccb34ef44_9_2",
+      "step_id": "step_filterOption_assertOption_ccb34ef44_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3330,7 +3354,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_ccb34ef44_9_2"
+        "step_filterOption_filter_ccb34ef44_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3341,7 +3365,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_ccb34ef44_9_2",
+      "step_id": "step_filterOption_confirm_ccb34ef44_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3353,7 +3377,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_ccb34ef44_9_2"
+        "step_filterOption_assertOption_ccb34ef44_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3363,7 +3387,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_assertAccount_ccb34ef44_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3373,7 +3397,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_ccb34ef44_9_2"
+        "step_filterOption_confirm_ccb34ef44_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3384,7 +3408,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_focusAccount_ccb34ef44_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3398,7 +3422,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_ccb34ef44_9_3"
+        "step_browserM365SignIn_assertAccount_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3408,7 +3432,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_enterAccount_ccb34ef44_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3420,7 +3444,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_ccb34ef44_9_3"
+        "step_browserM365SignIn_focusAccount_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3430,7 +3454,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_submitAccount_ccb34ef44_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3442,7 +3466,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_ccb34ef44_9_3"
+        "step_browserM365SignIn_enterAccount_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3452,7 +3476,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_assertPassword_ccb34ef44_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3462,7 +3486,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_ccb34ef44_9_3"
+        "step_browserM365SignIn_submitAccount_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3473,7 +3497,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_enterPassword_ccb34ef44_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3485,7 +3509,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_ccb34ef44_9_3"
+        "step_browserM365SignIn_assertPassword_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3495,7 +3519,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_submitPassword_ccb34ef44_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3507,7 +3531,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_ccb34ef44_9_3"
+        "step_browserM365SignIn_enterPassword_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3517,7 +3541,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_ccb34ef44_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3527,7 +3551,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_ccb34ef44_9_3"
+        "step_browserM365SignIn_submitPassword_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3538,7 +3562,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_ccb34ef44_9_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_ccb34ef44_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3550,7 +3574,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_ccb34ef44_9_3"
+        "step_browserM365SignIn_assertStaySignedIn_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3561,7 +3585,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_ccb34ef44_9_4",
+      "step_id": "step_assertReady_assertReady_ccb34ef44_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3571,7 +3595,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_ccb34ef44_9_3"
+        "step_browserM365SignIn_confirmStaySignedIn_ccb34ef44_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3582,7 +3606,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_ccb34ef44_9_5",
+      "step_id": "step_zoomOut_zoomOut_ccb34ef44_9_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3594,7 +3618,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_ccb34ef44_9_4"
+        "step_assertReady_assertReady_ccb34ef44_9_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3614,7 +3638,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_ccb34ef44_9_5"
+        "step_zoomOut_zoomOut_ccb34ef44_9_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-js-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 159,
+    "total_steps": 160,
     "name": "basic-cea-js-openai-remote-teams",
     "description": {
       "owner": "",
@@ -150,21 +150,22 @@
       "step_clickPrimaryAction_assertDialog_cdc2e2096_8_4",
       "step_clickPrimaryAction_click_cdc2e2096_8_4",
       "step_assertNotificationContains_assert_cdc2e2096_8_5",
-      "step_executeCommand_open_cdc2e2096_9_1",
-      "step_executeCommand_assertPalette_cdc2e2096_9_1",
-      "step_executeCommand_filter_cdc2e2096_9_1",
-      "step_executeCommand_assertCommand_cdc2e2096_9_1",
-      "step_executeCommand_execute_cdc2e2096_9_1",
-      "step_filterOption_filter_cdc2e2096_9_2",
-      "step_filterOption_assertOption_cdc2e2096_9_2",
-      "step_filterOption_confirm_cdc2e2096_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_cdc2e2096_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_cdc2e2096_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_cdc2e2096_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_cdc2e2096_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cdc2e2096_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cdc2e2096_9_3",
-      "step_assertReady_assertReady_cdc2e2096_9_4",
+      "step_assertDeployedRuntimeReady_cdc2e2096_9_1",
+      "step_executeCommand_open_cdc2e2096_9_2",
+      "step_executeCommand_assertPalette_cdc2e2096_9_2",
+      "step_executeCommand_filter_cdc2e2096_9_2",
+      "step_executeCommand_assertCommand_cdc2e2096_9_2",
+      "step_executeCommand_execute_cdc2e2096_9_2",
+      "step_filterOption_filter_cdc2e2096_9_3",
+      "step_filterOption_assertOption_cdc2e2096_9_3",
+      "step_filterOption_confirm_cdc2e2096_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_cdc2e2096_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_cdc2e2096_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_cdc2e2096_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_cdc2e2096_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cdc2e2096_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cdc2e2096_9_4",
+      "step_assertReady_assertReady_cdc2e2096_9_5",
       "step_addAndOpenApp_assertAdd_cdc2e2096_10_1",
       "step_addAndOpenApp_add_cdc2e2096_10_1",
       "step_addAndOpenApp_assertAdded_cdc2e2096_10_1",
@@ -3191,7 +3192,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cdc2e2096_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_cdc2e2096_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cdc2e2096_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cdc2e2096_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3203,7 +3227,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cdc2e2096_8_5"
+        "step_assertDeployedRuntimeReady_cdc2e2096_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3213,7 +3237,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cdc2e2096_9_1",
+      "step_id": "step_executeCommand_assertPalette_cdc2e2096_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3223,7 +3247,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cdc2e2096_9_1"
+        "step_executeCommand_open_cdc2e2096_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3234,7 +3258,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cdc2e2096_9_1",
+      "step_id": "step_executeCommand_filter_cdc2e2096_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3246,7 +3270,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cdc2e2096_9_1"
+        "step_executeCommand_assertPalette_cdc2e2096_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3256,7 +3280,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cdc2e2096_9_1",
+      "step_id": "step_executeCommand_assertCommand_cdc2e2096_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3266,7 +3290,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cdc2e2096_9_1"
+        "step_executeCommand_filter_cdc2e2096_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3277,7 +3301,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cdc2e2096_9_1",
+      "step_id": "step_executeCommand_execute_cdc2e2096_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3289,7 +3313,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cdc2e2096_9_1"
+        "step_executeCommand_assertCommand_cdc2e2096_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3299,7 +3323,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cdc2e2096_9_2",
+      "step_id": "step_filterOption_filter_cdc2e2096_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3311,7 +3335,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cdc2e2096_9_1"
+        "step_executeCommand_execute_cdc2e2096_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3321,7 +3345,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cdc2e2096_9_2",
+      "step_id": "step_filterOption_assertOption_cdc2e2096_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3331,7 +3355,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cdc2e2096_9_2"
+        "step_filterOption_filter_cdc2e2096_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3342,7 +3366,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cdc2e2096_9_2",
+      "step_id": "step_filterOption_confirm_cdc2e2096_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3354,7 +3378,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cdc2e2096_9_2"
+        "step_filterOption_assertOption_cdc2e2096_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3364,7 +3388,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cdc2e2096_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cdc2e2096_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3374,7 +3398,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cdc2e2096_9_2"
+        "step_filterOption_confirm_cdc2e2096_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3385,7 +3409,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cdc2e2096_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cdc2e2096_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3399,7 +3423,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cdc2e2096_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_cdc2e2096_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3409,7 +3433,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cdc2e2096_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cdc2e2096_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3421,7 +3445,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cdc2e2096_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_cdc2e2096_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3431,7 +3455,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cdc2e2096_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cdc2e2096_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cdc2e2096_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_cdc2e2096_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3453,7 +3477,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cdc2e2096_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cdc2e2096_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3463,7 +3487,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cdc2e2096_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_cdc2e2096_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3474,7 +3498,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cdc2e2096_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cdc2e2096_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cdc2e2096_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cdc2e2096_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cdc2e2096_9_4",
+      "step_id": "step_assertReady_assertReady_cdc2e2096_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3507,7 +3531,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cdc2e2096_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cdc2e2096_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3528,7 +3552,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cdc2e2096_9_4"
+        "step_assertReady_assertReady_cdc2e2096_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-py-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 188,
+    "total_steps": 189,
     "name": "basic-cea-py-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -179,21 +179,22 @@
       "step_clickPrimaryAction_assertDialog_c9bd6c5f6_7_4",
       "step_clickPrimaryAction_click_c9bd6c5f6_7_4",
       "step_assertNotificationContains_assert_c9bd6c5f6_7_5",
-      "step_executeCommand_open_c9bd6c5f6_8_1",
-      "step_executeCommand_assertPalette_c9bd6c5f6_8_1",
-      "step_executeCommand_filter_c9bd6c5f6_8_1",
-      "step_executeCommand_assertCommand_c9bd6c5f6_8_1",
-      "step_executeCommand_execute_c9bd6c5f6_8_1",
-      "step_filterOption_filter_c9bd6c5f6_8_2",
-      "step_filterOption_assertOption_c9bd6c5f6_8_2",
-      "step_filterOption_confirm_c9bd6c5f6_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_c9bd6c5f6_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_c9bd6c5f6_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_c9bd6c5f6_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_c9bd6c5f6_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c9bd6c5f6_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c9bd6c5f6_8_3",
-      "step_assertReady_assertReady_c9bd6c5f6_8_4",
+      "step_assertDeployedRuntimeReady_c9bd6c5f6_8_1",
+      "step_executeCommand_open_c9bd6c5f6_8_2",
+      "step_executeCommand_assertPalette_c9bd6c5f6_8_2",
+      "step_executeCommand_filter_c9bd6c5f6_8_2",
+      "step_executeCommand_assertCommand_c9bd6c5f6_8_2",
+      "step_executeCommand_execute_c9bd6c5f6_8_2",
+      "step_filterOption_filter_c9bd6c5f6_8_3",
+      "step_filterOption_assertOption_c9bd6c5f6_8_3",
+      "step_filterOption_confirm_c9bd6c5f6_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_c9bd6c5f6_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_c9bd6c5f6_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_c9bd6c5f6_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_c9bd6c5f6_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c9bd6c5f6_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c9bd6c5f6_8_4",
+      "step_assertReady_assertReady_c9bd6c5f6_8_5",
       "step_addAndOpenApp_assertAdd_c9bd6c5f6_9_1",
       "step_addAndOpenApp_add_c9bd6c5f6_9_1",
       "step_addAndOpenApp_assertAdded_c9bd6c5f6_9_1",
@@ -3847,7 +3848,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c9bd6c5f6_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_c9bd6c5f6_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c9bd6c5f6_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c9bd6c5f6_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3859,7 +3883,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c9bd6c5f6_7_5"
+        "step_assertDeployedRuntimeReady_c9bd6c5f6_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3869,7 +3893,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c9bd6c5f6_8_1",
+      "step_id": "step_executeCommand_assertPalette_c9bd6c5f6_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3879,7 +3903,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c9bd6c5f6_8_1"
+        "step_executeCommand_open_c9bd6c5f6_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3890,7 +3914,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c9bd6c5f6_8_1",
+      "step_id": "step_executeCommand_filter_c9bd6c5f6_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3902,7 +3926,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c9bd6c5f6_8_1"
+        "step_executeCommand_assertPalette_c9bd6c5f6_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3912,7 +3936,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c9bd6c5f6_8_1",
+      "step_id": "step_executeCommand_assertCommand_c9bd6c5f6_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3922,7 +3946,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c9bd6c5f6_8_1"
+        "step_executeCommand_filter_c9bd6c5f6_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3933,7 +3957,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c9bd6c5f6_8_1",
+      "step_id": "step_executeCommand_execute_c9bd6c5f6_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3945,7 +3969,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c9bd6c5f6_8_1"
+        "step_executeCommand_assertCommand_c9bd6c5f6_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3955,7 +3979,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c9bd6c5f6_8_2",
+      "step_id": "step_filterOption_filter_c9bd6c5f6_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3967,7 +3991,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c9bd6c5f6_8_1"
+        "step_executeCommand_execute_c9bd6c5f6_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3977,7 +4001,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c9bd6c5f6_8_2",
+      "step_id": "step_filterOption_assertOption_c9bd6c5f6_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3987,7 +4011,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c9bd6c5f6_8_2"
+        "step_filterOption_filter_c9bd6c5f6_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3998,7 +4022,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c9bd6c5f6_8_2",
+      "step_id": "step_filterOption_confirm_c9bd6c5f6_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4010,7 +4034,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c9bd6c5f6_8_2"
+        "step_filterOption_assertOption_c9bd6c5f6_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4020,7 +4044,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c9bd6c5f6_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c9bd6c5f6_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4030,7 +4054,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c9bd6c5f6_8_2"
+        "step_filterOption_confirm_c9bd6c5f6_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4041,7 +4065,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c9bd6c5f6_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c9bd6c5f6_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4055,7 +4079,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c9bd6c5f6_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_c9bd6c5f6_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4065,7 +4089,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c9bd6c5f6_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c9bd6c5f6_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4077,7 +4101,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c9bd6c5f6_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_c9bd6c5f6_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4087,7 +4111,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c9bd6c5f6_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c9bd6c5f6_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4099,7 +4123,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c9bd6c5f6_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_c9bd6c5f6_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4109,7 +4133,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c9bd6c5f6_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c9bd6c5f6_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4119,7 +4143,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c9bd6c5f6_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_c9bd6c5f6_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4130,7 +4154,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c9bd6c5f6_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c9bd6c5f6_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4142,7 +4166,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c9bd6c5f6_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c9bd6c5f6_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4153,7 +4177,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c9bd6c5f6_8_4",
+      "step_id": "step_assertReady_assertReady_c9bd6c5f6_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4163,7 +4187,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c9bd6c5f6_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c9bd6c5f6_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4184,7 +4208,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c9bd6c5f6_8_4"
+        "step_assertReady_assertReady_c9bd6c5f6_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 164,
+    "total_steps": 165,
     "name": "basic-cea-ts-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -155,25 +155,26 @@
       "step_clickPrimaryAction_assertDialog_c00983b32_6_4",
       "step_clickPrimaryAction_click_c00983b32_6_4",
       "step_assertNotificationContains_assert_c00983b32_6_5",
-      "step_executeCommand_open_c00983b32_7_1",
-      "step_executeCommand_assertPalette_c00983b32_7_1",
-      "step_executeCommand_filter_c00983b32_7_1",
-      "step_executeCommand_assertCommand_c00983b32_7_1",
-      "step_executeCommand_execute_c00983b32_7_1",
-      "step_filterOption_filter_c00983b32_7_2",
-      "step_filterOption_assertOption_c00983b32_7_2",
-      "step_filterOption_confirm_c00983b32_7_2",
-      "step_browserM365SignIn_assertAccount_c00983b32_7_3",
-      "step_browserM365SignIn_focusAccount_c00983b32_7_3",
-      "step_browserM365SignIn_enterAccount_c00983b32_7_3",
-      "step_browserM365SignIn_submitAccount_c00983b32_7_3",
-      "step_browserM365SignIn_assertPassword_c00983b32_7_3",
-      "step_browserM365SignIn_enterPassword_c00983b32_7_3",
-      "step_browserM365SignIn_submitPassword_c00983b32_7_3",
-      "step_browserM365SignIn_assertStaySignedIn_c00983b32_7_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c00983b32_7_3",
-      "step_assertReady_assertReady_c00983b32_7_4",
-      "step_zoomOut_zoomOut_c00983b32_7_5",
+      "step_assertDeployedRuntimeReady_c00983b32_7_1",
+      "step_executeCommand_open_c00983b32_7_2",
+      "step_executeCommand_assertPalette_c00983b32_7_2",
+      "step_executeCommand_filter_c00983b32_7_2",
+      "step_executeCommand_assertCommand_c00983b32_7_2",
+      "step_executeCommand_execute_c00983b32_7_2",
+      "step_filterOption_filter_c00983b32_7_3",
+      "step_filterOption_assertOption_c00983b32_7_3",
+      "step_filterOption_confirm_c00983b32_7_3",
+      "step_browserM365SignIn_assertAccount_c00983b32_7_4",
+      "step_browserM365SignIn_focusAccount_c00983b32_7_4",
+      "step_browserM365SignIn_enterAccount_c00983b32_7_4",
+      "step_browserM365SignIn_submitAccount_c00983b32_7_4",
+      "step_browserM365SignIn_assertPassword_c00983b32_7_4",
+      "step_browserM365SignIn_enterPassword_c00983b32_7_4",
+      "step_browserM365SignIn_submitPassword_c00983b32_7_4",
+      "step_browserM365SignIn_assertStaySignedIn_c00983b32_7_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c00983b32_7_4",
+      "step_assertReady_assertReady_c00983b32_7_5",
+      "step_zoomOut_zoomOut_c00983b32_7_6",
       "step_sendCopilotMessage_assertInput_c00983b32_9_1",
       "step_sendCopilotMessage_focusInput_c00983b32_9_1",
       "step_sendCopilotMessage_type_c00983b32_9_1",
@@ -3303,7 +3304,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c00983b32_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c00983b32_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c00983b32_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c00983b32_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3315,7 +3339,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c00983b32_6_5"
+        "step_assertDeployedRuntimeReady_c00983b32_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3325,7 +3349,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c00983b32_7_1",
+      "step_id": "step_executeCommand_assertPalette_c00983b32_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c00983b32_7_1"
+        "step_executeCommand_open_c00983b32_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3346,7 +3370,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c00983b32_7_1",
+      "step_id": "step_executeCommand_filter_c00983b32_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3358,7 +3382,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c00983b32_7_1"
+        "step_executeCommand_assertPalette_c00983b32_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3368,7 +3392,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c00983b32_7_1",
+      "step_id": "step_executeCommand_assertCommand_c00983b32_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c00983b32_7_1"
+        "step_executeCommand_filter_c00983b32_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3389,7 +3413,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c00983b32_7_1",
+      "step_id": "step_executeCommand_execute_c00983b32_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3401,7 +3425,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c00983b32_7_1"
+        "step_executeCommand_assertCommand_c00983b32_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3411,7 +3435,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c00983b32_7_2",
+      "step_id": "step_filterOption_filter_c00983b32_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c00983b32_7_1"
+        "step_executeCommand_execute_c00983b32_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c00983b32_7_2",
+      "step_id": "step_filterOption_assertOption_c00983b32_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c00983b32_7_2"
+        "step_filterOption_filter_c00983b32_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c00983b32_7_2",
+      "step_id": "step_filterOption_confirm_c00983b32_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c00983b32_7_2"
+        "step_filterOption_assertOption_c00983b32_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c00983b32_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c00983b32_7_2"
+        "step_filterOption_confirm_c00983b32_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c00983b32_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3511,7 +3535,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c00983b32_7_3"
+        "step_browserM365SignIn_assertAccount_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3521,7 +3545,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c00983b32_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3533,7 +3557,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c00983b32_7_3"
+        "step_browserM365SignIn_focusAccount_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c00983b32_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c00983b32_7_3"
+        "step_browserM365SignIn_enterAccount_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c00983b32_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c00983b32_7_3"
+        "step_browserM365SignIn_submitAccount_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c00983b32_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3598,7 +3622,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c00983b32_7_3"
+        "step_browserM365SignIn_assertPassword_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3608,7 +3632,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c00983b32_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3620,7 +3644,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c00983b32_7_3"
+        "step_browserM365SignIn_enterPassword_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3630,7 +3654,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c00983b32_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3640,7 +3664,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c00983b32_7_3"
+        "step_browserM365SignIn_submitPassword_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3651,7 +3675,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c00983b32_7_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c00983b32_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3663,7 +3687,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c00983b32_7_3"
+        "step_browserM365SignIn_assertStaySignedIn_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3674,7 +3698,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c00983b32_7_4",
+      "step_id": "step_assertReady_assertReady_c00983b32_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3684,7 +3708,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c00983b32_7_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c00983b32_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3695,7 +3719,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c00983b32_7_5",
+      "step_id": "step_zoomOut_zoomOut_c00983b32_7_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3707,7 +3731,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c00983b32_7_4"
+        "step_assertReady_assertReady_c00983b32_7_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3727,7 +3751,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c00983b32_7_5"
+        "step_zoomOut_zoomOut_c00983b32_7_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 164,
+    "total_steps": 165,
     "name": "basic-cea-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -155,21 +155,22 @@
       "step_clickPrimaryAction_assertDialog_caaec8c73_6_4",
       "step_clickPrimaryAction_click_caaec8c73_6_4",
       "step_assertNotificationContains_assert_caaec8c73_6_5",
-      "step_executeCommand_open_caaec8c73_7_1",
-      "step_executeCommand_assertPalette_caaec8c73_7_1",
-      "step_executeCommand_filter_caaec8c73_7_1",
-      "step_executeCommand_assertCommand_caaec8c73_7_1",
-      "step_executeCommand_execute_caaec8c73_7_1",
-      "step_filterOption_filter_caaec8c73_7_2",
-      "step_filterOption_assertOption_caaec8c73_7_2",
-      "step_filterOption_confirm_caaec8c73_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_caaec8c73_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_caaec8c73_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_caaec8c73_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_caaec8c73_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_caaec8c73_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_caaec8c73_7_3",
-      "step_assertReady_assertReady_caaec8c73_7_4",
+      "step_assertDeployedRuntimeReady_caaec8c73_7_1",
+      "step_executeCommand_open_caaec8c73_7_2",
+      "step_executeCommand_assertPalette_caaec8c73_7_2",
+      "step_executeCommand_filter_caaec8c73_7_2",
+      "step_executeCommand_assertCommand_caaec8c73_7_2",
+      "step_executeCommand_execute_caaec8c73_7_2",
+      "step_filterOption_filter_caaec8c73_7_3",
+      "step_filterOption_assertOption_caaec8c73_7_3",
+      "step_filterOption_confirm_caaec8c73_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_caaec8c73_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_caaec8c73_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_caaec8c73_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_caaec8c73_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_caaec8c73_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_caaec8c73_7_4",
+      "step_assertReady_assertReady_caaec8c73_7_5",
       "step_addAndOpenApp_assertAdd_caaec8c73_8_1",
       "step_addAndOpenApp_add_caaec8c73_8_1",
       "step_addAndOpenApp_assertAdded_caaec8c73_8_1",
@@ -3303,7 +3304,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_caaec8c73_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_caaec8c73_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_caaec8c73_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_caaec8c73_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3315,7 +3339,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_caaec8c73_6_5"
+        "step_assertDeployedRuntimeReady_caaec8c73_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3325,7 +3349,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_caaec8c73_7_1",
+      "step_id": "step_executeCommand_assertPalette_caaec8c73_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_caaec8c73_7_1"
+        "step_executeCommand_open_caaec8c73_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3346,7 +3370,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_caaec8c73_7_1",
+      "step_id": "step_executeCommand_filter_caaec8c73_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3358,7 +3382,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_caaec8c73_7_1"
+        "step_executeCommand_assertPalette_caaec8c73_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3368,7 +3392,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_caaec8c73_7_1",
+      "step_id": "step_executeCommand_assertCommand_caaec8c73_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_caaec8c73_7_1"
+        "step_executeCommand_filter_caaec8c73_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3389,7 +3413,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_caaec8c73_7_1",
+      "step_id": "step_executeCommand_execute_caaec8c73_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3401,7 +3425,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_caaec8c73_7_1"
+        "step_executeCommand_assertCommand_caaec8c73_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3411,7 +3435,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_caaec8c73_7_2",
+      "step_id": "step_filterOption_filter_caaec8c73_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_caaec8c73_7_1"
+        "step_executeCommand_execute_caaec8c73_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_caaec8c73_7_2",
+      "step_id": "step_filterOption_assertOption_caaec8c73_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_caaec8c73_7_2"
+        "step_filterOption_filter_caaec8c73_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_caaec8c73_7_2",
+      "step_id": "step_filterOption_confirm_caaec8c73_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_caaec8c73_7_2"
+        "step_filterOption_assertOption_caaec8c73_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_caaec8c73_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_caaec8c73_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_caaec8c73_7_2"
+        "step_filterOption_confirm_caaec8c73_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_caaec8c73_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_caaec8c73_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3511,7 +3535,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_caaec8c73_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_caaec8c73_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3521,7 +3545,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_caaec8c73_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_caaec8c73_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3533,7 +3557,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_caaec8c73_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_caaec8c73_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_caaec8c73_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_caaec8c73_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_caaec8c73_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_caaec8c73_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_caaec8c73_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_caaec8c73_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_caaec8c73_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_caaec8c73_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_caaec8c73_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_caaec8c73_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3598,7 +3622,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_caaec8c73_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_caaec8c73_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3609,7 +3633,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_caaec8c73_7_4",
+      "step_id": "step_assertReady_assertReady_caaec8c73_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3619,7 +3643,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_caaec8c73_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_caaec8c73_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3640,7 +3664,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_caaec8c73_7_4"
+        "step_assertReady_assertReady_caaec8c73_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 159,
+    "total_steps": 160,
     "name": "basic-cea-ts-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -151,25 +151,26 @@
       "step_clickPrimaryAction_assertDialog_c411d9011_8_4",
       "step_clickPrimaryAction_click_c411d9011_8_4",
       "step_assertNotificationContains_assert_c411d9011_8_5",
-      "step_executeCommand_open_c411d9011_9_1",
-      "step_executeCommand_assertPalette_c411d9011_9_1",
-      "step_executeCommand_filter_c411d9011_9_1",
-      "step_executeCommand_assertCommand_c411d9011_9_1",
-      "step_executeCommand_execute_c411d9011_9_1",
-      "step_filterOption_filter_c411d9011_9_2",
-      "step_filterOption_assertOption_c411d9011_9_2",
-      "step_filterOption_confirm_c411d9011_9_2",
-      "step_browserM365SignIn_assertAccount_c411d9011_9_3",
-      "step_browserM365SignIn_focusAccount_c411d9011_9_3",
-      "step_browserM365SignIn_enterAccount_c411d9011_9_3",
-      "step_browserM365SignIn_submitAccount_c411d9011_9_3",
-      "step_browserM365SignIn_assertPassword_c411d9011_9_3",
-      "step_browserM365SignIn_enterPassword_c411d9011_9_3",
-      "step_browserM365SignIn_submitPassword_c411d9011_9_3",
-      "step_browserM365SignIn_assertStaySignedIn_c411d9011_9_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c411d9011_9_3",
-      "step_assertReady_assertReady_c411d9011_9_4",
-      "step_zoomOut_zoomOut_c411d9011_9_5",
+      "step_assertDeployedRuntimeReady_c411d9011_9_1",
+      "step_executeCommand_open_c411d9011_9_2",
+      "step_executeCommand_assertPalette_c411d9011_9_2",
+      "step_executeCommand_filter_c411d9011_9_2",
+      "step_executeCommand_assertCommand_c411d9011_9_2",
+      "step_executeCommand_execute_c411d9011_9_2",
+      "step_filterOption_filter_c411d9011_9_3",
+      "step_filterOption_assertOption_c411d9011_9_3",
+      "step_filterOption_confirm_c411d9011_9_3",
+      "step_browserM365SignIn_assertAccount_c411d9011_9_4",
+      "step_browserM365SignIn_focusAccount_c411d9011_9_4",
+      "step_browserM365SignIn_enterAccount_c411d9011_9_4",
+      "step_browserM365SignIn_submitAccount_c411d9011_9_4",
+      "step_browserM365SignIn_assertPassword_c411d9011_9_4",
+      "step_browserM365SignIn_enterPassword_c411d9011_9_4",
+      "step_browserM365SignIn_submitPassword_c411d9011_9_4",
+      "step_browserM365SignIn_assertStaySignedIn_c411d9011_9_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c411d9011_9_4",
+      "step_assertReady_assertReady_c411d9011_9_5",
+      "step_zoomOut_zoomOut_c411d9011_9_6",
       "step_sendCopilotMessage_assertInput_c411d9011_11_1",
       "step_sendCopilotMessage_focusInput_c411d9011_11_1",
       "step_sendCopilotMessage_type_c411d9011_11_1",
@@ -3214,7 +3215,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c411d9011_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_c411d9011_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c411d9011_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c411d9011_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3226,7 +3250,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c411d9011_8_5"
+        "step_assertDeployedRuntimeReady_c411d9011_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3236,7 +3260,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c411d9011_9_1",
+      "step_id": "step_executeCommand_assertPalette_c411d9011_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3246,7 +3270,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c411d9011_9_1"
+        "step_executeCommand_open_c411d9011_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3257,7 +3281,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c411d9011_9_1",
+      "step_id": "step_executeCommand_filter_c411d9011_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3269,7 +3293,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c411d9011_9_1"
+        "step_executeCommand_assertPalette_c411d9011_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3279,7 +3303,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c411d9011_9_1",
+      "step_id": "step_executeCommand_assertCommand_c411d9011_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3289,7 +3313,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c411d9011_9_1"
+        "step_executeCommand_filter_c411d9011_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3300,7 +3324,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c411d9011_9_1",
+      "step_id": "step_executeCommand_execute_c411d9011_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3312,7 +3336,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c411d9011_9_1"
+        "step_executeCommand_assertCommand_c411d9011_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3322,7 +3346,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c411d9011_9_2",
+      "step_id": "step_filterOption_filter_c411d9011_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3334,7 +3358,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c411d9011_9_1"
+        "step_executeCommand_execute_c411d9011_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3344,7 +3368,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c411d9011_9_2",
+      "step_id": "step_filterOption_assertOption_c411d9011_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3354,7 +3378,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c411d9011_9_2"
+        "step_filterOption_filter_c411d9011_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3365,7 +3389,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c411d9011_9_2",
+      "step_id": "step_filterOption_confirm_c411d9011_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3377,7 +3401,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c411d9011_9_2"
+        "step_filterOption_assertOption_c411d9011_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3387,7 +3411,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c411d9011_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3397,7 +3421,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c411d9011_9_2"
+        "step_filterOption_confirm_c411d9011_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3408,7 +3432,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c411d9011_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3422,7 +3446,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c411d9011_9_3"
+        "step_browserM365SignIn_assertAccount_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3432,7 +3456,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c411d9011_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3444,7 +3468,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c411d9011_9_3"
+        "step_browserM365SignIn_focusAccount_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c411d9011_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c411d9011_9_3"
+        "step_browserM365SignIn_enterAccount_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c411d9011_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c411d9011_9_3"
+        "step_browserM365SignIn_submitAccount_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c411d9011_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3509,7 +3533,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c411d9011_9_3"
+        "step_browserM365SignIn_assertPassword_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3519,7 +3543,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c411d9011_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3531,7 +3555,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c411d9011_9_3"
+        "step_browserM365SignIn_enterPassword_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3541,7 +3565,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c411d9011_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3551,7 +3575,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c411d9011_9_3"
+        "step_browserM365SignIn_submitPassword_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3562,7 +3586,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c411d9011_9_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c411d9011_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3574,7 +3598,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c411d9011_9_3"
+        "step_browserM365SignIn_assertStaySignedIn_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3585,7 +3609,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c411d9011_9_4",
+      "step_id": "step_assertReady_assertReady_c411d9011_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3595,7 +3619,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c411d9011_9_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c411d9011_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3606,7 +3630,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c411d9011_9_5",
+      "step_id": "step_zoomOut_zoomOut_c411d9011_9_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3618,7 +3642,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c411d9011_9_4"
+        "step_assertReady_assertReady_c411d9011_9_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3638,7 +3662,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c411d9011_9_5"
+        "step_zoomOut_zoomOut_c411d9011_9_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/basic-custom-engine-agent--basic-cea-ts-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 160,
+    "total_steps": 161,
     "name": "basic-cea-ts-openai-remote-teams",
     "description": {
       "owner": "",
@@ -151,21 +151,22 @@
       "step_clickPrimaryAction_assertDialog_cdd367ed2_8_4",
       "step_clickPrimaryAction_click_cdd367ed2_8_4",
       "step_assertNotificationContains_assert_cdd367ed2_8_5",
-      "step_executeCommand_open_cdd367ed2_9_1",
-      "step_executeCommand_assertPalette_cdd367ed2_9_1",
-      "step_executeCommand_filter_cdd367ed2_9_1",
-      "step_executeCommand_assertCommand_cdd367ed2_9_1",
-      "step_executeCommand_execute_cdd367ed2_9_1",
-      "step_filterOption_filter_cdd367ed2_9_2",
-      "step_filterOption_assertOption_cdd367ed2_9_2",
-      "step_filterOption_confirm_cdd367ed2_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_cdd367ed2_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_cdd367ed2_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_cdd367ed2_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_cdd367ed2_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cdd367ed2_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cdd367ed2_9_3",
-      "step_assertReady_assertReady_cdd367ed2_9_4",
+      "step_assertDeployedRuntimeReady_cdd367ed2_9_1",
+      "step_executeCommand_open_cdd367ed2_9_2",
+      "step_executeCommand_assertPalette_cdd367ed2_9_2",
+      "step_executeCommand_filter_cdd367ed2_9_2",
+      "step_executeCommand_assertCommand_cdd367ed2_9_2",
+      "step_executeCommand_execute_cdd367ed2_9_2",
+      "step_filterOption_filter_cdd367ed2_9_3",
+      "step_filterOption_assertOption_cdd367ed2_9_3",
+      "step_filterOption_confirm_cdd367ed2_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_cdd367ed2_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_cdd367ed2_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_cdd367ed2_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_cdd367ed2_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cdd367ed2_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cdd367ed2_9_4",
+      "step_assertReady_assertReady_cdd367ed2_9_5",
       "step_addAndOpenApp_assertAdd_cdd367ed2_10_1",
       "step_addAndOpenApp_add_cdd367ed2_10_1",
       "step_addAndOpenApp_assertAdded_cdd367ed2_10_1",
@@ -3215,7 +3216,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cdd367ed2_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_cdd367ed2_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cdd367ed2_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cdd367ed2_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3227,7 +3251,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cdd367ed2_8_5"
+        "step_assertDeployedRuntimeReady_cdd367ed2_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3237,7 +3261,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cdd367ed2_9_1",
+      "step_id": "step_executeCommand_assertPalette_cdd367ed2_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3247,7 +3271,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cdd367ed2_9_1"
+        "step_executeCommand_open_cdd367ed2_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3258,7 +3282,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cdd367ed2_9_1",
+      "step_id": "step_executeCommand_filter_cdd367ed2_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3270,7 +3294,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cdd367ed2_9_1"
+        "step_executeCommand_assertPalette_cdd367ed2_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3280,7 +3304,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cdd367ed2_9_1",
+      "step_id": "step_executeCommand_assertCommand_cdd367ed2_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3290,7 +3314,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cdd367ed2_9_1"
+        "step_executeCommand_filter_cdd367ed2_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3301,7 +3325,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cdd367ed2_9_1",
+      "step_id": "step_executeCommand_execute_cdd367ed2_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3313,7 +3337,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cdd367ed2_9_1"
+        "step_executeCommand_assertCommand_cdd367ed2_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3323,7 +3347,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cdd367ed2_9_2",
+      "step_id": "step_filterOption_filter_cdd367ed2_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cdd367ed2_9_1"
+        "step_executeCommand_execute_cdd367ed2_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3345,7 +3369,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cdd367ed2_9_2",
+      "step_id": "step_filterOption_assertOption_cdd367ed2_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3355,7 +3379,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cdd367ed2_9_2"
+        "step_filterOption_filter_cdd367ed2_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3366,7 +3390,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cdd367ed2_9_2",
+      "step_id": "step_filterOption_confirm_cdd367ed2_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cdd367ed2_9_2"
+        "step_filterOption_assertOption_cdd367ed2_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3388,7 +3412,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cdd367ed2_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cdd367ed2_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3398,7 +3422,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cdd367ed2_9_2"
+        "step_filterOption_confirm_cdd367ed2_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3409,7 +3433,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cdd367ed2_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cdd367ed2_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cdd367ed2_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_cdd367ed2_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cdd367ed2_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cdd367ed2_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3445,7 +3469,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cdd367ed2_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_cdd367ed2_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3455,7 +3479,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cdd367ed2_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cdd367ed2_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3467,7 +3491,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cdd367ed2_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_cdd367ed2_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3477,7 +3501,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cdd367ed2_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cdd367ed2_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3487,7 +3511,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cdd367ed2_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_cdd367ed2_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3498,7 +3522,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cdd367ed2_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cdd367ed2_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3510,7 +3534,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cdd367ed2_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cdd367ed2_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3521,7 +3545,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cdd367ed2_9_4",
+      "step_id": "step_assertReady_assertReady_cdd367ed2_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3531,7 +3555,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cdd367ed2_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cdd367ed2_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3552,7 +3576,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cdd367ed2_9_4"
+        "step_assertReady_assertReady_cdd367ed2_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 163,
+    "total_steps": 164,
     "name": "general-teams-js-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -155,25 +155,26 @@
       "step_clickPrimaryAction_assertDialog_cb3c53da7_6_4",
       "step_clickPrimaryAction_click_cb3c53da7_6_4",
       "step_assertNotificationContains_assert_cb3c53da7_6_5",
-      "step_executeCommand_open_cb3c53da7_7_1",
-      "step_executeCommand_assertPalette_cb3c53da7_7_1",
-      "step_executeCommand_filter_cb3c53da7_7_1",
-      "step_executeCommand_assertCommand_cb3c53da7_7_1",
-      "step_executeCommand_execute_cb3c53da7_7_1",
-      "step_filterOption_filter_cb3c53da7_7_2",
-      "step_filterOption_assertOption_cb3c53da7_7_2",
-      "step_filterOption_confirm_cb3c53da7_7_2",
-      "step_browserM365SignIn_assertAccount_cb3c53da7_7_3",
-      "step_browserM365SignIn_focusAccount_cb3c53da7_7_3",
-      "step_browserM365SignIn_enterAccount_cb3c53da7_7_3",
-      "step_browserM365SignIn_submitAccount_cb3c53da7_7_3",
-      "step_browserM365SignIn_assertPassword_cb3c53da7_7_3",
-      "step_browserM365SignIn_enterPassword_cb3c53da7_7_3",
-      "step_browserM365SignIn_submitPassword_cb3c53da7_7_3",
-      "step_browserM365SignIn_assertStaySignedIn_cb3c53da7_7_3",
-      "step_browserM365SignIn_confirmStaySignedIn_cb3c53da7_7_3",
-      "step_assertReady_assertReady_cb3c53da7_7_4",
-      "step_zoomOut_zoomOut_cb3c53da7_7_5",
+      "step_assertDeployedRuntimeReady_cb3c53da7_7_1",
+      "step_executeCommand_open_cb3c53da7_7_2",
+      "step_executeCommand_assertPalette_cb3c53da7_7_2",
+      "step_executeCommand_filter_cb3c53da7_7_2",
+      "step_executeCommand_assertCommand_cb3c53da7_7_2",
+      "step_executeCommand_execute_cb3c53da7_7_2",
+      "step_filterOption_filter_cb3c53da7_7_3",
+      "step_filterOption_assertOption_cb3c53da7_7_3",
+      "step_filterOption_confirm_cb3c53da7_7_3",
+      "step_browserM365SignIn_assertAccount_cb3c53da7_7_4",
+      "step_browserM365SignIn_focusAccount_cb3c53da7_7_4",
+      "step_browserM365SignIn_enterAccount_cb3c53da7_7_4",
+      "step_browserM365SignIn_submitAccount_cb3c53da7_7_4",
+      "step_browserM365SignIn_assertPassword_cb3c53da7_7_4",
+      "step_browserM365SignIn_enterPassword_cb3c53da7_7_4",
+      "step_browserM365SignIn_submitPassword_cb3c53da7_7_4",
+      "step_browserM365SignIn_assertStaySignedIn_cb3c53da7_7_4",
+      "step_browserM365SignIn_confirmStaySignedIn_cb3c53da7_7_4",
+      "step_assertReady_assertReady_cb3c53da7_7_5",
+      "step_zoomOut_zoomOut_cb3c53da7_7_6",
       "step_sendCopilotMessage_assertInput_cb3c53da7_9_1",
       "step_sendCopilotMessage_focusInput_cb3c53da7_9_1",
       "step_sendCopilotMessage_type_cb3c53da7_9_1",
@@ -3303,7 +3304,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cb3c53da7_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_cb3c53da7_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cb3c53da7_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cb3c53da7_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3315,7 +3339,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cb3c53da7_6_5"
+        "step_assertDeployedRuntimeReady_cb3c53da7_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3325,7 +3349,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cb3c53da7_7_1",
+      "step_id": "step_executeCommand_assertPalette_cb3c53da7_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cb3c53da7_7_1"
+        "step_executeCommand_open_cb3c53da7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3346,7 +3370,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cb3c53da7_7_1",
+      "step_id": "step_executeCommand_filter_cb3c53da7_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3358,7 +3382,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cb3c53da7_7_1"
+        "step_executeCommand_assertPalette_cb3c53da7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3368,7 +3392,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cb3c53da7_7_1",
+      "step_id": "step_executeCommand_assertCommand_cb3c53da7_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cb3c53da7_7_1"
+        "step_executeCommand_filter_cb3c53da7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3389,7 +3413,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cb3c53da7_7_1",
+      "step_id": "step_executeCommand_execute_cb3c53da7_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3401,7 +3425,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cb3c53da7_7_1"
+        "step_executeCommand_assertCommand_cb3c53da7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3411,7 +3435,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cb3c53da7_7_2",
+      "step_id": "step_filterOption_filter_cb3c53da7_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cb3c53da7_7_1"
+        "step_executeCommand_execute_cb3c53da7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cb3c53da7_7_2",
+      "step_id": "step_filterOption_assertOption_cb3c53da7_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cb3c53da7_7_2"
+        "step_filterOption_filter_cb3c53da7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cb3c53da7_7_2",
+      "step_id": "step_filterOption_confirm_cb3c53da7_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cb3c53da7_7_2"
+        "step_filterOption_assertOption_cb3c53da7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_assertAccount_cb3c53da7_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cb3c53da7_7_2"
+        "step_filterOption_confirm_cb3c53da7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_focusAccount_cb3c53da7_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3511,7 +3535,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_cb3c53da7_7_3"
+        "step_browserM365SignIn_assertAccount_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3521,7 +3545,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_enterAccount_cb3c53da7_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3533,7 +3557,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_cb3c53da7_7_3"
+        "step_browserM365SignIn_focusAccount_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_submitAccount_cb3c53da7_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_cb3c53da7_7_3"
+        "step_browserM365SignIn_enterAccount_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_assertPassword_cb3c53da7_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_cb3c53da7_7_3"
+        "step_browserM365SignIn_submitAccount_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_enterPassword_cb3c53da7_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3598,7 +3622,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_cb3c53da7_7_3"
+        "step_browserM365SignIn_assertPassword_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3608,7 +3632,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_submitPassword_cb3c53da7_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3620,7 +3644,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_cb3c53da7_7_3"
+        "step_browserM365SignIn_enterPassword_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3630,7 +3654,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_cb3c53da7_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3640,7 +3664,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_cb3c53da7_7_3"
+        "step_browserM365SignIn_submitPassword_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3651,7 +3675,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cb3c53da7_7_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cb3c53da7_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3663,7 +3687,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_cb3c53da7_7_3"
+        "step_browserM365SignIn_assertStaySignedIn_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3674,7 +3698,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cb3c53da7_7_4",
+      "step_id": "step_assertReady_assertReady_cb3c53da7_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3684,7 +3708,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_cb3c53da7_7_3"
+        "step_browserM365SignIn_confirmStaySignedIn_cb3c53da7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3695,7 +3719,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_cb3c53da7_7_5",
+      "step_id": "step_zoomOut_zoomOut_cb3c53da7_7_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3707,7 +3731,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cb3c53da7_7_4"
+        "step_assertReady_assertReady_cb3c53da7_7_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3727,7 +3751,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_cb3c53da7_7_5"
+        "step_zoomOut_zoomOut_cb3c53da7_7_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 164,
+    "total_steps": 165,
     "name": "general-teams-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -155,21 +155,22 @@
       "step_clickPrimaryAction_assertDialog_cef87d3d9_6_4",
       "step_clickPrimaryAction_click_cef87d3d9_6_4",
       "step_assertNotificationContains_assert_cef87d3d9_6_5",
-      "step_executeCommand_open_cef87d3d9_7_1",
-      "step_executeCommand_assertPalette_cef87d3d9_7_1",
-      "step_executeCommand_filter_cef87d3d9_7_1",
-      "step_executeCommand_assertCommand_cef87d3d9_7_1",
-      "step_executeCommand_execute_cef87d3d9_7_1",
-      "step_filterOption_filter_cef87d3d9_7_2",
-      "step_filterOption_assertOption_cef87d3d9_7_2",
-      "step_filterOption_confirm_cef87d3d9_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_cef87d3d9_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_cef87d3d9_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_cef87d3d9_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_cef87d3d9_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cef87d3d9_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cef87d3d9_7_3",
-      "step_assertReady_assertReady_cef87d3d9_7_4",
+      "step_assertDeployedRuntimeReady_cef87d3d9_7_1",
+      "step_executeCommand_open_cef87d3d9_7_2",
+      "step_executeCommand_assertPalette_cef87d3d9_7_2",
+      "step_executeCommand_filter_cef87d3d9_7_2",
+      "step_executeCommand_assertCommand_cef87d3d9_7_2",
+      "step_executeCommand_execute_cef87d3d9_7_2",
+      "step_filterOption_filter_cef87d3d9_7_3",
+      "step_filterOption_assertOption_cef87d3d9_7_3",
+      "step_filterOption_confirm_cef87d3d9_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_cef87d3d9_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_cef87d3d9_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_cef87d3d9_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_cef87d3d9_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cef87d3d9_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cef87d3d9_7_4",
+      "step_assertReady_assertReady_cef87d3d9_7_5",
       "step_addAndOpenApp_assertAdd_cef87d3d9_8_1",
       "step_addAndOpenApp_add_cef87d3d9_8_1",
       "step_addAndOpenApp_assertAdded_cef87d3d9_8_1",
@@ -3303,7 +3304,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cef87d3d9_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_cef87d3d9_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cef87d3d9_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cef87d3d9_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3315,7 +3339,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cef87d3d9_6_5"
+        "step_assertDeployedRuntimeReady_cef87d3d9_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3325,7 +3349,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cef87d3d9_7_1",
+      "step_id": "step_executeCommand_assertPalette_cef87d3d9_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cef87d3d9_7_1"
+        "step_executeCommand_open_cef87d3d9_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3346,7 +3370,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cef87d3d9_7_1",
+      "step_id": "step_executeCommand_filter_cef87d3d9_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3358,7 +3382,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cef87d3d9_7_1"
+        "step_executeCommand_assertPalette_cef87d3d9_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3368,7 +3392,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cef87d3d9_7_1",
+      "step_id": "step_executeCommand_assertCommand_cef87d3d9_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cef87d3d9_7_1"
+        "step_executeCommand_filter_cef87d3d9_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3389,7 +3413,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cef87d3d9_7_1",
+      "step_id": "step_executeCommand_execute_cef87d3d9_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3401,7 +3425,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cef87d3d9_7_1"
+        "step_executeCommand_assertCommand_cef87d3d9_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3411,7 +3435,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cef87d3d9_7_2",
+      "step_id": "step_filterOption_filter_cef87d3d9_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cef87d3d9_7_1"
+        "step_executeCommand_execute_cef87d3d9_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cef87d3d9_7_2",
+      "step_id": "step_filterOption_assertOption_cef87d3d9_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cef87d3d9_7_2"
+        "step_filterOption_filter_cef87d3d9_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cef87d3d9_7_2",
+      "step_id": "step_filterOption_confirm_cef87d3d9_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cef87d3d9_7_2"
+        "step_filterOption_assertOption_cef87d3d9_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cef87d3d9_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cef87d3d9_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cef87d3d9_7_2"
+        "step_filterOption_confirm_cef87d3d9_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cef87d3d9_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cef87d3d9_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3511,7 +3535,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cef87d3d9_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_cef87d3d9_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3521,7 +3545,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cef87d3d9_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cef87d3d9_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3533,7 +3557,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cef87d3d9_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_cef87d3d9_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cef87d3d9_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cef87d3d9_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cef87d3d9_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_cef87d3d9_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cef87d3d9_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cef87d3d9_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cef87d3d9_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_cef87d3d9_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cef87d3d9_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cef87d3d9_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3598,7 +3622,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cef87d3d9_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cef87d3d9_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3609,7 +3633,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cef87d3d9_7_4",
+      "step_id": "step_assertReady_assertReady_cef87d3d9_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3619,7 +3643,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cef87d3d9_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cef87d3d9_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3640,7 +3664,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cef87d3d9_7_4"
+        "step_assertReady_assertReady_cef87d3d9_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-js-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 159,
+    "total_steps": 160,
     "name": "general-teams-js-openai-remote-teams",
     "description": {
       "owner": "",
@@ -149,21 +149,22 @@
       "step_clickPrimaryAction_assertDialog_c2801f25d_8_4",
       "step_clickPrimaryAction_click_c2801f25d_8_4",
       "step_assertNotificationContains_assert_c2801f25d_8_5",
-      "step_executeCommand_open_c2801f25d_9_1",
-      "step_executeCommand_assertPalette_c2801f25d_9_1",
-      "step_executeCommand_filter_c2801f25d_9_1",
-      "step_executeCommand_assertCommand_c2801f25d_9_1",
-      "step_executeCommand_execute_c2801f25d_9_1",
-      "step_filterOption_filter_c2801f25d_9_2",
-      "step_filterOption_assertOption_c2801f25d_9_2",
-      "step_filterOption_confirm_c2801f25d_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_c2801f25d_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_c2801f25d_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_c2801f25d_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_c2801f25d_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c2801f25d_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c2801f25d_9_3",
-      "step_assertReady_assertReady_c2801f25d_9_4",
+      "step_assertDeployedRuntimeReady_c2801f25d_9_1",
+      "step_executeCommand_open_c2801f25d_9_2",
+      "step_executeCommand_assertPalette_c2801f25d_9_2",
+      "step_executeCommand_filter_c2801f25d_9_2",
+      "step_executeCommand_assertCommand_c2801f25d_9_2",
+      "step_executeCommand_execute_c2801f25d_9_2",
+      "step_filterOption_filter_c2801f25d_9_3",
+      "step_filterOption_assertOption_c2801f25d_9_3",
+      "step_filterOption_confirm_c2801f25d_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_c2801f25d_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_c2801f25d_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_c2801f25d_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_c2801f25d_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c2801f25d_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c2801f25d_9_4",
+      "step_assertReady_assertReady_c2801f25d_9_5",
       "step_addAndOpenApp_assertAdd_c2801f25d_10_1",
       "step_addAndOpenApp_add_c2801f25d_10_1",
       "step_addAndOpenApp_assertAdded_c2801f25d_10_1",
@@ -3168,7 +3169,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c2801f25d_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_c2801f25d_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c2801f25d_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c2801f25d_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3180,7 +3204,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c2801f25d_8_5"
+        "step_assertDeployedRuntimeReady_c2801f25d_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3190,7 +3214,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c2801f25d_9_1",
+      "step_id": "step_executeCommand_assertPalette_c2801f25d_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3200,7 +3224,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c2801f25d_9_1"
+        "step_executeCommand_open_c2801f25d_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3211,7 +3235,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c2801f25d_9_1",
+      "step_id": "step_executeCommand_filter_c2801f25d_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3223,7 +3247,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c2801f25d_9_1"
+        "step_executeCommand_assertPalette_c2801f25d_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3233,7 +3257,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c2801f25d_9_1",
+      "step_id": "step_executeCommand_assertCommand_c2801f25d_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3243,7 +3267,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c2801f25d_9_1"
+        "step_executeCommand_filter_c2801f25d_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3254,7 +3278,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c2801f25d_9_1",
+      "step_id": "step_executeCommand_execute_c2801f25d_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3266,7 +3290,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c2801f25d_9_1"
+        "step_executeCommand_assertCommand_c2801f25d_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3276,7 +3300,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c2801f25d_9_2",
+      "step_id": "step_filterOption_filter_c2801f25d_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3288,7 +3312,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c2801f25d_9_1"
+        "step_executeCommand_execute_c2801f25d_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3298,7 +3322,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c2801f25d_9_2",
+      "step_id": "step_filterOption_assertOption_c2801f25d_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3308,7 +3332,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c2801f25d_9_2"
+        "step_filterOption_filter_c2801f25d_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3319,7 +3343,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c2801f25d_9_2",
+      "step_id": "step_filterOption_confirm_c2801f25d_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3331,7 +3355,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c2801f25d_9_2"
+        "step_filterOption_assertOption_c2801f25d_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3341,7 +3365,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c2801f25d_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c2801f25d_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3351,7 +3375,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c2801f25d_9_2"
+        "step_filterOption_confirm_c2801f25d_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3362,7 +3386,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c2801f25d_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c2801f25d_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3376,7 +3400,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c2801f25d_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_c2801f25d_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3386,7 +3410,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c2801f25d_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c2801f25d_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3398,7 +3422,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c2801f25d_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_c2801f25d_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3408,7 +3432,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c2801f25d_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c2801f25d_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3420,7 +3444,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c2801f25d_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_c2801f25d_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3430,7 +3454,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c2801f25d_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c2801f25d_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3440,7 +3464,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c2801f25d_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_c2801f25d_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3451,7 +3475,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c2801f25d_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c2801f25d_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3463,7 +3487,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c2801f25d_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c2801f25d_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3474,7 +3498,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c2801f25d_9_4",
+      "step_id": "step_assertReady_assertReady_c2801f25d_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3484,7 +3508,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c2801f25d_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c2801f25d_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3505,7 +3529,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c2801f25d_9_4"
+        "step_assertReady_assertReady_c2801f25d_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 185,
+    "total_steps": 186,
     "name": "general-teams-py-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -177,25 +177,26 @@
       "step_clickPrimaryAction_assertDialog_c3b344879_7_4",
       "step_clickPrimaryAction_click_c3b344879_7_4",
       "step_assertNotificationContains_assert_c3b344879_7_5",
-      "step_executeCommand_open_c3b344879_8_1",
-      "step_executeCommand_assertPalette_c3b344879_8_1",
-      "step_executeCommand_filter_c3b344879_8_1",
-      "step_executeCommand_assertCommand_c3b344879_8_1",
-      "step_executeCommand_execute_c3b344879_8_1",
-      "step_filterOption_filter_c3b344879_8_2",
-      "step_filterOption_assertOption_c3b344879_8_2",
-      "step_filterOption_confirm_c3b344879_8_2",
-      "step_browserM365SignIn_assertAccount_c3b344879_8_3",
-      "step_browserM365SignIn_focusAccount_c3b344879_8_3",
-      "step_browserM365SignIn_enterAccount_c3b344879_8_3",
-      "step_browserM365SignIn_submitAccount_c3b344879_8_3",
-      "step_browserM365SignIn_assertPassword_c3b344879_8_3",
-      "step_browserM365SignIn_enterPassword_c3b344879_8_3",
-      "step_browserM365SignIn_submitPassword_c3b344879_8_3",
-      "step_browserM365SignIn_assertStaySignedIn_c3b344879_8_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c3b344879_8_3",
-      "step_assertReady_assertReady_c3b344879_8_4",
-      "step_zoomOut_zoomOut_c3b344879_8_5",
+      "step_assertDeployedRuntimeReady_c3b344879_8_1",
+      "step_executeCommand_open_c3b344879_8_2",
+      "step_executeCommand_assertPalette_c3b344879_8_2",
+      "step_executeCommand_filter_c3b344879_8_2",
+      "step_executeCommand_assertCommand_c3b344879_8_2",
+      "step_executeCommand_execute_c3b344879_8_2",
+      "step_filterOption_filter_c3b344879_8_3",
+      "step_filterOption_assertOption_c3b344879_8_3",
+      "step_filterOption_confirm_c3b344879_8_3",
+      "step_browserM365SignIn_assertAccount_c3b344879_8_4",
+      "step_browserM365SignIn_focusAccount_c3b344879_8_4",
+      "step_browserM365SignIn_enterAccount_c3b344879_8_4",
+      "step_browserM365SignIn_submitAccount_c3b344879_8_4",
+      "step_browserM365SignIn_assertPassword_c3b344879_8_4",
+      "step_browserM365SignIn_enterPassword_c3b344879_8_4",
+      "step_browserM365SignIn_submitPassword_c3b344879_8_4",
+      "step_browserM365SignIn_assertStaySignedIn_c3b344879_8_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c3b344879_8_4",
+      "step_assertReady_assertReady_c3b344879_8_5",
+      "step_zoomOut_zoomOut_c3b344879_8_6",
       "step_sendCopilotMessage_assertInput_c3b344879_10_1",
       "step_sendCopilotMessage_focusInput_c3b344879_10_1",
       "step_sendCopilotMessage_type_c3b344879_10_1",
@@ -3799,7 +3800,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c3b344879_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_c3b344879_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c3b344879_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c3b344879_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3811,7 +3835,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c3b344879_7_5"
+        "step_assertDeployedRuntimeReady_c3b344879_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3821,7 +3845,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c3b344879_8_1",
+      "step_id": "step_executeCommand_assertPalette_c3b344879_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3831,7 +3855,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c3b344879_8_1"
+        "step_executeCommand_open_c3b344879_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3842,7 +3866,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c3b344879_8_1",
+      "step_id": "step_executeCommand_filter_c3b344879_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3854,7 +3878,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c3b344879_8_1"
+        "step_executeCommand_assertPalette_c3b344879_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3864,7 +3888,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c3b344879_8_1",
+      "step_id": "step_executeCommand_assertCommand_c3b344879_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3874,7 +3898,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c3b344879_8_1"
+        "step_executeCommand_filter_c3b344879_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3885,7 +3909,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c3b344879_8_1",
+      "step_id": "step_executeCommand_execute_c3b344879_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3897,7 +3921,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c3b344879_8_1"
+        "step_executeCommand_assertCommand_c3b344879_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3907,7 +3931,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c3b344879_8_2",
+      "step_id": "step_filterOption_filter_c3b344879_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3919,7 +3943,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c3b344879_8_1"
+        "step_executeCommand_execute_c3b344879_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3929,7 +3953,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c3b344879_8_2",
+      "step_id": "step_filterOption_assertOption_c3b344879_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3939,7 +3963,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c3b344879_8_2"
+        "step_filterOption_filter_c3b344879_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3950,7 +3974,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c3b344879_8_2",
+      "step_id": "step_filterOption_confirm_c3b344879_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3962,7 +3986,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c3b344879_8_2"
+        "step_filterOption_assertOption_c3b344879_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3972,7 +3996,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c3b344879_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3982,7 +4006,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c3b344879_8_2"
+        "step_filterOption_confirm_c3b344879_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3993,7 +4017,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c3b344879_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4007,7 +4031,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c3b344879_8_3"
+        "step_browserM365SignIn_assertAccount_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4017,7 +4041,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c3b344879_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4029,7 +4053,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c3b344879_8_3"
+        "step_browserM365SignIn_focusAccount_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4039,7 +4063,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c3b344879_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4051,7 +4075,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c3b344879_8_3"
+        "step_browserM365SignIn_enterAccount_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4061,7 +4085,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c3b344879_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4071,7 +4095,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c3b344879_8_3"
+        "step_browserM365SignIn_submitAccount_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4082,7 +4106,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c3b344879_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4094,7 +4118,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c3b344879_8_3"
+        "step_browserM365SignIn_assertPassword_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4104,7 +4128,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c3b344879_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4116,7 +4140,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c3b344879_8_3"
+        "step_browserM365SignIn_enterPassword_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4126,7 +4150,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c3b344879_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4136,7 +4160,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c3b344879_8_3"
+        "step_browserM365SignIn_submitPassword_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4147,7 +4171,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c3b344879_8_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c3b344879_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4159,7 +4183,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c3b344879_8_3"
+        "step_browserM365SignIn_assertStaySignedIn_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4170,7 +4194,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c3b344879_8_4",
+      "step_id": "step_assertReady_assertReady_c3b344879_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4180,7 +4204,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c3b344879_8_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c3b344879_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4191,7 +4215,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c3b344879_8_5",
+      "step_id": "step_zoomOut_zoomOut_c3b344879_8_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -4203,7 +4227,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c3b344879_8_4"
+        "step_assertReady_assertReady_c3b344879_8_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4223,7 +4247,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c3b344879_8_5"
+        "step_zoomOut_zoomOut_c3b344879_8_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 186,
+    "total_steps": 187,
     "name": "general-teams-py-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -177,21 +177,22 @@
       "step_clickPrimaryAction_assertDialog_cf4b7eba3_7_4",
       "step_clickPrimaryAction_click_cf4b7eba3_7_4",
       "step_assertNotificationContains_assert_cf4b7eba3_7_5",
-      "step_executeCommand_open_cf4b7eba3_8_1",
-      "step_executeCommand_assertPalette_cf4b7eba3_8_1",
-      "step_executeCommand_filter_cf4b7eba3_8_1",
-      "step_executeCommand_assertCommand_cf4b7eba3_8_1",
-      "step_executeCommand_execute_cf4b7eba3_8_1",
-      "step_filterOption_filter_cf4b7eba3_8_2",
-      "step_filterOption_assertOption_cf4b7eba3_8_2",
-      "step_filterOption_confirm_cf4b7eba3_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_cf4b7eba3_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_cf4b7eba3_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_cf4b7eba3_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_cf4b7eba3_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cf4b7eba3_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf4b7eba3_8_3",
-      "step_assertReady_assertReady_cf4b7eba3_8_4",
+      "step_assertDeployedRuntimeReady_cf4b7eba3_8_1",
+      "step_executeCommand_open_cf4b7eba3_8_2",
+      "step_executeCommand_assertPalette_cf4b7eba3_8_2",
+      "step_executeCommand_filter_cf4b7eba3_8_2",
+      "step_executeCommand_assertCommand_cf4b7eba3_8_2",
+      "step_executeCommand_execute_cf4b7eba3_8_2",
+      "step_filterOption_filter_cf4b7eba3_8_3",
+      "step_filterOption_assertOption_cf4b7eba3_8_3",
+      "step_filterOption_confirm_cf4b7eba3_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_cf4b7eba3_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_cf4b7eba3_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_cf4b7eba3_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_cf4b7eba3_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cf4b7eba3_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf4b7eba3_8_4",
+      "step_assertReady_assertReady_cf4b7eba3_8_5",
       "step_addAndOpenApp_assertAdd_cf4b7eba3_9_1",
       "step_addAndOpenApp_add_cf4b7eba3_9_1",
       "step_addAndOpenApp_assertAdded_cf4b7eba3_9_1",
@@ -3799,7 +3800,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cf4b7eba3_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_cf4b7eba3_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cf4b7eba3_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cf4b7eba3_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3811,7 +3835,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cf4b7eba3_7_5"
+        "step_assertDeployedRuntimeReady_cf4b7eba3_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3821,7 +3845,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cf4b7eba3_8_1",
+      "step_id": "step_executeCommand_assertPalette_cf4b7eba3_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3831,7 +3855,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cf4b7eba3_8_1"
+        "step_executeCommand_open_cf4b7eba3_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3842,7 +3866,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cf4b7eba3_8_1",
+      "step_id": "step_executeCommand_filter_cf4b7eba3_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3854,7 +3878,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cf4b7eba3_8_1"
+        "step_executeCommand_assertPalette_cf4b7eba3_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3864,7 +3888,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cf4b7eba3_8_1",
+      "step_id": "step_executeCommand_assertCommand_cf4b7eba3_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3874,7 +3898,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cf4b7eba3_8_1"
+        "step_executeCommand_filter_cf4b7eba3_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3885,7 +3909,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cf4b7eba3_8_1",
+      "step_id": "step_executeCommand_execute_cf4b7eba3_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3897,7 +3921,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cf4b7eba3_8_1"
+        "step_executeCommand_assertCommand_cf4b7eba3_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3907,7 +3931,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cf4b7eba3_8_2",
+      "step_id": "step_filterOption_filter_cf4b7eba3_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3919,7 +3943,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cf4b7eba3_8_1"
+        "step_executeCommand_execute_cf4b7eba3_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3929,7 +3953,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cf4b7eba3_8_2",
+      "step_id": "step_filterOption_assertOption_cf4b7eba3_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3939,7 +3963,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cf4b7eba3_8_2"
+        "step_filterOption_filter_cf4b7eba3_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3950,7 +3974,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cf4b7eba3_8_2",
+      "step_id": "step_filterOption_confirm_cf4b7eba3_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3962,7 +3986,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cf4b7eba3_8_2"
+        "step_filterOption_assertOption_cf4b7eba3_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3972,7 +3996,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf4b7eba3_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf4b7eba3_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3982,7 +4006,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cf4b7eba3_8_2"
+        "step_filterOption_confirm_cf4b7eba3_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3993,7 +4017,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf4b7eba3_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf4b7eba3_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4007,7 +4031,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cf4b7eba3_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_cf4b7eba3_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4017,7 +4041,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf4b7eba3_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf4b7eba3_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4029,7 +4053,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cf4b7eba3_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_cf4b7eba3_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4039,7 +4063,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf4b7eba3_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf4b7eba3_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4051,7 +4075,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cf4b7eba3_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_cf4b7eba3_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4061,7 +4085,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf4b7eba3_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf4b7eba3_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4071,7 +4095,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cf4b7eba3_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_cf4b7eba3_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4082,7 +4106,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf4b7eba3_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf4b7eba3_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4094,7 +4118,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cf4b7eba3_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cf4b7eba3_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4105,7 +4129,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cf4b7eba3_8_4",
+      "step_id": "step_assertReady_assertReady_cf4b7eba3_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4115,7 +4139,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf4b7eba3_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf4b7eba3_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4136,7 +4160,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cf4b7eba3_8_4"
+        "step_assertReady_assertReady_cf4b7eba3_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-py-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 182,
+    "total_steps": 183,
     "name": "general-teams-py-openai-remote-teams",
     "description": {
       "owner": "",
@@ -172,21 +172,22 @@
       "step_clickPrimaryAction_assertDialog_c152093f5_9_4",
       "step_clickPrimaryAction_click_c152093f5_9_4",
       "step_assertNotificationContains_assert_c152093f5_9_5",
-      "step_executeCommand_open_c152093f5_10_1",
-      "step_executeCommand_assertPalette_c152093f5_10_1",
-      "step_executeCommand_filter_c152093f5_10_1",
-      "step_executeCommand_assertCommand_c152093f5_10_1",
-      "step_executeCommand_execute_c152093f5_10_1",
-      "step_filterOption_filter_c152093f5_10_2",
-      "step_filterOption_assertOption_c152093f5_10_2",
-      "step_filterOption_confirm_c152093f5_10_2",
-      "step_browserM365PasswordSignIn_assertPassword_c152093f5_10_3",
-      "step_browserM365PasswordSignIn_focusPassword_c152093f5_10_3",
-      "step_browserM365PasswordSignIn_enterPassword_c152093f5_10_3",
-      "step_browserM365PasswordSignIn_submitPassword_c152093f5_10_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c152093f5_10_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c152093f5_10_3",
-      "step_assertReady_assertReady_c152093f5_10_4",
+      "step_assertDeployedRuntimeReady_c152093f5_10_1",
+      "step_executeCommand_open_c152093f5_10_2",
+      "step_executeCommand_assertPalette_c152093f5_10_2",
+      "step_executeCommand_filter_c152093f5_10_2",
+      "step_executeCommand_assertCommand_c152093f5_10_2",
+      "step_executeCommand_execute_c152093f5_10_2",
+      "step_filterOption_filter_c152093f5_10_3",
+      "step_filterOption_assertOption_c152093f5_10_3",
+      "step_filterOption_confirm_c152093f5_10_3",
+      "step_browserM365PasswordSignIn_assertPassword_c152093f5_10_4",
+      "step_browserM365PasswordSignIn_focusPassword_c152093f5_10_4",
+      "step_browserM365PasswordSignIn_enterPassword_c152093f5_10_4",
+      "step_browserM365PasswordSignIn_submitPassword_c152093f5_10_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c152093f5_10_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c152093f5_10_4",
+      "step_assertReady_assertReady_c152093f5_10_5",
       "step_addAndOpenApp_assertAdd_c152093f5_11_1",
       "step_addAndOpenApp_add_c152093f5_11_1",
       "step_addAndOpenApp_assertAdded_c152093f5_11_1",
@@ -3688,7 +3689,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c152093f5_10_1",
+      "step_id": "step_assertDeployedRuntimeReady_c152093f5_10_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c152093f5_9_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c152093f5_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3700,7 +3724,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c152093f5_9_5"
+        "step_assertDeployedRuntimeReady_c152093f5_10_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3710,7 +3734,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c152093f5_10_1",
+      "step_id": "step_executeCommand_assertPalette_c152093f5_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3720,7 +3744,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c152093f5_10_1"
+        "step_executeCommand_open_c152093f5_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3731,7 +3755,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c152093f5_10_1",
+      "step_id": "step_executeCommand_filter_c152093f5_10_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3743,7 +3767,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c152093f5_10_1"
+        "step_executeCommand_assertPalette_c152093f5_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3753,7 +3777,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c152093f5_10_1",
+      "step_id": "step_executeCommand_assertCommand_c152093f5_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3763,7 +3787,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c152093f5_10_1"
+        "step_executeCommand_filter_c152093f5_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3774,7 +3798,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c152093f5_10_1",
+      "step_id": "step_executeCommand_execute_c152093f5_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3786,7 +3810,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c152093f5_10_1"
+        "step_executeCommand_assertCommand_c152093f5_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3796,7 +3820,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c152093f5_10_2",
+      "step_id": "step_filterOption_filter_c152093f5_10_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3808,7 +3832,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c152093f5_10_1"
+        "step_executeCommand_execute_c152093f5_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3818,7 +3842,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c152093f5_10_2",
+      "step_id": "step_filterOption_assertOption_c152093f5_10_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3828,7 +3852,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c152093f5_10_2"
+        "step_filterOption_filter_c152093f5_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3839,7 +3863,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c152093f5_10_2",
+      "step_id": "step_filterOption_confirm_c152093f5_10_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3851,7 +3875,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c152093f5_10_2"
+        "step_filterOption_assertOption_c152093f5_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3861,7 +3885,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c152093f5_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c152093f5_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3871,7 +3895,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c152093f5_10_2"
+        "step_filterOption_confirm_c152093f5_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3882,7 +3906,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c152093f5_10_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c152093f5_10_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3896,7 +3920,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c152093f5_10_3"
+        "step_browserM365PasswordSignIn_assertPassword_c152093f5_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3906,7 +3930,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c152093f5_10_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c152093f5_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3918,7 +3942,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c152093f5_10_3"
+        "step_browserM365PasswordSignIn_focusPassword_c152093f5_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3928,7 +3952,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c152093f5_10_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c152093f5_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3940,7 +3964,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c152093f5_10_3"
+        "step_browserM365PasswordSignIn_enterPassword_c152093f5_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3950,7 +3974,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c152093f5_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c152093f5_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3960,7 +3984,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c152093f5_10_3"
+        "step_browserM365PasswordSignIn_submitPassword_c152093f5_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3971,7 +3995,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c152093f5_10_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c152093f5_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3983,7 +4007,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c152093f5_10_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c152093f5_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3994,7 +4018,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c152093f5_10_4",
+      "step_id": "step_assertReady_assertReady_c152093f5_10_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4004,7 +4028,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c152093f5_10_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c152093f5_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4025,7 +4049,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c152093f5_10_4"
+        "step_assertReady_assertReady_c152093f5_10_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 163,
+    "total_steps": 164,
     "name": "general-teams-ts-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -155,25 +155,26 @@
       "step_clickPrimaryAction_assertDialog_c85d00f90_6_4",
       "step_clickPrimaryAction_click_c85d00f90_6_4",
       "step_assertNotificationContains_assert_c85d00f90_6_5",
-      "step_executeCommand_open_c85d00f90_7_1",
-      "step_executeCommand_assertPalette_c85d00f90_7_1",
-      "step_executeCommand_filter_c85d00f90_7_1",
-      "step_executeCommand_assertCommand_c85d00f90_7_1",
-      "step_executeCommand_execute_c85d00f90_7_1",
-      "step_filterOption_filter_c85d00f90_7_2",
-      "step_filterOption_assertOption_c85d00f90_7_2",
-      "step_filterOption_confirm_c85d00f90_7_2",
-      "step_browserM365SignIn_assertAccount_c85d00f90_7_3",
-      "step_browserM365SignIn_focusAccount_c85d00f90_7_3",
-      "step_browserM365SignIn_enterAccount_c85d00f90_7_3",
-      "step_browserM365SignIn_submitAccount_c85d00f90_7_3",
-      "step_browserM365SignIn_assertPassword_c85d00f90_7_3",
-      "step_browserM365SignIn_enterPassword_c85d00f90_7_3",
-      "step_browserM365SignIn_submitPassword_c85d00f90_7_3",
-      "step_browserM365SignIn_assertStaySignedIn_c85d00f90_7_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c85d00f90_7_3",
-      "step_assertReady_assertReady_c85d00f90_7_4",
-      "step_zoomOut_zoomOut_c85d00f90_7_5",
+      "step_assertDeployedRuntimeReady_c85d00f90_7_1",
+      "step_executeCommand_open_c85d00f90_7_2",
+      "step_executeCommand_assertPalette_c85d00f90_7_2",
+      "step_executeCommand_filter_c85d00f90_7_2",
+      "step_executeCommand_assertCommand_c85d00f90_7_2",
+      "step_executeCommand_execute_c85d00f90_7_2",
+      "step_filterOption_filter_c85d00f90_7_3",
+      "step_filterOption_assertOption_c85d00f90_7_3",
+      "step_filterOption_confirm_c85d00f90_7_3",
+      "step_browserM365SignIn_assertAccount_c85d00f90_7_4",
+      "step_browserM365SignIn_focusAccount_c85d00f90_7_4",
+      "step_browserM365SignIn_enterAccount_c85d00f90_7_4",
+      "step_browserM365SignIn_submitAccount_c85d00f90_7_4",
+      "step_browserM365SignIn_assertPassword_c85d00f90_7_4",
+      "step_browserM365SignIn_enterPassword_c85d00f90_7_4",
+      "step_browserM365SignIn_submitPassword_c85d00f90_7_4",
+      "step_browserM365SignIn_assertStaySignedIn_c85d00f90_7_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c85d00f90_7_4",
+      "step_assertReady_assertReady_c85d00f90_7_5",
+      "step_zoomOut_zoomOut_c85d00f90_7_6",
       "step_sendCopilotMessage_assertInput_c85d00f90_9_1",
       "step_sendCopilotMessage_focusInput_c85d00f90_9_1",
       "step_sendCopilotMessage_type_c85d00f90_9_1",
@@ -3303,7 +3304,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c85d00f90_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c85d00f90_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c85d00f90_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c85d00f90_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3315,7 +3339,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c85d00f90_6_5"
+        "step_assertDeployedRuntimeReady_c85d00f90_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3325,7 +3349,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c85d00f90_7_1",
+      "step_id": "step_executeCommand_assertPalette_c85d00f90_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c85d00f90_7_1"
+        "step_executeCommand_open_c85d00f90_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3346,7 +3370,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c85d00f90_7_1",
+      "step_id": "step_executeCommand_filter_c85d00f90_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3358,7 +3382,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c85d00f90_7_1"
+        "step_executeCommand_assertPalette_c85d00f90_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3368,7 +3392,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c85d00f90_7_1",
+      "step_id": "step_executeCommand_assertCommand_c85d00f90_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c85d00f90_7_1"
+        "step_executeCommand_filter_c85d00f90_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3389,7 +3413,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c85d00f90_7_1",
+      "step_id": "step_executeCommand_execute_c85d00f90_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3401,7 +3425,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c85d00f90_7_1"
+        "step_executeCommand_assertCommand_c85d00f90_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3411,7 +3435,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c85d00f90_7_2",
+      "step_id": "step_filterOption_filter_c85d00f90_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c85d00f90_7_1"
+        "step_executeCommand_execute_c85d00f90_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c85d00f90_7_2",
+      "step_id": "step_filterOption_assertOption_c85d00f90_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c85d00f90_7_2"
+        "step_filterOption_filter_c85d00f90_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c85d00f90_7_2",
+      "step_id": "step_filterOption_confirm_c85d00f90_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c85d00f90_7_2"
+        "step_filterOption_assertOption_c85d00f90_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c85d00f90_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c85d00f90_7_2"
+        "step_filterOption_confirm_c85d00f90_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c85d00f90_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3511,7 +3535,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c85d00f90_7_3"
+        "step_browserM365SignIn_assertAccount_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3521,7 +3545,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c85d00f90_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3533,7 +3557,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c85d00f90_7_3"
+        "step_browserM365SignIn_focusAccount_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c85d00f90_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c85d00f90_7_3"
+        "step_browserM365SignIn_enterAccount_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c85d00f90_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c85d00f90_7_3"
+        "step_browserM365SignIn_submitAccount_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c85d00f90_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3598,7 +3622,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c85d00f90_7_3"
+        "step_browserM365SignIn_assertPassword_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3608,7 +3632,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c85d00f90_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3620,7 +3644,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c85d00f90_7_3"
+        "step_browserM365SignIn_enterPassword_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3630,7 +3654,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c85d00f90_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3640,7 +3664,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c85d00f90_7_3"
+        "step_browserM365SignIn_submitPassword_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3651,7 +3675,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c85d00f90_7_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c85d00f90_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3663,7 +3687,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c85d00f90_7_3"
+        "step_browserM365SignIn_assertStaySignedIn_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3674,7 +3698,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c85d00f90_7_4",
+      "step_id": "step_assertReady_assertReady_c85d00f90_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3684,7 +3708,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c85d00f90_7_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c85d00f90_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3695,7 +3719,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c85d00f90_7_5",
+      "step_id": "step_zoomOut_zoomOut_c85d00f90_7_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3707,7 +3731,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c85d00f90_7_4"
+        "step_assertReady_assertReady_c85d00f90_7_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3727,7 +3751,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c85d00f90_7_5"
+        "step_zoomOut_zoomOut_c85d00f90_7_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 164,
+    "total_steps": 165,
     "name": "general-teams-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -155,21 +155,22 @@
       "step_clickPrimaryAction_assertDialog_ce135a4b3_6_4",
       "step_clickPrimaryAction_click_ce135a4b3_6_4",
       "step_assertNotificationContains_assert_ce135a4b3_6_5",
-      "step_executeCommand_open_ce135a4b3_7_1",
-      "step_executeCommand_assertPalette_ce135a4b3_7_1",
-      "step_executeCommand_filter_ce135a4b3_7_1",
-      "step_executeCommand_assertCommand_ce135a4b3_7_1",
-      "step_executeCommand_execute_ce135a4b3_7_1",
-      "step_filterOption_filter_ce135a4b3_7_2",
-      "step_filterOption_assertOption_ce135a4b3_7_2",
-      "step_filterOption_confirm_ce135a4b3_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_ce135a4b3_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_ce135a4b3_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_ce135a4b3_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_ce135a4b3_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_ce135a4b3_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_ce135a4b3_7_3",
-      "step_assertReady_assertReady_ce135a4b3_7_4",
+      "step_assertDeployedRuntimeReady_ce135a4b3_7_1",
+      "step_executeCommand_open_ce135a4b3_7_2",
+      "step_executeCommand_assertPalette_ce135a4b3_7_2",
+      "step_executeCommand_filter_ce135a4b3_7_2",
+      "step_executeCommand_assertCommand_ce135a4b3_7_2",
+      "step_executeCommand_execute_ce135a4b3_7_2",
+      "step_filterOption_filter_ce135a4b3_7_3",
+      "step_filterOption_assertOption_ce135a4b3_7_3",
+      "step_filterOption_confirm_ce135a4b3_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_ce135a4b3_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_ce135a4b3_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_ce135a4b3_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_ce135a4b3_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_ce135a4b3_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_ce135a4b3_7_4",
+      "step_assertReady_assertReady_ce135a4b3_7_5",
       "step_addAndOpenApp_assertAdd_ce135a4b3_8_1",
       "step_addAndOpenApp_add_ce135a4b3_8_1",
       "step_addAndOpenApp_assertAdded_ce135a4b3_8_1",
@@ -3303,7 +3304,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_ce135a4b3_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_ce135a4b3_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_ce135a4b3_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_ce135a4b3_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3315,7 +3339,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_ce135a4b3_6_5"
+        "step_assertDeployedRuntimeReady_ce135a4b3_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3325,7 +3349,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_ce135a4b3_7_1",
+      "step_id": "step_executeCommand_assertPalette_ce135a4b3_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_ce135a4b3_7_1"
+        "step_executeCommand_open_ce135a4b3_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3346,7 +3370,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_ce135a4b3_7_1",
+      "step_id": "step_executeCommand_filter_ce135a4b3_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3358,7 +3382,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_ce135a4b3_7_1"
+        "step_executeCommand_assertPalette_ce135a4b3_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3368,7 +3392,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_ce135a4b3_7_1",
+      "step_id": "step_executeCommand_assertCommand_ce135a4b3_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_ce135a4b3_7_1"
+        "step_executeCommand_filter_ce135a4b3_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3389,7 +3413,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_ce135a4b3_7_1",
+      "step_id": "step_executeCommand_execute_ce135a4b3_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3401,7 +3425,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_ce135a4b3_7_1"
+        "step_executeCommand_assertCommand_ce135a4b3_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3411,7 +3435,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_ce135a4b3_7_2",
+      "step_id": "step_filterOption_filter_ce135a4b3_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_ce135a4b3_7_1"
+        "step_executeCommand_execute_ce135a4b3_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_ce135a4b3_7_2",
+      "step_id": "step_filterOption_assertOption_ce135a4b3_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_ce135a4b3_7_2"
+        "step_filterOption_filter_ce135a4b3_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_ce135a4b3_7_2",
+      "step_id": "step_filterOption_confirm_ce135a4b3_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_ce135a4b3_7_2"
+        "step_filterOption_assertOption_ce135a4b3_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_ce135a4b3_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_ce135a4b3_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_ce135a4b3_7_2"
+        "step_filterOption_confirm_ce135a4b3_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_ce135a4b3_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_ce135a4b3_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3511,7 +3535,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_ce135a4b3_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_ce135a4b3_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3521,7 +3545,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_ce135a4b3_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_ce135a4b3_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3533,7 +3557,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_ce135a4b3_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_ce135a4b3_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_ce135a4b3_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_ce135a4b3_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_ce135a4b3_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_ce135a4b3_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_ce135a4b3_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_ce135a4b3_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_ce135a4b3_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_ce135a4b3_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_ce135a4b3_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_ce135a4b3_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3598,7 +3622,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_ce135a4b3_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_ce135a4b3_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3609,7 +3633,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_ce135a4b3_7_4",
+      "step_id": "step_assertReady_assertReady_ce135a4b3_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3619,7 +3643,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_ce135a4b3_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_ce135a4b3_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3640,7 +3664,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_ce135a4b3_7_4"
+        "step_assertReady_assertReady_ce135a4b3_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-basic--general-teams-ts-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 159,
+    "total_steps": 160,
     "name": "general-teams-ts-openai-remote-teams",
     "description": {
       "owner": "",
@@ -149,21 +149,22 @@
       "step_clickPrimaryAction_assertDialog_cf58d3877_8_4",
       "step_clickPrimaryAction_click_cf58d3877_8_4",
       "step_assertNotificationContains_assert_cf58d3877_8_5",
-      "step_executeCommand_open_cf58d3877_9_1",
-      "step_executeCommand_assertPalette_cf58d3877_9_1",
-      "step_executeCommand_filter_cf58d3877_9_1",
-      "step_executeCommand_assertCommand_cf58d3877_9_1",
-      "step_executeCommand_execute_cf58d3877_9_1",
-      "step_filterOption_filter_cf58d3877_9_2",
-      "step_filterOption_assertOption_cf58d3877_9_2",
-      "step_filterOption_confirm_cf58d3877_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_cf58d3877_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_cf58d3877_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_cf58d3877_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_cf58d3877_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cf58d3877_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf58d3877_9_3",
-      "step_assertReady_assertReady_cf58d3877_9_4",
+      "step_assertDeployedRuntimeReady_cf58d3877_9_1",
+      "step_executeCommand_open_cf58d3877_9_2",
+      "step_executeCommand_assertPalette_cf58d3877_9_2",
+      "step_executeCommand_filter_cf58d3877_9_2",
+      "step_executeCommand_assertCommand_cf58d3877_9_2",
+      "step_executeCommand_execute_cf58d3877_9_2",
+      "step_filterOption_filter_cf58d3877_9_3",
+      "step_filterOption_assertOption_cf58d3877_9_3",
+      "step_filterOption_confirm_cf58d3877_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_cf58d3877_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_cf58d3877_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_cf58d3877_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_cf58d3877_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cf58d3877_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf58d3877_9_4",
+      "step_assertReady_assertReady_cf58d3877_9_5",
       "step_addAndOpenApp_assertAdd_cf58d3877_10_1",
       "step_addAndOpenApp_add_cf58d3877_10_1",
       "step_addAndOpenApp_assertAdded_cf58d3877_10_1",
@@ -3168,7 +3169,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cf58d3877_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_cf58d3877_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cf58d3877_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cf58d3877_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3180,7 +3204,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cf58d3877_8_5"
+        "step_assertDeployedRuntimeReady_cf58d3877_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3190,7 +3214,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cf58d3877_9_1",
+      "step_id": "step_executeCommand_assertPalette_cf58d3877_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3200,7 +3224,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cf58d3877_9_1"
+        "step_executeCommand_open_cf58d3877_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3211,7 +3235,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cf58d3877_9_1",
+      "step_id": "step_executeCommand_filter_cf58d3877_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3223,7 +3247,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cf58d3877_9_1"
+        "step_executeCommand_assertPalette_cf58d3877_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3233,7 +3257,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cf58d3877_9_1",
+      "step_id": "step_executeCommand_assertCommand_cf58d3877_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3243,7 +3267,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cf58d3877_9_1"
+        "step_executeCommand_filter_cf58d3877_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3254,7 +3278,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cf58d3877_9_1",
+      "step_id": "step_executeCommand_execute_cf58d3877_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3266,7 +3290,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cf58d3877_9_1"
+        "step_executeCommand_assertCommand_cf58d3877_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3276,7 +3300,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cf58d3877_9_2",
+      "step_id": "step_filterOption_filter_cf58d3877_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3288,7 +3312,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cf58d3877_9_1"
+        "step_executeCommand_execute_cf58d3877_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3298,7 +3322,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cf58d3877_9_2",
+      "step_id": "step_filterOption_assertOption_cf58d3877_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3308,7 +3332,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cf58d3877_9_2"
+        "step_filterOption_filter_cf58d3877_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3319,7 +3343,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cf58d3877_9_2",
+      "step_id": "step_filterOption_confirm_cf58d3877_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3331,7 +3355,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cf58d3877_9_2"
+        "step_filterOption_assertOption_cf58d3877_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3341,7 +3365,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf58d3877_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf58d3877_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3351,7 +3375,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cf58d3877_9_2"
+        "step_filterOption_confirm_cf58d3877_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3362,7 +3386,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf58d3877_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf58d3877_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3376,7 +3400,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cf58d3877_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_cf58d3877_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3386,7 +3410,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf58d3877_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf58d3877_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3398,7 +3422,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cf58d3877_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_cf58d3877_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3408,7 +3432,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf58d3877_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf58d3877_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3420,7 +3444,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cf58d3877_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_cf58d3877_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3430,7 +3454,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf58d3877_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf58d3877_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3440,7 +3464,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cf58d3877_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_cf58d3877_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3451,7 +3475,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf58d3877_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf58d3877_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3463,7 +3487,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cf58d3877_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cf58d3877_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3474,7 +3498,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cf58d3877_9_4",
+      "step_id": "step_assertReady_assertReady_cf58d3877_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3484,7 +3508,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf58d3877_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf58d3877_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3505,7 +3529,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cf58d3877_9_4"
+        "step_assertReady_assertReady_cf58d3877_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-js-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 194,
+    "total_steps": 195,
     "name": "rag-azure-ai-search-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -184,21 +184,22 @@
       "step_clickPrimaryAction_assertDialog_c66803030_7_4",
       "step_clickPrimaryAction_click_c66803030_7_4",
       "step_assertNotificationContains_assert_c66803030_7_5",
-      "step_executeCommand_open_c66803030_8_1",
-      "step_executeCommand_assertPalette_c66803030_8_1",
-      "step_executeCommand_filter_c66803030_8_1",
-      "step_executeCommand_assertCommand_c66803030_8_1",
-      "step_executeCommand_execute_c66803030_8_1",
-      "step_filterOption_filter_c66803030_8_2",
-      "step_filterOption_assertOption_c66803030_8_2",
-      "step_filterOption_confirm_c66803030_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_c66803030_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_c66803030_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_c66803030_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_c66803030_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c66803030_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c66803030_8_3",
-      "step_assertReady_assertReady_c66803030_8_4",
+      "step_assertDeployedRuntimeReady_c66803030_8_1",
+      "step_executeCommand_open_c66803030_8_2",
+      "step_executeCommand_assertPalette_c66803030_8_2",
+      "step_executeCommand_filter_c66803030_8_2",
+      "step_executeCommand_assertCommand_c66803030_8_2",
+      "step_executeCommand_execute_c66803030_8_2",
+      "step_filterOption_filter_c66803030_8_3",
+      "step_filterOption_assertOption_c66803030_8_3",
+      "step_filterOption_confirm_c66803030_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_c66803030_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_c66803030_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_c66803030_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_c66803030_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c66803030_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c66803030_8_4",
+      "step_assertReady_assertReady_c66803030_8_5",
       "step_addAndOpenApp_assertAdd_c66803030_9_1",
       "step_addAndOpenApp_add_c66803030_9_1",
       "step_addAndOpenApp_assertAdded_c66803030_9_1",
@@ -3956,7 +3957,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c66803030_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_c66803030_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c66803030_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c66803030_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3968,7 +3992,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c66803030_7_5"
+        "step_assertDeployedRuntimeReady_c66803030_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3978,7 +4002,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c66803030_8_1",
+      "step_id": "step_executeCommand_assertPalette_c66803030_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3988,7 +4012,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c66803030_8_1"
+        "step_executeCommand_open_c66803030_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3999,7 +4023,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c66803030_8_1",
+      "step_id": "step_executeCommand_filter_c66803030_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4011,7 +4035,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c66803030_8_1"
+        "step_executeCommand_assertPalette_c66803030_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4021,7 +4045,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c66803030_8_1",
+      "step_id": "step_executeCommand_assertCommand_c66803030_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4031,7 +4055,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c66803030_8_1"
+        "step_executeCommand_filter_c66803030_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4042,7 +4066,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c66803030_8_1",
+      "step_id": "step_executeCommand_execute_c66803030_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4054,7 +4078,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c66803030_8_1"
+        "step_executeCommand_assertCommand_c66803030_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4064,7 +4088,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c66803030_8_2",
+      "step_id": "step_filterOption_filter_c66803030_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4076,7 +4100,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c66803030_8_1"
+        "step_executeCommand_execute_c66803030_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4086,7 +4110,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c66803030_8_2",
+      "step_id": "step_filterOption_assertOption_c66803030_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4096,7 +4120,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c66803030_8_2"
+        "step_filterOption_filter_c66803030_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4107,7 +4131,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c66803030_8_2",
+      "step_id": "step_filterOption_confirm_c66803030_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4119,7 +4143,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c66803030_8_2"
+        "step_filterOption_assertOption_c66803030_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4129,7 +4153,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c66803030_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c66803030_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4139,7 +4163,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c66803030_8_2"
+        "step_filterOption_confirm_c66803030_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4150,7 +4174,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c66803030_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c66803030_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4164,7 +4188,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c66803030_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_c66803030_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4174,7 +4198,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c66803030_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c66803030_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4186,7 +4210,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c66803030_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_c66803030_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4196,7 +4220,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c66803030_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c66803030_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4208,7 +4232,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c66803030_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_c66803030_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4218,7 +4242,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c66803030_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c66803030_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4228,7 +4252,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c66803030_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_c66803030_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4239,7 +4263,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c66803030_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c66803030_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4251,7 +4275,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c66803030_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c66803030_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4262,7 +4286,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c66803030_8_4",
+      "step_id": "step_assertReady_assertReady_c66803030_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4272,7 +4296,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c66803030_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c66803030_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4293,7 +4317,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c66803030_8_4"
+        "step_assertReady_assertReady_c66803030_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-js-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-js-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 188,
+    "total_steps": 189,
     "name": "rag-azure-ai-search-js-openai-remote-teams",
     "description": {
       "owner": "",
@@ -178,21 +178,22 @@
       "step_clickPrimaryAction_assertDialog_c6b6d5e72_9_4",
       "step_clickPrimaryAction_click_c6b6d5e72_9_4",
       "step_assertNotificationContains_assert_c6b6d5e72_9_5",
-      "step_executeCommand_open_c6b6d5e72_10_1",
-      "step_executeCommand_assertPalette_c6b6d5e72_10_1",
-      "step_executeCommand_filter_c6b6d5e72_10_1",
-      "step_executeCommand_assertCommand_c6b6d5e72_10_1",
-      "step_executeCommand_execute_c6b6d5e72_10_1",
-      "step_filterOption_filter_c6b6d5e72_10_2",
-      "step_filterOption_assertOption_c6b6d5e72_10_2",
-      "step_filterOption_confirm_c6b6d5e72_10_2",
-      "step_browserM365PasswordSignIn_assertPassword_c6b6d5e72_10_3",
-      "step_browserM365PasswordSignIn_focusPassword_c6b6d5e72_10_3",
-      "step_browserM365PasswordSignIn_enterPassword_c6b6d5e72_10_3",
-      "step_browserM365PasswordSignIn_submitPassword_c6b6d5e72_10_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c6b6d5e72_10_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c6b6d5e72_10_3",
-      "step_assertReady_assertReady_c6b6d5e72_10_4",
+      "step_assertDeployedRuntimeReady_c6b6d5e72_10_1",
+      "step_executeCommand_open_c6b6d5e72_10_2",
+      "step_executeCommand_assertPalette_c6b6d5e72_10_2",
+      "step_executeCommand_filter_c6b6d5e72_10_2",
+      "step_executeCommand_assertCommand_c6b6d5e72_10_2",
+      "step_executeCommand_execute_c6b6d5e72_10_2",
+      "step_filterOption_filter_c6b6d5e72_10_3",
+      "step_filterOption_assertOption_c6b6d5e72_10_3",
+      "step_filterOption_confirm_c6b6d5e72_10_3",
+      "step_browserM365PasswordSignIn_assertPassword_c6b6d5e72_10_4",
+      "step_browserM365PasswordSignIn_focusPassword_c6b6d5e72_10_4",
+      "step_browserM365PasswordSignIn_enterPassword_c6b6d5e72_10_4",
+      "step_browserM365PasswordSignIn_submitPassword_c6b6d5e72_10_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c6b6d5e72_10_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c6b6d5e72_10_4",
+      "step_assertReady_assertReady_c6b6d5e72_10_5",
       "step_addAndOpenApp_assertAdd_c6b6d5e72_11_1",
       "step_addAndOpenApp_add_c6b6d5e72_11_1",
       "step_addAndOpenApp_assertAdded_c6b6d5e72_11_1",
@@ -3820,7 +3821,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c6b6d5e72_10_1",
+      "step_id": "step_assertDeployedRuntimeReady_c6b6d5e72_10_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c6b6d5e72_9_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c6b6d5e72_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3832,7 +3856,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c6b6d5e72_9_5"
+        "step_assertDeployedRuntimeReady_c6b6d5e72_10_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3842,7 +3866,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c6b6d5e72_10_1",
+      "step_id": "step_executeCommand_assertPalette_c6b6d5e72_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3852,7 +3876,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c6b6d5e72_10_1"
+        "step_executeCommand_open_c6b6d5e72_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3863,7 +3887,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c6b6d5e72_10_1",
+      "step_id": "step_executeCommand_filter_c6b6d5e72_10_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3875,7 +3899,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c6b6d5e72_10_1"
+        "step_executeCommand_assertPalette_c6b6d5e72_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3885,7 +3909,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c6b6d5e72_10_1",
+      "step_id": "step_executeCommand_assertCommand_c6b6d5e72_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3895,7 +3919,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c6b6d5e72_10_1"
+        "step_executeCommand_filter_c6b6d5e72_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3906,7 +3930,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c6b6d5e72_10_1",
+      "step_id": "step_executeCommand_execute_c6b6d5e72_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3918,7 +3942,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c6b6d5e72_10_1"
+        "step_executeCommand_assertCommand_c6b6d5e72_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3928,7 +3952,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c6b6d5e72_10_2",
+      "step_id": "step_filterOption_filter_c6b6d5e72_10_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3940,7 +3964,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c6b6d5e72_10_1"
+        "step_executeCommand_execute_c6b6d5e72_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3950,7 +3974,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c6b6d5e72_10_2",
+      "step_id": "step_filterOption_assertOption_c6b6d5e72_10_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3960,7 +3984,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c6b6d5e72_10_2"
+        "step_filterOption_filter_c6b6d5e72_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3971,7 +3995,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c6b6d5e72_10_2",
+      "step_id": "step_filterOption_confirm_c6b6d5e72_10_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3983,7 +4007,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c6b6d5e72_10_2"
+        "step_filterOption_assertOption_c6b6d5e72_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3993,7 +4017,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c6b6d5e72_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c6b6d5e72_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4003,7 +4027,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c6b6d5e72_10_2"
+        "step_filterOption_confirm_c6b6d5e72_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4014,7 +4038,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c6b6d5e72_10_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c6b6d5e72_10_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4028,7 +4052,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c6b6d5e72_10_3"
+        "step_browserM365PasswordSignIn_assertPassword_c6b6d5e72_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4038,7 +4062,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c6b6d5e72_10_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c6b6d5e72_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4050,7 +4074,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c6b6d5e72_10_3"
+        "step_browserM365PasswordSignIn_focusPassword_c6b6d5e72_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4060,7 +4084,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c6b6d5e72_10_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c6b6d5e72_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4072,7 +4096,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c6b6d5e72_10_3"
+        "step_browserM365PasswordSignIn_enterPassword_c6b6d5e72_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4082,7 +4106,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c6b6d5e72_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c6b6d5e72_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4092,7 +4116,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c6b6d5e72_10_3"
+        "step_browserM365PasswordSignIn_submitPassword_c6b6d5e72_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4103,7 +4127,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c6b6d5e72_10_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c6b6d5e72_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4115,7 +4139,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c6b6d5e72_10_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c6b6d5e72_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4126,7 +4150,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c6b6d5e72_10_4",
+      "step_id": "step_assertReady_assertReady_c6b6d5e72_10_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4136,7 +4160,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c6b6d5e72_10_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c6b6d5e72_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4157,7 +4181,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c6b6d5e72_10_4"
+        "step_assertReady_assertReady_c6b6d5e72_10_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-py-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 219,
+    "total_steps": 220,
     "name": "rag-azure-ai-search-py-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -209,21 +209,22 @@
       "step_clickPrimaryAction_assertDialog_ce3d0110e_8_4",
       "step_clickPrimaryAction_click_ce3d0110e_8_4",
       "step_assertNotificationContains_assert_ce3d0110e_8_5",
-      "step_executeCommand_open_ce3d0110e_9_1",
-      "step_executeCommand_assertPalette_ce3d0110e_9_1",
-      "step_executeCommand_filter_ce3d0110e_9_1",
-      "step_executeCommand_assertCommand_ce3d0110e_9_1",
-      "step_executeCommand_execute_ce3d0110e_9_1",
-      "step_filterOption_filter_ce3d0110e_9_2",
-      "step_filterOption_assertOption_ce3d0110e_9_2",
-      "step_filterOption_confirm_ce3d0110e_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_ce3d0110e_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_ce3d0110e_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_ce3d0110e_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_ce3d0110e_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_ce3d0110e_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_ce3d0110e_9_3",
-      "step_assertReady_assertReady_ce3d0110e_9_4",
+      "step_assertDeployedRuntimeReady_ce3d0110e_9_1",
+      "step_executeCommand_open_ce3d0110e_9_2",
+      "step_executeCommand_assertPalette_ce3d0110e_9_2",
+      "step_executeCommand_filter_ce3d0110e_9_2",
+      "step_executeCommand_assertCommand_ce3d0110e_9_2",
+      "step_executeCommand_execute_ce3d0110e_9_2",
+      "step_filterOption_filter_ce3d0110e_9_3",
+      "step_filterOption_assertOption_ce3d0110e_9_3",
+      "step_filterOption_confirm_ce3d0110e_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_ce3d0110e_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_ce3d0110e_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_ce3d0110e_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_ce3d0110e_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_ce3d0110e_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_ce3d0110e_9_4",
+      "step_assertReady_assertReady_ce3d0110e_9_5",
       "step_addAndOpenApp_assertAdd_ce3d0110e_10_1",
       "step_addAndOpenApp_add_ce3d0110e_10_1",
       "step_addAndOpenApp_assertAdded_ce3d0110e_10_1",
@@ -4524,7 +4525,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_ce3d0110e_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_ce3d0110e_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_ce3d0110e_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_ce3d0110e_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4536,7 +4560,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_ce3d0110e_8_5"
+        "step_assertDeployedRuntimeReady_ce3d0110e_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4546,7 +4570,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_ce3d0110e_9_1",
+      "step_id": "step_executeCommand_assertPalette_ce3d0110e_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4556,7 +4580,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_ce3d0110e_9_1"
+        "step_executeCommand_open_ce3d0110e_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4567,7 +4591,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_ce3d0110e_9_1",
+      "step_id": "step_executeCommand_filter_ce3d0110e_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4579,7 +4603,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_ce3d0110e_9_1"
+        "step_executeCommand_assertPalette_ce3d0110e_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4589,7 +4613,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_ce3d0110e_9_1",
+      "step_id": "step_executeCommand_assertCommand_ce3d0110e_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4599,7 +4623,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_ce3d0110e_9_1"
+        "step_executeCommand_filter_ce3d0110e_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4610,7 +4634,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_ce3d0110e_9_1",
+      "step_id": "step_executeCommand_execute_ce3d0110e_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4622,7 +4646,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_ce3d0110e_9_1"
+        "step_executeCommand_assertCommand_ce3d0110e_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4632,7 +4656,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_ce3d0110e_9_2",
+      "step_id": "step_filterOption_filter_ce3d0110e_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4644,7 +4668,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_ce3d0110e_9_1"
+        "step_executeCommand_execute_ce3d0110e_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4654,7 +4678,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_ce3d0110e_9_2",
+      "step_id": "step_filterOption_assertOption_ce3d0110e_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4664,7 +4688,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_ce3d0110e_9_2"
+        "step_filterOption_filter_ce3d0110e_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4675,7 +4699,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_ce3d0110e_9_2",
+      "step_id": "step_filterOption_confirm_ce3d0110e_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4687,7 +4711,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_ce3d0110e_9_2"
+        "step_filterOption_assertOption_ce3d0110e_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4697,7 +4721,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_ce3d0110e_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_ce3d0110e_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4707,7 +4731,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_ce3d0110e_9_2"
+        "step_filterOption_confirm_ce3d0110e_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4718,7 +4742,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_ce3d0110e_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_ce3d0110e_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4732,7 +4756,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_ce3d0110e_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_ce3d0110e_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4742,7 +4766,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_ce3d0110e_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_ce3d0110e_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4754,7 +4778,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_ce3d0110e_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_ce3d0110e_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4764,7 +4788,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_ce3d0110e_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_ce3d0110e_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4776,7 +4800,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_ce3d0110e_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_ce3d0110e_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4786,7 +4810,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_ce3d0110e_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_ce3d0110e_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4796,7 +4820,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_ce3d0110e_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_ce3d0110e_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4807,7 +4831,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_ce3d0110e_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_ce3d0110e_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4819,7 +4843,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_ce3d0110e_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_ce3d0110e_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4830,7 +4854,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_ce3d0110e_9_4",
+      "step_id": "step_assertReady_assertReady_ce3d0110e_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4840,7 +4864,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_ce3d0110e_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_ce3d0110e_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4861,7 +4885,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_ce3d0110e_9_4"
+        "step_assertReady_assertReady_ce3d0110e_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-py-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-py-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 211,
+    "total_steps": 212,
     "name": "rag-azure-ai-search-py-openai-remote-teams",
     "description": {
       "owner": "",
@@ -201,21 +201,22 @@
       "step_clickPrimaryAction_assertDialog_cc1031db7_10_4",
       "step_clickPrimaryAction_click_cc1031db7_10_4",
       "step_assertNotificationContains_assert_cc1031db7_10_5",
-      "step_executeCommand_open_cc1031db7_11_1",
-      "step_executeCommand_assertPalette_cc1031db7_11_1",
-      "step_executeCommand_filter_cc1031db7_11_1",
-      "step_executeCommand_assertCommand_cc1031db7_11_1",
-      "step_executeCommand_execute_cc1031db7_11_1",
-      "step_filterOption_filter_cc1031db7_11_2",
-      "step_filterOption_assertOption_cc1031db7_11_2",
-      "step_filterOption_confirm_cc1031db7_11_2",
-      "step_browserM365PasswordSignIn_assertPassword_cc1031db7_11_3",
-      "step_browserM365PasswordSignIn_focusPassword_cc1031db7_11_3",
-      "step_browserM365PasswordSignIn_enterPassword_cc1031db7_11_3",
-      "step_browserM365PasswordSignIn_submitPassword_cc1031db7_11_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cc1031db7_11_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cc1031db7_11_3",
-      "step_assertReady_assertReady_cc1031db7_11_4",
+      "step_assertDeployedRuntimeReady_cc1031db7_11_1",
+      "step_executeCommand_open_cc1031db7_11_2",
+      "step_executeCommand_assertPalette_cc1031db7_11_2",
+      "step_executeCommand_filter_cc1031db7_11_2",
+      "step_executeCommand_assertCommand_cc1031db7_11_2",
+      "step_executeCommand_execute_cc1031db7_11_2",
+      "step_filterOption_filter_cc1031db7_11_3",
+      "step_filterOption_assertOption_cc1031db7_11_3",
+      "step_filterOption_confirm_cc1031db7_11_3",
+      "step_browserM365PasswordSignIn_assertPassword_cc1031db7_11_4",
+      "step_browserM365PasswordSignIn_focusPassword_cc1031db7_11_4",
+      "step_browserM365PasswordSignIn_enterPassword_cc1031db7_11_4",
+      "step_browserM365PasswordSignIn_submitPassword_cc1031db7_11_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cc1031db7_11_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cc1031db7_11_4",
+      "step_assertReady_assertReady_cc1031db7_11_5",
       "step_addAndOpenApp_assertAdd_cc1031db7_12_1",
       "step_addAndOpenApp_add_cc1031db7_12_1",
       "step_addAndOpenApp_assertAdded_cc1031db7_12_1",
@@ -4340,7 +4341,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cc1031db7_11_1",
+      "step_id": "step_assertDeployedRuntimeReady_cc1031db7_11_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cc1031db7_10_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cc1031db7_11_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4352,7 +4376,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cc1031db7_10_5"
+        "step_assertDeployedRuntimeReady_cc1031db7_11_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4362,7 +4386,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cc1031db7_11_1",
+      "step_id": "step_executeCommand_assertPalette_cc1031db7_11_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4372,7 +4396,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cc1031db7_11_1"
+        "step_executeCommand_open_cc1031db7_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4383,7 +4407,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cc1031db7_11_1",
+      "step_id": "step_executeCommand_filter_cc1031db7_11_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4395,7 +4419,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cc1031db7_11_1"
+        "step_executeCommand_assertPalette_cc1031db7_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4405,7 +4429,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cc1031db7_11_1",
+      "step_id": "step_executeCommand_assertCommand_cc1031db7_11_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4415,7 +4439,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cc1031db7_11_1"
+        "step_executeCommand_filter_cc1031db7_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4426,7 +4450,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cc1031db7_11_1",
+      "step_id": "step_executeCommand_execute_cc1031db7_11_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4438,7 +4462,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cc1031db7_11_1"
+        "step_executeCommand_assertCommand_cc1031db7_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4448,7 +4472,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cc1031db7_11_2",
+      "step_id": "step_filterOption_filter_cc1031db7_11_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4460,7 +4484,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cc1031db7_11_1"
+        "step_executeCommand_execute_cc1031db7_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4470,7 +4494,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cc1031db7_11_2",
+      "step_id": "step_filterOption_assertOption_cc1031db7_11_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4480,7 +4504,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cc1031db7_11_2"
+        "step_filterOption_filter_cc1031db7_11_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4491,7 +4515,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cc1031db7_11_2",
+      "step_id": "step_filterOption_confirm_cc1031db7_11_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4503,7 +4527,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cc1031db7_11_2"
+        "step_filterOption_assertOption_cc1031db7_11_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4513,7 +4537,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cc1031db7_11_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cc1031db7_11_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4523,7 +4547,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cc1031db7_11_2"
+        "step_filterOption_confirm_cc1031db7_11_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4534,7 +4558,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cc1031db7_11_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cc1031db7_11_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4548,7 +4572,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cc1031db7_11_3"
+        "step_browserM365PasswordSignIn_assertPassword_cc1031db7_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4558,7 +4582,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cc1031db7_11_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cc1031db7_11_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4570,7 +4594,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cc1031db7_11_3"
+        "step_browserM365PasswordSignIn_focusPassword_cc1031db7_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4580,7 +4604,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cc1031db7_11_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cc1031db7_11_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4592,7 +4616,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cc1031db7_11_3"
+        "step_browserM365PasswordSignIn_enterPassword_cc1031db7_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4602,7 +4626,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cc1031db7_11_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cc1031db7_11_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4612,7 +4636,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cc1031db7_11_3"
+        "step_browserM365PasswordSignIn_submitPassword_cc1031db7_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4623,7 +4647,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cc1031db7_11_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cc1031db7_11_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4635,7 +4659,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cc1031db7_11_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cc1031db7_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4646,7 +4670,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cc1031db7_11_4",
+      "step_id": "step_assertReady_assertReady_cc1031db7_11_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4656,7 +4680,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cc1031db7_11_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cc1031db7_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4677,7 +4701,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cc1031db7_11_4"
+        "step_assertReady_assertReady_cc1031db7_11_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-ts-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 197,
+    "total_steps": 198,
     "name": "rag-azure-ai-search-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -187,21 +187,22 @@
       "step_clickPrimaryAction_assertDialog_cbecd742b_7_4",
       "step_clickPrimaryAction_click_cbecd742b_7_4",
       "step_assertNotificationContains_assert_cbecd742b_7_5",
-      "step_executeCommand_open_cbecd742b_8_1",
-      "step_executeCommand_assertPalette_cbecd742b_8_1",
-      "step_executeCommand_filter_cbecd742b_8_1",
-      "step_executeCommand_assertCommand_cbecd742b_8_1",
-      "step_executeCommand_execute_cbecd742b_8_1",
-      "step_filterOption_filter_cbecd742b_8_2",
-      "step_filterOption_assertOption_cbecd742b_8_2",
-      "step_filterOption_confirm_cbecd742b_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_cbecd742b_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_cbecd742b_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_cbecd742b_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_cbecd742b_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cbecd742b_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cbecd742b_8_3",
-      "step_assertReady_assertReady_cbecd742b_8_4",
+      "step_assertDeployedRuntimeReady_cbecd742b_8_1",
+      "step_executeCommand_open_cbecd742b_8_2",
+      "step_executeCommand_assertPalette_cbecd742b_8_2",
+      "step_executeCommand_filter_cbecd742b_8_2",
+      "step_executeCommand_assertCommand_cbecd742b_8_2",
+      "step_executeCommand_execute_cbecd742b_8_2",
+      "step_filterOption_filter_cbecd742b_8_3",
+      "step_filterOption_assertOption_cbecd742b_8_3",
+      "step_filterOption_confirm_cbecd742b_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_cbecd742b_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_cbecd742b_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_cbecd742b_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_cbecd742b_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cbecd742b_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cbecd742b_8_4",
+      "step_assertReady_assertReady_cbecd742b_8_5",
       "step_addAndOpenApp_assertAdd_cbecd742b_9_1",
       "step_addAndOpenApp_add_cbecd742b_9_1",
       "step_addAndOpenApp_assertAdded_cbecd742b_9_1",
@@ -4028,7 +4029,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cbecd742b_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_cbecd742b_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cbecd742b_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cbecd742b_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4040,7 +4064,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cbecd742b_7_5"
+        "step_assertDeployedRuntimeReady_cbecd742b_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4050,7 +4074,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cbecd742b_8_1",
+      "step_id": "step_executeCommand_assertPalette_cbecd742b_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4060,7 +4084,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cbecd742b_8_1"
+        "step_executeCommand_open_cbecd742b_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4071,7 +4095,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cbecd742b_8_1",
+      "step_id": "step_executeCommand_filter_cbecd742b_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4083,7 +4107,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cbecd742b_8_1"
+        "step_executeCommand_assertPalette_cbecd742b_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4093,7 +4117,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cbecd742b_8_1",
+      "step_id": "step_executeCommand_assertCommand_cbecd742b_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4103,7 +4127,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cbecd742b_8_1"
+        "step_executeCommand_filter_cbecd742b_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4114,7 +4138,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cbecd742b_8_1",
+      "step_id": "step_executeCommand_execute_cbecd742b_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4126,7 +4150,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cbecd742b_8_1"
+        "step_executeCommand_assertCommand_cbecd742b_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4136,7 +4160,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cbecd742b_8_2",
+      "step_id": "step_filterOption_filter_cbecd742b_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4148,7 +4172,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cbecd742b_8_1"
+        "step_executeCommand_execute_cbecd742b_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4158,7 +4182,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cbecd742b_8_2",
+      "step_id": "step_filterOption_assertOption_cbecd742b_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4168,7 +4192,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cbecd742b_8_2"
+        "step_filterOption_filter_cbecd742b_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4179,7 +4203,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cbecd742b_8_2",
+      "step_id": "step_filterOption_confirm_cbecd742b_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4191,7 +4215,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cbecd742b_8_2"
+        "step_filterOption_assertOption_cbecd742b_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4201,7 +4225,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cbecd742b_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cbecd742b_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4211,7 +4235,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cbecd742b_8_2"
+        "step_filterOption_confirm_cbecd742b_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4222,7 +4246,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cbecd742b_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cbecd742b_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4236,7 +4260,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cbecd742b_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_cbecd742b_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4246,7 +4270,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cbecd742b_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cbecd742b_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4258,7 +4282,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cbecd742b_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_cbecd742b_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4268,7 +4292,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cbecd742b_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cbecd742b_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4280,7 +4304,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cbecd742b_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_cbecd742b_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4290,7 +4314,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cbecd742b_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cbecd742b_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4300,7 +4324,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cbecd742b_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_cbecd742b_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4311,7 +4335,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cbecd742b_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cbecd742b_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4323,7 +4347,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cbecd742b_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cbecd742b_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4334,7 +4358,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cbecd742b_8_4",
+      "step_id": "step_assertReady_assertReady_cbecd742b_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4344,7 +4368,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cbecd742b_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cbecd742b_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4365,7 +4389,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cbecd742b_8_4"
+        "step_assertReady_assertReady_cbecd742b_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-ts-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-azure-ai-search--rag-azure-ai-search-ts-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 189,
+    "total_steps": 190,
     "name": "rag-azure-ai-search-ts-openai-remote-teams",
     "description": {
       "owner": "",
@@ -179,21 +179,22 @@
       "step_clickPrimaryAction_assertDialog_cf6c84ebd_9_4",
       "step_clickPrimaryAction_click_cf6c84ebd_9_4",
       "step_assertNotificationContains_assert_cf6c84ebd_9_5",
-      "step_executeCommand_open_cf6c84ebd_10_1",
-      "step_executeCommand_assertPalette_cf6c84ebd_10_1",
-      "step_executeCommand_filter_cf6c84ebd_10_1",
-      "step_executeCommand_assertCommand_cf6c84ebd_10_1",
-      "step_executeCommand_execute_cf6c84ebd_10_1",
-      "step_filterOption_filter_cf6c84ebd_10_2",
-      "step_filterOption_assertOption_cf6c84ebd_10_2",
-      "step_filterOption_confirm_cf6c84ebd_10_2",
-      "step_browserM365PasswordSignIn_assertPassword_cf6c84ebd_10_3",
-      "step_browserM365PasswordSignIn_focusPassword_cf6c84ebd_10_3",
-      "step_browserM365PasswordSignIn_enterPassword_cf6c84ebd_10_3",
-      "step_browserM365PasswordSignIn_submitPassword_cf6c84ebd_10_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cf6c84ebd_10_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf6c84ebd_10_3",
-      "step_assertReady_assertReady_cf6c84ebd_10_4",
+      "step_assertDeployedRuntimeReady_cf6c84ebd_10_1",
+      "step_executeCommand_open_cf6c84ebd_10_2",
+      "step_executeCommand_assertPalette_cf6c84ebd_10_2",
+      "step_executeCommand_filter_cf6c84ebd_10_2",
+      "step_executeCommand_assertCommand_cf6c84ebd_10_2",
+      "step_executeCommand_execute_cf6c84ebd_10_2",
+      "step_filterOption_filter_cf6c84ebd_10_3",
+      "step_filterOption_assertOption_cf6c84ebd_10_3",
+      "step_filterOption_confirm_cf6c84ebd_10_3",
+      "step_browserM365PasswordSignIn_assertPassword_cf6c84ebd_10_4",
+      "step_browserM365PasswordSignIn_focusPassword_cf6c84ebd_10_4",
+      "step_browserM365PasswordSignIn_enterPassword_cf6c84ebd_10_4",
+      "step_browserM365PasswordSignIn_submitPassword_cf6c84ebd_10_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cf6c84ebd_10_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf6c84ebd_10_4",
+      "step_assertReady_assertReady_cf6c84ebd_10_5",
       "step_addAndOpenApp_assertAdd_cf6c84ebd_11_1",
       "step_addAndOpenApp_add_cf6c84ebd_11_1",
       "step_addAndOpenApp_assertAdded_cf6c84ebd_11_1",
@@ -3844,7 +3845,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cf6c84ebd_10_1",
+      "step_id": "step_assertDeployedRuntimeReady_cf6c84ebd_10_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cf6c84ebd_9_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cf6c84ebd_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3856,7 +3880,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cf6c84ebd_9_5"
+        "step_assertDeployedRuntimeReady_cf6c84ebd_10_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3866,7 +3890,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cf6c84ebd_10_1",
+      "step_id": "step_executeCommand_assertPalette_cf6c84ebd_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3876,7 +3900,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cf6c84ebd_10_1"
+        "step_executeCommand_open_cf6c84ebd_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3887,7 +3911,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cf6c84ebd_10_1",
+      "step_id": "step_executeCommand_filter_cf6c84ebd_10_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3899,7 +3923,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cf6c84ebd_10_1"
+        "step_executeCommand_assertPalette_cf6c84ebd_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3909,7 +3933,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cf6c84ebd_10_1",
+      "step_id": "step_executeCommand_assertCommand_cf6c84ebd_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3919,7 +3943,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cf6c84ebd_10_1"
+        "step_executeCommand_filter_cf6c84ebd_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3930,7 +3954,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cf6c84ebd_10_1",
+      "step_id": "step_executeCommand_execute_cf6c84ebd_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3942,7 +3966,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cf6c84ebd_10_1"
+        "step_executeCommand_assertCommand_cf6c84ebd_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3952,7 +3976,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cf6c84ebd_10_2",
+      "step_id": "step_filterOption_filter_cf6c84ebd_10_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3964,7 +3988,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cf6c84ebd_10_1"
+        "step_executeCommand_execute_cf6c84ebd_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3974,7 +3998,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cf6c84ebd_10_2",
+      "step_id": "step_filterOption_assertOption_cf6c84ebd_10_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3984,7 +4008,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cf6c84ebd_10_2"
+        "step_filterOption_filter_cf6c84ebd_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3995,7 +4019,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cf6c84ebd_10_2",
+      "step_id": "step_filterOption_confirm_cf6c84ebd_10_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4007,7 +4031,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cf6c84ebd_10_2"
+        "step_filterOption_assertOption_cf6c84ebd_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4017,7 +4041,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf6c84ebd_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf6c84ebd_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4027,7 +4051,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cf6c84ebd_10_2"
+        "step_filterOption_confirm_cf6c84ebd_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4038,7 +4062,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf6c84ebd_10_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf6c84ebd_10_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4052,7 +4076,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cf6c84ebd_10_3"
+        "step_browserM365PasswordSignIn_assertPassword_cf6c84ebd_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4062,7 +4086,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf6c84ebd_10_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf6c84ebd_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4074,7 +4098,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cf6c84ebd_10_3"
+        "step_browserM365PasswordSignIn_focusPassword_cf6c84ebd_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4084,7 +4108,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf6c84ebd_10_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf6c84ebd_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4096,7 +4120,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cf6c84ebd_10_3"
+        "step_browserM365PasswordSignIn_enterPassword_cf6c84ebd_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4106,7 +4130,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf6c84ebd_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf6c84ebd_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4116,7 +4140,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cf6c84ebd_10_3"
+        "step_browserM365PasswordSignIn_submitPassword_cf6c84ebd_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4127,7 +4151,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf6c84ebd_10_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf6c84ebd_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4139,7 +4163,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cf6c84ebd_10_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cf6c84ebd_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4150,7 +4174,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cf6c84ebd_10_4",
+      "step_id": "step_assertReady_assertReady_cf6c84ebd_10_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4160,7 +4184,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf6c84ebd_10_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf6c84ebd_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4181,7 +4205,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cf6c84ebd_10_4"
+        "step_assertReady_assertReady_cf6c84ebd_10_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-js-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 181,
+    "total_steps": 182,
     "name": "rag-custom-api-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -171,21 +171,22 @@
       "step_clickPrimaryAction_assertDialog_caa0053de_6_4",
       "step_clickPrimaryAction_click_caa0053de_6_4",
       "step_assertNotificationContains_assert_caa0053de_6_5",
-      "step_executeCommand_open_caa0053de_7_1",
-      "step_executeCommand_assertPalette_caa0053de_7_1",
-      "step_executeCommand_filter_caa0053de_7_1",
-      "step_executeCommand_assertCommand_caa0053de_7_1",
-      "step_executeCommand_execute_caa0053de_7_1",
-      "step_filterOption_filter_caa0053de_7_2",
-      "step_filterOption_assertOption_caa0053de_7_2",
-      "step_filterOption_confirm_caa0053de_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_caa0053de_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_caa0053de_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_caa0053de_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_caa0053de_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_caa0053de_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_caa0053de_7_3",
-      "step_assertReady_assertReady_caa0053de_7_4",
+      "step_assertDeployedRuntimeReady_caa0053de_7_1",
+      "step_executeCommand_open_caa0053de_7_2",
+      "step_executeCommand_assertPalette_caa0053de_7_2",
+      "step_executeCommand_filter_caa0053de_7_2",
+      "step_executeCommand_assertCommand_caa0053de_7_2",
+      "step_executeCommand_execute_caa0053de_7_2",
+      "step_filterOption_filter_caa0053de_7_3",
+      "step_filterOption_assertOption_caa0053de_7_3",
+      "step_filterOption_confirm_caa0053de_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_caa0053de_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_caa0053de_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_caa0053de_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_caa0053de_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_caa0053de_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_caa0053de_7_4",
+      "step_assertReady_assertReady_caa0053de_7_5",
       "step_addAndOpenApp_assertAdd_caa0053de_8_1",
       "step_addAndOpenApp_add_caa0053de_8_1",
       "step_addAndOpenApp_assertAdded_caa0053de_8_1",
@@ -3660,7 +3661,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_caa0053de_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_caa0053de_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_caa0053de_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_caa0053de_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3672,7 +3696,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_caa0053de_6_5"
+        "step_assertDeployedRuntimeReady_caa0053de_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3682,7 +3706,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_caa0053de_7_1",
+      "step_id": "step_executeCommand_assertPalette_caa0053de_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3692,7 +3716,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_caa0053de_7_1"
+        "step_executeCommand_open_caa0053de_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3703,7 +3727,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_caa0053de_7_1",
+      "step_id": "step_executeCommand_filter_caa0053de_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3715,7 +3739,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_caa0053de_7_1"
+        "step_executeCommand_assertPalette_caa0053de_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3725,7 +3749,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_caa0053de_7_1",
+      "step_id": "step_executeCommand_assertCommand_caa0053de_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3735,7 +3759,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_caa0053de_7_1"
+        "step_executeCommand_filter_caa0053de_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3746,7 +3770,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_caa0053de_7_1",
+      "step_id": "step_executeCommand_execute_caa0053de_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3758,7 +3782,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_caa0053de_7_1"
+        "step_executeCommand_assertCommand_caa0053de_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3768,7 +3792,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_caa0053de_7_2",
+      "step_id": "step_filterOption_filter_caa0053de_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3780,7 +3804,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_caa0053de_7_1"
+        "step_executeCommand_execute_caa0053de_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3790,7 +3814,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_caa0053de_7_2",
+      "step_id": "step_filterOption_assertOption_caa0053de_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3800,7 +3824,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_caa0053de_7_2"
+        "step_filterOption_filter_caa0053de_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3811,7 +3835,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_caa0053de_7_2",
+      "step_id": "step_filterOption_confirm_caa0053de_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3823,7 +3847,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_caa0053de_7_2"
+        "step_filterOption_assertOption_caa0053de_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3833,7 +3857,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_caa0053de_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_caa0053de_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3843,7 +3867,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_caa0053de_7_2"
+        "step_filterOption_confirm_caa0053de_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3854,7 +3878,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_caa0053de_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_caa0053de_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3868,7 +3892,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_caa0053de_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_caa0053de_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3878,7 +3902,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_caa0053de_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_caa0053de_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3890,7 +3914,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_caa0053de_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_caa0053de_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3900,7 +3924,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_caa0053de_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_caa0053de_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3912,7 +3936,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_caa0053de_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_caa0053de_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3922,7 +3946,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_caa0053de_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_caa0053de_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3932,7 +3956,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_caa0053de_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_caa0053de_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3943,7 +3967,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_caa0053de_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_caa0053de_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3955,7 +3979,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_caa0053de_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_caa0053de_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3966,7 +3990,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_caa0053de_7_4",
+      "step_id": "step_assertReady_assertReady_caa0053de_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3976,7 +4000,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_caa0053de_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_caa0053de_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3997,7 +4021,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_caa0053de_7_4"
+        "step_assertReady_assertReady_caa0053de_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-js-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-js-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 176,
+    "total_steps": 177,
     "name": "rag-custom-api-js-openai-remote-teams",
     "description": {
       "owner": "",
@@ -166,21 +166,22 @@
       "step_clickPrimaryAction_assertDialog_c9205d970_8_4",
       "step_clickPrimaryAction_click_c9205d970_8_4",
       "step_assertNotificationContains_assert_c9205d970_8_5",
-      "step_executeCommand_open_c9205d970_9_1",
-      "step_executeCommand_assertPalette_c9205d970_9_1",
-      "step_executeCommand_filter_c9205d970_9_1",
-      "step_executeCommand_assertCommand_c9205d970_9_1",
-      "step_executeCommand_execute_c9205d970_9_1",
-      "step_filterOption_filter_c9205d970_9_2",
-      "step_filterOption_assertOption_c9205d970_9_2",
-      "step_filterOption_confirm_c9205d970_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_c9205d970_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_c9205d970_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_c9205d970_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_c9205d970_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c9205d970_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c9205d970_9_3",
-      "step_assertReady_assertReady_c9205d970_9_4",
+      "step_assertDeployedRuntimeReady_c9205d970_9_1",
+      "step_executeCommand_open_c9205d970_9_2",
+      "step_executeCommand_assertPalette_c9205d970_9_2",
+      "step_executeCommand_filter_c9205d970_9_2",
+      "step_executeCommand_assertCommand_c9205d970_9_2",
+      "step_executeCommand_execute_c9205d970_9_2",
+      "step_filterOption_filter_c9205d970_9_3",
+      "step_filterOption_assertOption_c9205d970_9_3",
+      "step_filterOption_confirm_c9205d970_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_c9205d970_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_c9205d970_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_c9205d970_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_c9205d970_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c9205d970_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c9205d970_9_4",
+      "step_assertReady_assertReady_c9205d970_9_5",
       "step_addAndOpenApp_assertAdd_c9205d970_10_1",
       "step_addAndOpenApp_add_c9205d970_10_1",
       "step_addAndOpenApp_assertAdded_c9205d970_10_1",
@@ -3548,7 +3549,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c9205d970_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_c9205d970_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c9205d970_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c9205d970_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3560,7 +3584,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c9205d970_8_5"
+        "step_assertDeployedRuntimeReady_c9205d970_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3570,7 +3594,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c9205d970_9_1",
+      "step_id": "step_executeCommand_assertPalette_c9205d970_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3580,7 +3604,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c9205d970_9_1"
+        "step_executeCommand_open_c9205d970_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3591,7 +3615,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c9205d970_9_1",
+      "step_id": "step_executeCommand_filter_c9205d970_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3603,7 +3627,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c9205d970_9_1"
+        "step_executeCommand_assertPalette_c9205d970_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3613,7 +3637,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c9205d970_9_1",
+      "step_id": "step_executeCommand_assertCommand_c9205d970_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3623,7 +3647,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c9205d970_9_1"
+        "step_executeCommand_filter_c9205d970_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3634,7 +3658,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c9205d970_9_1",
+      "step_id": "step_executeCommand_execute_c9205d970_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3646,7 +3670,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c9205d970_9_1"
+        "step_executeCommand_assertCommand_c9205d970_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3656,7 +3680,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c9205d970_9_2",
+      "step_id": "step_filterOption_filter_c9205d970_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3668,7 +3692,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c9205d970_9_1"
+        "step_executeCommand_execute_c9205d970_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3678,7 +3702,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c9205d970_9_2",
+      "step_id": "step_filterOption_assertOption_c9205d970_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3688,7 +3712,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c9205d970_9_2"
+        "step_filterOption_filter_c9205d970_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3699,7 +3723,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c9205d970_9_2",
+      "step_id": "step_filterOption_confirm_c9205d970_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3711,7 +3735,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c9205d970_9_2"
+        "step_filterOption_assertOption_c9205d970_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3721,7 +3745,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c9205d970_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c9205d970_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3731,7 +3755,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c9205d970_9_2"
+        "step_filterOption_confirm_c9205d970_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3742,7 +3766,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c9205d970_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c9205d970_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3756,7 +3780,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c9205d970_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_c9205d970_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3766,7 +3790,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c9205d970_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c9205d970_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3778,7 +3802,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c9205d970_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_c9205d970_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3788,7 +3812,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c9205d970_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c9205d970_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3800,7 +3824,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c9205d970_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_c9205d970_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3810,7 +3834,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c9205d970_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c9205d970_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3820,7 +3844,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c9205d970_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_c9205d970_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3831,7 +3855,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c9205d970_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c9205d970_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3843,7 +3867,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c9205d970_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c9205d970_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3854,7 +3878,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c9205d970_9_4",
+      "step_id": "step_assertReady_assertReady_c9205d970_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3864,7 +3888,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c9205d970_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c9205d970_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3885,7 +3909,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c9205d970_9_4"
+        "step_assertReady_assertReady_c9205d970_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-py-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 207,
+    "total_steps": 208,
     "name": "rag-custom-api-py-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -197,21 +197,22 @@
       "step_clickPrimaryAction_assertDialog_c569027de_7_4",
       "step_clickPrimaryAction_click_c569027de_7_4",
       "step_assertNotificationContains_assert_c569027de_7_5",
-      "step_executeCommand_open_c569027de_8_1",
-      "step_executeCommand_assertPalette_c569027de_8_1",
-      "step_executeCommand_filter_c569027de_8_1",
-      "step_executeCommand_assertCommand_c569027de_8_1",
-      "step_executeCommand_execute_c569027de_8_1",
-      "step_filterOption_filter_c569027de_8_2",
-      "step_filterOption_assertOption_c569027de_8_2",
-      "step_filterOption_confirm_c569027de_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_c569027de_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_c569027de_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_c569027de_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_c569027de_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c569027de_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c569027de_8_3",
-      "step_assertReady_assertReady_c569027de_8_4",
+      "step_assertDeployedRuntimeReady_c569027de_8_1",
+      "step_executeCommand_open_c569027de_8_2",
+      "step_executeCommand_assertPalette_c569027de_8_2",
+      "step_executeCommand_filter_c569027de_8_2",
+      "step_executeCommand_assertCommand_c569027de_8_2",
+      "step_executeCommand_execute_c569027de_8_2",
+      "step_filterOption_filter_c569027de_8_3",
+      "step_filterOption_assertOption_c569027de_8_3",
+      "step_filterOption_confirm_c569027de_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_c569027de_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_c569027de_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_c569027de_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_c569027de_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c569027de_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c569027de_8_4",
+      "step_assertReady_assertReady_c569027de_8_5",
       "step_addAndOpenApp_assertAdd_c569027de_9_1",
       "step_addAndOpenApp_add_c569027de_9_1",
       "step_addAndOpenApp_assertAdded_c569027de_9_1",
@@ -4252,7 +4253,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c569027de_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_c569027de_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c569027de_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c569027de_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4264,7 +4288,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c569027de_7_5"
+        "step_assertDeployedRuntimeReady_c569027de_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4274,7 +4298,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c569027de_8_1",
+      "step_id": "step_executeCommand_assertPalette_c569027de_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4284,7 +4308,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c569027de_8_1"
+        "step_executeCommand_open_c569027de_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4295,7 +4319,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c569027de_8_1",
+      "step_id": "step_executeCommand_filter_c569027de_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4307,7 +4331,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c569027de_8_1"
+        "step_executeCommand_assertPalette_c569027de_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4317,7 +4341,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c569027de_8_1",
+      "step_id": "step_executeCommand_assertCommand_c569027de_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4327,7 +4351,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c569027de_8_1"
+        "step_executeCommand_filter_c569027de_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4338,7 +4362,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c569027de_8_1",
+      "step_id": "step_executeCommand_execute_c569027de_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4350,7 +4374,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c569027de_8_1"
+        "step_executeCommand_assertCommand_c569027de_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4360,7 +4384,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c569027de_8_2",
+      "step_id": "step_filterOption_filter_c569027de_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4372,7 +4396,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c569027de_8_1"
+        "step_executeCommand_execute_c569027de_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4382,7 +4406,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c569027de_8_2",
+      "step_id": "step_filterOption_assertOption_c569027de_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4392,7 +4416,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c569027de_8_2"
+        "step_filterOption_filter_c569027de_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4403,7 +4427,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c569027de_8_2",
+      "step_id": "step_filterOption_confirm_c569027de_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4415,7 +4439,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c569027de_8_2"
+        "step_filterOption_assertOption_c569027de_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4425,7 +4449,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c569027de_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c569027de_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4435,7 +4459,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c569027de_8_2"
+        "step_filterOption_confirm_c569027de_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4446,7 +4470,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c569027de_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c569027de_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4460,7 +4484,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c569027de_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_c569027de_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4470,7 +4494,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c569027de_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c569027de_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4482,7 +4506,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c569027de_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_c569027de_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4492,7 +4516,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c569027de_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c569027de_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4504,7 +4528,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c569027de_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_c569027de_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4514,7 +4538,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c569027de_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c569027de_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4524,7 +4548,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c569027de_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_c569027de_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4535,7 +4559,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c569027de_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c569027de_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4547,7 +4571,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c569027de_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c569027de_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4558,7 +4582,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c569027de_8_4",
+      "step_id": "step_assertReady_assertReady_c569027de_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4568,7 +4592,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c569027de_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c569027de_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4589,7 +4613,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c569027de_8_4"
+        "step_assertReady_assertReady_c569027de_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-py-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-py-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 199,
+    "total_steps": 200,
     "name": "rag-custom-api-py-openai-remote-teams",
     "description": {
       "owner": "",
@@ -189,21 +189,22 @@
       "step_clickPrimaryAction_assertDialog_c61c82267_9_4",
       "step_clickPrimaryAction_click_c61c82267_9_4",
       "step_assertNotificationContains_assert_c61c82267_9_5",
-      "step_executeCommand_open_c61c82267_10_1",
-      "step_executeCommand_assertPalette_c61c82267_10_1",
-      "step_executeCommand_filter_c61c82267_10_1",
-      "step_executeCommand_assertCommand_c61c82267_10_1",
-      "step_executeCommand_execute_c61c82267_10_1",
-      "step_filterOption_filter_c61c82267_10_2",
-      "step_filterOption_assertOption_c61c82267_10_2",
-      "step_filterOption_confirm_c61c82267_10_2",
-      "step_browserM365PasswordSignIn_assertPassword_c61c82267_10_3",
-      "step_browserM365PasswordSignIn_focusPassword_c61c82267_10_3",
-      "step_browserM365PasswordSignIn_enterPassword_c61c82267_10_3",
-      "step_browserM365PasswordSignIn_submitPassword_c61c82267_10_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c61c82267_10_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c61c82267_10_3",
-      "step_assertReady_assertReady_c61c82267_10_4",
+      "step_assertDeployedRuntimeReady_c61c82267_10_1",
+      "step_executeCommand_open_c61c82267_10_2",
+      "step_executeCommand_assertPalette_c61c82267_10_2",
+      "step_executeCommand_filter_c61c82267_10_2",
+      "step_executeCommand_assertCommand_c61c82267_10_2",
+      "step_executeCommand_execute_c61c82267_10_2",
+      "step_filterOption_filter_c61c82267_10_3",
+      "step_filterOption_assertOption_c61c82267_10_3",
+      "step_filterOption_confirm_c61c82267_10_3",
+      "step_browserM365PasswordSignIn_assertPassword_c61c82267_10_4",
+      "step_browserM365PasswordSignIn_focusPassword_c61c82267_10_4",
+      "step_browserM365PasswordSignIn_enterPassword_c61c82267_10_4",
+      "step_browserM365PasswordSignIn_submitPassword_c61c82267_10_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c61c82267_10_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c61c82267_10_4",
+      "step_assertReady_assertReady_c61c82267_10_5",
       "step_addAndOpenApp_assertAdd_c61c82267_11_1",
       "step_addAndOpenApp_add_c61c82267_11_1",
       "step_addAndOpenApp_assertAdded_c61c82267_11_1",
@@ -4068,7 +4069,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c61c82267_10_1",
+      "step_id": "step_assertDeployedRuntimeReady_c61c82267_10_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c61c82267_9_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c61c82267_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4080,7 +4104,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c61c82267_9_5"
+        "step_assertDeployedRuntimeReady_c61c82267_10_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4090,7 +4114,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c61c82267_10_1",
+      "step_id": "step_executeCommand_assertPalette_c61c82267_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4100,7 +4124,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c61c82267_10_1"
+        "step_executeCommand_open_c61c82267_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4111,7 +4135,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c61c82267_10_1",
+      "step_id": "step_executeCommand_filter_c61c82267_10_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4123,7 +4147,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c61c82267_10_1"
+        "step_executeCommand_assertPalette_c61c82267_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4133,7 +4157,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c61c82267_10_1",
+      "step_id": "step_executeCommand_assertCommand_c61c82267_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4143,7 +4167,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c61c82267_10_1"
+        "step_executeCommand_filter_c61c82267_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4154,7 +4178,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c61c82267_10_1",
+      "step_id": "step_executeCommand_execute_c61c82267_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4166,7 +4190,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c61c82267_10_1"
+        "step_executeCommand_assertCommand_c61c82267_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4176,7 +4200,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c61c82267_10_2",
+      "step_id": "step_filterOption_filter_c61c82267_10_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4188,7 +4212,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c61c82267_10_1"
+        "step_executeCommand_execute_c61c82267_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4198,7 +4222,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c61c82267_10_2",
+      "step_id": "step_filterOption_assertOption_c61c82267_10_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4208,7 +4232,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c61c82267_10_2"
+        "step_filterOption_filter_c61c82267_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4219,7 +4243,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c61c82267_10_2",
+      "step_id": "step_filterOption_confirm_c61c82267_10_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4231,7 +4255,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c61c82267_10_2"
+        "step_filterOption_assertOption_c61c82267_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4241,7 +4265,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c61c82267_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c61c82267_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4251,7 +4275,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c61c82267_10_2"
+        "step_filterOption_confirm_c61c82267_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4262,7 +4286,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c61c82267_10_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c61c82267_10_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4276,7 +4300,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c61c82267_10_3"
+        "step_browserM365PasswordSignIn_assertPassword_c61c82267_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4286,7 +4310,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c61c82267_10_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c61c82267_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4298,7 +4322,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c61c82267_10_3"
+        "step_browserM365PasswordSignIn_focusPassword_c61c82267_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4308,7 +4332,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c61c82267_10_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c61c82267_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4320,7 +4344,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c61c82267_10_3"
+        "step_browserM365PasswordSignIn_enterPassword_c61c82267_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4330,7 +4354,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c61c82267_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c61c82267_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4340,7 +4364,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c61c82267_10_3"
+        "step_browserM365PasswordSignIn_submitPassword_c61c82267_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4351,7 +4375,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c61c82267_10_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c61c82267_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4363,7 +4387,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c61c82267_10_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c61c82267_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4374,7 +4398,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c61c82267_10_4",
+      "step_id": "step_assertReady_assertReady_c61c82267_10_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4384,7 +4408,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c61c82267_10_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c61c82267_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4405,7 +4429,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c61c82267_10_4"
+        "step_assertReady_assertReady_c61c82267_10_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-ts-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 185,
+    "total_steps": 186,
     "name": "rag-custom-api-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -175,21 +175,22 @@
       "step_clickPrimaryAction_assertDialog_c5961e56e_6_4",
       "step_clickPrimaryAction_click_c5961e56e_6_4",
       "step_assertNotificationContains_assert_c5961e56e_6_5",
-      "step_executeCommand_open_c5961e56e_7_1",
-      "step_executeCommand_assertPalette_c5961e56e_7_1",
-      "step_executeCommand_filter_c5961e56e_7_1",
-      "step_executeCommand_assertCommand_c5961e56e_7_1",
-      "step_executeCommand_execute_c5961e56e_7_1",
-      "step_filterOption_filter_c5961e56e_7_2",
-      "step_filterOption_assertOption_c5961e56e_7_2",
-      "step_filterOption_confirm_c5961e56e_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c5961e56e_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c5961e56e_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c5961e56e_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c5961e56e_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c5961e56e_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c5961e56e_7_3",
-      "step_assertReady_assertReady_c5961e56e_7_4",
+      "step_assertDeployedRuntimeReady_c5961e56e_7_1",
+      "step_executeCommand_open_c5961e56e_7_2",
+      "step_executeCommand_assertPalette_c5961e56e_7_2",
+      "step_executeCommand_filter_c5961e56e_7_2",
+      "step_executeCommand_assertCommand_c5961e56e_7_2",
+      "step_executeCommand_execute_c5961e56e_7_2",
+      "step_filterOption_filter_c5961e56e_7_3",
+      "step_filterOption_assertOption_c5961e56e_7_3",
+      "step_filterOption_confirm_c5961e56e_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c5961e56e_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c5961e56e_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c5961e56e_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c5961e56e_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c5961e56e_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c5961e56e_7_4",
+      "step_assertReady_assertReady_c5961e56e_7_5",
       "step_addAndOpenApp_assertAdd_c5961e56e_8_1",
       "step_addAndOpenApp_add_c5961e56e_8_1",
       "step_addAndOpenApp_assertAdded_c5961e56e_8_1",
@@ -3756,7 +3757,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c5961e56e_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c5961e56e_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c5961e56e_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c5961e56e_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3768,7 +3792,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c5961e56e_6_5"
+        "step_assertDeployedRuntimeReady_c5961e56e_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3778,7 +3802,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c5961e56e_7_1",
+      "step_id": "step_executeCommand_assertPalette_c5961e56e_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3788,7 +3812,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c5961e56e_7_1"
+        "step_executeCommand_open_c5961e56e_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3799,7 +3823,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c5961e56e_7_1",
+      "step_id": "step_executeCommand_filter_c5961e56e_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3811,7 +3835,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c5961e56e_7_1"
+        "step_executeCommand_assertPalette_c5961e56e_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3821,7 +3845,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c5961e56e_7_1",
+      "step_id": "step_executeCommand_assertCommand_c5961e56e_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3831,7 +3855,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c5961e56e_7_1"
+        "step_executeCommand_filter_c5961e56e_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3842,7 +3866,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c5961e56e_7_1",
+      "step_id": "step_executeCommand_execute_c5961e56e_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3854,7 +3878,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c5961e56e_7_1"
+        "step_executeCommand_assertCommand_c5961e56e_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3864,7 +3888,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c5961e56e_7_2",
+      "step_id": "step_filterOption_filter_c5961e56e_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3876,7 +3900,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c5961e56e_7_1"
+        "step_executeCommand_execute_c5961e56e_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3886,7 +3910,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c5961e56e_7_2",
+      "step_id": "step_filterOption_assertOption_c5961e56e_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3896,7 +3920,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c5961e56e_7_2"
+        "step_filterOption_filter_c5961e56e_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3907,7 +3931,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c5961e56e_7_2",
+      "step_id": "step_filterOption_confirm_c5961e56e_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3919,7 +3943,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c5961e56e_7_2"
+        "step_filterOption_assertOption_c5961e56e_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3929,7 +3953,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c5961e56e_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c5961e56e_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3939,7 +3963,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c5961e56e_7_2"
+        "step_filterOption_confirm_c5961e56e_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3950,7 +3974,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c5961e56e_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c5961e56e_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3964,7 +3988,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c5961e56e_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c5961e56e_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3974,7 +3998,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c5961e56e_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c5961e56e_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3986,7 +4010,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c5961e56e_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c5961e56e_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3996,7 +4020,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c5961e56e_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c5961e56e_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4008,7 +4032,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c5961e56e_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c5961e56e_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4018,7 +4042,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c5961e56e_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c5961e56e_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4028,7 +4052,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c5961e56e_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c5961e56e_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4039,7 +4063,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c5961e56e_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c5961e56e_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4051,7 +4075,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c5961e56e_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c5961e56e_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4062,7 +4086,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c5961e56e_7_4",
+      "step_id": "step_assertReady_assertReady_c5961e56e_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4072,7 +4096,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c5961e56e_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c5961e56e_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4093,7 +4117,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c5961e56e_7_4"
+        "step_assertReady_assertReady_c5961e56e_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-ts-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-custom-api--rag-custom-api-ts-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 176,
+    "total_steps": 177,
     "name": "rag-custom-api-ts-openai-remote-teams",
     "description": {
       "owner": "",
@@ -166,21 +166,22 @@
       "step_clickPrimaryAction_assertDialog_cb81a5d53_8_4",
       "step_clickPrimaryAction_click_cb81a5d53_8_4",
       "step_assertNotificationContains_assert_cb81a5d53_8_5",
-      "step_executeCommand_open_cb81a5d53_9_1",
-      "step_executeCommand_assertPalette_cb81a5d53_9_1",
-      "step_executeCommand_filter_cb81a5d53_9_1",
-      "step_executeCommand_assertCommand_cb81a5d53_9_1",
-      "step_executeCommand_execute_cb81a5d53_9_1",
-      "step_filterOption_filter_cb81a5d53_9_2",
-      "step_filterOption_assertOption_cb81a5d53_9_2",
-      "step_filterOption_confirm_cb81a5d53_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_cb81a5d53_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_cb81a5d53_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_cb81a5d53_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_cb81a5d53_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cb81a5d53_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cb81a5d53_9_3",
-      "step_assertReady_assertReady_cb81a5d53_9_4",
+      "step_assertDeployedRuntimeReady_cb81a5d53_9_1",
+      "step_executeCommand_open_cb81a5d53_9_2",
+      "step_executeCommand_assertPalette_cb81a5d53_9_2",
+      "step_executeCommand_filter_cb81a5d53_9_2",
+      "step_executeCommand_assertCommand_cb81a5d53_9_2",
+      "step_executeCommand_execute_cb81a5d53_9_2",
+      "step_filterOption_filter_cb81a5d53_9_3",
+      "step_filterOption_assertOption_cb81a5d53_9_3",
+      "step_filterOption_confirm_cb81a5d53_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_cb81a5d53_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_cb81a5d53_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_cb81a5d53_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_cb81a5d53_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cb81a5d53_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cb81a5d53_9_4",
+      "step_assertReady_assertReady_cb81a5d53_9_5",
       "step_addAndOpenApp_assertAdd_cb81a5d53_10_1",
       "step_addAndOpenApp_add_cb81a5d53_10_1",
       "step_addAndOpenApp_assertAdded_cb81a5d53_10_1",
@@ -3548,7 +3549,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cb81a5d53_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_cb81a5d53_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cb81a5d53_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cb81a5d53_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3560,7 +3584,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cb81a5d53_8_5"
+        "step_assertDeployedRuntimeReady_cb81a5d53_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3570,7 +3594,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cb81a5d53_9_1",
+      "step_id": "step_executeCommand_assertPalette_cb81a5d53_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3580,7 +3604,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cb81a5d53_9_1"
+        "step_executeCommand_open_cb81a5d53_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3591,7 +3615,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cb81a5d53_9_1",
+      "step_id": "step_executeCommand_filter_cb81a5d53_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3603,7 +3627,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cb81a5d53_9_1"
+        "step_executeCommand_assertPalette_cb81a5d53_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3613,7 +3637,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cb81a5d53_9_1",
+      "step_id": "step_executeCommand_assertCommand_cb81a5d53_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3623,7 +3647,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cb81a5d53_9_1"
+        "step_executeCommand_filter_cb81a5d53_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3634,7 +3658,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cb81a5d53_9_1",
+      "step_id": "step_executeCommand_execute_cb81a5d53_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3646,7 +3670,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cb81a5d53_9_1"
+        "step_executeCommand_assertCommand_cb81a5d53_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3656,7 +3680,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cb81a5d53_9_2",
+      "step_id": "step_filterOption_filter_cb81a5d53_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3668,7 +3692,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cb81a5d53_9_1"
+        "step_executeCommand_execute_cb81a5d53_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3678,7 +3702,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cb81a5d53_9_2",
+      "step_id": "step_filterOption_assertOption_cb81a5d53_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3688,7 +3712,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cb81a5d53_9_2"
+        "step_filterOption_filter_cb81a5d53_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3699,7 +3723,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cb81a5d53_9_2",
+      "step_id": "step_filterOption_confirm_cb81a5d53_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3711,7 +3735,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cb81a5d53_9_2"
+        "step_filterOption_assertOption_cb81a5d53_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3721,7 +3745,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cb81a5d53_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cb81a5d53_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3731,7 +3755,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cb81a5d53_9_2"
+        "step_filterOption_confirm_cb81a5d53_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3742,7 +3766,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cb81a5d53_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cb81a5d53_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3756,7 +3780,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cb81a5d53_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_cb81a5d53_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3766,7 +3790,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cb81a5d53_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cb81a5d53_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3778,7 +3802,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cb81a5d53_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_cb81a5d53_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3788,7 +3812,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cb81a5d53_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cb81a5d53_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3800,7 +3824,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cb81a5d53_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_cb81a5d53_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3810,7 +3834,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cb81a5d53_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cb81a5d53_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3820,7 +3844,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cb81a5d53_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_cb81a5d53_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3831,7 +3855,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cb81a5d53_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cb81a5d53_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3843,7 +3867,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cb81a5d53_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cb81a5d53_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3854,7 +3878,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cb81a5d53_9_4",
+      "step_id": "step_assertReady_assertReady_cb81a5d53_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3864,7 +3888,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cb81a5d53_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cb81a5d53_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3885,7 +3909,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cb81a5d53_9_4"
+        "step_assertReady_assertReady_cb81a5d53_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 168,
+    "total_steps": 169,
     "name": "rag-customize-js-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -159,25 +159,26 @@
       "step_clickPrimaryAction_assertDialog_cf0c4f904_7_4",
       "step_clickPrimaryAction_click_cf0c4f904_7_4",
       "step_assertNotificationContains_assert_cf0c4f904_7_5",
-      "step_executeCommand_open_cf0c4f904_8_1",
-      "step_executeCommand_assertPalette_cf0c4f904_8_1",
-      "step_executeCommand_filter_cf0c4f904_8_1",
-      "step_executeCommand_assertCommand_cf0c4f904_8_1",
-      "step_executeCommand_execute_cf0c4f904_8_1",
-      "step_filterOption_filter_cf0c4f904_8_2",
-      "step_filterOption_assertOption_cf0c4f904_8_2",
-      "step_filterOption_confirm_cf0c4f904_8_2",
-      "step_browserM365SignIn_assertAccount_cf0c4f904_8_3",
-      "step_browserM365SignIn_focusAccount_cf0c4f904_8_3",
-      "step_browserM365SignIn_enterAccount_cf0c4f904_8_3",
-      "step_browserM365SignIn_submitAccount_cf0c4f904_8_3",
-      "step_browserM365SignIn_assertPassword_cf0c4f904_8_3",
-      "step_browserM365SignIn_enterPassword_cf0c4f904_8_3",
-      "step_browserM365SignIn_submitPassword_cf0c4f904_8_3",
-      "step_browserM365SignIn_assertStaySignedIn_cf0c4f904_8_3",
-      "step_browserM365SignIn_confirmStaySignedIn_cf0c4f904_8_3",
-      "step_assertReady_assertReady_cf0c4f904_8_4",
-      "step_zoomOut_zoomOut_cf0c4f904_8_5",
+      "step_assertDeployedRuntimeReady_cf0c4f904_8_1",
+      "step_executeCommand_open_cf0c4f904_8_2",
+      "step_executeCommand_assertPalette_cf0c4f904_8_2",
+      "step_executeCommand_filter_cf0c4f904_8_2",
+      "step_executeCommand_assertCommand_cf0c4f904_8_2",
+      "step_executeCommand_execute_cf0c4f904_8_2",
+      "step_filterOption_filter_cf0c4f904_8_3",
+      "step_filterOption_assertOption_cf0c4f904_8_3",
+      "step_filterOption_confirm_cf0c4f904_8_3",
+      "step_browserM365SignIn_assertAccount_cf0c4f904_8_4",
+      "step_browserM365SignIn_focusAccount_cf0c4f904_8_4",
+      "step_browserM365SignIn_enterAccount_cf0c4f904_8_4",
+      "step_browserM365SignIn_submitAccount_cf0c4f904_8_4",
+      "step_browserM365SignIn_assertPassword_cf0c4f904_8_4",
+      "step_browserM365SignIn_enterPassword_cf0c4f904_8_4",
+      "step_browserM365SignIn_submitPassword_cf0c4f904_8_4",
+      "step_browserM365SignIn_assertStaySignedIn_cf0c4f904_8_4",
+      "step_browserM365SignIn_confirmStaySignedIn_cf0c4f904_8_4",
+      "step_assertReady_assertReady_cf0c4f904_8_5",
+      "step_zoomOut_zoomOut_cf0c4f904_8_6",
       "step_sendCopilotMessage_assertInput_cf0c4f904_10_1",
       "step_sendCopilotMessage_focusInput_cf0c4f904_10_1",
       "step_sendCopilotMessage_type_cf0c4f904_10_1",
@@ -3392,7 +3393,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cf0c4f904_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_cf0c4f904_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cf0c4f904_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cf0c4f904_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3404,7 +3428,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cf0c4f904_7_5"
+        "step_assertDeployedRuntimeReady_cf0c4f904_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3414,7 +3438,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cf0c4f904_8_1",
+      "step_id": "step_executeCommand_assertPalette_cf0c4f904_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3424,7 +3448,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cf0c4f904_8_1"
+        "step_executeCommand_open_cf0c4f904_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3435,7 +3459,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cf0c4f904_8_1",
+      "step_id": "step_executeCommand_filter_cf0c4f904_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3447,7 +3471,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cf0c4f904_8_1"
+        "step_executeCommand_assertPalette_cf0c4f904_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3457,7 +3481,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cf0c4f904_8_1",
+      "step_id": "step_executeCommand_assertCommand_cf0c4f904_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3467,7 +3491,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cf0c4f904_8_1"
+        "step_executeCommand_filter_cf0c4f904_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3478,7 +3502,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cf0c4f904_8_1",
+      "step_id": "step_executeCommand_execute_cf0c4f904_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3490,7 +3514,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cf0c4f904_8_1"
+        "step_executeCommand_assertCommand_cf0c4f904_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3500,7 +3524,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cf0c4f904_8_2",
+      "step_id": "step_filterOption_filter_cf0c4f904_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3512,7 +3536,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cf0c4f904_8_1"
+        "step_executeCommand_execute_cf0c4f904_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3522,7 +3546,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cf0c4f904_8_2",
+      "step_id": "step_filterOption_assertOption_cf0c4f904_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3532,7 +3556,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cf0c4f904_8_2"
+        "step_filterOption_filter_cf0c4f904_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cf0c4f904_8_2",
+      "step_id": "step_filterOption_confirm_cf0c4f904_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cf0c4f904_8_2"
+        "step_filterOption_assertOption_cf0c4f904_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_assertAccount_cf0c4f904_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cf0c4f904_8_2"
+        "step_filterOption_confirm_cf0c4f904_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_focusAccount_cf0c4f904_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3600,7 +3624,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_cf0c4f904_8_3"
+        "step_browserM365SignIn_assertAccount_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3610,7 +3634,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_enterAccount_cf0c4f904_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3622,7 +3646,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_cf0c4f904_8_3"
+        "step_browserM365SignIn_focusAccount_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3632,7 +3656,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_submitAccount_cf0c4f904_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3644,7 +3668,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_cf0c4f904_8_3"
+        "step_browserM365SignIn_enterAccount_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3654,7 +3678,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_assertPassword_cf0c4f904_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3664,7 +3688,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_cf0c4f904_8_3"
+        "step_browserM365SignIn_submitAccount_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3675,7 +3699,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_enterPassword_cf0c4f904_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3687,7 +3711,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_cf0c4f904_8_3"
+        "step_browserM365SignIn_assertPassword_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3697,7 +3721,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_submitPassword_cf0c4f904_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3709,7 +3733,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_cf0c4f904_8_3"
+        "step_browserM365SignIn_enterPassword_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3719,7 +3743,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_cf0c4f904_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3729,7 +3753,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_cf0c4f904_8_3"
+        "step_browserM365SignIn_submitPassword_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3740,7 +3764,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cf0c4f904_8_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cf0c4f904_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3752,7 +3776,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_cf0c4f904_8_3"
+        "step_browserM365SignIn_assertStaySignedIn_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3763,7 +3787,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cf0c4f904_8_4",
+      "step_id": "step_assertReady_assertReady_cf0c4f904_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3773,7 +3797,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_cf0c4f904_8_3"
+        "step_browserM365SignIn_confirmStaySignedIn_cf0c4f904_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3784,7 +3808,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_cf0c4f904_8_5",
+      "step_id": "step_zoomOut_zoomOut_cf0c4f904_8_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3796,7 +3820,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cf0c4f904_8_4"
+        "step_assertReady_assertReady_cf0c4f904_8_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3816,7 +3840,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_cf0c4f904_8_5"
+        "step_zoomOut_zoomOut_cf0c4f904_8_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 168,
+    "total_steps": 169,
     "name": "rag-customize-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -158,21 +158,22 @@
       "step_clickPrimaryAction_assertDialog_c30cfa855_6_4",
       "step_clickPrimaryAction_click_c30cfa855_6_4",
       "step_assertNotificationContains_assert_c30cfa855_6_5",
-      "step_executeCommand_open_c30cfa855_7_1",
-      "step_executeCommand_assertPalette_c30cfa855_7_1",
-      "step_executeCommand_filter_c30cfa855_7_1",
-      "step_executeCommand_assertCommand_c30cfa855_7_1",
-      "step_executeCommand_execute_c30cfa855_7_1",
-      "step_filterOption_filter_c30cfa855_7_2",
-      "step_filterOption_assertOption_c30cfa855_7_2",
-      "step_filterOption_confirm_c30cfa855_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c30cfa855_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c30cfa855_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c30cfa855_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c30cfa855_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c30cfa855_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c30cfa855_7_3",
-      "step_assertReady_assertReady_c30cfa855_7_4",
+      "step_assertDeployedRuntimeReady_c30cfa855_7_1",
+      "step_executeCommand_open_c30cfa855_7_2",
+      "step_executeCommand_assertPalette_c30cfa855_7_2",
+      "step_executeCommand_filter_c30cfa855_7_2",
+      "step_executeCommand_assertCommand_c30cfa855_7_2",
+      "step_executeCommand_execute_c30cfa855_7_2",
+      "step_filterOption_filter_c30cfa855_7_3",
+      "step_filterOption_assertOption_c30cfa855_7_3",
+      "step_filterOption_confirm_c30cfa855_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c30cfa855_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c30cfa855_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c30cfa855_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c30cfa855_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c30cfa855_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c30cfa855_7_4",
+      "step_assertReady_assertReady_c30cfa855_7_5",
       "step_addAndOpenApp_assertAdd_c30cfa855_8_1",
       "step_addAndOpenApp_add_c30cfa855_8_1",
       "step_addAndOpenApp_assertAdded_c30cfa855_8_1",
@@ -3368,7 +3369,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c30cfa855_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c30cfa855_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c30cfa855_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c30cfa855_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3380,7 +3404,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c30cfa855_6_5"
+        "step_assertDeployedRuntimeReady_c30cfa855_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3390,7 +3414,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c30cfa855_7_1",
+      "step_id": "step_executeCommand_assertPalette_c30cfa855_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3400,7 +3424,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c30cfa855_7_1"
+        "step_executeCommand_open_c30cfa855_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3411,7 +3435,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c30cfa855_7_1",
+      "step_id": "step_executeCommand_filter_c30cfa855_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c30cfa855_7_1"
+        "step_executeCommand_assertPalette_c30cfa855_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c30cfa855_7_1",
+      "step_id": "step_executeCommand_assertCommand_c30cfa855_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c30cfa855_7_1"
+        "step_executeCommand_filter_c30cfa855_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c30cfa855_7_1",
+      "step_id": "step_executeCommand_execute_c30cfa855_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c30cfa855_7_1"
+        "step_executeCommand_assertCommand_c30cfa855_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c30cfa855_7_2",
+      "step_id": "step_filterOption_filter_c30cfa855_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3488,7 +3512,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c30cfa855_7_1"
+        "step_executeCommand_execute_c30cfa855_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3498,7 +3522,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c30cfa855_7_2",
+      "step_id": "step_filterOption_assertOption_c30cfa855_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3508,7 +3532,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c30cfa855_7_2"
+        "step_filterOption_filter_c30cfa855_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3519,7 +3543,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c30cfa855_7_2",
+      "step_id": "step_filterOption_confirm_c30cfa855_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3531,7 +3555,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c30cfa855_7_2"
+        "step_filterOption_assertOption_c30cfa855_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3541,7 +3565,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c30cfa855_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c30cfa855_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3551,7 +3575,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c30cfa855_7_2"
+        "step_filterOption_confirm_c30cfa855_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3562,7 +3586,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c30cfa855_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c30cfa855_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3576,7 +3600,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c30cfa855_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c30cfa855_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c30cfa855_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c30cfa855_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3598,7 +3622,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c30cfa855_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c30cfa855_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3608,7 +3632,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c30cfa855_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c30cfa855_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3620,7 +3644,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c30cfa855_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c30cfa855_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3630,7 +3654,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c30cfa855_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c30cfa855_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3640,7 +3664,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c30cfa855_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c30cfa855_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3651,7 +3675,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c30cfa855_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c30cfa855_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3663,7 +3687,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c30cfa855_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c30cfa855_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3674,7 +3698,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c30cfa855_7_4",
+      "step_id": "step_assertReady_assertReady_c30cfa855_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3684,7 +3708,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c30cfa855_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c30cfa855_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3705,7 +3729,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c30cfa855_7_4"
+        "step_assertReady_assertReady_c30cfa855_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 162,
+    "total_steps": 163,
     "name": "rag-customize-js-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -153,25 +153,26 @@
       "step_clickPrimaryAction_assertDialog_c6a4d2a52_9_4",
       "step_clickPrimaryAction_click_c6a4d2a52_9_4",
       "step_assertNotificationContains_assert_c6a4d2a52_9_5",
-      "step_executeCommand_open_c6a4d2a52_10_1",
-      "step_executeCommand_assertPalette_c6a4d2a52_10_1",
-      "step_executeCommand_filter_c6a4d2a52_10_1",
-      "step_executeCommand_assertCommand_c6a4d2a52_10_1",
-      "step_executeCommand_execute_c6a4d2a52_10_1",
-      "step_filterOption_filter_c6a4d2a52_10_2",
-      "step_filterOption_assertOption_c6a4d2a52_10_2",
-      "step_filterOption_confirm_c6a4d2a52_10_2",
-      "step_browserM365SignIn_assertAccount_c6a4d2a52_10_3",
-      "step_browserM365SignIn_focusAccount_c6a4d2a52_10_3",
-      "step_browserM365SignIn_enterAccount_c6a4d2a52_10_3",
-      "step_browserM365SignIn_submitAccount_c6a4d2a52_10_3",
-      "step_browserM365SignIn_assertPassword_c6a4d2a52_10_3",
-      "step_browserM365SignIn_enterPassword_c6a4d2a52_10_3",
-      "step_browserM365SignIn_submitPassword_c6a4d2a52_10_3",
-      "step_browserM365SignIn_assertStaySignedIn_c6a4d2a52_10_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c6a4d2a52_10_3",
-      "step_assertReady_assertReady_c6a4d2a52_10_4",
-      "step_zoomOut_zoomOut_c6a4d2a52_10_5",
+      "step_assertDeployedRuntimeReady_c6a4d2a52_10_1",
+      "step_executeCommand_open_c6a4d2a52_10_2",
+      "step_executeCommand_assertPalette_c6a4d2a52_10_2",
+      "step_executeCommand_filter_c6a4d2a52_10_2",
+      "step_executeCommand_assertCommand_c6a4d2a52_10_2",
+      "step_executeCommand_execute_c6a4d2a52_10_2",
+      "step_filterOption_filter_c6a4d2a52_10_3",
+      "step_filterOption_assertOption_c6a4d2a52_10_3",
+      "step_filterOption_confirm_c6a4d2a52_10_3",
+      "step_browserM365SignIn_assertAccount_c6a4d2a52_10_4",
+      "step_browserM365SignIn_focusAccount_c6a4d2a52_10_4",
+      "step_browserM365SignIn_enterAccount_c6a4d2a52_10_4",
+      "step_browserM365SignIn_submitAccount_c6a4d2a52_10_4",
+      "step_browserM365SignIn_assertPassword_c6a4d2a52_10_4",
+      "step_browserM365SignIn_enterPassword_c6a4d2a52_10_4",
+      "step_browserM365SignIn_submitPassword_c6a4d2a52_10_4",
+      "step_browserM365SignIn_assertStaySignedIn_c6a4d2a52_10_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c6a4d2a52_10_4",
+      "step_assertReady_assertReady_c6a4d2a52_10_5",
+      "step_zoomOut_zoomOut_c6a4d2a52_10_6",
       "step_sendCopilotMessage_assertInput_c6a4d2a52_12_1",
       "step_sendCopilotMessage_focusInput_c6a4d2a52_12_1",
       "step_sendCopilotMessage_type_c6a4d2a52_12_1",
@@ -3256,7 +3257,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c6a4d2a52_10_1",
+      "step_id": "step_assertDeployedRuntimeReady_c6a4d2a52_10_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c6a4d2a52_9_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c6a4d2a52_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3268,7 +3292,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c6a4d2a52_9_5"
+        "step_assertDeployedRuntimeReady_c6a4d2a52_10_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3278,7 +3302,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c6a4d2a52_10_1",
+      "step_id": "step_executeCommand_assertPalette_c6a4d2a52_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3288,7 +3312,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c6a4d2a52_10_1"
+        "step_executeCommand_open_c6a4d2a52_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3299,7 +3323,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c6a4d2a52_10_1",
+      "step_id": "step_executeCommand_filter_c6a4d2a52_10_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3311,7 +3335,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c6a4d2a52_10_1"
+        "step_executeCommand_assertPalette_c6a4d2a52_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3321,7 +3345,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c6a4d2a52_10_1",
+      "step_id": "step_executeCommand_assertCommand_c6a4d2a52_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3331,7 +3355,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c6a4d2a52_10_1"
+        "step_executeCommand_filter_c6a4d2a52_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3342,7 +3366,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c6a4d2a52_10_1",
+      "step_id": "step_executeCommand_execute_c6a4d2a52_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3354,7 +3378,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c6a4d2a52_10_1"
+        "step_executeCommand_assertCommand_c6a4d2a52_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3364,7 +3388,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c6a4d2a52_10_2",
+      "step_id": "step_filterOption_filter_c6a4d2a52_10_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3376,7 +3400,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c6a4d2a52_10_1"
+        "step_executeCommand_execute_c6a4d2a52_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3386,7 +3410,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c6a4d2a52_10_2",
+      "step_id": "step_filterOption_assertOption_c6a4d2a52_10_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3396,7 +3420,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c6a4d2a52_10_2"
+        "step_filterOption_filter_c6a4d2a52_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3407,7 +3431,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c6a4d2a52_10_2",
+      "step_id": "step_filterOption_confirm_c6a4d2a52_10_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3419,7 +3443,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c6a4d2a52_10_2"
+        "step_filterOption_assertOption_c6a4d2a52_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3429,7 +3453,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c6a4d2a52_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3439,7 +3463,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c6a4d2a52_10_2"
+        "step_filterOption_confirm_c6a4d2a52_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3450,7 +3474,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c6a4d2a52_10_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3464,7 +3488,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c6a4d2a52_10_3"
+        "step_browserM365SignIn_assertAccount_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3474,7 +3498,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c6a4d2a52_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c6a4d2a52_10_3"
+        "step_browserM365SignIn_focusAccount_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3496,7 +3520,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c6a4d2a52_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3508,7 +3532,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c6a4d2a52_10_3"
+        "step_browserM365SignIn_enterAccount_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3518,7 +3542,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c6a4d2a52_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3528,7 +3552,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c6a4d2a52_10_3"
+        "step_browserM365SignIn_submitAccount_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3539,7 +3563,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c6a4d2a52_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3551,7 +3575,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c6a4d2a52_10_3"
+        "step_browserM365SignIn_assertPassword_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3561,7 +3585,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c6a4d2a52_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3573,7 +3597,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c6a4d2a52_10_3"
+        "step_browserM365SignIn_enterPassword_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3583,7 +3607,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c6a4d2a52_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3593,7 +3617,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c6a4d2a52_10_3"
+        "step_browserM365SignIn_submitPassword_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3604,7 +3628,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c6a4d2a52_10_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c6a4d2a52_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3616,7 +3640,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c6a4d2a52_10_3"
+        "step_browserM365SignIn_assertStaySignedIn_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3627,7 +3651,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c6a4d2a52_10_4",
+      "step_id": "step_assertReady_assertReady_c6a4d2a52_10_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3637,7 +3661,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c6a4d2a52_10_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c6a4d2a52_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3648,7 +3672,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c6a4d2a52_10_5",
+      "step_id": "step_zoomOut_zoomOut_c6a4d2a52_10_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3660,7 +3684,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c6a4d2a52_10_4"
+        "step_assertReady_assertReady_c6a4d2a52_10_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3680,7 +3704,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c6a4d2a52_10_5"
+        "step_zoomOut_zoomOut_c6a4d2a52_10_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-js-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 162,
+    "total_steps": 163,
     "name": "rag-customize-js-openai-remote-teams",
     "description": {
       "owner": "",
@@ -152,21 +152,22 @@
       "step_clickPrimaryAction_assertDialog_cf389c8ff_8_4",
       "step_clickPrimaryAction_click_cf389c8ff_8_4",
       "step_assertNotificationContains_assert_cf389c8ff_8_5",
-      "step_executeCommand_open_cf389c8ff_9_1",
-      "step_executeCommand_assertPalette_cf389c8ff_9_1",
-      "step_executeCommand_filter_cf389c8ff_9_1",
-      "step_executeCommand_assertCommand_cf389c8ff_9_1",
-      "step_executeCommand_execute_cf389c8ff_9_1",
-      "step_filterOption_filter_cf389c8ff_9_2",
-      "step_filterOption_assertOption_cf389c8ff_9_2",
-      "step_filterOption_confirm_cf389c8ff_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_cf389c8ff_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_cf389c8ff_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_cf389c8ff_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_cf389c8ff_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cf389c8ff_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf389c8ff_9_3",
-      "step_assertReady_assertReady_cf389c8ff_9_4",
+      "step_assertDeployedRuntimeReady_cf389c8ff_9_1",
+      "step_executeCommand_open_cf389c8ff_9_2",
+      "step_executeCommand_assertPalette_cf389c8ff_9_2",
+      "step_executeCommand_filter_cf389c8ff_9_2",
+      "step_executeCommand_assertCommand_cf389c8ff_9_2",
+      "step_executeCommand_execute_cf389c8ff_9_2",
+      "step_filterOption_filter_cf389c8ff_9_3",
+      "step_filterOption_assertOption_cf389c8ff_9_3",
+      "step_filterOption_confirm_cf389c8ff_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_cf389c8ff_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_cf389c8ff_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_cf389c8ff_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_cf389c8ff_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cf389c8ff_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf389c8ff_9_4",
+      "step_assertReady_assertReady_cf389c8ff_9_5",
       "step_addAndOpenApp_assertAdd_cf389c8ff_10_1",
       "step_addAndOpenApp_add_cf389c8ff_10_1",
       "step_addAndOpenApp_assertAdded_cf389c8ff_10_1",
@@ -3232,7 +3233,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cf389c8ff_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_cf389c8ff_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cf389c8ff_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cf389c8ff_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3244,7 +3268,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cf389c8ff_8_5"
+        "step_assertDeployedRuntimeReady_cf389c8ff_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3254,7 +3278,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cf389c8ff_9_1",
+      "step_id": "step_executeCommand_assertPalette_cf389c8ff_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3264,7 +3288,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cf389c8ff_9_1"
+        "step_executeCommand_open_cf389c8ff_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3275,7 +3299,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cf389c8ff_9_1",
+      "step_id": "step_executeCommand_filter_cf389c8ff_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3287,7 +3311,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cf389c8ff_9_1"
+        "step_executeCommand_assertPalette_cf389c8ff_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3297,7 +3321,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cf389c8ff_9_1",
+      "step_id": "step_executeCommand_assertCommand_cf389c8ff_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3307,7 +3331,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cf389c8ff_9_1"
+        "step_executeCommand_filter_cf389c8ff_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3318,7 +3342,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cf389c8ff_9_1",
+      "step_id": "step_executeCommand_execute_cf389c8ff_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3330,7 +3354,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cf389c8ff_9_1"
+        "step_executeCommand_assertCommand_cf389c8ff_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3340,7 +3364,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cf389c8ff_9_2",
+      "step_id": "step_filterOption_filter_cf389c8ff_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3352,7 +3376,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cf389c8ff_9_1"
+        "step_executeCommand_execute_cf389c8ff_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3362,7 +3386,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cf389c8ff_9_2",
+      "step_id": "step_filterOption_assertOption_cf389c8ff_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3372,7 +3396,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cf389c8ff_9_2"
+        "step_filterOption_filter_cf389c8ff_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3383,7 +3407,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cf389c8ff_9_2",
+      "step_id": "step_filterOption_confirm_cf389c8ff_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3395,7 +3419,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cf389c8ff_9_2"
+        "step_filterOption_assertOption_cf389c8ff_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3405,7 +3429,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf389c8ff_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf389c8ff_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3415,7 +3439,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cf389c8ff_9_2"
+        "step_filterOption_confirm_cf389c8ff_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3426,7 +3450,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf389c8ff_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf389c8ff_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3440,7 +3464,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cf389c8ff_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_cf389c8ff_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3450,7 +3474,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf389c8ff_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf389c8ff_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3462,7 +3486,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cf389c8ff_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_cf389c8ff_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3472,7 +3496,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf389c8ff_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf389c8ff_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3484,7 +3508,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cf389c8ff_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_cf389c8ff_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3494,7 +3518,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf389c8ff_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf389c8ff_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3504,7 +3528,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cf389c8ff_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_cf389c8ff_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3515,7 +3539,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf389c8ff_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf389c8ff_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3527,7 +3551,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cf389c8ff_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cf389c8ff_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3538,7 +3562,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cf389c8ff_9_4",
+      "step_id": "step_assertReady_assertReady_cf389c8ff_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3548,7 +3572,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf389c8ff_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf389c8ff_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3569,7 +3593,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cf389c8ff_9_4"
+        "step_assertReady_assertReady_cf389c8ff_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 192,
+    "total_steps": 193,
     "name": "rag-customize-py-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -183,25 +183,26 @@
       "step_clickPrimaryAction_assertDialog_c38c3c3c8_8_4",
       "step_clickPrimaryAction_click_c38c3c3c8_8_4",
       "step_assertNotificationContains_assert_c38c3c3c8_8_5",
-      "step_executeCommand_open_c38c3c3c8_9_1",
-      "step_executeCommand_assertPalette_c38c3c3c8_9_1",
-      "step_executeCommand_filter_c38c3c3c8_9_1",
-      "step_executeCommand_assertCommand_c38c3c3c8_9_1",
-      "step_executeCommand_execute_c38c3c3c8_9_1",
-      "step_filterOption_filter_c38c3c3c8_9_2",
-      "step_filterOption_assertOption_c38c3c3c8_9_2",
-      "step_filterOption_confirm_c38c3c3c8_9_2",
-      "step_browserM365SignIn_assertAccount_c38c3c3c8_9_3",
-      "step_browserM365SignIn_focusAccount_c38c3c3c8_9_3",
-      "step_browserM365SignIn_enterAccount_c38c3c3c8_9_3",
-      "step_browserM365SignIn_submitAccount_c38c3c3c8_9_3",
-      "step_browserM365SignIn_assertPassword_c38c3c3c8_9_3",
-      "step_browserM365SignIn_enterPassword_c38c3c3c8_9_3",
-      "step_browserM365SignIn_submitPassword_c38c3c3c8_9_3",
-      "step_browserM365SignIn_assertStaySignedIn_c38c3c3c8_9_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c38c3c3c8_9_3",
-      "step_assertReady_assertReady_c38c3c3c8_9_4",
-      "step_zoomOut_zoomOut_c38c3c3c8_9_5",
+      "step_assertDeployedRuntimeReady_c38c3c3c8_9_1",
+      "step_executeCommand_open_c38c3c3c8_9_2",
+      "step_executeCommand_assertPalette_c38c3c3c8_9_2",
+      "step_executeCommand_filter_c38c3c3c8_9_2",
+      "step_executeCommand_assertCommand_c38c3c3c8_9_2",
+      "step_executeCommand_execute_c38c3c3c8_9_2",
+      "step_filterOption_filter_c38c3c3c8_9_3",
+      "step_filterOption_assertOption_c38c3c3c8_9_3",
+      "step_filterOption_confirm_c38c3c3c8_9_3",
+      "step_browserM365SignIn_assertAccount_c38c3c3c8_9_4",
+      "step_browserM365SignIn_focusAccount_c38c3c3c8_9_4",
+      "step_browserM365SignIn_enterAccount_c38c3c3c8_9_4",
+      "step_browserM365SignIn_submitAccount_c38c3c3c8_9_4",
+      "step_browserM365SignIn_assertPassword_c38c3c3c8_9_4",
+      "step_browserM365SignIn_enterPassword_c38c3c3c8_9_4",
+      "step_browserM365SignIn_submitPassword_c38c3c3c8_9_4",
+      "step_browserM365SignIn_assertStaySignedIn_c38c3c3c8_9_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c38c3c3c8_9_4",
+      "step_assertReady_assertReady_c38c3c3c8_9_5",
+      "step_zoomOut_zoomOut_c38c3c3c8_9_6",
       "step_sendCopilotMessage_assertInput_c38c3c3c8_11_1",
       "step_sendCopilotMessage_focusInput_c38c3c3c8_11_1",
       "step_sendCopilotMessage_type_c38c3c3c8_11_1",
@@ -3936,7 +3937,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c38c3c3c8_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_c38c3c3c8_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c38c3c3c8_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c38c3c3c8_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3948,7 +3972,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c38c3c3c8_8_5"
+        "step_assertDeployedRuntimeReady_c38c3c3c8_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3958,7 +3982,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c38c3c3c8_9_1",
+      "step_id": "step_executeCommand_assertPalette_c38c3c3c8_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3968,7 +3992,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c38c3c3c8_9_1"
+        "step_executeCommand_open_c38c3c3c8_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3979,7 +4003,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c38c3c3c8_9_1",
+      "step_id": "step_executeCommand_filter_c38c3c3c8_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3991,7 +4015,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c38c3c3c8_9_1"
+        "step_executeCommand_assertPalette_c38c3c3c8_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4001,7 +4025,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c38c3c3c8_9_1",
+      "step_id": "step_executeCommand_assertCommand_c38c3c3c8_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4011,7 +4035,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c38c3c3c8_9_1"
+        "step_executeCommand_filter_c38c3c3c8_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4022,7 +4046,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c38c3c3c8_9_1",
+      "step_id": "step_executeCommand_execute_c38c3c3c8_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4034,7 +4058,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c38c3c3c8_9_1"
+        "step_executeCommand_assertCommand_c38c3c3c8_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4044,7 +4068,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c38c3c3c8_9_2",
+      "step_id": "step_filterOption_filter_c38c3c3c8_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4056,7 +4080,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c38c3c3c8_9_1"
+        "step_executeCommand_execute_c38c3c3c8_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4066,7 +4090,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c38c3c3c8_9_2",
+      "step_id": "step_filterOption_assertOption_c38c3c3c8_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4076,7 +4100,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c38c3c3c8_9_2"
+        "step_filterOption_filter_c38c3c3c8_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4087,7 +4111,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c38c3c3c8_9_2",
+      "step_id": "step_filterOption_confirm_c38c3c3c8_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4099,7 +4123,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c38c3c3c8_9_2"
+        "step_filterOption_assertOption_c38c3c3c8_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4109,7 +4133,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c38c3c3c8_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4119,7 +4143,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c38c3c3c8_9_2"
+        "step_filterOption_confirm_c38c3c3c8_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4130,7 +4154,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c38c3c3c8_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -4144,7 +4168,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c38c3c3c8_9_3"
+        "step_browserM365SignIn_assertAccount_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4154,7 +4178,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c38c3c3c8_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4166,7 +4190,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c38c3c3c8_9_3"
+        "step_browserM365SignIn_focusAccount_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4176,7 +4200,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c38c3c3c8_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4188,7 +4212,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c38c3c3c8_9_3"
+        "step_browserM365SignIn_enterAccount_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4198,7 +4222,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c38c3c3c8_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4208,7 +4232,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c38c3c3c8_9_3"
+        "step_browserM365SignIn_submitAccount_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4219,7 +4243,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c38c3c3c8_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4231,7 +4255,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c38c3c3c8_9_3"
+        "step_browserM365SignIn_assertPassword_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4241,7 +4265,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c38c3c3c8_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4253,7 +4277,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c38c3c3c8_9_3"
+        "step_browserM365SignIn_enterPassword_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4263,7 +4287,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c38c3c3c8_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4273,7 +4297,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c38c3c3c8_9_3"
+        "step_browserM365SignIn_submitPassword_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4284,7 +4308,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c38c3c3c8_9_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c38c3c3c8_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4296,7 +4320,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c38c3c3c8_9_3"
+        "step_browserM365SignIn_assertStaySignedIn_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4307,7 +4331,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c38c3c3c8_9_4",
+      "step_id": "step_assertReady_assertReady_c38c3c3c8_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4317,7 +4341,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c38c3c3c8_9_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c38c3c3c8_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4328,7 +4352,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c38c3c3c8_9_5",
+      "step_id": "step_zoomOut_zoomOut_c38c3c3c8_9_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -4340,7 +4364,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c38c3c3c8_9_4"
+        "step_assertReady_assertReady_c38c3c3c8_9_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4360,7 +4384,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c38c3c3c8_9_5"
+        "step_zoomOut_zoomOut_c38c3c3c8_9_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 169,
+    "total_steps": 170,
     "name": "rag-customize-py-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -159,21 +159,22 @@
       "step_clickPrimaryAction_assertDialog_c94c0e335_6_4",
       "step_clickPrimaryAction_click_c94c0e335_6_4",
       "step_assertNotificationContains_assert_c94c0e335_6_5",
-      "step_executeCommand_open_c94c0e335_7_1",
-      "step_executeCommand_assertPalette_c94c0e335_7_1",
-      "step_executeCommand_filter_c94c0e335_7_1",
-      "step_executeCommand_assertCommand_c94c0e335_7_1",
-      "step_executeCommand_execute_c94c0e335_7_1",
-      "step_filterOption_filter_c94c0e335_7_2",
-      "step_filterOption_assertOption_c94c0e335_7_2",
-      "step_filterOption_confirm_c94c0e335_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c94c0e335_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c94c0e335_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c94c0e335_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c94c0e335_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c94c0e335_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c94c0e335_7_3",
-      "step_assertReady_assertReady_c94c0e335_7_4",
+      "step_assertDeployedRuntimeReady_c94c0e335_7_1",
+      "step_executeCommand_open_c94c0e335_7_2",
+      "step_executeCommand_assertPalette_c94c0e335_7_2",
+      "step_executeCommand_filter_c94c0e335_7_2",
+      "step_executeCommand_assertCommand_c94c0e335_7_2",
+      "step_executeCommand_execute_c94c0e335_7_2",
+      "step_filterOption_filter_c94c0e335_7_3",
+      "step_filterOption_assertOption_c94c0e335_7_3",
+      "step_filterOption_confirm_c94c0e335_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c94c0e335_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c94c0e335_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c94c0e335_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c94c0e335_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c94c0e335_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c94c0e335_7_4",
+      "step_assertReady_assertReady_c94c0e335_7_5",
       "step_addAndOpenApp_assertAdd_c94c0e335_8_1",
       "step_addAndOpenApp_add_c94c0e335_8_1",
       "step_addAndOpenApp_assertAdded_c94c0e335_8_1",
@@ -3392,7 +3393,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c94c0e335_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c94c0e335_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c94c0e335_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c94c0e335_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3404,7 +3428,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c94c0e335_6_5"
+        "step_assertDeployedRuntimeReady_c94c0e335_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3414,7 +3438,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c94c0e335_7_1",
+      "step_id": "step_executeCommand_assertPalette_c94c0e335_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3424,7 +3448,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c94c0e335_7_1"
+        "step_executeCommand_open_c94c0e335_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3435,7 +3459,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c94c0e335_7_1",
+      "step_id": "step_executeCommand_filter_c94c0e335_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3447,7 +3471,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c94c0e335_7_1"
+        "step_executeCommand_assertPalette_c94c0e335_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3457,7 +3481,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c94c0e335_7_1",
+      "step_id": "step_executeCommand_assertCommand_c94c0e335_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3467,7 +3491,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c94c0e335_7_1"
+        "step_executeCommand_filter_c94c0e335_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3478,7 +3502,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c94c0e335_7_1",
+      "step_id": "step_executeCommand_execute_c94c0e335_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3490,7 +3514,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c94c0e335_7_1"
+        "step_executeCommand_assertCommand_c94c0e335_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3500,7 +3524,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c94c0e335_7_2",
+      "step_id": "step_filterOption_filter_c94c0e335_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3512,7 +3536,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c94c0e335_7_1"
+        "step_executeCommand_execute_c94c0e335_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3522,7 +3546,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c94c0e335_7_2",
+      "step_id": "step_filterOption_assertOption_c94c0e335_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3532,7 +3556,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c94c0e335_7_2"
+        "step_filterOption_filter_c94c0e335_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c94c0e335_7_2",
+      "step_id": "step_filterOption_confirm_c94c0e335_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c94c0e335_7_2"
+        "step_filterOption_assertOption_c94c0e335_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c94c0e335_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c94c0e335_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c94c0e335_7_2"
+        "step_filterOption_confirm_c94c0e335_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c94c0e335_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c94c0e335_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3600,7 +3624,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c94c0e335_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c94c0e335_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3610,7 +3634,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c94c0e335_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c94c0e335_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3622,7 +3646,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c94c0e335_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c94c0e335_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3632,7 +3656,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c94c0e335_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c94c0e335_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3644,7 +3668,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c94c0e335_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c94c0e335_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3654,7 +3678,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c94c0e335_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c94c0e335_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3664,7 +3688,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c94c0e335_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c94c0e335_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3675,7 +3699,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c94c0e335_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c94c0e335_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3687,7 +3711,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c94c0e335_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c94c0e335_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3698,7 +3722,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c94c0e335_7_4",
+      "step_id": "step_assertReady_assertReady_c94c0e335_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3708,7 +3732,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c94c0e335_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c94c0e335_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3729,7 +3753,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c94c0e335_7_4"
+        "step_assertReady_assertReady_c94c0e335_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 185,
+    "total_steps": 186,
     "name": "rag-customize-py-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -176,25 +176,26 @@
       "step_clickPrimaryAction_assertDialog_cd633d59b_10_4",
       "step_clickPrimaryAction_click_cd633d59b_10_4",
       "step_assertNotificationContains_assert_cd633d59b_10_5",
-      "step_executeCommand_open_cd633d59b_11_1",
-      "step_executeCommand_assertPalette_cd633d59b_11_1",
-      "step_executeCommand_filter_cd633d59b_11_1",
-      "step_executeCommand_assertCommand_cd633d59b_11_1",
-      "step_executeCommand_execute_cd633d59b_11_1",
-      "step_filterOption_filter_cd633d59b_11_2",
-      "step_filterOption_assertOption_cd633d59b_11_2",
-      "step_filterOption_confirm_cd633d59b_11_2",
-      "step_browserM365SignIn_assertAccount_cd633d59b_11_3",
-      "step_browserM365SignIn_focusAccount_cd633d59b_11_3",
-      "step_browserM365SignIn_enterAccount_cd633d59b_11_3",
-      "step_browserM365SignIn_submitAccount_cd633d59b_11_3",
-      "step_browserM365SignIn_assertPassword_cd633d59b_11_3",
-      "step_browserM365SignIn_enterPassword_cd633d59b_11_3",
-      "step_browserM365SignIn_submitPassword_cd633d59b_11_3",
-      "step_browserM365SignIn_assertStaySignedIn_cd633d59b_11_3",
-      "step_browserM365SignIn_confirmStaySignedIn_cd633d59b_11_3",
-      "step_assertReady_assertReady_cd633d59b_11_4",
-      "step_zoomOut_zoomOut_cd633d59b_11_5",
+      "step_assertDeployedRuntimeReady_cd633d59b_11_1",
+      "step_executeCommand_open_cd633d59b_11_2",
+      "step_executeCommand_assertPalette_cd633d59b_11_2",
+      "step_executeCommand_filter_cd633d59b_11_2",
+      "step_executeCommand_assertCommand_cd633d59b_11_2",
+      "step_executeCommand_execute_cd633d59b_11_2",
+      "step_filterOption_filter_cd633d59b_11_3",
+      "step_filterOption_assertOption_cd633d59b_11_3",
+      "step_filterOption_confirm_cd633d59b_11_3",
+      "step_browserM365SignIn_assertAccount_cd633d59b_11_4",
+      "step_browserM365SignIn_focusAccount_cd633d59b_11_4",
+      "step_browserM365SignIn_enterAccount_cd633d59b_11_4",
+      "step_browserM365SignIn_submitAccount_cd633d59b_11_4",
+      "step_browserM365SignIn_assertPassword_cd633d59b_11_4",
+      "step_browserM365SignIn_enterPassword_cd633d59b_11_4",
+      "step_browserM365SignIn_submitPassword_cd633d59b_11_4",
+      "step_browserM365SignIn_assertStaySignedIn_cd633d59b_11_4",
+      "step_browserM365SignIn_confirmStaySignedIn_cd633d59b_11_4",
+      "step_assertReady_assertReady_cd633d59b_11_5",
+      "step_zoomOut_zoomOut_cd633d59b_11_6",
       "step_sendCopilotMessage_assertInput_cd633d59b_13_1",
       "step_sendCopilotMessage_focusInput_cd633d59b_13_1",
       "step_sendCopilotMessage_type_cd633d59b_13_1",
@@ -3776,7 +3777,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cd633d59b_11_1",
+      "step_id": "step_assertDeployedRuntimeReady_cd633d59b_11_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cd633d59b_10_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cd633d59b_11_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3788,7 +3812,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cd633d59b_10_5"
+        "step_assertDeployedRuntimeReady_cd633d59b_11_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3798,7 +3822,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cd633d59b_11_1",
+      "step_id": "step_executeCommand_assertPalette_cd633d59b_11_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3808,7 +3832,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cd633d59b_11_1"
+        "step_executeCommand_open_cd633d59b_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3819,7 +3843,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cd633d59b_11_1",
+      "step_id": "step_executeCommand_filter_cd633d59b_11_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3831,7 +3855,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cd633d59b_11_1"
+        "step_executeCommand_assertPalette_cd633d59b_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3841,7 +3865,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cd633d59b_11_1",
+      "step_id": "step_executeCommand_assertCommand_cd633d59b_11_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3851,7 +3875,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cd633d59b_11_1"
+        "step_executeCommand_filter_cd633d59b_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3862,7 +3886,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cd633d59b_11_1",
+      "step_id": "step_executeCommand_execute_cd633d59b_11_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3874,7 +3898,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cd633d59b_11_1"
+        "step_executeCommand_assertCommand_cd633d59b_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3884,7 +3908,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cd633d59b_11_2",
+      "step_id": "step_filterOption_filter_cd633d59b_11_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3896,7 +3920,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cd633d59b_11_1"
+        "step_executeCommand_execute_cd633d59b_11_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3906,7 +3930,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cd633d59b_11_2",
+      "step_id": "step_filterOption_assertOption_cd633d59b_11_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3916,7 +3940,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cd633d59b_11_2"
+        "step_filterOption_filter_cd633d59b_11_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3927,7 +3951,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cd633d59b_11_2",
+      "step_id": "step_filterOption_confirm_cd633d59b_11_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3939,7 +3963,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cd633d59b_11_2"
+        "step_filterOption_assertOption_cd633d59b_11_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3949,7 +3973,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_assertAccount_cd633d59b_11_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3959,7 +3983,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cd633d59b_11_2"
+        "step_filterOption_confirm_cd633d59b_11_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3970,7 +3994,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_focusAccount_cd633d59b_11_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3984,7 +4008,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_cd633d59b_11_3"
+        "step_browserM365SignIn_assertAccount_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3994,7 +4018,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_enterAccount_cd633d59b_11_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4006,7 +4030,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_cd633d59b_11_3"
+        "step_browserM365SignIn_focusAccount_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4016,7 +4040,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_submitAccount_cd633d59b_11_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4028,7 +4052,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_cd633d59b_11_3"
+        "step_browserM365SignIn_enterAccount_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4038,7 +4062,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_assertPassword_cd633d59b_11_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4048,7 +4072,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_cd633d59b_11_3"
+        "step_browserM365SignIn_submitAccount_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4059,7 +4083,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_enterPassword_cd633d59b_11_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -4071,7 +4095,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_cd633d59b_11_3"
+        "step_browserM365SignIn_assertPassword_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4081,7 +4105,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_submitPassword_cd633d59b_11_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4093,7 +4117,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_cd633d59b_11_3"
+        "step_browserM365SignIn_enterPassword_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4103,7 +4127,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_cd633d59b_11_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4113,7 +4137,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_cd633d59b_11_3"
+        "step_browserM365SignIn_submitPassword_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4124,7 +4148,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cd633d59b_11_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cd633d59b_11_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4136,7 +4160,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_cd633d59b_11_3"
+        "step_browserM365SignIn_assertStaySignedIn_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4147,7 +4171,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cd633d59b_11_4",
+      "step_id": "step_assertReady_assertReady_cd633d59b_11_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4157,7 +4181,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_cd633d59b_11_3"
+        "step_browserM365SignIn_confirmStaySignedIn_cd633d59b_11_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4168,7 +4192,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_cd633d59b_11_5",
+      "step_id": "step_zoomOut_zoomOut_cd633d59b_11_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -4180,7 +4204,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cd633d59b_11_4"
+        "step_assertReady_assertReady_cd633d59b_11_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4200,7 +4224,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_cd633d59b_11_5"
+        "step_zoomOut_zoomOut_cd633d59b_11_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-py-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 185,
+    "total_steps": 186,
     "name": "rag-customize-py-openai-remote-teams",
     "description": {
       "owner": "",
@@ -175,21 +175,22 @@
       "step_clickPrimaryAction_assertDialog_cb37be18f_9_4",
       "step_clickPrimaryAction_click_cb37be18f_9_4",
       "step_assertNotificationContains_assert_cb37be18f_9_5",
-      "step_executeCommand_open_cb37be18f_10_1",
-      "step_executeCommand_assertPalette_cb37be18f_10_1",
-      "step_executeCommand_filter_cb37be18f_10_1",
-      "step_executeCommand_assertCommand_cb37be18f_10_1",
-      "step_executeCommand_execute_cb37be18f_10_1",
-      "step_filterOption_filter_cb37be18f_10_2",
-      "step_filterOption_assertOption_cb37be18f_10_2",
-      "step_filterOption_confirm_cb37be18f_10_2",
-      "step_browserM365PasswordSignIn_assertPassword_cb37be18f_10_3",
-      "step_browserM365PasswordSignIn_focusPassword_cb37be18f_10_3",
-      "step_browserM365PasswordSignIn_enterPassword_cb37be18f_10_3",
-      "step_browserM365PasswordSignIn_submitPassword_cb37be18f_10_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cb37be18f_10_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cb37be18f_10_3",
-      "step_assertReady_assertReady_cb37be18f_10_4",
+      "step_assertDeployedRuntimeReady_cb37be18f_10_1",
+      "step_executeCommand_open_cb37be18f_10_2",
+      "step_executeCommand_assertPalette_cb37be18f_10_2",
+      "step_executeCommand_filter_cb37be18f_10_2",
+      "step_executeCommand_assertCommand_cb37be18f_10_2",
+      "step_executeCommand_execute_cb37be18f_10_2",
+      "step_filterOption_filter_cb37be18f_10_3",
+      "step_filterOption_assertOption_cb37be18f_10_3",
+      "step_filterOption_confirm_cb37be18f_10_3",
+      "step_browserM365PasswordSignIn_assertPassword_cb37be18f_10_4",
+      "step_browserM365PasswordSignIn_focusPassword_cb37be18f_10_4",
+      "step_browserM365PasswordSignIn_enterPassword_cb37be18f_10_4",
+      "step_browserM365PasswordSignIn_submitPassword_cb37be18f_10_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cb37be18f_10_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cb37be18f_10_4",
+      "step_assertReady_assertReady_cb37be18f_10_5",
       "step_addAndOpenApp_assertAdd_cb37be18f_11_1",
       "step_addAndOpenApp_add_cb37be18f_11_1",
       "step_addAndOpenApp_assertAdded_cb37be18f_11_1",
@@ -3752,7 +3753,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cb37be18f_10_1",
+      "step_id": "step_assertDeployedRuntimeReady_cb37be18f_10_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cb37be18f_9_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cb37be18f_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3764,7 +3788,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cb37be18f_9_5"
+        "step_assertDeployedRuntimeReady_cb37be18f_10_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3774,7 +3798,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cb37be18f_10_1",
+      "step_id": "step_executeCommand_assertPalette_cb37be18f_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3784,7 +3808,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cb37be18f_10_1"
+        "step_executeCommand_open_cb37be18f_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3795,7 +3819,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cb37be18f_10_1",
+      "step_id": "step_executeCommand_filter_cb37be18f_10_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3807,7 +3831,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cb37be18f_10_1"
+        "step_executeCommand_assertPalette_cb37be18f_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3817,7 +3841,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cb37be18f_10_1",
+      "step_id": "step_executeCommand_assertCommand_cb37be18f_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3827,7 +3851,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cb37be18f_10_1"
+        "step_executeCommand_filter_cb37be18f_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3838,7 +3862,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cb37be18f_10_1",
+      "step_id": "step_executeCommand_execute_cb37be18f_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3850,7 +3874,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cb37be18f_10_1"
+        "step_executeCommand_assertCommand_cb37be18f_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3860,7 +3884,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cb37be18f_10_2",
+      "step_id": "step_filterOption_filter_cb37be18f_10_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3872,7 +3896,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cb37be18f_10_1"
+        "step_executeCommand_execute_cb37be18f_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3882,7 +3906,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cb37be18f_10_2",
+      "step_id": "step_filterOption_assertOption_cb37be18f_10_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3892,7 +3916,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cb37be18f_10_2"
+        "step_filterOption_filter_cb37be18f_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3903,7 +3927,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cb37be18f_10_2",
+      "step_id": "step_filterOption_confirm_cb37be18f_10_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3915,7 +3939,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cb37be18f_10_2"
+        "step_filterOption_assertOption_cb37be18f_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3925,7 +3949,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cb37be18f_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cb37be18f_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3935,7 +3959,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cb37be18f_10_2"
+        "step_filterOption_confirm_cb37be18f_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3946,7 +3970,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cb37be18f_10_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cb37be18f_10_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3960,7 +3984,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cb37be18f_10_3"
+        "step_browserM365PasswordSignIn_assertPassword_cb37be18f_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3970,7 +3994,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cb37be18f_10_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cb37be18f_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3982,7 +4006,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cb37be18f_10_3"
+        "step_browserM365PasswordSignIn_focusPassword_cb37be18f_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3992,7 +4016,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cb37be18f_10_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cb37be18f_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4004,7 +4028,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cb37be18f_10_3"
+        "step_browserM365PasswordSignIn_enterPassword_cb37be18f_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4014,7 +4038,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cb37be18f_10_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cb37be18f_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4024,7 +4048,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cb37be18f_10_3"
+        "step_browserM365PasswordSignIn_submitPassword_cb37be18f_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4035,7 +4059,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cb37be18f_10_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cb37be18f_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -4047,7 +4071,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cb37be18f_10_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cb37be18f_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4058,7 +4082,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cb37be18f_10_4",
+      "step_id": "step_assertReady_assertReady_cb37be18f_10_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -4068,7 +4092,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cb37be18f_10_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cb37be18f_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -4089,7 +4113,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cb37be18f_10_4"
+        "step_assertReady_assertReady_cb37be18f_10_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 170,
+    "total_steps": 171,
     "name": "rag-customize-ts-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -161,25 +161,26 @@
       "step_clickPrimaryAction_assertDialog_cdfe67c35_7_4",
       "step_clickPrimaryAction_click_cdfe67c35_7_4",
       "step_assertNotificationContains_assert_cdfe67c35_7_5",
-      "step_executeCommand_open_cdfe67c35_8_1",
-      "step_executeCommand_assertPalette_cdfe67c35_8_1",
-      "step_executeCommand_filter_cdfe67c35_8_1",
-      "step_executeCommand_assertCommand_cdfe67c35_8_1",
-      "step_executeCommand_execute_cdfe67c35_8_1",
-      "step_filterOption_filter_cdfe67c35_8_2",
-      "step_filterOption_assertOption_cdfe67c35_8_2",
-      "step_filterOption_confirm_cdfe67c35_8_2",
-      "step_browserM365SignIn_assertAccount_cdfe67c35_8_3",
-      "step_browserM365SignIn_focusAccount_cdfe67c35_8_3",
-      "step_browserM365SignIn_enterAccount_cdfe67c35_8_3",
-      "step_browserM365SignIn_submitAccount_cdfe67c35_8_3",
-      "step_browserM365SignIn_assertPassword_cdfe67c35_8_3",
-      "step_browserM365SignIn_enterPassword_cdfe67c35_8_3",
-      "step_browserM365SignIn_submitPassword_cdfe67c35_8_3",
-      "step_browserM365SignIn_assertStaySignedIn_cdfe67c35_8_3",
-      "step_browserM365SignIn_confirmStaySignedIn_cdfe67c35_8_3",
-      "step_assertReady_assertReady_cdfe67c35_8_4",
-      "step_zoomOut_zoomOut_cdfe67c35_8_5",
+      "step_assertDeployedRuntimeReady_cdfe67c35_8_1",
+      "step_executeCommand_open_cdfe67c35_8_2",
+      "step_executeCommand_assertPalette_cdfe67c35_8_2",
+      "step_executeCommand_filter_cdfe67c35_8_2",
+      "step_executeCommand_assertCommand_cdfe67c35_8_2",
+      "step_executeCommand_execute_cdfe67c35_8_2",
+      "step_filterOption_filter_cdfe67c35_8_3",
+      "step_filterOption_assertOption_cdfe67c35_8_3",
+      "step_filterOption_confirm_cdfe67c35_8_3",
+      "step_browserM365SignIn_assertAccount_cdfe67c35_8_4",
+      "step_browserM365SignIn_focusAccount_cdfe67c35_8_4",
+      "step_browserM365SignIn_enterAccount_cdfe67c35_8_4",
+      "step_browserM365SignIn_submitAccount_cdfe67c35_8_4",
+      "step_browserM365SignIn_assertPassword_cdfe67c35_8_4",
+      "step_browserM365SignIn_enterPassword_cdfe67c35_8_4",
+      "step_browserM365SignIn_submitPassword_cdfe67c35_8_4",
+      "step_browserM365SignIn_assertStaySignedIn_cdfe67c35_8_4",
+      "step_browserM365SignIn_confirmStaySignedIn_cdfe67c35_8_4",
+      "step_assertReady_assertReady_cdfe67c35_8_5",
+      "step_zoomOut_zoomOut_cdfe67c35_8_6",
       "step_sendCopilotMessage_assertInput_cdfe67c35_10_1",
       "step_sendCopilotMessage_focusInput_cdfe67c35_10_1",
       "step_sendCopilotMessage_type_cdfe67c35_10_1",
@@ -3440,7 +3441,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cdfe67c35_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_cdfe67c35_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cdfe67c35_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cdfe67c35_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3452,7 +3476,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cdfe67c35_7_5"
+        "step_assertDeployedRuntimeReady_cdfe67c35_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3462,7 +3486,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cdfe67c35_8_1",
+      "step_id": "step_executeCommand_assertPalette_cdfe67c35_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3472,7 +3496,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cdfe67c35_8_1"
+        "step_executeCommand_open_cdfe67c35_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3483,7 +3507,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cdfe67c35_8_1",
+      "step_id": "step_executeCommand_filter_cdfe67c35_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3495,7 +3519,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cdfe67c35_8_1"
+        "step_executeCommand_assertPalette_cdfe67c35_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3505,7 +3529,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cdfe67c35_8_1",
+      "step_id": "step_executeCommand_assertCommand_cdfe67c35_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3515,7 +3539,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cdfe67c35_8_1"
+        "step_executeCommand_filter_cdfe67c35_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3526,7 +3550,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cdfe67c35_8_1",
+      "step_id": "step_executeCommand_execute_cdfe67c35_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3538,7 +3562,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cdfe67c35_8_1"
+        "step_executeCommand_assertCommand_cdfe67c35_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3548,7 +3572,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cdfe67c35_8_2",
+      "step_id": "step_filterOption_filter_cdfe67c35_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3560,7 +3584,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cdfe67c35_8_1"
+        "step_executeCommand_execute_cdfe67c35_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3570,7 +3594,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cdfe67c35_8_2",
+      "step_id": "step_filterOption_assertOption_cdfe67c35_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3580,7 +3604,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cdfe67c35_8_2"
+        "step_filterOption_filter_cdfe67c35_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3591,7 +3615,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cdfe67c35_8_2",
+      "step_id": "step_filterOption_confirm_cdfe67c35_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3603,7 +3627,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cdfe67c35_8_2"
+        "step_filterOption_assertOption_cdfe67c35_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3613,7 +3637,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_assertAccount_cdfe67c35_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3623,7 +3647,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cdfe67c35_8_2"
+        "step_filterOption_confirm_cdfe67c35_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3634,7 +3658,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_focusAccount_cdfe67c35_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3648,7 +3672,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_cdfe67c35_8_3"
+        "step_browserM365SignIn_assertAccount_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3658,7 +3682,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_enterAccount_cdfe67c35_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3670,7 +3694,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_cdfe67c35_8_3"
+        "step_browserM365SignIn_focusAccount_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3680,7 +3704,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_submitAccount_cdfe67c35_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3692,7 +3716,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_cdfe67c35_8_3"
+        "step_browserM365SignIn_enterAccount_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3702,7 +3726,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_assertPassword_cdfe67c35_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3712,7 +3736,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_cdfe67c35_8_3"
+        "step_browserM365SignIn_submitAccount_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3723,7 +3747,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_enterPassword_cdfe67c35_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3735,7 +3759,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_cdfe67c35_8_3"
+        "step_browserM365SignIn_assertPassword_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3745,7 +3769,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_submitPassword_cdfe67c35_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3757,7 +3781,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_cdfe67c35_8_3"
+        "step_browserM365SignIn_enterPassword_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3767,7 +3791,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_cdfe67c35_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3777,7 +3801,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_cdfe67c35_8_3"
+        "step_browserM365SignIn_submitPassword_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3788,7 +3812,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cdfe67c35_8_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cdfe67c35_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3800,7 +3824,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_cdfe67c35_8_3"
+        "step_browserM365SignIn_assertStaySignedIn_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3811,7 +3835,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cdfe67c35_8_4",
+      "step_id": "step_assertReady_assertReady_cdfe67c35_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3821,7 +3845,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_cdfe67c35_8_3"
+        "step_browserM365SignIn_confirmStaySignedIn_cdfe67c35_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3832,7 +3856,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_cdfe67c35_8_5",
+      "step_id": "step_zoomOut_zoomOut_cdfe67c35_8_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3844,7 +3868,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cdfe67c35_8_4"
+        "step_assertReady_assertReady_cdfe67c35_8_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3864,7 +3888,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_cdfe67c35_8_5"
+        "step_zoomOut_zoomOut_cdfe67c35_8_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 170,
+    "total_steps": 171,
     "name": "rag-customize-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -160,21 +160,22 @@
       "step_clickPrimaryAction_assertDialog_c45a484e7_6_4",
       "step_clickPrimaryAction_click_c45a484e7_6_4",
       "step_assertNotificationContains_assert_c45a484e7_6_5",
-      "step_executeCommand_open_c45a484e7_7_1",
-      "step_executeCommand_assertPalette_c45a484e7_7_1",
-      "step_executeCommand_filter_c45a484e7_7_1",
-      "step_executeCommand_assertCommand_c45a484e7_7_1",
-      "step_executeCommand_execute_c45a484e7_7_1",
-      "step_filterOption_filter_c45a484e7_7_2",
-      "step_filterOption_assertOption_c45a484e7_7_2",
-      "step_filterOption_confirm_c45a484e7_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c45a484e7_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c45a484e7_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c45a484e7_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c45a484e7_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c45a484e7_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c45a484e7_7_3",
-      "step_assertReady_assertReady_c45a484e7_7_4",
+      "step_assertDeployedRuntimeReady_c45a484e7_7_1",
+      "step_executeCommand_open_c45a484e7_7_2",
+      "step_executeCommand_assertPalette_c45a484e7_7_2",
+      "step_executeCommand_filter_c45a484e7_7_2",
+      "step_executeCommand_assertCommand_c45a484e7_7_2",
+      "step_executeCommand_execute_c45a484e7_7_2",
+      "step_filterOption_filter_c45a484e7_7_3",
+      "step_filterOption_assertOption_c45a484e7_7_3",
+      "step_filterOption_confirm_c45a484e7_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c45a484e7_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c45a484e7_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c45a484e7_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c45a484e7_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c45a484e7_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c45a484e7_7_4",
+      "step_assertReady_assertReady_c45a484e7_7_5",
       "step_addAndOpenApp_assertAdd_c45a484e7_8_1",
       "step_addAndOpenApp_add_c45a484e7_8_1",
       "step_addAndOpenApp_assertAdded_c45a484e7_8_1",
@@ -3416,7 +3417,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c45a484e7_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c45a484e7_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c45a484e7_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c45a484e7_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3428,7 +3452,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c45a484e7_6_5"
+        "step_assertDeployedRuntimeReady_c45a484e7_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3438,7 +3462,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c45a484e7_7_1",
+      "step_id": "step_executeCommand_assertPalette_c45a484e7_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3448,7 +3472,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c45a484e7_7_1"
+        "step_executeCommand_open_c45a484e7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3459,7 +3483,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c45a484e7_7_1",
+      "step_id": "step_executeCommand_filter_c45a484e7_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3471,7 +3495,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c45a484e7_7_1"
+        "step_executeCommand_assertPalette_c45a484e7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3481,7 +3505,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c45a484e7_7_1",
+      "step_id": "step_executeCommand_assertCommand_c45a484e7_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3491,7 +3515,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c45a484e7_7_1"
+        "step_executeCommand_filter_c45a484e7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3502,7 +3526,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c45a484e7_7_1",
+      "step_id": "step_executeCommand_execute_c45a484e7_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3514,7 +3538,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c45a484e7_7_1"
+        "step_executeCommand_assertCommand_c45a484e7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3524,7 +3548,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c45a484e7_7_2",
+      "step_id": "step_filterOption_filter_c45a484e7_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3536,7 +3560,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c45a484e7_7_1"
+        "step_executeCommand_execute_c45a484e7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3546,7 +3570,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c45a484e7_7_2",
+      "step_id": "step_filterOption_assertOption_c45a484e7_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3556,7 +3580,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c45a484e7_7_2"
+        "step_filterOption_filter_c45a484e7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3567,7 +3591,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c45a484e7_7_2",
+      "step_id": "step_filterOption_confirm_c45a484e7_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3579,7 +3603,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c45a484e7_7_2"
+        "step_filterOption_assertOption_c45a484e7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3589,7 +3613,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c45a484e7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c45a484e7_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3599,7 +3623,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c45a484e7_7_2"
+        "step_filterOption_confirm_c45a484e7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3610,7 +3634,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c45a484e7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c45a484e7_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3624,7 +3648,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c45a484e7_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c45a484e7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3634,7 +3658,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c45a484e7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c45a484e7_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3646,7 +3670,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c45a484e7_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c45a484e7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3656,7 +3680,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c45a484e7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c45a484e7_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3668,7 +3692,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c45a484e7_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c45a484e7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3678,7 +3702,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c45a484e7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c45a484e7_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3688,7 +3712,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c45a484e7_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c45a484e7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3699,7 +3723,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c45a484e7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c45a484e7_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3711,7 +3735,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c45a484e7_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c45a484e7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3722,7 +3746,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c45a484e7_7_4",
+      "step_id": "step_assertReady_assertReady_c45a484e7_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3732,7 +3756,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c45a484e7_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c45a484e7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3753,7 +3777,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c45a484e7_7_4"
+        "step_assertReady_assertReady_c45a484e7_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 164,
+    "total_steps": 165,
     "name": "rag-customize-ts-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -155,25 +155,26 @@
       "step_clickPrimaryAction_assertDialog_c4d414b44_9_4",
       "step_clickPrimaryAction_click_c4d414b44_9_4",
       "step_assertNotificationContains_assert_c4d414b44_9_5",
-      "step_executeCommand_open_c4d414b44_10_1",
-      "step_executeCommand_assertPalette_c4d414b44_10_1",
-      "step_executeCommand_filter_c4d414b44_10_1",
-      "step_executeCommand_assertCommand_c4d414b44_10_1",
-      "step_executeCommand_execute_c4d414b44_10_1",
-      "step_filterOption_filter_c4d414b44_10_2",
-      "step_filterOption_assertOption_c4d414b44_10_2",
-      "step_filterOption_confirm_c4d414b44_10_2",
-      "step_browserM365SignIn_assertAccount_c4d414b44_10_3",
-      "step_browserM365SignIn_focusAccount_c4d414b44_10_3",
-      "step_browserM365SignIn_enterAccount_c4d414b44_10_3",
-      "step_browserM365SignIn_submitAccount_c4d414b44_10_3",
-      "step_browserM365SignIn_assertPassword_c4d414b44_10_3",
-      "step_browserM365SignIn_enterPassword_c4d414b44_10_3",
-      "step_browserM365SignIn_submitPassword_c4d414b44_10_3",
-      "step_browserM365SignIn_assertStaySignedIn_c4d414b44_10_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c4d414b44_10_3",
-      "step_assertReady_assertReady_c4d414b44_10_4",
-      "step_zoomOut_zoomOut_c4d414b44_10_5",
+      "step_assertDeployedRuntimeReady_c4d414b44_10_1",
+      "step_executeCommand_open_c4d414b44_10_2",
+      "step_executeCommand_assertPalette_c4d414b44_10_2",
+      "step_executeCommand_filter_c4d414b44_10_2",
+      "step_executeCommand_assertCommand_c4d414b44_10_2",
+      "step_executeCommand_execute_c4d414b44_10_2",
+      "step_filterOption_filter_c4d414b44_10_3",
+      "step_filterOption_assertOption_c4d414b44_10_3",
+      "step_filterOption_confirm_c4d414b44_10_3",
+      "step_browserM365SignIn_assertAccount_c4d414b44_10_4",
+      "step_browserM365SignIn_focusAccount_c4d414b44_10_4",
+      "step_browserM365SignIn_enterAccount_c4d414b44_10_4",
+      "step_browserM365SignIn_submitAccount_c4d414b44_10_4",
+      "step_browserM365SignIn_assertPassword_c4d414b44_10_4",
+      "step_browserM365SignIn_enterPassword_c4d414b44_10_4",
+      "step_browserM365SignIn_submitPassword_c4d414b44_10_4",
+      "step_browserM365SignIn_assertStaySignedIn_c4d414b44_10_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c4d414b44_10_4",
+      "step_assertReady_assertReady_c4d414b44_10_5",
+      "step_zoomOut_zoomOut_c4d414b44_10_6",
       "step_sendCopilotMessage_assertInput_c4d414b44_12_1",
       "step_sendCopilotMessage_focusInput_c4d414b44_12_1",
       "step_sendCopilotMessage_type_c4d414b44_12_1",
@@ -3304,7 +3305,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c4d414b44_10_1",
+      "step_id": "step_assertDeployedRuntimeReady_c4d414b44_10_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c4d414b44_9_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c4d414b44_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3316,7 +3340,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c4d414b44_9_5"
+        "step_assertDeployedRuntimeReady_c4d414b44_10_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3326,7 +3350,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c4d414b44_10_1",
+      "step_id": "step_executeCommand_assertPalette_c4d414b44_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3336,7 +3360,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c4d414b44_10_1"
+        "step_executeCommand_open_c4d414b44_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3347,7 +3371,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c4d414b44_10_1",
+      "step_id": "step_executeCommand_filter_c4d414b44_10_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3359,7 +3383,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c4d414b44_10_1"
+        "step_executeCommand_assertPalette_c4d414b44_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3369,7 +3393,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c4d414b44_10_1",
+      "step_id": "step_executeCommand_assertCommand_c4d414b44_10_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3379,7 +3403,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c4d414b44_10_1"
+        "step_executeCommand_filter_c4d414b44_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3390,7 +3414,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c4d414b44_10_1",
+      "step_id": "step_executeCommand_execute_c4d414b44_10_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3402,7 +3426,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c4d414b44_10_1"
+        "step_executeCommand_assertCommand_c4d414b44_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3412,7 +3436,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c4d414b44_10_2",
+      "step_id": "step_filterOption_filter_c4d414b44_10_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3424,7 +3448,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c4d414b44_10_1"
+        "step_executeCommand_execute_c4d414b44_10_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3434,7 +3458,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c4d414b44_10_2",
+      "step_id": "step_filterOption_assertOption_c4d414b44_10_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3444,7 +3468,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c4d414b44_10_2"
+        "step_filterOption_filter_c4d414b44_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3455,7 +3479,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c4d414b44_10_2",
+      "step_id": "step_filterOption_confirm_c4d414b44_10_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3467,7 +3491,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c4d414b44_10_2"
+        "step_filterOption_assertOption_c4d414b44_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3477,7 +3501,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c4d414b44_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3487,7 +3511,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c4d414b44_10_2"
+        "step_filterOption_confirm_c4d414b44_10_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3498,7 +3522,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c4d414b44_10_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3512,7 +3536,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c4d414b44_10_3"
+        "step_browserM365SignIn_assertAccount_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3522,7 +3546,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c4d414b44_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3534,7 +3558,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c4d414b44_10_3"
+        "step_browserM365SignIn_focusAccount_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3544,7 +3568,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c4d414b44_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3556,7 +3580,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c4d414b44_10_3"
+        "step_browserM365SignIn_enterAccount_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3566,7 +3590,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c4d414b44_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3576,7 +3600,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c4d414b44_10_3"
+        "step_browserM365SignIn_submitAccount_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3587,7 +3611,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c4d414b44_10_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3599,7 +3623,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c4d414b44_10_3"
+        "step_browserM365SignIn_assertPassword_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3609,7 +3633,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c4d414b44_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3621,7 +3645,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c4d414b44_10_3"
+        "step_browserM365SignIn_enterPassword_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3631,7 +3655,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c4d414b44_10_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3641,7 +3665,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c4d414b44_10_3"
+        "step_browserM365SignIn_submitPassword_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3652,7 +3676,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c4d414b44_10_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c4d414b44_10_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3664,7 +3688,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c4d414b44_10_3"
+        "step_browserM365SignIn_assertStaySignedIn_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3675,7 +3699,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c4d414b44_10_4",
+      "step_id": "step_assertReady_assertReady_c4d414b44_10_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3685,7 +3709,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c4d414b44_10_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c4d414b44_10_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3696,7 +3720,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c4d414b44_10_5",
+      "step_id": "step_zoomOut_zoomOut_c4d414b44_10_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3708,7 +3732,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c4d414b44_10_4"
+        "step_assertReady_assertReady_c4d414b44_10_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3728,7 +3752,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c4d414b44_10_5"
+        "step_zoomOut_zoomOut_c4d414b44_10_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/custom-copilot-rag-customize--rag-customize-ts-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 164,
+    "total_steps": 165,
     "name": "rag-customize-ts-openai-remote-teams",
     "description": {
       "owner": "",
@@ -154,21 +154,22 @@
       "step_clickPrimaryAction_assertDialog_c2d82a6c9_8_4",
       "step_clickPrimaryAction_click_c2d82a6c9_8_4",
       "step_assertNotificationContains_assert_c2d82a6c9_8_5",
-      "step_executeCommand_open_c2d82a6c9_9_1",
-      "step_executeCommand_assertPalette_c2d82a6c9_9_1",
-      "step_executeCommand_filter_c2d82a6c9_9_1",
-      "step_executeCommand_assertCommand_c2d82a6c9_9_1",
-      "step_executeCommand_execute_c2d82a6c9_9_1",
-      "step_filterOption_filter_c2d82a6c9_9_2",
-      "step_filterOption_assertOption_c2d82a6c9_9_2",
-      "step_filterOption_confirm_c2d82a6c9_9_2",
-      "step_browserM365PasswordSignIn_assertPassword_c2d82a6c9_9_3",
-      "step_browserM365PasswordSignIn_focusPassword_c2d82a6c9_9_3",
-      "step_browserM365PasswordSignIn_enterPassword_c2d82a6c9_9_3",
-      "step_browserM365PasswordSignIn_submitPassword_c2d82a6c9_9_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c2d82a6c9_9_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c2d82a6c9_9_3",
-      "step_assertReady_assertReady_c2d82a6c9_9_4",
+      "step_assertDeployedRuntimeReady_c2d82a6c9_9_1",
+      "step_executeCommand_open_c2d82a6c9_9_2",
+      "step_executeCommand_assertPalette_c2d82a6c9_9_2",
+      "step_executeCommand_filter_c2d82a6c9_9_2",
+      "step_executeCommand_assertCommand_c2d82a6c9_9_2",
+      "step_executeCommand_execute_c2d82a6c9_9_2",
+      "step_filterOption_filter_c2d82a6c9_9_3",
+      "step_filterOption_assertOption_c2d82a6c9_9_3",
+      "step_filterOption_confirm_c2d82a6c9_9_3",
+      "step_browserM365PasswordSignIn_assertPassword_c2d82a6c9_9_4",
+      "step_browserM365PasswordSignIn_focusPassword_c2d82a6c9_9_4",
+      "step_browserM365PasswordSignIn_enterPassword_c2d82a6c9_9_4",
+      "step_browserM365PasswordSignIn_submitPassword_c2d82a6c9_9_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c2d82a6c9_9_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c2d82a6c9_9_4",
+      "step_assertReady_assertReady_c2d82a6c9_9_5",
       "step_addAndOpenApp_assertAdd_c2d82a6c9_10_1",
       "step_addAndOpenApp_add_c2d82a6c9_10_1",
       "step_addAndOpenApp_assertAdded_c2d82a6c9_10_1",
@@ -3280,7 +3281,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c2d82a6c9_9_1",
+      "step_id": "step_assertDeployedRuntimeReady_c2d82a6c9_9_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c2d82a6c9_8_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c2d82a6c9_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3292,7 +3316,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c2d82a6c9_8_5"
+        "step_assertDeployedRuntimeReady_c2d82a6c9_9_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3302,7 +3326,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c2d82a6c9_9_1",
+      "step_id": "step_executeCommand_assertPalette_c2d82a6c9_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3312,7 +3336,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c2d82a6c9_9_1"
+        "step_executeCommand_open_c2d82a6c9_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3323,7 +3347,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c2d82a6c9_9_1",
+      "step_id": "step_executeCommand_filter_c2d82a6c9_9_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c2d82a6c9_9_1"
+        "step_executeCommand_assertPalette_c2d82a6c9_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3345,7 +3369,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c2d82a6c9_9_1",
+      "step_id": "step_executeCommand_assertCommand_c2d82a6c9_9_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3355,7 +3379,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c2d82a6c9_9_1"
+        "step_executeCommand_filter_c2d82a6c9_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3366,7 +3390,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c2d82a6c9_9_1",
+      "step_id": "step_executeCommand_execute_c2d82a6c9_9_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c2d82a6c9_9_1"
+        "step_executeCommand_assertCommand_c2d82a6c9_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3388,7 +3412,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c2d82a6c9_9_2",
+      "step_id": "step_filterOption_filter_c2d82a6c9_9_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3400,7 +3424,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c2d82a6c9_9_1"
+        "step_executeCommand_execute_c2d82a6c9_9_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3410,7 +3434,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c2d82a6c9_9_2",
+      "step_id": "step_filterOption_assertOption_c2d82a6c9_9_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3420,7 +3444,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c2d82a6c9_9_2"
+        "step_filterOption_filter_c2d82a6c9_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3431,7 +3455,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c2d82a6c9_9_2",
+      "step_id": "step_filterOption_confirm_c2d82a6c9_9_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c2d82a6c9_9_2"
+        "step_filterOption_assertOption_c2d82a6c9_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3453,7 +3477,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c2d82a6c9_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c2d82a6c9_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3463,7 +3487,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c2d82a6c9_9_2"
+        "step_filterOption_confirm_c2d82a6c9_9_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3474,7 +3498,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c2d82a6c9_9_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c2d82a6c9_9_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3488,7 +3512,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c2d82a6c9_9_3"
+        "step_browserM365PasswordSignIn_assertPassword_c2d82a6c9_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3498,7 +3522,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c2d82a6c9_9_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c2d82a6c9_9_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3510,7 +3534,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c2d82a6c9_9_3"
+        "step_browserM365PasswordSignIn_focusPassword_c2d82a6c9_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3520,7 +3544,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c2d82a6c9_9_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c2d82a6c9_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3532,7 +3556,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c2d82a6c9_9_3"
+        "step_browserM365PasswordSignIn_enterPassword_c2d82a6c9_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3542,7 +3566,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c2d82a6c9_9_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c2d82a6c9_9_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3552,7 +3576,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c2d82a6c9_9_3"
+        "step_browserM365PasswordSignIn_submitPassword_c2d82a6c9_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3563,7 +3587,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c2d82a6c9_9_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c2d82a6c9_9_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c2d82a6c9_9_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c2d82a6c9_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c2d82a6c9_9_4",
+      "step_id": "step_assertReady_assertReady_c2d82a6c9_9_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3596,7 +3620,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c2d82a6c9_9_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c2d82a6c9_9_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3617,7 +3641,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c2d82a6c9_9_4"
+        "step_assertReady_assertReady_c2d82a6c9_9_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-js-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-js-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 154,
+    "total_steps": 155,
     "name": "simple-bot-js-remote-teams",
     "description": {
       "owner": "",
@@ -144,21 +144,22 @@
       "step_clickPrimaryAction_assertDialog_c972729f7_6_4",
       "step_clickPrimaryAction_click_c972729f7_6_4",
       "step_assertNotificationContains_assert_c972729f7_6_5",
-      "step_executeCommand_open_c972729f7_7_1",
-      "step_executeCommand_assertPalette_c972729f7_7_1",
-      "step_executeCommand_filter_c972729f7_7_1",
-      "step_executeCommand_assertCommand_c972729f7_7_1",
-      "step_executeCommand_execute_c972729f7_7_1",
-      "step_filterOption_filter_c972729f7_7_2",
-      "step_filterOption_assertOption_c972729f7_7_2",
-      "step_filterOption_confirm_c972729f7_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c972729f7_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c972729f7_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c972729f7_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c972729f7_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c972729f7_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c972729f7_7_3",
-      "step_assertReady_assertReady_c972729f7_7_4",
+      "step_assertDeployedRuntimeReady_c972729f7_7_1",
+      "step_executeCommand_open_c972729f7_7_2",
+      "step_executeCommand_assertPalette_c972729f7_7_2",
+      "step_executeCommand_filter_c972729f7_7_2",
+      "step_executeCommand_assertCommand_c972729f7_7_2",
+      "step_executeCommand_execute_c972729f7_7_2",
+      "step_filterOption_filter_c972729f7_7_3",
+      "step_filterOption_assertOption_c972729f7_7_3",
+      "step_filterOption_confirm_c972729f7_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c972729f7_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c972729f7_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c972729f7_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c972729f7_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c972729f7_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c972729f7_7_4",
+      "step_assertReady_assertReady_c972729f7_7_5",
       "step_addAndOpenApp_assertAdd_c972729f7_8_1",
       "step_addAndOpenApp_add_c972729f7_8_1",
       "step_addAndOpenApp_assertAdded_c972729f7_8_1",
@@ -3052,7 +3053,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c972729f7_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c972729f7_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c972729f7_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c972729f7_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3064,7 +3088,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c972729f7_6_5"
+        "step_assertDeployedRuntimeReady_c972729f7_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3074,7 +3098,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c972729f7_7_1",
+      "step_id": "step_executeCommand_assertPalette_c972729f7_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3084,7 +3108,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c972729f7_7_1"
+        "step_executeCommand_open_c972729f7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3095,7 +3119,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c972729f7_7_1",
+      "step_id": "step_executeCommand_filter_c972729f7_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3107,7 +3131,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c972729f7_7_1"
+        "step_executeCommand_assertPalette_c972729f7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3117,7 +3141,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c972729f7_7_1",
+      "step_id": "step_executeCommand_assertCommand_c972729f7_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3127,7 +3151,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c972729f7_7_1"
+        "step_executeCommand_filter_c972729f7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3138,7 +3162,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c972729f7_7_1",
+      "step_id": "step_executeCommand_execute_c972729f7_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3150,7 +3174,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c972729f7_7_1"
+        "step_executeCommand_assertCommand_c972729f7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3160,7 +3184,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c972729f7_7_2",
+      "step_id": "step_filterOption_filter_c972729f7_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3172,7 +3196,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c972729f7_7_1"
+        "step_executeCommand_execute_c972729f7_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3182,7 +3206,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c972729f7_7_2",
+      "step_id": "step_filterOption_assertOption_c972729f7_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3192,7 +3216,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c972729f7_7_2"
+        "step_filterOption_filter_c972729f7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3203,7 +3227,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c972729f7_7_2",
+      "step_id": "step_filterOption_confirm_c972729f7_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3215,7 +3239,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c972729f7_7_2"
+        "step_filterOption_assertOption_c972729f7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3225,7 +3249,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c972729f7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c972729f7_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3235,7 +3259,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c972729f7_7_2"
+        "step_filterOption_confirm_c972729f7_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3246,7 +3270,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c972729f7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c972729f7_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3260,7 +3284,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c972729f7_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c972729f7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3270,7 +3294,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c972729f7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c972729f7_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3282,7 +3306,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c972729f7_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c972729f7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3292,7 +3316,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c972729f7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c972729f7_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3304,7 +3328,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c972729f7_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c972729f7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3314,7 +3338,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c972729f7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c972729f7_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3324,7 +3348,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c972729f7_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c972729f7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3335,7 +3359,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c972729f7_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c972729f7_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3347,7 +3371,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c972729f7_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c972729f7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3358,7 +3382,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c972729f7_7_4",
+      "step_id": "step_assertReady_assertReady_c972729f7_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3368,7 +3392,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c972729f7_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c972729f7_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3389,7 +3413,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c972729f7_7_4"
+        "step_assertReady_assertReady_c972729f7_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-py-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-py-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 177,
+    "total_steps": 178,
     "name": "simple-bot-py-remote-teams",
     "description": {
       "owner": "",
@@ -167,21 +167,22 @@
       "step_clickPrimaryAction_assertDialog_cf2cbb81e_7_4",
       "step_clickPrimaryAction_click_cf2cbb81e_7_4",
       "step_assertNotificationContains_assert_cf2cbb81e_7_5",
-      "step_executeCommand_open_cf2cbb81e_8_1",
-      "step_executeCommand_assertPalette_cf2cbb81e_8_1",
-      "step_executeCommand_filter_cf2cbb81e_8_1",
-      "step_executeCommand_assertCommand_cf2cbb81e_8_1",
-      "step_executeCommand_execute_cf2cbb81e_8_1",
-      "step_filterOption_filter_cf2cbb81e_8_2",
-      "step_filterOption_assertOption_cf2cbb81e_8_2",
-      "step_filterOption_confirm_cf2cbb81e_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_cf2cbb81e_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_cf2cbb81e_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_cf2cbb81e_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_cf2cbb81e_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cf2cbb81e_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf2cbb81e_8_3",
-      "step_assertReady_assertReady_cf2cbb81e_8_4",
+      "step_assertDeployedRuntimeReady_cf2cbb81e_8_1",
+      "step_executeCommand_open_cf2cbb81e_8_2",
+      "step_executeCommand_assertPalette_cf2cbb81e_8_2",
+      "step_executeCommand_filter_cf2cbb81e_8_2",
+      "step_executeCommand_assertCommand_cf2cbb81e_8_2",
+      "step_executeCommand_execute_cf2cbb81e_8_2",
+      "step_filterOption_filter_cf2cbb81e_8_3",
+      "step_filterOption_assertOption_cf2cbb81e_8_3",
+      "step_filterOption_confirm_cf2cbb81e_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_cf2cbb81e_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_cf2cbb81e_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_cf2cbb81e_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_cf2cbb81e_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cf2cbb81e_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cf2cbb81e_8_4",
+      "step_assertReady_assertReady_cf2cbb81e_8_5",
       "step_addAndOpenApp_assertAdd_cf2cbb81e_9_1",
       "step_addAndOpenApp_add_cf2cbb81e_9_1",
       "step_addAndOpenApp_assertAdded_cf2cbb81e_9_1",
@@ -3572,7 +3573,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cf2cbb81e_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_cf2cbb81e_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cf2cbb81e_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cf2cbb81e_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3584,7 +3608,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cf2cbb81e_7_5"
+        "step_assertDeployedRuntimeReady_cf2cbb81e_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3594,7 +3618,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cf2cbb81e_8_1",
+      "step_id": "step_executeCommand_assertPalette_cf2cbb81e_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3604,7 +3628,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cf2cbb81e_8_1"
+        "step_executeCommand_open_cf2cbb81e_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3615,7 +3639,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cf2cbb81e_8_1",
+      "step_id": "step_executeCommand_filter_cf2cbb81e_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3627,7 +3651,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cf2cbb81e_8_1"
+        "step_executeCommand_assertPalette_cf2cbb81e_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3637,7 +3661,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cf2cbb81e_8_1",
+      "step_id": "step_executeCommand_assertCommand_cf2cbb81e_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3647,7 +3671,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cf2cbb81e_8_1"
+        "step_executeCommand_filter_cf2cbb81e_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3658,7 +3682,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cf2cbb81e_8_1",
+      "step_id": "step_executeCommand_execute_cf2cbb81e_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3670,7 +3694,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cf2cbb81e_8_1"
+        "step_executeCommand_assertCommand_cf2cbb81e_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3680,7 +3704,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cf2cbb81e_8_2",
+      "step_id": "step_filterOption_filter_cf2cbb81e_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3692,7 +3716,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cf2cbb81e_8_1"
+        "step_executeCommand_execute_cf2cbb81e_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3702,7 +3726,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cf2cbb81e_8_2",
+      "step_id": "step_filterOption_assertOption_cf2cbb81e_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3712,7 +3736,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cf2cbb81e_8_2"
+        "step_filterOption_filter_cf2cbb81e_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3723,7 +3747,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cf2cbb81e_8_2",
+      "step_id": "step_filterOption_confirm_cf2cbb81e_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3735,7 +3759,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cf2cbb81e_8_2"
+        "step_filterOption_assertOption_cf2cbb81e_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3745,7 +3769,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf2cbb81e_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cf2cbb81e_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3755,7 +3779,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cf2cbb81e_8_2"
+        "step_filterOption_confirm_cf2cbb81e_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3766,7 +3790,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf2cbb81e_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cf2cbb81e_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3780,7 +3804,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cf2cbb81e_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_cf2cbb81e_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3790,7 +3814,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf2cbb81e_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cf2cbb81e_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3802,7 +3826,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cf2cbb81e_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_cf2cbb81e_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3812,7 +3836,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf2cbb81e_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cf2cbb81e_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3824,7 +3848,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cf2cbb81e_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_cf2cbb81e_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3834,7 +3858,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf2cbb81e_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cf2cbb81e_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3844,7 +3868,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cf2cbb81e_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_cf2cbb81e_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3855,7 +3879,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf2cbb81e_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cf2cbb81e_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3867,7 +3891,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cf2cbb81e_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cf2cbb81e_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3878,7 +3902,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cf2cbb81e_8_4",
+      "step_id": "step_assertReady_assertReady_cf2cbb81e_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3888,7 +3912,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf2cbb81e_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cf2cbb81e_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3909,7 +3933,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cf2cbb81e_8_4"
+        "step_assertReady_assertReady_cf2cbb81e_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-ts-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-bot--simple-bot-ts-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 156,
+    "total_steps": 157,
     "name": "simple-bot-ts-remote-teams",
     "description": {
       "owner": "",
@@ -146,21 +146,22 @@
       "step_clickPrimaryAction_assertDialog_c3e3e2eac_6_4",
       "step_clickPrimaryAction_click_c3e3e2eac_6_4",
       "step_assertNotificationContains_assert_c3e3e2eac_6_5",
-      "step_executeCommand_open_c3e3e2eac_7_1",
-      "step_executeCommand_assertPalette_c3e3e2eac_7_1",
-      "step_executeCommand_filter_c3e3e2eac_7_1",
-      "step_executeCommand_assertCommand_c3e3e2eac_7_1",
-      "step_executeCommand_execute_c3e3e2eac_7_1",
-      "step_filterOption_filter_c3e3e2eac_7_2",
-      "step_filterOption_assertOption_c3e3e2eac_7_2",
-      "step_filterOption_confirm_c3e3e2eac_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c3e3e2eac_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c3e3e2eac_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c3e3e2eac_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c3e3e2eac_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c3e3e2eac_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c3e3e2eac_7_3",
-      "step_assertReady_assertReady_c3e3e2eac_7_4",
+      "step_assertDeployedRuntimeReady_c3e3e2eac_7_1",
+      "step_executeCommand_open_c3e3e2eac_7_2",
+      "step_executeCommand_assertPalette_c3e3e2eac_7_2",
+      "step_executeCommand_filter_c3e3e2eac_7_2",
+      "step_executeCommand_assertCommand_c3e3e2eac_7_2",
+      "step_executeCommand_execute_c3e3e2eac_7_2",
+      "step_filterOption_filter_c3e3e2eac_7_3",
+      "step_filterOption_assertOption_c3e3e2eac_7_3",
+      "step_filterOption_confirm_c3e3e2eac_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c3e3e2eac_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c3e3e2eac_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c3e3e2eac_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c3e3e2eac_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c3e3e2eac_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c3e3e2eac_7_4",
+      "step_assertReady_assertReady_c3e3e2eac_7_5",
       "step_addAndOpenApp_assertAdd_c3e3e2eac_8_1",
       "step_addAndOpenApp_add_c3e3e2eac_8_1",
       "step_addAndOpenApp_assertAdded_c3e3e2eac_8_1",
@@ -3100,7 +3101,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c3e3e2eac_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c3e3e2eac_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c3e3e2eac_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c3e3e2eac_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3112,7 +3136,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c3e3e2eac_6_5"
+        "step_assertDeployedRuntimeReady_c3e3e2eac_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3122,7 +3146,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c3e3e2eac_7_1",
+      "step_id": "step_executeCommand_assertPalette_c3e3e2eac_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3132,7 +3156,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c3e3e2eac_7_1"
+        "step_executeCommand_open_c3e3e2eac_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3143,7 +3167,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c3e3e2eac_7_1",
+      "step_id": "step_executeCommand_filter_c3e3e2eac_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3155,7 +3179,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c3e3e2eac_7_1"
+        "step_executeCommand_assertPalette_c3e3e2eac_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3165,7 +3189,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c3e3e2eac_7_1",
+      "step_id": "step_executeCommand_assertCommand_c3e3e2eac_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3175,7 +3199,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c3e3e2eac_7_1"
+        "step_executeCommand_filter_c3e3e2eac_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3186,7 +3210,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c3e3e2eac_7_1",
+      "step_id": "step_executeCommand_execute_c3e3e2eac_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3198,7 +3222,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c3e3e2eac_7_1"
+        "step_executeCommand_assertCommand_c3e3e2eac_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3208,7 +3232,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c3e3e2eac_7_2",
+      "step_id": "step_filterOption_filter_c3e3e2eac_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3220,7 +3244,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c3e3e2eac_7_1"
+        "step_executeCommand_execute_c3e3e2eac_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3230,7 +3254,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c3e3e2eac_7_2",
+      "step_id": "step_filterOption_assertOption_c3e3e2eac_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3240,7 +3264,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c3e3e2eac_7_2"
+        "step_filterOption_filter_c3e3e2eac_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3251,7 +3275,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c3e3e2eac_7_2",
+      "step_id": "step_filterOption_confirm_c3e3e2eac_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3263,7 +3287,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c3e3e2eac_7_2"
+        "step_filterOption_assertOption_c3e3e2eac_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3273,7 +3297,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c3e3e2eac_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c3e3e2eac_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3283,7 +3307,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c3e3e2eac_7_2"
+        "step_filterOption_confirm_c3e3e2eac_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3294,7 +3318,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c3e3e2eac_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c3e3e2eac_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3308,7 +3332,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c3e3e2eac_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c3e3e2eac_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3318,7 +3342,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c3e3e2eac_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c3e3e2eac_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3330,7 +3354,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c3e3e2eac_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c3e3e2eac_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3340,7 +3364,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c3e3e2eac_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c3e3e2eac_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3352,7 +3376,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c3e3e2eac_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c3e3e2eac_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3362,7 +3386,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c3e3e2eac_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c3e3e2eac_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3372,7 +3396,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c3e3e2eac_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c3e3e2eac_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3383,7 +3407,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c3e3e2eac_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c3e3e2eac_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3395,7 +3419,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c3e3e2eac_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c3e3e2eac_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3406,7 +3430,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c3e3e2eac_7_4",
+      "step_id": "step_assertReady_assertReady_c3e3e2eac_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3416,7 +3440,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c3e3e2eac_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c3e3e2eac_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3437,7 +3461,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c3e3e2eac_7_4"
+        "step_assertReady_assertReady_c3e3e2eac_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-py-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-py-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 182,
+    "total_steps": 183,
     "name": "message-extension-py-remote-teams",
     "description": {
       "owner": "",
@@ -168,21 +168,22 @@
       "step_clickPrimaryAction_assertDialog_cec030aaf_7_4",
       "step_clickPrimaryAction_click_cec030aaf_7_4",
       "step_assertNotificationContains_assert_cec030aaf_7_5",
-      "step_executeCommand_open_cec030aaf_8_1",
-      "step_executeCommand_assertPalette_cec030aaf_8_1",
-      "step_executeCommand_filter_cec030aaf_8_1",
-      "step_executeCommand_assertCommand_cec030aaf_8_1",
-      "step_executeCommand_execute_cec030aaf_8_1",
-      "step_filterOption_filter_cec030aaf_8_2",
-      "step_filterOption_assertOption_cec030aaf_8_2",
-      "step_filterOption_confirm_cec030aaf_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_cec030aaf_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_cec030aaf_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_cec030aaf_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_cec030aaf_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_cec030aaf_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_cec030aaf_8_3",
-      "step_assertReady_assertReady_cec030aaf_8_4",
+      "step_assertDeployedRuntimeReady_cec030aaf_8_1",
+      "step_executeCommand_open_cec030aaf_8_2",
+      "step_executeCommand_assertPalette_cec030aaf_8_2",
+      "step_executeCommand_filter_cec030aaf_8_2",
+      "step_executeCommand_assertCommand_cec030aaf_8_2",
+      "step_executeCommand_execute_cec030aaf_8_2",
+      "step_filterOption_filter_cec030aaf_8_3",
+      "step_filterOption_assertOption_cec030aaf_8_3",
+      "step_filterOption_confirm_cec030aaf_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_cec030aaf_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_cec030aaf_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_cec030aaf_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_cec030aaf_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_cec030aaf_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_cec030aaf_8_4",
+      "step_assertReady_assertReady_cec030aaf_8_5",
       "step_addAndOpenApp_assertAdd_cec030aaf_9_1",
       "step_addAndOpenApp_add_cec030aaf_9_1",
       "step_addAndOpenApp_assertAdded_cec030aaf_9_1",
@@ -3600,7 +3601,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cec030aaf_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_cec030aaf_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cec030aaf_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cec030aaf_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3612,7 +3636,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cec030aaf_7_5"
+        "step_assertDeployedRuntimeReady_cec030aaf_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3622,7 +3646,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cec030aaf_8_1",
+      "step_id": "step_executeCommand_assertPalette_cec030aaf_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3632,7 +3656,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cec030aaf_8_1"
+        "step_executeCommand_open_cec030aaf_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3643,7 +3667,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cec030aaf_8_1",
+      "step_id": "step_executeCommand_filter_cec030aaf_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3655,7 +3679,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cec030aaf_8_1"
+        "step_executeCommand_assertPalette_cec030aaf_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3665,7 +3689,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cec030aaf_8_1",
+      "step_id": "step_executeCommand_assertCommand_cec030aaf_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3675,7 +3699,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cec030aaf_8_1"
+        "step_executeCommand_filter_cec030aaf_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3686,7 +3710,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cec030aaf_8_1",
+      "step_id": "step_executeCommand_execute_cec030aaf_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3698,7 +3722,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cec030aaf_8_1"
+        "step_executeCommand_assertCommand_cec030aaf_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3708,7 +3732,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cec030aaf_8_2",
+      "step_id": "step_filterOption_filter_cec030aaf_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3720,7 +3744,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cec030aaf_8_1"
+        "step_executeCommand_execute_cec030aaf_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3730,7 +3754,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cec030aaf_8_2",
+      "step_id": "step_filterOption_assertOption_cec030aaf_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3740,7 +3764,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cec030aaf_8_2"
+        "step_filterOption_filter_cec030aaf_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3751,7 +3775,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cec030aaf_8_2",
+      "step_id": "step_filterOption_confirm_cec030aaf_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3763,7 +3787,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cec030aaf_8_2"
+        "step_filterOption_assertOption_cec030aaf_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3773,7 +3797,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_cec030aaf_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_cec030aaf_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3783,7 +3807,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cec030aaf_8_2"
+        "step_filterOption_confirm_cec030aaf_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3794,7 +3818,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_cec030aaf_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_cec030aaf_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3808,7 +3832,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_cec030aaf_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_cec030aaf_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3818,7 +3842,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_cec030aaf_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_cec030aaf_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3830,7 +3854,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_cec030aaf_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_cec030aaf_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3840,7 +3864,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_cec030aaf_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_cec030aaf_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3852,7 +3876,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_cec030aaf_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_cec030aaf_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3862,7 +3886,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cec030aaf_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_cec030aaf_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3872,7 +3896,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_cec030aaf_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_cec030aaf_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3883,7 +3907,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cec030aaf_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_cec030aaf_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3895,7 +3919,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_cec030aaf_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_cec030aaf_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3906,7 +3930,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cec030aaf_8_4",
+      "step_id": "step_assertReady_assertReady_cec030aaf_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3916,7 +3940,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_cec030aaf_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_cec030aaf_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3937,7 +3961,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cec030aaf_8_4"
+        "step_assertReady_assertReady_cec030aaf_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-ts-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/default-message-extension--message-extension-ts-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 159,
+    "total_steps": 160,
     "name": "message-extension-ts-remote-teams",
     "description": {
       "owner": "",
@@ -145,21 +145,22 @@
       "step_clickPrimaryAction_assertDialog_c62609d07_6_4",
       "step_clickPrimaryAction_click_c62609d07_6_4",
       "step_assertNotificationContains_assert_c62609d07_6_5",
-      "step_executeCommand_open_c62609d07_7_1",
-      "step_executeCommand_assertPalette_c62609d07_7_1",
-      "step_executeCommand_filter_c62609d07_7_1",
-      "step_executeCommand_assertCommand_c62609d07_7_1",
-      "step_executeCommand_execute_c62609d07_7_1",
-      "step_filterOption_filter_c62609d07_7_2",
-      "step_filterOption_assertOption_c62609d07_7_2",
-      "step_filterOption_confirm_c62609d07_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c62609d07_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c62609d07_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c62609d07_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c62609d07_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c62609d07_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c62609d07_7_3",
-      "step_assertReady_assertReady_c62609d07_7_4",
+      "step_assertDeployedRuntimeReady_c62609d07_7_1",
+      "step_executeCommand_open_c62609d07_7_2",
+      "step_executeCommand_assertPalette_c62609d07_7_2",
+      "step_executeCommand_filter_c62609d07_7_2",
+      "step_executeCommand_assertCommand_c62609d07_7_2",
+      "step_executeCommand_execute_c62609d07_7_2",
+      "step_filterOption_filter_c62609d07_7_3",
+      "step_filterOption_assertOption_c62609d07_7_3",
+      "step_filterOption_confirm_c62609d07_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c62609d07_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c62609d07_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c62609d07_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c62609d07_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c62609d07_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c62609d07_7_4",
+      "step_assertReady_assertReady_c62609d07_7_5",
       "step_addAndOpenApp_assertAdd_c62609d07_8_1",
       "step_addAndOpenApp_add_c62609d07_8_1",
       "step_addAndOpenApp_assertAdded_c62609d07_8_1",
@@ -3080,7 +3081,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c62609d07_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c62609d07_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c62609d07_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c62609d07_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3092,7 +3116,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c62609d07_6_5"
+        "step_assertDeployedRuntimeReady_c62609d07_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3102,7 +3126,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c62609d07_7_1",
+      "step_id": "step_executeCommand_assertPalette_c62609d07_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3112,7 +3136,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c62609d07_7_1"
+        "step_executeCommand_open_c62609d07_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3123,7 +3147,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c62609d07_7_1",
+      "step_id": "step_executeCommand_filter_c62609d07_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3135,7 +3159,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c62609d07_7_1"
+        "step_executeCommand_assertPalette_c62609d07_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3145,7 +3169,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c62609d07_7_1",
+      "step_id": "step_executeCommand_assertCommand_c62609d07_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3155,7 +3179,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c62609d07_7_1"
+        "step_executeCommand_filter_c62609d07_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3166,7 +3190,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c62609d07_7_1",
+      "step_id": "step_executeCommand_execute_c62609d07_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3178,7 +3202,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c62609d07_7_1"
+        "step_executeCommand_assertCommand_c62609d07_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3188,7 +3212,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c62609d07_7_2",
+      "step_id": "step_filterOption_filter_c62609d07_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3200,7 +3224,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c62609d07_7_1"
+        "step_executeCommand_execute_c62609d07_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3210,7 +3234,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c62609d07_7_2",
+      "step_id": "step_filterOption_assertOption_c62609d07_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3220,7 +3244,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c62609d07_7_2"
+        "step_filterOption_filter_c62609d07_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3231,7 +3255,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c62609d07_7_2",
+      "step_id": "step_filterOption_confirm_c62609d07_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3243,7 +3267,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c62609d07_7_2"
+        "step_filterOption_assertOption_c62609d07_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3253,7 +3277,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c62609d07_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c62609d07_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3263,7 +3287,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c62609d07_7_2"
+        "step_filterOption_confirm_c62609d07_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3274,7 +3298,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c62609d07_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c62609d07_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3288,7 +3312,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c62609d07_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c62609d07_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3298,7 +3322,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c62609d07_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c62609d07_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3310,7 +3334,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c62609d07_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c62609d07_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3320,7 +3344,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c62609d07_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c62609d07_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3332,7 +3356,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c62609d07_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c62609d07_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3342,7 +3366,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c62609d07_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c62609d07_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3352,7 +3376,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c62609d07_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c62609d07_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3363,7 +3387,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c62609d07_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c62609d07_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3375,7 +3399,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c62609d07_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c62609d07_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3386,7 +3410,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c62609d07_7_4",
+      "step_id": "step_assertReady_assertReady_c62609d07_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3396,7 +3420,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c62609d07_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c62609d07_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3417,7 +3441,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c62609d07_7_4"
+        "step_assertReady_assertReady_c62609d07_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 162,
+    "total_steps": 163,
     "name": "weather-js-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -153,25 +153,26 @@
       "step_clickPrimaryAction_assertDialog_cb070a9e1_6_4",
       "step_clickPrimaryAction_click_cb070a9e1_6_4",
       "step_assertNotificationContains_assert_cb070a9e1_6_5",
-      "step_executeCommand_open_cb070a9e1_7_1",
-      "step_executeCommand_assertPalette_cb070a9e1_7_1",
-      "step_executeCommand_filter_cb070a9e1_7_1",
-      "step_executeCommand_assertCommand_cb070a9e1_7_1",
-      "step_executeCommand_execute_cb070a9e1_7_1",
-      "step_filterOption_filter_cb070a9e1_7_2",
-      "step_filterOption_assertOption_cb070a9e1_7_2",
-      "step_filterOption_confirm_cb070a9e1_7_2",
-      "step_browserM365SignIn_assertAccount_cb070a9e1_7_3",
-      "step_browserM365SignIn_focusAccount_cb070a9e1_7_3",
-      "step_browserM365SignIn_enterAccount_cb070a9e1_7_3",
-      "step_browserM365SignIn_submitAccount_cb070a9e1_7_3",
-      "step_browserM365SignIn_assertPassword_cb070a9e1_7_3",
-      "step_browserM365SignIn_enterPassword_cb070a9e1_7_3",
-      "step_browserM365SignIn_submitPassword_cb070a9e1_7_3",
-      "step_browserM365SignIn_assertStaySignedIn_cb070a9e1_7_3",
-      "step_browserM365SignIn_confirmStaySignedIn_cb070a9e1_7_3",
-      "step_assertReady_assertReady_cb070a9e1_7_4",
-      "step_zoomOut_zoomOut_cb070a9e1_7_5",
+      "step_assertDeployedRuntimeReady_cb070a9e1_7_1",
+      "step_executeCommand_open_cb070a9e1_7_2",
+      "step_executeCommand_assertPalette_cb070a9e1_7_2",
+      "step_executeCommand_filter_cb070a9e1_7_2",
+      "step_executeCommand_assertCommand_cb070a9e1_7_2",
+      "step_executeCommand_execute_cb070a9e1_7_2",
+      "step_filterOption_filter_cb070a9e1_7_3",
+      "step_filterOption_assertOption_cb070a9e1_7_3",
+      "step_filterOption_confirm_cb070a9e1_7_3",
+      "step_browserM365SignIn_assertAccount_cb070a9e1_7_4",
+      "step_browserM365SignIn_focusAccount_cb070a9e1_7_4",
+      "step_browserM365SignIn_enterAccount_cb070a9e1_7_4",
+      "step_browserM365SignIn_submitAccount_cb070a9e1_7_4",
+      "step_browserM365SignIn_assertPassword_cb070a9e1_7_4",
+      "step_browserM365SignIn_enterPassword_cb070a9e1_7_4",
+      "step_browserM365SignIn_submitPassword_cb070a9e1_7_4",
+      "step_browserM365SignIn_assertStaySignedIn_cb070a9e1_7_4",
+      "step_browserM365SignIn_confirmStaySignedIn_cb070a9e1_7_4",
+      "step_assertReady_assertReady_cb070a9e1_7_5",
+      "step_zoomOut_zoomOut_cb070a9e1_7_6",
       "step_sendCopilotMessage_assertInput_cb070a9e1_9_1",
       "step_sendCopilotMessage_focusInput_cb070a9e1_9_1",
       "step_sendCopilotMessage_type_cb070a9e1_9_1",
@@ -3255,7 +3256,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_cb070a9e1_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_cb070a9e1_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_cb070a9e1_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_cb070a9e1_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3267,7 +3291,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_cb070a9e1_6_5"
+        "step_assertDeployedRuntimeReady_cb070a9e1_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3277,7 +3301,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_cb070a9e1_7_1",
+      "step_id": "step_executeCommand_assertPalette_cb070a9e1_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3287,7 +3311,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_cb070a9e1_7_1"
+        "step_executeCommand_open_cb070a9e1_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3298,7 +3322,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_cb070a9e1_7_1",
+      "step_id": "step_executeCommand_filter_cb070a9e1_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3310,7 +3334,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_cb070a9e1_7_1"
+        "step_executeCommand_assertPalette_cb070a9e1_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3320,7 +3344,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_cb070a9e1_7_1",
+      "step_id": "step_executeCommand_assertCommand_cb070a9e1_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3330,7 +3354,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_cb070a9e1_7_1"
+        "step_executeCommand_filter_cb070a9e1_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3341,7 +3365,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_cb070a9e1_7_1",
+      "step_id": "step_executeCommand_execute_cb070a9e1_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3353,7 +3377,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_cb070a9e1_7_1"
+        "step_executeCommand_assertCommand_cb070a9e1_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3363,7 +3387,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_cb070a9e1_7_2",
+      "step_id": "step_filterOption_filter_cb070a9e1_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3375,7 +3399,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_cb070a9e1_7_1"
+        "step_executeCommand_execute_cb070a9e1_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3385,7 +3409,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_cb070a9e1_7_2",
+      "step_id": "step_filterOption_assertOption_cb070a9e1_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3395,7 +3419,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_cb070a9e1_7_2"
+        "step_filterOption_filter_cb070a9e1_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3406,7 +3430,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_cb070a9e1_7_2",
+      "step_id": "step_filterOption_confirm_cb070a9e1_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3418,7 +3442,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_cb070a9e1_7_2"
+        "step_filterOption_assertOption_cb070a9e1_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3428,7 +3452,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_assertAccount_cb070a9e1_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3438,7 +3462,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_cb070a9e1_7_2"
+        "step_filterOption_confirm_cb070a9e1_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3449,7 +3473,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_focusAccount_cb070a9e1_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3463,7 +3487,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_cb070a9e1_7_3"
+        "step_browserM365SignIn_assertAccount_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3473,7 +3497,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_enterAccount_cb070a9e1_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3485,7 +3509,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_cb070a9e1_7_3"
+        "step_browserM365SignIn_focusAccount_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3495,7 +3519,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_submitAccount_cb070a9e1_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3507,7 +3531,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_cb070a9e1_7_3"
+        "step_browserM365SignIn_enterAccount_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3517,7 +3541,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_assertPassword_cb070a9e1_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3527,7 +3551,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_cb070a9e1_7_3"
+        "step_browserM365SignIn_submitAccount_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3538,7 +3562,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_enterPassword_cb070a9e1_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3550,7 +3574,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_cb070a9e1_7_3"
+        "step_browserM365SignIn_assertPassword_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3560,7 +3584,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_submitPassword_cb070a9e1_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3572,7 +3596,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_cb070a9e1_7_3"
+        "step_browserM365SignIn_enterPassword_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3582,7 +3606,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_cb070a9e1_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3592,7 +3616,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_cb070a9e1_7_3"
+        "step_browserM365SignIn_submitPassword_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3603,7 +3627,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cb070a9e1_7_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_cb070a9e1_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3615,7 +3639,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_cb070a9e1_7_3"
+        "step_browserM365SignIn_assertStaySignedIn_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3626,7 +3650,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_cb070a9e1_7_4",
+      "step_id": "step_assertReady_assertReady_cb070a9e1_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3636,7 +3660,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_cb070a9e1_7_3"
+        "step_browserM365SignIn_confirmStaySignedIn_cb070a9e1_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3647,7 +3671,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_cb070a9e1_7_5",
+      "step_id": "step_zoomOut_zoomOut_cb070a9e1_7_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3659,7 +3683,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_cb070a9e1_7_4"
+        "step_assertReady_assertReady_cb070a9e1_7_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3679,7 +3703,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_cb070a9e1_7_5"
+        "step_zoomOut_zoomOut_cb070a9e1_7_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 163,
+    "total_steps": 164,
     "name": "weather-js-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -153,21 +153,22 @@
       "step_clickPrimaryAction_assertDialog_c1d26615d_6_4",
       "step_clickPrimaryAction_click_c1d26615d_6_4",
       "step_assertNotificationContains_assert_c1d26615d_6_5",
-      "step_executeCommand_open_c1d26615d_7_1",
-      "step_executeCommand_assertPalette_c1d26615d_7_1",
-      "step_executeCommand_filter_c1d26615d_7_1",
-      "step_executeCommand_assertCommand_c1d26615d_7_1",
-      "step_executeCommand_execute_c1d26615d_7_1",
-      "step_filterOption_filter_c1d26615d_7_2",
-      "step_filterOption_assertOption_c1d26615d_7_2",
-      "step_filterOption_confirm_c1d26615d_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c1d26615d_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c1d26615d_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c1d26615d_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c1d26615d_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c1d26615d_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c1d26615d_7_3",
-      "step_assertReady_assertReady_c1d26615d_7_4",
+      "step_assertDeployedRuntimeReady_c1d26615d_7_1",
+      "step_executeCommand_open_c1d26615d_7_2",
+      "step_executeCommand_assertPalette_c1d26615d_7_2",
+      "step_executeCommand_filter_c1d26615d_7_2",
+      "step_executeCommand_assertCommand_c1d26615d_7_2",
+      "step_executeCommand_execute_c1d26615d_7_2",
+      "step_filterOption_filter_c1d26615d_7_3",
+      "step_filterOption_assertOption_c1d26615d_7_3",
+      "step_filterOption_confirm_c1d26615d_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c1d26615d_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c1d26615d_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c1d26615d_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c1d26615d_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c1d26615d_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c1d26615d_7_4",
+      "step_assertReady_assertReady_c1d26615d_7_5",
       "step_addAndOpenApp_assertAdd_c1d26615d_8_1",
       "step_addAndOpenApp_add_c1d26615d_8_1",
       "step_addAndOpenApp_assertAdded_c1d26615d_8_1",
@@ -3256,7 +3257,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c1d26615d_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c1d26615d_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c1d26615d_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c1d26615d_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3268,7 +3292,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c1d26615d_6_5"
+        "step_assertDeployedRuntimeReady_c1d26615d_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3278,7 +3302,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c1d26615d_7_1",
+      "step_id": "step_executeCommand_assertPalette_c1d26615d_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3288,7 +3312,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c1d26615d_7_1"
+        "step_executeCommand_open_c1d26615d_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3299,7 +3323,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c1d26615d_7_1",
+      "step_id": "step_executeCommand_filter_c1d26615d_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3311,7 +3335,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c1d26615d_7_1"
+        "step_executeCommand_assertPalette_c1d26615d_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3321,7 +3345,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c1d26615d_7_1",
+      "step_id": "step_executeCommand_assertCommand_c1d26615d_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3331,7 +3355,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c1d26615d_7_1"
+        "step_executeCommand_filter_c1d26615d_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3342,7 +3366,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c1d26615d_7_1",
+      "step_id": "step_executeCommand_execute_c1d26615d_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3354,7 +3378,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c1d26615d_7_1"
+        "step_executeCommand_assertCommand_c1d26615d_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3364,7 +3388,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c1d26615d_7_2",
+      "step_id": "step_filterOption_filter_c1d26615d_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3376,7 +3400,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c1d26615d_7_1"
+        "step_executeCommand_execute_c1d26615d_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3386,7 +3410,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c1d26615d_7_2",
+      "step_id": "step_filterOption_assertOption_c1d26615d_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3396,7 +3420,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c1d26615d_7_2"
+        "step_filterOption_filter_c1d26615d_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3407,7 +3431,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c1d26615d_7_2",
+      "step_id": "step_filterOption_confirm_c1d26615d_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3419,7 +3443,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c1d26615d_7_2"
+        "step_filterOption_assertOption_c1d26615d_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3429,7 +3453,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c1d26615d_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c1d26615d_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3439,7 +3463,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c1d26615d_7_2"
+        "step_filterOption_confirm_c1d26615d_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3450,7 +3474,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c1d26615d_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c1d26615d_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3464,7 +3488,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c1d26615d_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c1d26615d_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3474,7 +3498,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c1d26615d_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c1d26615d_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c1d26615d_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c1d26615d_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3496,7 +3520,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c1d26615d_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c1d26615d_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3508,7 +3532,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c1d26615d_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c1d26615d_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3518,7 +3542,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c1d26615d_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c1d26615d_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3528,7 +3552,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c1d26615d_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c1d26615d_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3539,7 +3563,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c1d26615d_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c1d26615d_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3551,7 +3575,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c1d26615d_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c1d26615d_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3562,7 +3586,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c1d26615d_7_4",
+      "step_id": "step_assertReady_assertReady_c1d26615d_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3572,7 +3596,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c1d26615d_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c1d26615d_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3593,7 +3617,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c1d26615d_7_4"
+        "step_assertReady_assertReady_c1d26615d_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-js-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 158,
+    "total_steps": 159,
     "name": "weather-js-openai-remote-teams",
     "description": {
       "owner": "",
@@ -148,21 +148,22 @@
       "step_clickPrimaryAction_assertDialog_c36a630d1_7_4",
       "step_clickPrimaryAction_click_c36a630d1_7_4",
       "step_assertNotificationContains_assert_c36a630d1_7_5",
-      "step_executeCommand_open_c36a630d1_8_1",
-      "step_executeCommand_assertPalette_c36a630d1_8_1",
-      "step_executeCommand_filter_c36a630d1_8_1",
-      "step_executeCommand_assertCommand_c36a630d1_8_1",
-      "step_executeCommand_execute_c36a630d1_8_1",
-      "step_filterOption_filter_c36a630d1_8_2",
-      "step_filterOption_assertOption_c36a630d1_8_2",
-      "step_filterOption_confirm_c36a630d1_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_c36a630d1_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_c36a630d1_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_c36a630d1_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_c36a630d1_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c36a630d1_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c36a630d1_8_3",
-      "step_assertReady_assertReady_c36a630d1_8_4",
+      "step_assertDeployedRuntimeReady_c36a630d1_8_1",
+      "step_executeCommand_open_c36a630d1_8_2",
+      "step_executeCommand_assertPalette_c36a630d1_8_2",
+      "step_executeCommand_filter_c36a630d1_8_2",
+      "step_executeCommand_assertCommand_c36a630d1_8_2",
+      "step_executeCommand_execute_c36a630d1_8_2",
+      "step_filterOption_filter_c36a630d1_8_3",
+      "step_filterOption_assertOption_c36a630d1_8_3",
+      "step_filterOption_confirm_c36a630d1_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_c36a630d1_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_c36a630d1_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_c36a630d1_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_c36a630d1_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c36a630d1_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c36a630d1_8_4",
+      "step_assertReady_assertReady_c36a630d1_8_5",
       "step_addAndOpenApp_assertAdd_c36a630d1_9_1",
       "step_addAndOpenApp_add_c36a630d1_9_1",
       "step_addAndOpenApp_assertAdded_c36a630d1_9_1",
@@ -3144,7 +3145,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c36a630d1_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_c36a630d1_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c36a630d1_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c36a630d1_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3156,7 +3180,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c36a630d1_7_5"
+        "step_assertDeployedRuntimeReady_c36a630d1_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3166,7 +3190,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c36a630d1_8_1",
+      "step_id": "step_executeCommand_assertPalette_c36a630d1_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3176,7 +3200,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c36a630d1_8_1"
+        "step_executeCommand_open_c36a630d1_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3187,7 +3211,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c36a630d1_8_1",
+      "step_id": "step_executeCommand_filter_c36a630d1_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3199,7 +3223,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c36a630d1_8_1"
+        "step_executeCommand_assertPalette_c36a630d1_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3209,7 +3233,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c36a630d1_8_1",
+      "step_id": "step_executeCommand_assertCommand_c36a630d1_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3219,7 +3243,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c36a630d1_8_1"
+        "step_executeCommand_filter_c36a630d1_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3230,7 +3254,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c36a630d1_8_1",
+      "step_id": "step_executeCommand_execute_c36a630d1_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3242,7 +3266,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c36a630d1_8_1"
+        "step_executeCommand_assertCommand_c36a630d1_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3252,7 +3276,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c36a630d1_8_2",
+      "step_id": "step_filterOption_filter_c36a630d1_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3264,7 +3288,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c36a630d1_8_1"
+        "step_executeCommand_execute_c36a630d1_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3274,7 +3298,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c36a630d1_8_2",
+      "step_id": "step_filterOption_assertOption_c36a630d1_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3284,7 +3308,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c36a630d1_8_2"
+        "step_filterOption_filter_c36a630d1_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3295,7 +3319,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c36a630d1_8_2",
+      "step_id": "step_filterOption_confirm_c36a630d1_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3307,7 +3331,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c36a630d1_8_2"
+        "step_filterOption_assertOption_c36a630d1_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3317,7 +3341,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c36a630d1_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c36a630d1_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3327,7 +3351,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c36a630d1_8_2"
+        "step_filterOption_confirm_c36a630d1_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3338,7 +3362,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c36a630d1_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c36a630d1_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3352,7 +3376,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c36a630d1_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_c36a630d1_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3362,7 +3386,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c36a630d1_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c36a630d1_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3374,7 +3398,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c36a630d1_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_c36a630d1_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3384,7 +3408,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c36a630d1_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c36a630d1_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3396,7 +3420,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c36a630d1_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_c36a630d1_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3406,7 +3430,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c36a630d1_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c36a630d1_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3416,7 +3440,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c36a630d1_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_c36a630d1_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3427,7 +3451,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c36a630d1_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c36a630d1_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3439,7 +3463,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c36a630d1_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c36a630d1_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3450,7 +3474,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c36a630d1_8_4",
+      "step_id": "step_assertReady_assertReady_c36a630d1_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3460,7 +3484,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c36a630d1_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c36a630d1_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3481,7 +3505,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c36a630d1_8_4"
+        "step_assertReady_assertReady_c36a630d1_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-remote-copilot.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-remote-copilot.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 164,
+    "total_steps": 165,
     "name": "weather-ts-azure-openai-remote-copilot",
     "description": {
       "owner": "",
@@ -155,25 +155,26 @@
       "step_clickPrimaryAction_assertDialog_c41d76889_6_4",
       "step_clickPrimaryAction_click_c41d76889_6_4",
       "step_assertNotificationContains_assert_c41d76889_6_5",
-      "step_executeCommand_open_c41d76889_7_1",
-      "step_executeCommand_assertPalette_c41d76889_7_1",
-      "step_executeCommand_filter_c41d76889_7_1",
-      "step_executeCommand_assertCommand_c41d76889_7_1",
-      "step_executeCommand_execute_c41d76889_7_1",
-      "step_filterOption_filter_c41d76889_7_2",
-      "step_filterOption_assertOption_c41d76889_7_2",
-      "step_filterOption_confirm_c41d76889_7_2",
-      "step_browserM365SignIn_assertAccount_c41d76889_7_3",
-      "step_browserM365SignIn_focusAccount_c41d76889_7_3",
-      "step_browserM365SignIn_enterAccount_c41d76889_7_3",
-      "step_browserM365SignIn_submitAccount_c41d76889_7_3",
-      "step_browserM365SignIn_assertPassword_c41d76889_7_3",
-      "step_browserM365SignIn_enterPassword_c41d76889_7_3",
-      "step_browserM365SignIn_submitPassword_c41d76889_7_3",
-      "step_browserM365SignIn_assertStaySignedIn_c41d76889_7_3",
-      "step_browserM365SignIn_confirmStaySignedIn_c41d76889_7_3",
-      "step_assertReady_assertReady_c41d76889_7_4",
-      "step_zoomOut_zoomOut_c41d76889_7_5",
+      "step_assertDeployedRuntimeReady_c41d76889_7_1",
+      "step_executeCommand_open_c41d76889_7_2",
+      "step_executeCommand_assertPalette_c41d76889_7_2",
+      "step_executeCommand_filter_c41d76889_7_2",
+      "step_executeCommand_assertCommand_c41d76889_7_2",
+      "step_executeCommand_execute_c41d76889_7_2",
+      "step_filterOption_filter_c41d76889_7_3",
+      "step_filterOption_assertOption_c41d76889_7_3",
+      "step_filterOption_confirm_c41d76889_7_3",
+      "step_browserM365SignIn_assertAccount_c41d76889_7_4",
+      "step_browserM365SignIn_focusAccount_c41d76889_7_4",
+      "step_browserM365SignIn_enterAccount_c41d76889_7_4",
+      "step_browserM365SignIn_submitAccount_c41d76889_7_4",
+      "step_browserM365SignIn_assertPassword_c41d76889_7_4",
+      "step_browserM365SignIn_enterPassword_c41d76889_7_4",
+      "step_browserM365SignIn_submitPassword_c41d76889_7_4",
+      "step_browserM365SignIn_assertStaySignedIn_c41d76889_7_4",
+      "step_browserM365SignIn_confirmStaySignedIn_c41d76889_7_4",
+      "step_assertReady_assertReady_c41d76889_7_5",
+      "step_zoomOut_zoomOut_c41d76889_7_6",
       "step_sendCopilotMessage_assertInput_c41d76889_9_1",
       "step_sendCopilotMessage_focusInput_c41d76889_9_1",
       "step_sendCopilotMessage_type_c41d76889_9_1",
@@ -3303,7 +3304,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c41d76889_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c41d76889_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c41d76889_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c41d76889_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3315,7 +3339,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c41d76889_6_5"
+        "step_assertDeployedRuntimeReady_c41d76889_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3325,7 +3349,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c41d76889_7_1",
+      "step_id": "step_executeCommand_assertPalette_c41d76889_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3335,7 +3359,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c41d76889_7_1"
+        "step_executeCommand_open_c41d76889_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3346,7 +3370,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c41d76889_7_1",
+      "step_id": "step_executeCommand_filter_c41d76889_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3358,7 +3382,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c41d76889_7_1"
+        "step_executeCommand_assertPalette_c41d76889_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3368,7 +3392,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c41d76889_7_1",
+      "step_id": "step_executeCommand_assertCommand_c41d76889_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3378,7 +3402,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c41d76889_7_1"
+        "step_executeCommand_filter_c41d76889_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3389,7 +3413,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c41d76889_7_1",
+      "step_id": "step_executeCommand_execute_c41d76889_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3401,7 +3425,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c41d76889_7_1"
+        "step_executeCommand_assertCommand_c41d76889_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3411,7 +3435,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c41d76889_7_2",
+      "step_id": "step_filterOption_filter_c41d76889_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3423,7 +3447,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c41d76889_7_1"
+        "step_executeCommand_execute_c41d76889_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3433,7 +3457,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c41d76889_7_2",
+      "step_id": "step_filterOption_assertOption_c41d76889_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3443,7 +3467,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c41d76889_7_2"
+        "step_filterOption_filter_c41d76889_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c41d76889_7_2",
+      "step_id": "step_filterOption_confirm_c41d76889_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3466,7 +3490,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c41d76889_7_2"
+        "step_filterOption_assertOption_c41d76889_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3476,7 +3500,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertAccount_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_assertAccount_c41d76889_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3486,7 +3510,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c41d76889_7_2"
+        "step_filterOption_confirm_c41d76889_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3497,7 +3521,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_focusAccount_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_focusAccount_c41d76889_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3511,7 +3535,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertAccount_c41d76889_7_3"
+        "step_browserM365SignIn_assertAccount_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3521,7 +3545,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterAccount_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_enterAccount_c41d76889_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3533,7 +3557,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_focusAccount_c41d76889_7_3"
+        "step_browserM365SignIn_focusAccount_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3543,7 +3567,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitAccount_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_submitAccount_c41d76889_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3555,7 +3579,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterAccount_c41d76889_7_3"
+        "step_browserM365SignIn_enterAccount_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3565,7 +3589,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertPassword_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_assertPassword_c41d76889_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3575,7 +3599,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitAccount_c41d76889_7_3"
+        "step_browserM365SignIn_submitAccount_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3586,7 +3610,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_enterPassword_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_enterPassword_c41d76889_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3598,7 +3622,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertPassword_c41d76889_7_3"
+        "step_browserM365SignIn_assertPassword_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3608,7 +3632,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_submitPassword_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_submitPassword_c41d76889_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3620,7 +3644,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_enterPassword_c41d76889_7_3"
+        "step_browserM365SignIn_enterPassword_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3630,7 +3654,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_assertStaySignedIn_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_assertStaySignedIn_c41d76889_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3640,7 +3664,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_submitPassword_c41d76889_7_3"
+        "step_browserM365SignIn_submitPassword_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3651,7 +3675,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c41d76889_7_3",
+      "step_id": "step_browserM365SignIn_confirmStaySignedIn_c41d76889_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3663,7 +3687,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_assertStaySignedIn_c41d76889_7_3"
+        "step_browserM365SignIn_assertStaySignedIn_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3674,7 +3698,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c41d76889_7_4",
+      "step_id": "step_assertReady_assertReady_c41d76889_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3684,7 +3708,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365SignIn_confirmStaySignedIn_c41d76889_7_3"
+        "step_browserM365SignIn_confirmStaySignedIn_c41d76889_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3695,7 +3719,7 @@
       ]
     },
     {
-      "step_id": "step_zoomOut_zoomOut_c41d76889_7_5",
+      "step_id": "step_zoomOut_zoomOut_c41d76889_7_6",
       "agent": "interaction",
       "tool": "keyboard_shortcut",
       "parameters": {
@@ -3707,7 +3731,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c41d76889_7_4"
+        "step_assertReady_assertReady_c41d76889_7_5"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3727,7 +3751,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_zoomOut_zoomOut_c41d76889_7_5"
+        "step_zoomOut_zoomOut_c41d76889_7_6"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-azure-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 165,
+    "total_steps": 166,
     "name": "weather-ts-azure-openai-remote-teams",
     "description": {
       "owner": "",
@@ -155,21 +155,22 @@
       "step_clickPrimaryAction_assertDialog_c16c2d022_6_4",
       "step_clickPrimaryAction_click_c16c2d022_6_4",
       "step_assertNotificationContains_assert_c16c2d022_6_5",
-      "step_executeCommand_open_c16c2d022_7_1",
-      "step_executeCommand_assertPalette_c16c2d022_7_1",
-      "step_executeCommand_filter_c16c2d022_7_1",
-      "step_executeCommand_assertCommand_c16c2d022_7_1",
-      "step_executeCommand_execute_c16c2d022_7_1",
-      "step_filterOption_filter_c16c2d022_7_2",
-      "step_filterOption_assertOption_c16c2d022_7_2",
-      "step_filterOption_confirm_c16c2d022_7_2",
-      "step_browserM365PasswordSignIn_assertPassword_c16c2d022_7_3",
-      "step_browserM365PasswordSignIn_focusPassword_c16c2d022_7_3",
-      "step_browserM365PasswordSignIn_enterPassword_c16c2d022_7_3",
-      "step_browserM365PasswordSignIn_submitPassword_c16c2d022_7_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c16c2d022_7_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c16c2d022_7_3",
-      "step_assertReady_assertReady_c16c2d022_7_4",
+      "step_assertDeployedRuntimeReady_c16c2d022_7_1",
+      "step_executeCommand_open_c16c2d022_7_2",
+      "step_executeCommand_assertPalette_c16c2d022_7_2",
+      "step_executeCommand_filter_c16c2d022_7_2",
+      "step_executeCommand_assertCommand_c16c2d022_7_2",
+      "step_executeCommand_execute_c16c2d022_7_2",
+      "step_filterOption_filter_c16c2d022_7_3",
+      "step_filterOption_assertOption_c16c2d022_7_3",
+      "step_filterOption_confirm_c16c2d022_7_3",
+      "step_browserM365PasswordSignIn_assertPassword_c16c2d022_7_4",
+      "step_browserM365PasswordSignIn_focusPassword_c16c2d022_7_4",
+      "step_browserM365PasswordSignIn_enterPassword_c16c2d022_7_4",
+      "step_browserM365PasswordSignIn_submitPassword_c16c2d022_7_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c16c2d022_7_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c16c2d022_7_4",
+      "step_assertReady_assertReady_c16c2d022_7_5",
       "step_addAndOpenApp_assertAdd_c16c2d022_8_1",
       "step_addAndOpenApp_add_c16c2d022_8_1",
       "step_addAndOpenApp_assertAdded_c16c2d022_8_1",
@@ -3304,7 +3305,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c16c2d022_7_1",
+      "step_id": "step_assertDeployedRuntimeReady_c16c2d022_7_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c16c2d022_6_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c16c2d022_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3316,7 +3340,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c16c2d022_6_5"
+        "step_assertDeployedRuntimeReady_c16c2d022_7_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3326,7 +3350,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c16c2d022_7_1",
+      "step_id": "step_executeCommand_assertPalette_c16c2d022_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3336,7 +3360,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c16c2d022_7_1"
+        "step_executeCommand_open_c16c2d022_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3347,7 +3371,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c16c2d022_7_1",
+      "step_id": "step_executeCommand_filter_c16c2d022_7_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3359,7 +3383,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c16c2d022_7_1"
+        "step_executeCommand_assertPalette_c16c2d022_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3369,7 +3393,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c16c2d022_7_1",
+      "step_id": "step_executeCommand_assertCommand_c16c2d022_7_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3379,7 +3403,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c16c2d022_7_1"
+        "step_executeCommand_filter_c16c2d022_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3390,7 +3414,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c16c2d022_7_1",
+      "step_id": "step_executeCommand_execute_c16c2d022_7_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3402,7 +3426,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c16c2d022_7_1"
+        "step_executeCommand_assertCommand_c16c2d022_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3412,7 +3436,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c16c2d022_7_2",
+      "step_id": "step_filterOption_filter_c16c2d022_7_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3424,7 +3448,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c16c2d022_7_1"
+        "step_executeCommand_execute_c16c2d022_7_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3434,7 +3458,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c16c2d022_7_2",
+      "step_id": "step_filterOption_assertOption_c16c2d022_7_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3444,7 +3468,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c16c2d022_7_2"
+        "step_filterOption_filter_c16c2d022_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3455,7 +3479,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c16c2d022_7_2",
+      "step_id": "step_filterOption_confirm_c16c2d022_7_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3467,7 +3491,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c16c2d022_7_2"
+        "step_filterOption_assertOption_c16c2d022_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3477,7 +3501,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c16c2d022_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c16c2d022_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3487,7 +3511,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c16c2d022_7_2"
+        "step_filterOption_confirm_c16c2d022_7_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3498,7 +3522,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c16c2d022_7_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c16c2d022_7_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3512,7 +3536,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c16c2d022_7_3"
+        "step_browserM365PasswordSignIn_assertPassword_c16c2d022_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3522,7 +3546,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c16c2d022_7_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c16c2d022_7_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3534,7 +3558,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c16c2d022_7_3"
+        "step_browserM365PasswordSignIn_focusPassword_c16c2d022_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3544,7 +3568,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c16c2d022_7_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c16c2d022_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3556,7 +3580,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c16c2d022_7_3"
+        "step_browserM365PasswordSignIn_enterPassword_c16c2d022_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3566,7 +3590,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c16c2d022_7_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c16c2d022_7_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3576,7 +3600,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c16c2d022_7_3"
+        "step_browserM365PasswordSignIn_submitPassword_c16c2d022_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3587,7 +3611,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c16c2d022_7_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c16c2d022_7_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3599,7 +3623,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c16c2d022_7_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c16c2d022_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3610,7 +3634,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c16c2d022_7_4",
+      "step_id": "step_assertReady_assertReady_c16c2d022_7_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3620,7 +3644,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c16c2d022_7_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c16c2d022_7_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3641,7 +3665,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c16c2d022_7_4"
+        "step_assertReady_assertReady_c16c2d022_7_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-openai-remote-teams.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/weather-agent--weather-ts-openai-remote-teams.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 30,
       "precondition_retry_interval": 1
     },
-    "total_steps": 160,
+    "total_steps": 161,
     "name": "weather-ts-openai-remote-teams",
     "description": {
       "owner": "",
@@ -150,21 +150,22 @@
       "step_clickPrimaryAction_assertDialog_c3f41809f_7_4",
       "step_clickPrimaryAction_click_c3f41809f_7_4",
       "step_assertNotificationContains_assert_c3f41809f_7_5",
-      "step_executeCommand_open_c3f41809f_8_1",
-      "step_executeCommand_assertPalette_c3f41809f_8_1",
-      "step_executeCommand_filter_c3f41809f_8_1",
-      "step_executeCommand_assertCommand_c3f41809f_8_1",
-      "step_executeCommand_execute_c3f41809f_8_1",
-      "step_filterOption_filter_c3f41809f_8_2",
-      "step_filterOption_assertOption_c3f41809f_8_2",
-      "step_filterOption_confirm_c3f41809f_8_2",
-      "step_browserM365PasswordSignIn_assertPassword_c3f41809f_8_3",
-      "step_browserM365PasswordSignIn_focusPassword_c3f41809f_8_3",
-      "step_browserM365PasswordSignIn_enterPassword_c3f41809f_8_3",
-      "step_browserM365PasswordSignIn_submitPassword_c3f41809f_8_3",
-      "step_browserM365PasswordSignIn_assertStaySignedIn_c3f41809f_8_3",
-      "step_browserM365PasswordSignIn_confirmStaySignedIn_c3f41809f_8_3",
-      "step_assertReady_assertReady_c3f41809f_8_4",
+      "step_assertDeployedRuntimeReady_c3f41809f_8_1",
+      "step_executeCommand_open_c3f41809f_8_2",
+      "step_executeCommand_assertPalette_c3f41809f_8_2",
+      "step_executeCommand_filter_c3f41809f_8_2",
+      "step_executeCommand_assertCommand_c3f41809f_8_2",
+      "step_executeCommand_execute_c3f41809f_8_2",
+      "step_filterOption_filter_c3f41809f_8_3",
+      "step_filterOption_assertOption_c3f41809f_8_3",
+      "step_filterOption_confirm_c3f41809f_8_3",
+      "step_browserM365PasswordSignIn_assertPassword_c3f41809f_8_4",
+      "step_browserM365PasswordSignIn_focusPassword_c3f41809f_8_4",
+      "step_browserM365PasswordSignIn_enterPassword_c3f41809f_8_4",
+      "step_browserM365PasswordSignIn_submitPassword_c3f41809f_8_4",
+      "step_browserM365PasswordSignIn_assertStaySignedIn_c3f41809f_8_4",
+      "step_browserM365PasswordSignIn_confirmStaySignedIn_c3f41809f_8_4",
+      "step_assertReady_assertReady_c3f41809f_8_5",
       "step_addAndOpenApp_assertAdd_c3f41809f_9_1",
       "step_addAndOpenApp_add_c3f41809f_9_1",
       "step_addAndOpenApp_assertAdded_c3f41809f_9_1",
@@ -3192,7 +3193,30 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_open_c3f41809f_8_1",
+      "step_id": "step_assertDeployedRuntimeReady_c3f41809f_8_1",
+      "agent": "code",
+      "tool": "",
+      "parameters": {
+        "sample": "=== Generated Script ===\nLanguage: bash\n\n```bash\nset -euo pipefail\nPROJECT_DIR=\"/home/vscode/AgentsToolkitProjects/${{var:app_name}}\" python3 - <<'PY'\nimport os\nfrom pathlib import Path\nfrom urllib.error import HTTPError, URLError\nfrom urllib.parse import urlsplit, urlunsplit\nfrom urllib.request import HTTPRedirectHandler, Request, build_opener\n\nproject = Path(os.environ[\"PROJECT_DIR\"]).resolve()\nenvironment = project / \"env\" / \".env.dev\"\nvalues = []\nfor raw_line in environment.read_text(encoding=\"utf-8\").splitlines():\n    line = raw_line.strip()\n    if not line or line.startswith(\"#\"):\n        continue\n    name, separator, value = line.partition(\"=\")\n    if separator and name.strip() == \"BOT_ENDPOINT\":\n        values.append(value.strip())\nif len(values) != 1 or not values[0]:\n    raise AssertionError(\"The deployed bot endpoint is unavailable\")\nendpoint = values[0]\nif len(endpoint) >= 2 and endpoint[0] == endpoint[-1] and endpoint[0] in {\"'\", '\"'}:\n    endpoint = endpoint[1:-1]\ntry:\n    parsed = urlsplit(endpoint)\n    if (\n        parsed.scheme != \"https\"\n        or not parsed.hostname\n        or not parsed.hostname.endswith(\".azurewebsites.net\")\n        or parsed.username is not None\n        or parsed.password is not None\n        or parsed.port is not None\n        or parsed.path not in {\"\", \"/\"}\n        or parsed.query\n        or parsed.fragment\n    ):\n        raise ValueError\nexcept ValueError:\n    raise AssertionError(\"The deployed bot endpoint is invalid\") from None\nurl = urlunsplit((\"https\", parsed.netloc, \"/api/messages\", \"\", \"\"))\nrequest = Request(\n    url,\n    data=b\"\",\n    headers={\"Content-Type\": \"application/json\"},\n    method=\"POST\",\n)\n\nclass NoRedirect(HTTPRedirectHandler):\n    def redirect_request(self, req, fp, code, msg, headers, newurl):\n        return None\n\ntry:\n    with build_opener(NoRedirect).open(request, timeout=15) as response:\n        status = response.status\nexcept HTTPError as error:\n    status = error.code\nexcept (OSError, URLError, ValueError):\n    raise AssertionError(\"The deployed bot runtime is not ready\") from None\nif status not in {400, 401, 403, 415}:\n    raise AssertionError(\"The deployed bot runtime is not ready\")\nPY\n```"
+      },
+      "description": "@code execute the supplied generated bash script exactly as authored and read its exact PROJECT_DIR under /home/vscode/AgentsToolkitProjects/ from that script; verify that the deployed bot runtime owns its message route, do not use /workspace, and do not log the endpoint or environment file contents.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [
+        "step_assertNotificationContains_assert_c3f41809f_7_5"
+      ],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "component:workspace",
+        "readiness:deployed-runtime",
+        "step_retry_timeout:600"
+      ]
+    },
+    {
+      "step_id": "step_executeCommand_open_c3f41809f_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3204,7 +3228,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertNotificationContains_assert_c3f41809f_7_5"
+        "step_assertDeployedRuntimeReady_c3f41809f_8_1"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3214,7 +3238,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertPalette_c3f41809f_8_1",
+      "step_id": "step_executeCommand_assertPalette_c3f41809f_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3224,7 +3248,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_open_c3f41809f_8_1"
+        "step_executeCommand_open_c3f41809f_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3235,7 +3259,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_filter_c3f41809f_8_1",
+      "step_id": "step_executeCommand_filter_c3f41809f_8_2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3247,7 +3271,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertPalette_c3f41809f_8_1"
+        "step_executeCommand_assertPalette_c3f41809f_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3257,7 +3281,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_assertCommand_c3f41809f_8_1",
+      "step_id": "step_executeCommand_assertCommand_c3f41809f_8_2",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3267,7 +3291,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_filter_c3f41809f_8_1"
+        "step_executeCommand_filter_c3f41809f_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3278,7 +3302,7 @@
       ]
     },
     {
-      "step_id": "step_executeCommand_execute_c3f41809f_8_1",
+      "step_id": "step_executeCommand_execute_c3f41809f_8_2",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3290,7 +3314,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_assertCommand_c3f41809f_8_1"
+        "step_executeCommand_assertCommand_c3f41809f_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3300,7 +3324,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_filter_c3f41809f_8_2",
+      "step_id": "step_filterOption_filter_c3f41809f_8_3",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3312,7 +3336,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_executeCommand_execute_c3f41809f_8_1"
+        "step_executeCommand_execute_c3f41809f_8_2"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3322,7 +3346,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_assertOption_c3f41809f_8_2",
+      "step_id": "step_filterOption_assertOption_c3f41809f_8_3",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3332,7 +3356,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_filter_c3f41809f_8_2"
+        "step_filterOption_filter_c3f41809f_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3343,7 +3367,7 @@
       ]
     },
     {
-      "step_id": "step_filterOption_confirm_c3f41809f_8_2",
+      "step_id": "step_filterOption_confirm_c3f41809f_8_3",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3355,7 +3379,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_assertOption_c3f41809f_8_2"
+        "step_filterOption_assertOption_c3f41809f_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3365,7 +3389,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertPassword_c3f41809f_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertPassword_c3f41809f_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3375,7 +3399,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_filterOption_confirm_c3f41809f_8_2"
+        "step_filterOption_confirm_c3f41809f_8_3"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3386,7 +3410,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_focusPassword_c3f41809f_8_3",
+      "step_id": "step_browserM365PasswordSignIn_focusPassword_c3f41809f_8_4",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
@@ -3400,7 +3424,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertPassword_c3f41809f_8_3"
+        "step_browserM365PasswordSignIn_assertPassword_c3f41809f_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3410,7 +3434,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_enterPassword_c3f41809f_8_3",
+      "step_id": "step_browserM365PasswordSignIn_enterPassword_c3f41809f_8_4",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
@@ -3422,7 +3446,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_focusPassword_c3f41809f_8_3"
+        "step_browserM365PasswordSignIn_focusPassword_c3f41809f_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3432,7 +3456,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_submitPassword_c3f41809f_8_3",
+      "step_id": "step_browserM365PasswordSignIn_submitPassword_c3f41809f_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3444,7 +3468,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_enterPassword_c3f41809f_8_3"
+        "step_browserM365PasswordSignIn_enterPassword_c3f41809f_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3454,7 +3478,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c3f41809f_8_3",
+      "step_id": "step_browserM365PasswordSignIn_assertStaySignedIn_c3f41809f_8_4",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3464,7 +3488,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_submitPassword_c3f41809f_8_3"
+        "step_browserM365PasswordSignIn_submitPassword_c3f41809f_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3475,7 +3499,7 @@
       ]
     },
     {
-      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c3f41809f_8_3",
+      "step_id": "step_browserM365PasswordSignIn_confirmStaySignedIn_c3f41809f_8_4",
       "agent": "interaction",
       "tool": "key_press",
       "parameters": {
@@ -3487,7 +3511,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_assertStaySignedIn_c3f41809f_8_3"
+        "step_browserM365PasswordSignIn_assertStaySignedIn_c3f41809f_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3498,7 +3522,7 @@
       ]
     },
     {
-      "step_id": "step_assertReady_assertReady_c3f41809f_8_4",
+      "step_id": "step_assertReady_assertReady_c3f41809f_8_5",
       "agent": "assertion",
       "tool": "",
       "parameters": {},
@@ -3508,7 +3532,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_browserM365PasswordSignIn_confirmStaySignedIn_c3f41809f_8_3"
+        "step_browserM365PasswordSignIn_confirmStaySignedIn_c3f41809f_8_4"
       ],
       "preconditions": [],
       "postconditions": [],
@@ -3529,7 +3553,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [
-        "step_assertReady_assertReady_c3f41809f_8_4"
+        "step_assertReady_assertReady_c3f41809f_8_5"
       ],
       "preconditions": [],
       "postconditions": [],

--- a/templates/v4/create/basic-custom-engine-agent/content/python/src/agent.py.tpl
+++ b/templates/v4/create/basic-custom-engine-agent/content/python/src/agent.py.tpl
@@ -75,6 +75,7 @@ adapter = CloudAdapter(connection_manager=connection_manager)
 agent_app = AgentApplication[TurnState](
     storage=storage,
     adapter=adapter,
+    connection_manager=connection_manager,
     **agents_sdk_config
 )
 


### PR DESCRIPTION
## Summary

- pass the generated MSAL connection manager to the V4 Python `AgentApplication`, matching the working V3 template
- add `SCN-CREATE-BASIC-CEA-07` to document the Python authorization compatibility requirement
- add a V3/V4 compatibility regression test over the rendered `AgentApplication` arguments

## Root cause

The V4 Python basic custom engine agent passed `connection_manager` to `CloudAdapter` but omitted it from `AgentApplication`. The generated app therefore failed at startup with `AgentApplication requires an Authorization instance`, which surfaced downstream as playground and local Teams readiness failures.

## Validation

- `cd packages/fx-core && pnpm run test:unit:vitest -- tests/v4/scenarios` (31 files, 223 tests passed)
- `cd packages/fx-core && pnpm run build`
- targeted ESLint for `createBasicCustomEngineAgent.test.ts`
- targeted Prettier check for the scenario test and spec
- `git diff --check`

## Scope

Shared login components and generated vscuse plans are unchanged. The separate remote sign-in evaluator failure is not addressed by this product fix.