### PR TITLE
fix(scaffolding): pass authorization to Python basic CEA

### DIFF
--- a/docs/03-specs/scenarios/teams/create-basic-custom-engine-agent.md
+++ b/docs/03-specs/scenarios/teams/create-basic-custom-engine-agent.md
@@ -4,14 +4,15 @@
 
 ## Acceptance Criteria
 
-| ID | Runtime | Purpose | Gate | Harness | Scenario | Expected result |
-| --- | --- | --- | --- | --- | --- | --- |
-| SCN-CREATE-BASIC-CEA-01 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the TypeScript basic custom engine agent template. | The scaffold writes the TypeScript agent app files. |
-| SCN-CREATE-BASIC-CEA-02 | L1 | scenario | per-PR | InMemoryRuntime | Render a TypeScript basic custom engine agent with app name `My Agent App`. | Package and manifest app-name fields are rendered from caller floor values. |
-| SCN-CREATE-BASIC-CEA-03 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the JavaScript basic custom engine agent template. | The scaffold selects the JavaScript subtree and writes JavaScript entry files. |
-| SCN-CREATE-BASIC-CEA-04 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold the Python basic custom engine agent template. | The scaffold selects the Python subtree and omits Node package files. |
-| SCN-CREATE-BASIC-CEA-05 | L1 | scenario | per-PR | InMemoryRuntime | Run the scaffold pipeline. | The only pipeline step is `require-empty-target`. |
-| SCN-CREATE-BASIC-CEA-06 | L1 | scenario | per-PR | InMemoryRuntime | Scaffold into a target that already contains a file. | The scaffold fails with `REQUIRE_EMPTY_TARGET` before writing files. |
+| ID                      | Runtime | Purpose       | Gate   | Harness                  | Scenario                                                                    | Expected result                                                                                                      |
+| ----------------------- | ------- | ------------- | ------ | ------------------------ | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| SCN-CREATE-BASIC-CEA-01 | L1      | scenario      | per-PR | InMemoryRuntime          | Scaffold the TypeScript basic custom engine agent template.                 | The scaffold writes the TypeScript agent app files.                                                                  |
+| SCN-CREATE-BASIC-CEA-02 | L1      | scenario      | per-PR | InMemoryRuntime          | Render a TypeScript basic custom engine agent with app name `My Agent App`. | Package and manifest app-name fields are rendered from caller floor values.                                          |
+| SCN-CREATE-BASIC-CEA-03 | L1      | scenario      | per-PR | InMemoryRuntime          | Scaffold the JavaScript basic custom engine agent template.                 | The scaffold selects the JavaScript subtree and writes JavaScript entry files.                                       |
+| SCN-CREATE-BASIC-CEA-04 | L1      | scenario      | per-PR | InMemoryRuntime          | Scaffold the Python basic custom engine agent template.                     | The scaffold selects the Python subtree and omits Node package files.                                                |
+| SCN-CREATE-BASIC-CEA-05 | L1      | scenario      | per-PR | InMemoryRuntime          | Run the scaffold pipeline.                                                  | The only pipeline step is `require-empty-target`.                                                                    |
+| SCN-CREATE-BASIC-CEA-06 | L1      | scenario      | per-PR | InMemoryRuntime          | Scaffold into a target that already contains a file.                        | The scaffold fails with `REQUIRE_EMPTY_TARGET` before writing files.                                                 |
+| SCN-CREATE-BASIC-CEA-07 | L1      | compatibility | per-PR | CompatibilityDiffHarness | Compare the v3 and rendered v4 Python `AgentApplication` construction.      | V4 supplies the same MSAL connection manager as v3 so the Agents SDK receives its required authorization dependency. |
 
 ## Flow
 
@@ -26,10 +27,11 @@ flowchart TD
 ## Boundary
 
 - This scenario covers v4 package rendering for a new basic custom engine agent project.
-- It does not provision Azure, register a bot, or run CLI/VS Code end-to-end scaffolding.
+- It does not provision Azure, register a bot, or run CLI/VS Code end-to-end scaffolding; AC-07 compares the Python template construction statically.
 
 ## Invariants
 
 - The v4 create route must not fall back to the v3 `DefaultTemplateGenerator`.
 - The package must render only the selected language subtree.
 - The package must reject non-empty targets before writing output.
+- The Python template must preserve the v3 `AgentApplication` authorization wiring.

--- a/packages/fx-core/tests/v4/scenarios/createBasicCustomEngineAgent.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createBasicCustomEngineAgent.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as fs from "fs";
+import * as path from "path";
 import { UserError } from "@microsoft/teamsfx-api";
 import { assert } from "vitest";
 import { REQUIRE_EMPTY_TARGET } from "../../../src/v4/pipeline/runScaffoldPipeline";
@@ -11,6 +13,7 @@ import {
   readJsonObject,
   recordProperty,
   runV4Package,
+  text,
 } from "./helpers/scenarioHarness";
 
 /**
@@ -18,7 +21,7 @@ import {
  * `InMemoryRuntime`.
  *
  * Spec: docs/03-specs/scenarios/teams/create-basic-custom-engine-agent.md
- * (SCN-CREATE-BASIC-CEA-01..06)
+ * (SCN-CREATE-BASIC-CEA-01..07)
  */
 
 const templatePackage = loadV4Package("create", "basic-custom-engine-agent");
@@ -26,6 +29,12 @@ const appName = "My Agent App";
 
 async function run(language: "typescript" | "javascript" | "python" = "typescript") {
   return runV4Package(templatePackage, { callerFloor: { appName, language } });
+}
+
+function agentApplicationArguments(source: string): string {
+  const match = source.match(/AgentApplication\[TurnState\]\(\s*([\s\S]*?)\n\)/);
+  assert.isNotNull(match, "Python agent must construct AgentApplication[TurnState]");
+  return (match?.[1] ?? "").replace(/\s+/g, " ").trim();
 }
 
 describe("SCN-TEAMS-CREATE-BASIC-CUSTOM-ENGINE-AGENT (v4, T3 InMemoryRuntime)", () => {
@@ -89,5 +98,17 @@ describe("SCN-TEAMS-CREATE-BASIC-CUSTOM-ENGINE-AGENT (v4, T3 InMemoryRuntime)", 
     assert.instanceOf(error, UserError);
     assert.strictEqual(error.name, REQUIRE_EMPTY_TARGET);
     assert.strictEqual(runtime.files.size, 0);
+  });
+
+  it("SCN-CREATE-BASIC-CEA-07: Python preserves v3 AgentApplication authorization wiring", async () => {
+    const v3AgentPath = path.resolve(
+      templatePackage.packageDir,
+      "../../../vsc/python/basic-custom-engine-agent/src/agent.py.tpl"
+    );
+    const v3Arguments = agentApplicationArguments(fs.readFileSync(v3AgentPath, "utf8"));
+    const { files } = await run("python");
+
+    assert.include(v3Arguments, "connection_manager=connection_manager");
+    assert.strictEqual(agentApplicationArguments(text(files, "src/agent.py")), v3Arguments);
   });
 });

--- a/templates/v4/create/basic-custom-engine-agent/content/python/src/agent.py.tpl
+++ b/templates/v4/create/basic-custom-engine-agent/content/python/src/agent.py.tpl
@@ -75,6 +75,7 @@ adapter = CloudAdapter(connection_manager=connection_manager)
 agent_app = AgentApplication[TurnState](
     storage=storage,
     adapter=adapter,
+    connection_manager=connection_manager,
     **agents_sdk_config
 )
 


### PR DESCRIPTION
## Summary
- restore the MSAL connection manager when constructing the V4 Python basic custom engine agent `AgentApplication`
- preserve the V3 authorization wiring in the V4 template
- add AC-backed V3/V4 compatibility coverage for the generated Python agent

## Test Plan
- `pnpm --dir packages/fx-core test:unit:fast -- tests/v4/scenarios/createBasicCustomEngineAgent.test.ts` (7 passed)