### PR TITLE
fix(cli): allow auth list to target one account type

### DIFF
--- a/docs/03-specs/operations/auth/list-account-status.md
+++ b/docs/03-specs/operations/auth/list-account-status.md
@@ -1,0 +1,66 @@
+# List Account Status
+
+- **Status:** Approved
+- **Domain:** Authentication
+- **Owner:** Microsoft 365 Agents Toolkit maintainers
+- **Requirement source:** WIQD CI/CD investigation for `gim-home/wiqd#1490`
+- **Product impact:** Existing `atk auth list` behavior remains unchanged; callers may limit the
+  status lookup to Microsoft 365 or Azure.
+
+## Purpose
+
+Report authentication status without consulting an unrelated account provider. This allows
+non-interactive callers that require only Microsoft 365 authentication to avoid Azure status
+work and any Azure authentication side effects.
+
+## Inputs
+
+| Input   | Type              | Required | Description                                     |
+| ------- | ----------------- | -------: | ----------------------------------------------- |
+| service | `m365` \| `azure` |       no | Account provider whose status should be listed. |
+
+## Outputs
+
+The command displays status information for the requested provider. When `service` is omitted,
+the command displays both providers in the existing Microsoft 365-then-Azure order.
+
+## Acceptance Criteria
+
+| ID              | Runtime | Purpose               | Gate     | Harness           | Given                                            | When                               | Then                                                                                      |
+| --------------- | ------- | --------------------- | -------- | ----------------- | ------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| AUTH-LIST-AC-01 | L1      | operation-integration | required | CliCommandHarness | No service is supplied                           | `atk auth list` runs               | Microsoft 365 and Azure status are both queried, preserving existing behavior and order.  |
+| AUTH-LIST-AC-02 | L1      | operation-integration | required | CliCommandHarness | `m365` is supplied                               | The command runs                   | Only Microsoft 365 status is queried; no Azure provider method is called.                 |
+| AUTH-LIST-AC-03 | L1      | operation-integration | required | CliCommandHarness | `azure` is supplied                              | The command runs                   | Only Azure status is queried; no Microsoft 365 provider method is called.                 |
+| AUTH-LIST-AC-04 | L1      | operation-integration | required | CliCommandHarness | A value other than `m365` or `azure` is supplied | Argument parsing runs              | The command rejects the value before invoking either provider.                            |
+| AUTH-LIST-AC-05 | L2      | CLI-E2E               | tracked  | cli-matrix        | M365 username/password CI credentials exist      | `atk auth list m365 -i false` runs | The command completes without displaying an Azure or interactive authentication prompt.   |
+| AUTH-LIST-AC-06 | L1      | operation-integration | required | CliCommandHarness | The requested `m365` account is signed out       | `atk auth list m365` runs          | The guidance names only `atk auth login m365`; it does not mention Azure login.           |
+| AUTH-LIST-AC-07 | L1      | operation-integration | required | CliCommandHarness | The requested `azure` account is signed out      | `atk auth list azure` runs         | The guidance names only `atk auth login azure`; it does not mention Microsoft 365 login.  |
+| AUTH-LIST-AC-08 | L1      | operation-integration | required | CliCommandHarness | A service positional argument is supplied        | `atk auth list <service>` runs     | Status mode is non-interactive by default, so the CLI preserves and applies the argument. |
+
+## Flow
+
+```mermaid
+flowchart TD
+  A[Receive optional service] --> B{service}
+  B -- omitted --> C[Query Microsoft 365]
+  C --> D[Query Azure]
+  B -- m365 --> E[Query Microsoft 365 only]
+  B -- azure --> F[Query Azure only]
+```
+
+## Boundary
+
+This operation does not change login, logout, token acquisition, credential storage, or the
+default output of `atk auth list`. It does not repair provider-specific status implementations;
+it prevents an unrequested provider from participating in a scoped status lookup.
+
+## Invariants
+
+1. Omitting `service` preserves the existing two-provider behavior and ordering.
+2. A scoped status lookup never invokes methods on the unrequested provider.
+3. Status lookup remains non-interactive when `-i false` is supplied.
+4. Only `m365` and `azure` are accepted service values.
+5. Signed-out guidance is scoped to the requested provider; unscoped guidance continues to name
+   both providers.
+6. Account status is non-interactive by default so positional service arguments are not discarded
+   by the interactive command engine.

--- a/packages/cli/src/commands/models/accountShow.ts
+++ b/packages/cli/src/commands/models/accountShow.ts
@@ -7,7 +7,7 @@ import {
   featureFlagManager,
   FeatureFlags,
 } from "@microsoft/teamsfx-core";
-import { TextType, colorize } from "../../colorize";
+import { TextType, colorize, replaceTemplateString } from "../../colorize";
 import AzureTokenProvider, { getAzureProvider } from "../../commonlib/azureLogin";
 import AzureTokenCIProvider from "../../commonlib/azureLoginCI";
 import { checkIsOnline } from "../../commonlib/codeFlowLogin";
@@ -140,38 +140,69 @@ export const accountShowCommand: CLICommand = {
   name: "list",
   aliases: ["show"],
   description: commands["auth.show"].description,
+  arguments: [
+    {
+      type: "string",
+      name: "service",
+      description: commands["auth.show"].arguments.service,
+      choices: ["azure", "m365"],
+      required: false,
+    },
+  ],
   telemetry: {
     event: TelemetryEvent.AccountShow,
   },
+  defaultInteractiveOption: false,
   handler: async (ctx) => {
-    const m365StatusRes = await M365TokenProvider.getStatus({ scopes: AppStudioScopes() });
-    if (m365StatusRes.isErr()) {
-      return err(m365StatusRes.error);
-    }
-    const m365Status = m365StatusRes.value;
-    if (m365Status.status === signedIn) {
-      (await accountUtils.checkIsOnline())
-        ? await accountUtils.outputM365Info("show")
-        : accountUtils.outputAccountInfoOffline(
-            "Microsoft 365",
-            getUsernameFromClaims(m365Status.accountInfo as Record<string, unknown>)
-          );
+    const service = ctx.argumentValues[0];
+    const listM365 = service === undefined || service === "m365";
+    const listAzure = service === undefined || service === "azure";
+    let m365SignedIn = false;
+    let azureSignedIn = false;
+
+    if (typeof service === "string") {
+      ctx.telemetryProperties.service = service;
     }
 
-    const azureStatus = await AzureTokenProvider.getStatus();
-    if (azureStatus.status === signedIn) {
-      (await accountUtils.checkIsOnline())
-        ? await accountUtils.outputAzureInfo("show")
-        : accountUtils.outputAccountInfoOffline(
-            "Azure",
-            getUsernameFromClaims(azureStatus.accountInfo as Record<string, unknown>)
-          );
+    if (listM365) {
+      const m365StatusRes = await M365TokenProvider.getStatus({ scopes: AppStudioScopes() });
+      if (m365StatusRes.isErr()) {
+        return err(m365StatusRes.error);
+      }
+      const m365Status = m365StatusRes.value;
+      m365SignedIn = m365Status.status === signedIn;
+      if (m365SignedIn) {
+        (await accountUtils.checkIsOnline())
+          ? await accountUtils.outputM365Info("show")
+          : accountUtils.outputAccountInfoOffline(
+              "Microsoft 365",
+              getUsernameFromClaims(m365Status.accountInfo as Record<string, unknown>)
+            );
+      }
     }
 
-    if (m365Status.status !== signedIn && azureStatus.status !== signedIn) {
-      logger.info(
-        `Use \`${process.env.TEAMSFX_CLI_BIN_NAME} auth login azure\` or \`${process.env.TEAMSFX_CLI_BIN_NAME} auth login m365\` to log in to Azure or Microsoft 365 account.`
-      );
+    if (listAzure) {
+      const azureStatus = await AzureTokenProvider.getStatus();
+      azureSignedIn = azureStatus.status === signedIn;
+      if (azureSignedIn) {
+        (await accountUtils.checkIsOnline())
+          ? await accountUtils.outputAzureInfo("show")
+          : accountUtils.outputAccountInfoOffline(
+              "Azure",
+              getUsernameFromClaims(azureStatus.accountInfo as Record<string, unknown>)
+            );
+      }
+    }
+
+    if (!m365SignedIn && !azureSignedIn) {
+      const cliName = process.env.TEAMSFX_CLI_BIN_NAME ?? "atk";
+      if (service === "m365") {
+        logger.info(replaceTemplateString(strings["account.show.signin.m365"], cliName));
+      } else if (service === "azure") {
+        logger.info(replaceTemplateString(strings["account.show.signin.azure"], cliName));
+      } else {
+        logger.info(replaceTemplateString(strings["account.show.signin.all"], cliName, cliName));
+      }
     }
     return ok(undefined);
   },

--- a/packages/cli/src/resource/commands.json
+++ b/packages/cli/src/resource/commands.json
@@ -45,7 +45,10 @@
     }
   },
   "auth.show": {
-    "description": "Display all connected Microsoft 365 and Azure accounts."
+    "description": "Display connected Microsoft 365 and Azure accounts.",
+    "arguments": {
+      "service": "Azure or Microsoft 365."
+    }
   },
   "add": {
     "description": "Add feature to your app."

--- a/packages/cli/src/resource/strings.json
+++ b/packages/cli/src/resource/strings.json
@@ -12,6 +12,9 @@
   "account.show.m365": "Your Microsoft 365 account is: %s.",
   "account.show.m365.tenant": "Your Microsoft 365 account is: %s(%s).",
   "account.show.info": "Your %s account is: %s.",
+  "account.show.signin.azure": "Use `%s auth login azure` to log in to Azure account.",
+  "account.show.signin.m365": "Use `%s auth login m365` to log in to Microsoft 365 account.",
+  "account.show.signin.all": "Use `%s auth login azure` or `%s auth login m365` to log in to Azure or Microsoft 365 account.",
   "command": {
     "doctor": {
       "account": {
@@ -19,28 +22,28 @@
         "NotSignIn": "You've not signed into your Microsoft 365 account yet. Please use 'atk auth login' command to sign into your Microsoft 365 account.",
         "SignInSuccess": "Microsoft 365 Account (%s) is signed in and custom app upload permission is enabled."
       },
-      "node" : {
+      "node": {
         "NotFound": "Cannot find Node.js, which is used for developing apps with JavaScript or TypeScript using Microsoft 365 Toolkit for Visual Studio Code. Visit https://nodejs.org to install the LTS version.",
         "NotSupported": "Node.js (%s) is not the officially supported version (%s). Your project may continue to work but we recommend to install the supported version.",
         "Success": "Node.js version (%s) is installed."
       },
-      "dotnet" : {
+      "dotnet": {
         "NotFound": "Cannot find .NET Core SDK, which is used for developing app in C# using Microsoft 365 Toolkit for Visual Studio. Visit https://dotnet.microsoft.com/en-us/download to install the LTS version.",
         "NotSupported": ".NET Core SDK (%s) is not the officially supported version (%s).",
         "Success": ".NET Core SDK version (%s) is installed."
       },
-      "func" : {
+      "func": {
         "NotFound": "Cannot find Azure Functions Core Tools.",
         "NotSupported": "Azure Functions Core Tools (%s) is not the officially supported version (%s).",
         "Success": "Azure Functions Core Tools version (%s) is installed."
       },
-      "cert" : {
+      "cert": {
         "NotFound": "Cannot find local Certificate.",
         "FoundNotTrust": "Local Certificate is found but not trusted.",
         "Success": "Local Certificate is found and is trusted."
       }
     },
-    "add":{
+    "add": {
       "auth-config": {
         "notification": "Microsoft 365 Agents Toolkit has successfully updated your project configuration (m365agents.yaml) files with added action to support authentication flow. You can proceed to remote provision."
       }

--- a/packages/cli/tests/unit/commands.readonly.account.tests.ts
+++ b/packages/cli/tests/unit/commands.readonly.account.tests.ts
@@ -225,9 +225,25 @@ describe("CLI read-only commands account", () => {
     });
   });
   describe("accountShowCommand", async () => {
-    it("both signedOut", async () => {
-      vi.spyOn(M365TokenProvider, "getStatus").mockResolvedValue(ok({ status: signedOut }));
-      vi.spyOn(AzureTokenProvider, "getStatus").mockResolvedValue({ status: signedOut });
+    it("AUTH-LIST-AC-04: service argument accepts only m365 and azure", () => {
+      expect(accountShowCommand.arguments).toEqual([
+        expect.objectContaining({
+          name: "service",
+          choices: ["azure", "m365"],
+          required: false,
+        }),
+      ]);
+    });
+    it("AUTH-LIST-AC-08: account status is non-interactive by default", () => {
+      expect(accountShowCommand.defaultInteractiveOption).toBe(false);
+    });
+    it("AUTH-LIST-AC-01: both signedOut", async () => {
+      const m365Status = vi
+        .spyOn(M365TokenProvider, "getStatus")
+        .mockResolvedValue(ok({ status: signedOut }));
+      const azureStatus = vi
+        .spyOn(AzureTokenProvider, "getStatus")
+        .mockResolvedValue({ status: signedOut });
       messages = [];
       const ctx: CLIContext = {
         command: {
@@ -241,6 +257,117 @@ describe("CLI read-only commands account", () => {
       };
       const res = await accountShowCommand.handler!(ctx);
       assert.isTrue(res.isOk());
+      expect(m365Status).toHaveBeenCalledOnce();
+      expect(azureStatus).toHaveBeenCalledOnce();
+      expect(m365Status.mock.invocationCallOrder[0]).toBeLessThan(
+        azureStatus.mock.invocationCallOrder[0]
+      );
+      const cliName = process.env.TEAMSFX_CLI_BIN_NAME ?? "atk";
+      expect(messages).toContain(
+        `Use \`${cliName} auth login azure\` or \`${cliName} auth login m365\` to log in to Azure or Microsoft 365 account.`
+      );
+    });
+    it("AUTH-LIST-AC-02: m365 service does not query Azure", async () => {
+      const m365Status = vi
+        .spyOn(M365TokenProvider, "getStatus")
+        .mockResolvedValue(ok({ status: signedIn }));
+      const azureStatus = vi
+        .spyOn(AzureTokenProvider, "getStatus")
+        .mockResolvedValue({ status: signedIn });
+      vi.spyOn(accountUtils, "checkIsOnline").mockResolvedValue(true);
+      const outputM365Info = vi.spyOn(accountUtils, "outputM365Info").mockResolvedValue(true);
+      const outputAzureInfo = vi.spyOn(accountUtils, "outputAzureInfo").mockResolvedValue(true);
+      const ctx: CLIContext = {
+        command: {
+          ...accountShowCommand,
+          fullName: `${process.env.TEAMSFX_CLI_BIN_NAME} auth list`,
+        },
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: ["m365"],
+        telemetryProperties: {},
+      };
+
+      const res = await accountShowCommand.handler!(ctx);
+
+      assert.isTrue(res.isOk());
+      expect(m365Status).toHaveBeenCalledOnce();
+      expect(outputM365Info).toHaveBeenCalledOnce();
+      expect(azureStatus).not.toHaveBeenCalled();
+      expect(outputAzureInfo).not.toHaveBeenCalled();
+    });
+    it("AUTH-LIST-AC-03: azure service does not query Microsoft 365", async () => {
+      const m365Status = vi
+        .spyOn(M365TokenProvider, "getStatus")
+        .mockResolvedValue(ok({ status: signedIn }));
+      const azureStatus = vi
+        .spyOn(AzureTokenProvider, "getStatus")
+        .mockResolvedValue({ status: signedIn });
+      vi.spyOn(accountUtils, "checkIsOnline").mockResolvedValue(true);
+      const outputM365Info = vi.spyOn(accountUtils, "outputM365Info").mockResolvedValue(true);
+      const outputAzureInfo = vi.spyOn(accountUtils, "outputAzureInfo").mockResolvedValue(true);
+      const ctx: CLIContext = {
+        command: {
+          ...accountShowCommand,
+          fullName: `${process.env.TEAMSFX_CLI_BIN_NAME} auth list`,
+        },
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: ["azure"],
+        telemetryProperties: {},
+      };
+
+      const res = await accountShowCommand.handler!(ctx);
+
+      assert.isTrue(res.isOk());
+      expect(azureStatus).toHaveBeenCalledOnce();
+      expect(outputAzureInfo).toHaveBeenCalledOnce();
+      expect(m365Status).not.toHaveBeenCalled();
+      expect(outputM365Info).not.toHaveBeenCalled();
+    });
+    it("AUTH-LIST-AC-06: signed-out m365 guidance does not mention Azure login", async () => {
+      vi.spyOn(M365TokenProvider, "getStatus").mockResolvedValue(ok({ status: signedOut }));
+      const info = vi.spyOn(logger, "info");
+      const ctx: CLIContext = {
+        command: {
+          ...accountShowCommand,
+          fullName: `${process.env.TEAMSFX_CLI_BIN_NAME} auth list`,
+        },
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: ["m365"],
+        telemetryProperties: {},
+      };
+
+      const res = await accountShowCommand.handler!(ctx);
+
+      assert.isTrue(res.isOk());
+      expect(info).toHaveBeenCalledWith(
+        `Use \`${process.env.TEAMSFX_CLI_BIN_NAME ?? "atk"} auth login m365\` to log in to Microsoft 365 account.`
+      );
+      expect(info.mock.calls.flat().join(" ")).not.toContain("auth login azure");
+    });
+    it("AUTH-LIST-AC-07: signed-out Azure guidance does not mention Microsoft 365 login", async () => {
+      vi.spyOn(AzureTokenProvider, "getStatus").mockResolvedValue({ status: signedOut });
+      const info = vi.spyOn(logger, "info");
+      const ctx: CLIContext = {
+        command: {
+          ...accountShowCommand,
+          fullName: `${process.env.TEAMSFX_CLI_BIN_NAME} auth list`,
+        },
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: ["azure"],
+        telemetryProperties: {},
+      };
+
+      const res = await accountShowCommand.handler!(ctx);
+
+      assert.isTrue(res.isOk());
+      expect(info).toHaveBeenCalledWith(
+        `Use \`${process.env.TEAMSFX_CLI_BIN_NAME ?? "atk"} auth login azure\` to log in to Azure account.`
+      );
+      expect(info.mock.calls.flat().join(" ")).not.toContain("auth login m365");
     });
     it("both signedIn and checkIsOnline = true", async () => {
       vi.spyOn(M365TokenProvider, "getStatus").mockResolvedValue(ok({ status: signedIn }));


### PR DESCRIPTION
## Summary

Adds an optional account provider to `atk auth list`:

- `atk auth list` checks Microsoft 365 and Azure, preserving existing behavior.
- `atk auth list m365` checks Microsoft 365 only.
- `atk auth list azure` checks Azure only.

## Motivation

Non-interactive callers may require only Microsoft 365 authentication. Previously, `atk auth list` always queried Azure as well, which could trigger unrelated Azure authentication side effects or prompts.

## Changes

- Add an optional `m365 | azure` positional argument.
- Prevent scoped queries from invoking the unrequested provider.
- Make account status listing non-interactive by default so the provider argument is preserved.
- Show provider-specific sign-in guidance when the requested account is signed out.
- Preserve the existing provider order and output when no provider is specified.
- Record the selected provider in telemetry.
- Add an operation specification and acceptance-criteria-based regression tests.

## Compatibility

- Existing `atk auth list` behavior is preserved, except that status listing now defaults to non-interactive mode.
- `atk auth login m365` and `atk auth login azure` remain interactive and are unaffected.
- Login, logout, token acquisition, and credential storage are unchanged.

## Validation

- [x] Focused account-status tests: 30 passed
- [x] Status and interactive-login regression tests: 14 passed
- [x] CLI build passed
- [x] Formatting and whitespace checks passed
- [x] Manually verified that `atk auth list m365` queries only Microsoft 365 and shows only Microsoft 365 sign-in guidance when signed out