### PR TITLE
feat(fx-core): infer Open Plugin MCP auth

### DIFF
--- a/docs/01-product/scenarios/index.html
+++ b/docs/01-product/scenarios/index.html
@@ -283,7 +283,8 @@
         "current": [
           "da/add-mcp-action-to-da.html",
           "da/create-da-with-mcp-server.html",
-          "da/fetch-mcp-tools.html"
+          "da/fetch-mcp-tools.html",
+          "toolkit/import-open-plugin.html"
         ],
         "inReview": []
       }

--- a/docs/01-product/scenarios/toolkit/import-open-plugin.html
+++ b/docs/01-product/scenarios/toolkit/import-open-plugin.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<!-- Generated from scenario Markdown and v4 declarations. Do not edit. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Import an Open Plugin project Scenario</title>
+  <link rel="stylesheet" href="../../_assets/product-review/product-review.css">
+  <link rel="stylesheet" href="../../_assets/scenario-components/scenario-components.css">
+  <script type="module" src="../../_assets/scenario-components/scenario-components.js"></script>
+</head>
+<body>
+  <header>
+    <p class="eyebrow">IMPLEMENTED · SCN-TOOLKIT-IMPORT-OPEN-PLUGIN</p>
+    <h1>Import an Open Plugin project</h1>
+    <p class="intro">Behavior belongs in <a href="import-open-plugin.md">import-open-plugin.md</a>; this page is a generated review projection.</p>
+    <div class="legend" aria-label="Review links"><a class="link" href="../index.html">Back to product index</a></div>
+  </header>
+  <main>
+    <section class="scenario-flow" aria-labelledby="scenario-heading">
+      <div class="section-head"><h2 id="scenario-heading">Cross-surface Scenario Contract</h2></div>
+      <scenario-markdown-section src="import-open-plugin.md" heading="Scenario" level="2" title="Scenario"></scenario-markdown-section>
+      <scenario-markdown-section src="import-open-plugin.md" heading="States" level="2" title="States"></scenario-markdown-section>
+      <scenario-markdown-section src="import-open-plugin.md" heading="User-visible outputs" level="2" title="User-visible outputs"></scenario-markdown-section>
+      <scenario-markdown-section src="import-open-plugin.md" heading="Validation notes" level="2" title="Validation notes"></scenario-markdown-section>
+    </section>
+    <section class="scenario-flow" aria-labelledby="flow-heading">
+      <div class="section-head"><h2 id="flow-heading">Flow</h2></div>
+      <scenario-mermaid-flow src="import-open-plugin.md" title="SCN-TOOLKIT-IMPORT-OPEN-PLUGIN"></scenario-mermaid-flow>
+    </section>
+    <section class="scenario-flow" aria-labelledby="implementation-heading">
+      <div class="section-head"><h2 id="implementation-heading">Implementation Binding</h2></div>
+      <p>This scenario has no scaffolding implementation binding.</p>
+    </section>
+  </main>
+  <footer>Generated review projection. Scenario behavior remains in <code>import-open-plugin.md</code>.</footer>
+</body>
+</html>

--- a/docs/01-product/scenarios/toolkit/import-open-plugin.md
+++ b/docs/01-product/scenarios/toolkit/import-open-plugin.md
@@ -1,0 +1,78 @@
+# Import an Open Plugin project
+
+## Metadata
+
+- Created: 2026-08-18T00:00:00Z
+- Last updated: 2026-08-18T00:00:00Z
+- Status: implemented
+- PM owner: summzhan
+- Engineer owner: @tecton
+- Scenario group: toolkit
+- Scenario ID: SCN-TOOLKIT-IMPORT-OPEN-PLUGIN
+- Primary goal: migrate
+- Start state: A developer has an Open Plugin, Claude Code plugin, or Cursor plugin directory.
+- Success state: The developer has a scaffolded Agents Toolkit project with equivalent skills and MCP connectors.
+- Lifecycle phases: [create]
+- Visual/state reference: import-open-plugin.html
+
+## Scenario
+
+A developer imports an existing portable plugin through `atk import openplugin`. The Toolkit reads
+the plugin manifest, skills, commands, and MCP server declarations, resolves connector
+authentication, and writes a new Agents Toolkit project. When authentication is set to `Auto`, the
+Toolkit may contact remote HTTPS MCP servers and their OAuth metadata endpoints before writing the
+project. Explicit authentication choices and authentication preserved from a previous Toolkit
+export do not trigger discovery.
+
+## Surfaces
+
+- CLI non-interactive: `atk import openplugin` with flags.
+- VS Code and Visual Studio are not part of this scenario.
+
+## States
+
+- Success: the destination contains a usable Agents Toolkit project and inferred authentication
+  decisions are reported as warnings.
+- Input error: malformed plugin content, missing required developer URLs, too many MCP connectors,
+  or a non-empty destination stops the import without modifying the destination.
+- Authentication unresolved: Auto cannot establish an MCP endpoint/authentication result, so the
+  import stops and asks the developer to verify the server and choose an explicit authentication
+  type.
+- Untrusted source: the developer can select an explicit authentication type to skip outbound Auto
+  discovery.
+
+## User-visible outputs
+
+- Creates the standard Agents Toolkit project baseline in the selected destination.
+- Creates `appPackage/manifest.json` with imported `agentSkills` and URL-based `agentConnectors`.
+- Copies imported skill and command files and creates package icons.
+- Reports warnings for skipped stdio servers, unsupported source fields, sanitized skill metadata,
+  and every authentication choice inferred by Auto.
+- Creates no project files when local validation or Auto authentication resolution fails.
+
+## Flow
+
+```mermaid
+flowchart TD
+  Start([Developer runs atk import openplugin]) --> Read[Read plugin directory]
+  Read --> Validate{Local inputs and destination valid?}
+  Validate -- No --> LocalError[Return actionable error; write nothing]
+  Validate -- Yes --> Auth{Authentication explicit or preserved?}
+  Auth -- Yes --> Map[Map plugin to Toolkit project]
+  Auth -- No --> Discover[Probe remote MCP and OAuth metadata]
+  Discover --> Resolved{Authentication resolved?}
+  Resolved -- No --> AuthError[Return UnresolvedMcpAuth; write nothing]
+  Resolved -- Yes --> Map
+  Map --> Scaffold[Scaffold and write project]
+  Scaffold --> Done([Toolkit project ready with warnings])
+```
+
+## Validation notes
+
+- L1 scenario coverage uses a temporary plugin directory and destination, stubbing only MCP/OAuth
+  network calls and the static template provider.
+- The scenario test asserts the generated project tree, mapped remote connector authorization, and
+  visible Auto inference warning.
+- L2 CLI E2E is deferred; it should verify command exit codes and emitted warnings with a controlled
+  MCP endpoint.
+- No L3 UI validation is applicable.

--- a/docs/01-product/scenarios/toolkit/import-open-plugin.md
+++ b/docs/01-product/scenarios/toolkit/import-open-plugin.md
@@ -38,6 +38,8 @@ export do not trigger discovery.
 - Authentication unresolved: Auto cannot establish an MCP endpoint/authentication result, so the
   import stops and asks the developer to verify the server and choose an explicit authentication
   type.
+- Authentication challenge without metadata: Auto falls back to OAuth, creates the project, and
+  warns the developer to verify the authentication type and register the placeholder reference.
 - Untrusted source: the developer can select an explicit authentication type to skip outbound Auto
   discovery.
 
@@ -47,8 +49,8 @@ export do not trigger discovery.
 - Creates `appPackage/manifest.json` with imported `agentSkills` and URL-based `agentConnectors`.
 - Copies imported skill and command files and creates package icons.
 - Reports warnings for skipped stdio servers, unsupported source fields, sanitized skill metadata,
-  and every authentication choice inferred by Auto.
-- Creates no project files when local validation or Auto authentication resolution fails.
+  every authentication choice inferred by Auto, and an OAuth fallback that lacks metadata.
+- Creates no project files when local validation fails or Auto cannot confirm the MCP endpoint.
 
 ## Flow
 
@@ -60,9 +62,15 @@ flowchart TD
   Validate -- Yes --> Auth{Authentication explicit or preserved?}
   Auth -- Yes --> Map[Map plugin to Toolkit project]
   Auth -- No --> Discover[Probe remote MCP and OAuth metadata]
-  Discover --> Resolved{Authentication resolved?}
-  Resolved -- No --> AuthError[Return UnresolvedMcpAuth; write nothing]
-  Resolved -- Yes --> Map
+  Discover --> Endpoint{MCP endpoint confirmed?}
+  Endpoint -- No --> AuthError[Return UnresolvedMcpAuth; write nothing]
+  Endpoint -- Yes --> Challenge{Auth challenge confirmed?}
+  Challenge -- Yes --> OAuth[Use metadata-resolved or fallback OAuth; warn]
+  Challenge -- No --> Metadata{OAuth metadata resolved?}
+  Metadata -- Yes --> OAuth
+  Metadata -- No --> None[Infer None; warn]
+  OAuth --> Map
+  None --> Map
   Map --> Scaffold[Scaffold and write project]
   Scaffold --> Done([Toolkit project ready with warnings])
 ```

--- a/docs/03-specs/operations/product/resolve-open-plugin-mcp-auth.md
+++ b/docs/03-specs/operations/product/resolve-open-plugin-mcp-auth.md
@@ -27,7 +27,8 @@ connector metadata and explicit CLI defaults remain authoritative.
 The operation returns either:
 
 - one authorization type per URL-based server plus ordered inference warnings; or
-- an unresolved-auth `UserError`, before project scaffolding or connector reference generation.
+- an unresolved-auth `UserError` when the MCP endpoint itself cannot be confirmed, before project
+  scaffolding or connector reference generation.
 
 ## Acceptance Criteria
 
@@ -38,8 +39,9 @@ The operation returns either:
 | OPI-AUTH-03 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto, a remote MCP endpoint whose `initialize` response confirms the endpoint without an auth challenge, and no resolvable OAuth metadata, when importing, then the connector uses `None`, has no `referenceId`, and the result warns that Auto inferred the choice.     |
 | OPI-AUTH-04 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto and a confirmed auth challenge with resolvable OAuth metadata, when importing, then the connector uses `OAuthPluginVault`, receives the deterministic placeholder `referenceId`, and the result warns that the reference still requires registration.               |
 | OPI-AUTH-05 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto, a successful unauthenticated `initialize`, and resolvable OAuth metadata for a server that defers auth to tool calls, when importing, then the connector uses `OAuthPluginVault` and reports the inferred placeholder warning.                                     |
-| OPI-AUTH-06 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto and a probe that is `undetermined`, reports `notEndpoint`, throws, or requires auth whose OAuth metadata cannot be resolved, when importing, then the operation returns `UnresolvedMcpAuth` before scaffolding and does not synthesize a connector reference.       |
+| OPI-AUTH-06 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto and an invalid URL or a probe that is `undetermined`, reports `notEndpoint`, or throws, when importing, then the operation returns `UnresolvedMcpAuth` before scaffolding and does not synthesize a connector reference.                                            |
 | OPI-AUTH-07 | L1      | compatibility         | per-PR | mapper unit + importer dependency fake           | Given multiple connectors, explicit ATK overrides continue to win per connector, Auto resolutions are applied by server name in deterministic order, stdio entries remain skipped, and localhost/non-HTTPS entries retain the existing `None` behavior without network access. |
+| OPI-AUTH-08 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto and a confirmed auth challenge whose OAuth metadata cannot be resolved, when importing, then the connector falls back to `OAuthPluginVault`, receives the deterministic placeholder `referenceId`, and warns that the type must be verified and registered.         |
 
 ## Flow
 
@@ -58,7 +60,7 @@ flowchart TD
   Discover --> OAuth{Metadata resolved?}
   OAuth -- Yes --> InferOAuth[Infer OAuthPluginVault and warn]
   OAuth -- No --> Challenge{Probe required auth?}
-  Challenge -- Yes --> Unresolved
+  Challenge -- Yes --> FallbackOAuth[Fallback to OAuthPluginVault and warn to verify]
   Challenge -- No --> InferNone
 ```
 
@@ -82,5 +84,7 @@ flowchart TD
 - An unresolved Auto decision never generates a project or placeholder `referenceId`.
 - A connector with `None` never has a `referenceId`.
 - Every inferred Auto decision is visible in the returned warnings.
+- A confirmed auth challenge may fall back only to `OAuthPluginVault`, with a warning that the
+  authentication type was not metadata-verified and the placeholder must be registered.
 - A failed or inconclusive `initialize` probe never becomes evidence for `None` or `OAuthPluginVault`.
 - Output and warning order are deterministic for equal resolved inputs.

--- a/docs/03-specs/operations/product/resolve-open-plugin-mcp-auth.md
+++ b/docs/03-specs/operations/product/resolve-open-plugin-mcp-auth.md
@@ -1,0 +1,86 @@
+# Operation — `resolve-open-plugin-mcp-auth`
+
+- **Status:** Approved
+- **Product behavior change:** Existing `atk import openplugin` Auto authentication inference becomes evidence-based instead of URL-shape-based.
+- **Related request:** [GitHub issue #16606](https://github.com/OfficeDev/microsoft-365-agents-toolkit/issues/16606)
+- **Related architecture:** [`ADR-0020`](../../../02-architecture/adr/ADR-0020-mcp-server-url-validity.md), [remote MCP server facts](../../../02-architecture/external-dependencies/mcp-remote-servers.md)
+
+## Purpose
+
+Resolve the authorization type for every URL-based MCP server imported from an Open Plugin source.
+The portable source does not carry connector authorization semantics, so `Auto` uses an
+unauthenticated MCP `initialize` request and OAuth metadata discovery as evidence. Explicit
+connector metadata and explicit CLI defaults remain authoritative.
+
+## Inputs
+
+| Input                   | Meaning                                                                 |
+| ----------------------- | ----------------------------------------------------------------------- |
+| Parsed MCP server map   | Named `.mcp.json` entries; only entries with a URL participate.         |
+| ATK extension overrides | Per-connector authorization preserved by a previous ATK export.         |
+| Default auth option     | `Auto`, `None`, `OAuthPluginVault`, or `ApiKeyPluginVault`.             |
+| MCP auth probe          | Existing unauthenticated `initialize` probe and endpoint-status result. |
+| OAuth metadata resolver | Existing RFC 9728 / RFC 8414 / OIDC discovery chain.                    |
+
+## Outputs
+
+The operation returns either:
+
+- one authorization type per URL-based server plus ordered inference warnings; or
+- an unresolved-auth `UserError`, before project scaffolding or connector reference generation.
+
+## Acceptance Criteria
+
+| ID          | Runtime | Purpose               | Gate   | Harness                                          | Given / When / Then                                                                                                                                                                                                                                                            |
+| ----------- | ------- | --------------------- | ------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| OPI-AUTH-01 | L1      | operation-integration | per-PR | importer dependency fake                         | Given a connector authorization override preserved in the ATK extension, when importing with any default, then the override is retained and no network auth probe runs for that connector.                                                                                     |
+| OPI-AUTH-02 | L1      | operation-integration | per-PR | importer dependency fake                         | Given an explicit `None`, `OAuthPluginVault`, or `ApiKeyPluginVault` default, when importing, then that type is applied to connectors without overrides and no network auth probe runs.                                                                                        |
+| OPI-AUTH-03 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto, a remote MCP endpoint whose `initialize` response confirms the endpoint without an auth challenge, and no resolvable OAuth metadata, when importing, then the connector uses `None`, has no `referenceId`, and the result warns that Auto inferred the choice.     |
+| OPI-AUTH-04 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto and a confirmed auth challenge with resolvable OAuth metadata, when importing, then the connector uses `OAuthPluginVault`, receives the deterministic placeholder `referenceId`, and the result warns that the reference still requires registration.               |
+| OPI-AUTH-05 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto, a successful unauthenticated `initialize`, and resolvable OAuth metadata for a server that defers auth to tool calls, when importing, then the connector uses `OAuthPluginVault` and reports the inferred placeholder warning.                                     |
+| OPI-AUTH-06 | L1      | operation-integration | per-PR | importer dependency fake + temporary plugin tree | Given Auto and a probe that is `undetermined`, reports `notEndpoint`, throws, or requires auth whose OAuth metadata cannot be resolved, when importing, then the operation returns `UnresolvedMcpAuth` before scaffolding and does not synthesize a connector reference.       |
+| OPI-AUTH-07 | L1      | compatibility         | per-PR | mapper unit + importer dependency fake           | Given multiple connectors, explicit ATK overrides continue to win per connector, Auto resolutions are applied by server name in deterministic order, stdio entries remain skipped, and localhost/non-HTTPS entries retain the existing `None` behavior without network access. |
+
+## Flow
+
+```mermaid
+flowchart TD
+  Server[Next MCP server] --> Override{ATK override exists?}
+  Override -- Yes --> Preserve[Preserve authorization]
+  Override -- No --> Explicit{Default is explicit?}
+  Explicit -- Yes --> Apply[Apply explicit default]
+  Explicit -- No --> Local{Localhost or non-HTTPS?}
+  Local -- Yes --> InferNone[Infer None and warn]
+  Local -- No --> Probe[Send unauthenticated initialize]
+  Probe --> Confirmed{Endpoint confirmed?}
+  Confirmed -- No --> Unresolved[Return UnresolvedMcpAuth]
+  Confirmed -- Yes --> Discover[Resolve OAuth metadata]
+  Discover --> OAuth{Metadata resolved?}
+  OAuth -- Yes --> InferOAuth[Infer OAuthPluginVault and warn]
+  OAuth -- No --> Challenge{Probe required auth?}
+  Challenge -- Yes --> Unresolved
+  Challenge -- No --> InferNone
+```
+
+## Boundary
+
+- The operation does not infer `ApiKeyPluginVault`; API-key auth remains explicit.
+- It does not invoke tools to test tool-specific authorization.
+- It does not register an OAuth client or validate that a generated reference already exists.
+- It does not add a per-server CLI override syntax in this change.
+- It does not change preserved ATK extension metadata or explicit default-auth semantics.
+- It does not make the pure manifest mapper perform network I/O.
+- Auto is an explicit local-client discovery action. The initial MCP URLs come from the imported
+  plugin; server responses and redirects can direct subsequent metadata requests to other URLs.
+  This operation does not define an egress allowlist or SSRF denylist. Callers that do not trust
+  those URLs must select an explicit default, which skips discovery.
+
+## Invariants
+
+- Preserved per-connector authorization always wins.
+- Explicit defaults never trigger auth discovery.
+- An unresolved Auto decision never generates a project or placeholder `referenceId`.
+- A connector with `None` never has a `referenceId`.
+- Every inferred Auto decision is visible in the returned warnings.
+- A failed or inconclusive `initialize` probe never becomes evidence for `None` or `OAuthPluginVault`.
+- Output and warning order are deterministic for equal resolved inputs.

--- a/docs/03-specs/scenarios/toolkit/import-open-plugin.md
+++ b/docs/03-specs/scenarios/toolkit/import-open-plugin.md
@@ -1,0 +1,67 @@
+# Scenario - Import an Open Plugin project
+
+- **Status:** Implemented with L1 scenario coverage
+- **Domain:** Product import/export
+- **Scenario ID:** `SCN-TOOLKIT-IMPORT-OPEN-PLUGIN` (mirrors product scenario
+  [`import-open-plugin.md`](../../../01-product/scenarios/toolkit/import-open-plugin.md))
+- **Feature workflow:** `atk import openplugin`
+
+This is the vertical contract for importing one portable plugin directory into a usable Agents
+Toolkit project. It pins only the concrete workflow outputs and composes the auth-resolution
+operation rather than restating its evidence rules.
+
+## Acceptance Criteria
+
+| ID                                | Runtime | Purpose  | Gate     | Harness                                                   | Given                                                                                                          | When                                           | Then                                                                                                                                                                                                                 |
+| --------------------------------- | ------- | -------- | -------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-01 | L1      | scenario | per-PR   | TempDirRuntime with MCP/OAuth and template-provider fakes | an Open Plugin directory containing two skills, commands, one remote HTTPS MCP server, and Auto authentication | the fx-core importer completes                 | the destination contains the standard Toolkit project files, copied skills and commands, and a manifest whose remote connector uses the evidence-resolved OAuth type; the result includes the Auto inference warning |
+| SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-02 | L2      | CLI-E2E  | deferred | CLI command harness with controlled MCP endpoint          | the same plugin and destination inputs                                                                         | `atk import openplugin` runs non-interactively | the command exit code, generated project, and warning output match the L1 scenario oracle                                                                                                                            |
+| SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-03 | L1      | scenario | per-PR   | TempDirRuntime with network fakes                         | the selected destination is non-empty                                                                          | the fx-core importer runs                      | it returns `OutputDirectoryNotEmpty` before auth discovery and preserves the destination                                                                                                                             |
+| SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-04 | L1      | scenario | per-PR   | TempDirRuntime with network fakes                         | the source declares more than ten URL-based MCP servers                                                        | the fx-core importer runs                      | it rejects the manifest-limit violation before auth discovery or scaffolding                                                                                                                                         |
+
+## Composed operations
+
+- [`resolve-open-plugin-mcp-auth`](../../operations/product/resolve-open-plugin-mcp-auth.md) owns
+  authentication precedence, endpoint evidence, unresolved behavior, and inference warnings.
+- Existing Open Plugin parsing, mapping, template scaffolding, and artifact-writing operations own
+  their horizontal contracts; this scenario asserts only their composed observable result.
+
+## Flow
+
+The end-to-end behavior follows the product scenario
+[`import-open-plugin.md`](../../../01-product/scenarios/toolkit/import-open-plugin.md#flow): read and
+locally validate the source/destination, resolve authentication, map the plugin, then scaffold and
+write the project. Any local validation or unresolved authentication error terminates before
+scaffolding.
+
+## Executable validation
+
+- **Harness:**
+  [`importer.test.ts`](../../../../packages/fx-core/tests/component/generator/openPlugin/importer.test.ts)
+  uses temporary source/destination directories, the production parser/importer/mapper/writers, a
+  static template-provider fake, and fakes only the MCP/OAuth network boundary.
+- **Traceability:** the three required L1 rows map 1:1 to scenario-tier tests in that file.
+- **Deferred surface:** `SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-02` records the L2 CLI E2E intent and is not a
+  current per-PR gate.
+
+Run the focused scenario validation from the repository root:
+
+```bash
+pnpm --dir packages/fx-core exec vitest run --config vitest.config.ts tests/component/generator/openPlugin/importer.test.ts
+```
+
+## Boundary
+
+This scenario does not assert:
+
+- live behavior of an arbitrary MCP or OAuth server;
+- OAuth client registration or credential provisioning;
+- stdio MCP conversion to a local connector;
+- VS Code or Visual Studio surfaces;
+- the internal evidence rules owned by the composed auth-resolution operation.
+
+## Invariants
+
+- Guaranteed local validation failures make no outbound auth-discovery request and write no project.
+- An unresolved Auto decision writes no project or placeholder connector reference.
+- Explicit or preserved authentication remains authoritative for each connector.

--- a/docs/03-specs/scenarios/toolkit/import-open-plugin.md
+++ b/docs/03-specs/scenarios/toolkit/import-open-plugin.md
@@ -18,6 +18,7 @@ operation rather than restating its evidence rules.
 | SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-02 | L2      | CLI-E2E  | deferred | CLI command harness with controlled MCP endpoint          | the same plugin and destination inputs                                                                         | `atk import openplugin` runs non-interactively | the command exit code, generated project, and warning output match the L1 scenario oracle                                                                                                                            |
 | SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-03 | L1      | scenario | per-PR   | TempDirRuntime with network fakes                         | the selected destination is non-empty                                                                          | the fx-core importer runs                      | it returns `OutputDirectoryNotEmpty` before auth discovery and preserves the destination                                                                                                                             |
 | SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-04 | L1      | scenario | per-PR   | TempDirRuntime with network fakes                         | the source declares more than ten URL-based MCP servers                                                        | the fx-core importer runs                      | it rejects the manifest-limit violation before auth discovery or scaffolding                                                                                                                                         |
+| SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-05 | L1      | scenario | per-PR   | TempDirRuntime with MCP/OAuth and template-provider fakes | Auto receives a confirmed auth challenge but OAuth metadata cannot be resolved                                 | the fx-core importer runs                      | the destination is scaffolded with an `OAuthPluginVault` connector and deterministic placeholder reference; the result warns that the fallback type must be verified and registered                                  |
 
 ## Composed operations
 
@@ -31,8 +32,9 @@ operation rather than restating its evidence rules.
 The end-to-end behavior follows the product scenario
 [`import-open-plugin.md`](../../../01-product/scenarios/toolkit/import-open-plugin.md#flow): read and
 locally validate the source/destination, resolve authentication, map the plugin, then scaffold and
-write the project. Any local validation or unresolved authentication error terminates before
-scaffolding.
+write the project. Local validation or an unconfirmed MCP endpoint terminates before scaffolding;
+a confirmed auth challenge with incomplete metadata falls back to OAuth and continues with a
+warning.
 
 ## Executable validation
 
@@ -40,7 +42,7 @@ scaffolding.
   [`importer.test.ts`](../../../../packages/fx-core/tests/component/generator/openPlugin/importer.test.ts)
   uses temporary source/destination directories, the production parser/importer/mapper/writers, a
   static template-provider fake, and fakes only the MCP/OAuth network boundary.
-- **Traceability:** the three required L1 rows map 1:1 to scenario-tier tests in that file.
+- **Traceability:** the four required L1 rows map 1:1 to scenario-tier tests in that file.
 - **Deferred surface:** `SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-02` records the L2 CLI E2E intent and is not a
   current per-PR gate.
 
@@ -63,5 +65,8 @@ This scenario does not assert:
 ## Invariants
 
 - Guaranteed local validation failures make no outbound auth-discovery request and write no project.
-- An unresolved Auto decision writes no project or placeholder connector reference.
+- An Auto decision with an unconfirmed MCP endpoint writes no project or placeholder connector
+  reference.
+- A confirmed auth challenge with unresolved metadata writes an OAuth placeholder and a visible
+  verification warning.
 - Explicit or preserved authentication remains authoritative for each connector.

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -1195,6 +1195,9 @@
   "core.MCPForDA.authRequired": "The MCP server at %s requires authentication. Tools could not be fetched automatically. To add tools, run:\n  %s",
   "core.MCPForDA.noToolsFetched": "No tools were discovered from the MCP server at %s. To add tools later, run:\n  %s",
   "core.MCPForDA.mcpServerUrlNotAnEndpoint": "%s answered an MCP initialize request with HTTP %s, so it may not be an MCP server URL. Verify the URL before provisioning.",
+  "core.openPluginImport.autoAuthNone": "Auto inferred authentication type None for MCP server '%s'. Verify this choice if individual tools require authentication or use an API key.",
+  "core.openPluginImport.autoAuthOAuth": "Auto inferred OAuthPluginVault for MCP server '%s'. The generated reference ID is a placeholder and must be registered before use.",
+  "core.openPluginImport.unresolvedMcpAuth": "Unable to resolve authentication for MCP server '%s' while --default-auth-type is Auto. Specify None, OAuthPluginVault, or ApiKeyPluginVault explicitly.",
   "core.MCPForDA.openYmlFile": "Open m365agents.yml",
   "core.MCPForDA.fetchError": "Failed to fetch tools from the MCP server at %s. To add tools later, run:\n  %s"
 }

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -1197,6 +1197,7 @@
   "core.MCPForDA.mcpServerUrlNotAnEndpoint": "%s answered an MCP initialize request with HTTP %s, so it may not be an MCP server URL. Verify the URL before provisioning.",
   "core.openPluginImport.autoAuthNone": "Auto inferred authentication type None for MCP server '%s'. Verify this choice if individual tools require authentication or use an API key.",
   "core.openPluginImport.autoAuthOAuth": "Auto inferred OAuthPluginVault for MCP server '%s'. The generated reference ID is a placeholder and must be registered before use.",
+  "core.openPluginImport.authFallback": "OAuth metadata could not be resolved for MCP server '%s' after it confirmed authentication is required. Auto fell back to OAuthPluginVault. Verify the authentication type and register the generated reference ID before use.",
   "core.openPluginImport.unresolvedMcpAuth": "Unable to resolve authentication for MCP server '%s' while --default-auth-type is Auto. Specify None, OAuthPluginVault, or ApiKeyPluginVault explicitly.",
   "core.MCPForDA.openYmlFile": "Open m365agents.yml",
   "core.MCPForDA.fetchError": "Failed to fetch tools from the MCP server at %s. To add tools later, run:\n  %s"

--- a/packages/fx-core/src/common/mcpToolFetcher.ts
+++ b/packages/fx-core/src/common/mcpToolFetcher.ts
@@ -168,6 +168,9 @@ const LEGACY_SSE_TIMEOUT_MS = 5000;
 /** Stop buffering an event stream that is not going to name an endpoint. */
 const LEGACY_SSE_MAX_BYTES = 8192;
 
+/** Bound each OAuth metadata discovery hop so an unreachable issuer cannot stall scaffolding. */
+const MCP_AUTH_METADATA_TIMEOUT_MS = 10000;
+
 /**
  * A 2xx alone proves nothing: a truncated URL on a host that serves a landing page answers 200
  * with HTML. The JSON-RPC envelope in the payload is the actual proof. The body text is searched
@@ -413,7 +416,7 @@ async function candidatesFromProtectedResourceMetadata(
 ): Promise<string[]> {
   let response;
   try {
-    response = await axios.get(authMetadataUrl);
+    response = await axios.get(authMetadataUrl, { timeout: MCP_AUTH_METADATA_TIMEOUT_MS });
   } catch (error) {
     // A server advertising a document it cannot serve is broken, but the MCP server URL may
     // still lead to the authorization server, so let the caller try that before failing.
@@ -483,7 +486,9 @@ export async function resolveMCPOAuthMetadata(
 
   for (const candidate of candidates) {
     try {
-      const metadataResponse = await axios.get(candidate);
+      const metadataResponse = await axios.get(candidate, {
+        timeout: MCP_AUTH_METADATA_TIMEOUT_MS,
+      });
       const authorizationUrl = metadataResponse.data?.authorization_endpoint;
       const tokenUrl = metadataResponse.data?.token_endpoint;
       const refreshUrl = metadataResponse.data?.refresh_endpoint;

--- a/packages/fx-core/src/component/generator/openPlugin/README.md
+++ b/packages/fx-core/src/component/generator/openPlugin/README.md
@@ -5,6 +5,7 @@ plugin directory and a Microsoft 365 Agents Toolkit project (devPreview
 manifest with `agentSkills` and `agentConnectors`).
 
 Accepts plugins using any of the three manifest locations:
+
 - `.plugin/plugin.json` (vendor-neutral, recommended)
 - `.claude-plugin/plugin.json` (Claude Code)
 - `.cursor-plugin/plugin.json` (Cursor)
@@ -38,34 +39,34 @@ atk export openplugin --path ./my-project --manifest-kind claude-plugin
 
 ## CLI options — import
 
-| Flag | Required | Description |
-|---|---|---|
-| `--path / -p` | yes | Path to the Open Plugin directory. |
-| `--output / -o` | no | Destination project folder. Defaults to `./<plugin-name>`. |
-| `--privacy-url` | conditional | `developer.privacyUrl`. Required unless plugin.json carries an `x-microsoft-365-agents-toolkit` block. |
-| `--terms-url` | conditional | `developer.termsOfUseUrl`. Required unless plugin.json carries an `x-microsoft-365-agents-toolkit` block. |
-| `--website-url` | no | `developer.websiteUrl`. Falls back to plugin.json `homepage` then `author.url`. |
-| `--app-id` | no | Override the deterministic UUIDv5 manifest id. |
-| `--default-auth-type` | no | `Auto` (default), `None`, `OAuthPluginVault`, or `ApiKeyPluginVault`. |
-| `--package-name` | no | Full reverse-DNS packageName (omitted from manifest when absent). |
+| Flag                  | Required    | Description                                                                                                                                                              |
+| --------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--path / -p`         | yes         | Path to the Open Plugin directory.                                                                                                                                       |
+| `--output / -o`       | no          | Destination project folder. Defaults to `./<plugin-name>`.                                                                                                               |
+| `--privacy-url`       | conditional | `developer.privacyUrl`. Required unless plugin.json carries an `x-microsoft-365-agents-toolkit` block.                                                                   |
+| `--terms-url`         | conditional | `developer.termsOfUseUrl`. Required unless plugin.json carries an `x-microsoft-365-agents-toolkit` block.                                                                |
+| `--website-url`       | no          | `developer.websiteUrl`. Falls back to plugin.json `homepage` then `author.url`.                                                                                          |
+| `--app-id`            | no          | Override the deterministic UUIDv5 manifest id.                                                                                                                           |
+| `--default-auth-type` | no          | `Auto` (default), `None`, `OAuthPluginVault`, or `ApiKeyPluginVault`. Auto probes remote HTTPS MCP endpoints and OAuth metadata, and fails when auth remains unresolved. |
+| `--package-name`      | no          | Full reverse-DNS packageName (omitted from manifest when absent).                                                                                                        |
 
 ## CLI options — export
 
-| Flag | Required | Description |
-|---|---|---|
-| `--path / -p` | yes | ATK project folder (must contain `appPackage/manifest.json`). |
-| `--output / -o` | no | Destination Open Plugin folder. Defaults to `./<plugin-name>-openplugin`. |
-| `--manifest-kind` | no | `open-plugin` (default), `claude-plugin`, or `cursor-plugin`. |
+| Flag              | Required | Description                                                               |
+| ----------------- | -------- | ------------------------------------------------------------------------- |
+| `--path / -p`     | yes      | ATK project folder (must contain `appPackage/manifest.json`).             |
+| `--output / -o`   | no       | Destination Open Plugin folder. Defaults to `./<plugin-name>-openplugin`. |
+| `--manifest-kind` | no       | `open-plugin` (default), `claude-plugin`, or `cursor-plugin`.             |
 
 ## What gets mapped
 
-| Open Plugin component | Manifest field | Notes |
-|---|---|---|
-| `skills/<name>/SKILL.md` | `agentSkills[].folder` | Copied verbatim; sorted alphabetically. |
-| `.mcp.json` HTTP servers | `agentConnectors[].toolSource.remoteMcpServer` | Auth auto-detected: HTTPS non-localhost → `OAuthPluginVault`, else `None`. |
-| `.mcp.json` stdio servers | *(skipped)* | Warning emitted; requires manual `localMcpServer` setup. |
-| `commands/*.md` | *(copied alongside, inert)* | Not yet in MOS3 manifest; kept for forward compatibility. |
-| `hooks/`, `agents/`, `rules/`, `lspServers/`, `outputStyles/` | *(dropped)* | Warning emitted per field. Not representable in MOS3 today. |
+| Open Plugin component                                         | Manifest field                                 | Notes                                                                                                                                                                  |
+| ------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `skills/<name>/SKILL.md`                                      | `agentSkills[].folder`                         | Copied verbatim; sorted alphabetically.                                                                                                                                |
+| `.mcp.json` HTTP servers                                      | `agentConnectors[].toolSource.remoteMcpServer` | Preserved auth metadata or an explicit default wins. Auto uses an MCP `initialize` probe plus OAuth metadata discovery; localhost and non-HTTPS entries remain `None`. |
+| `.mcp.json` stdio servers                                     | _(skipped)_                                    | Warning emitted; requires manual `localMcpServer` setup.                                                                                                               |
+| `commands/*.md`                                               | _(copied alongside, inert)_                    | Not yet in MOS3 manifest; kept for forward compatibility.                                                                                                              |
+| `hooks/`, `agents/`, `rules/`, `lspServers/`, `outputStyles/` | _(dropped)_                                    | Warning emitted per field. Not representable in MOS3 today.                                                                                                            |
 
 ## Lossless round-trip via the `x-microsoft-365-agents-toolkit` extension
 
@@ -76,6 +77,22 @@ developer.privacyUrl, developer.termsOfUseUrl, `name.short`/`full`,
 `description.short`/`full`, per-connector displayName/description/authorization
 overrides). On the next `atk import openplugin` the block is read back so the
 reconstructed manifest matches the original byte-for-byte where possible.
+
+## Auto authentication discovery
+
+`--default-auth-type Auto` performs network requests for each remote HTTPS MCP URL whose auth is
+not preserved in the ATK extension block. A confirmed endpoint with resolvable OAuth metadata maps
+to `OAuthPluginVault`. A confirmed unauthenticated `initialize` response with no resolved OAuth
+metadata maps to `None`. Both outcomes produce a warning because MCP servers can defer auth to
+individual tool calls or use auth mechanisms that discovery cannot identify.
+
+Auto visits MCP URLs supplied by the source plugin, then follows OAuth metadata URLs and redirects
+returned during discovery. It does not enforce an egress allowlist. For an untrusted plugin, verify
+the URLs first or use an explicit `--default-auth-type` to skip discovery requests.
+
+If the endpoint cannot be confirmed, or it challenges for auth without resolvable OAuth metadata,
+the import stops with `UnresolvedMcpAuth`. Re-run with an explicit `--default-auth-type` after
+verifying the server's requirements. `ApiKeyPluginVault` is never inferred automatically.
 
 ## Module structure
 
@@ -95,7 +112,7 @@ openPlugin/
 
 ## Feature flags
 
-| Flag | Default | Purpose |
-|---|---|---|
-| `TEAMSFX_OPENPLUGIN_IMPORT_EXPORT` | `true` | Gates registration of `atk import openplugin` and `atk export openplugin`. |
-| `TEAMSFX_AGENT_SKILLS` | `false` | Gates `createAppPackage` folder walk for the DA-level `agent_skills` property. Top-level Teams manifest `agentSkills` is packaged unconditionally. |
+| Flag                               | Default | Purpose                                                                                                                                            |
+| ---------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TEAMSFX_OPENPLUGIN_IMPORT_EXPORT` | `true`  | Gates registration of `atk import openplugin` and `atk export openplugin`.                                                                         |
+| `TEAMSFX_AGENT_SKILLS`             | `false` | Gates `createAppPackage` folder walk for the DA-level `agent_skills` property. Top-level Teams manifest `agentSkills` is packaged unconditionally. |

--- a/packages/fx-core/src/component/generator/openPlugin/README.md
+++ b/packages/fx-core/src/component/generator/openPlugin/README.md
@@ -39,16 +39,16 @@ atk export openplugin --path ./my-project --manifest-kind claude-plugin
 
 ## CLI options — import
 
-| Flag                  | Required    | Description                                                                                                                                                              |
-| --------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--path / -p`         | yes         | Path to the Open Plugin directory.                                                                                                                                       |
-| `--output / -o`       | no          | Destination project folder. Defaults to `./<plugin-name>`.                                                                                                               |
-| `--privacy-url`       | conditional | `developer.privacyUrl`. Required unless plugin.json carries an `x-microsoft-365-agents-toolkit` block.                                                                   |
-| `--terms-url`         | conditional | `developer.termsOfUseUrl`. Required unless plugin.json carries an `x-microsoft-365-agents-toolkit` block.                                                                |
-| `--website-url`       | no          | `developer.websiteUrl`. Falls back to plugin.json `homepage` then `author.url`.                                                                                          |
-| `--app-id`            | no          | Override the deterministic UUIDv5 manifest id.                                                                                                                           |
-| `--default-auth-type` | no          | `Auto` (default), `None`, `OAuthPluginVault`, or `ApiKeyPluginVault`. Auto probes remote HTTPS MCP endpoints and OAuth metadata, and fails when auth remains unresolved. |
-| `--package-name`      | no          | Full reverse-DNS packageName (omitted from manifest when absent).                                                                                                        |
+| Flag                  | Required    | Description                                                                                                                                                                                                              |
+| --------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--path / -p`         | yes         | Path to the Open Plugin directory.                                                                                                                                                                                       |
+| `--output / -o`       | no          | Destination project folder. Defaults to `./<plugin-name>`.                                                                                                                                                               |
+| `--privacy-url`       | conditional | `developer.privacyUrl`. Required unless plugin.json carries an `x-microsoft-365-agents-toolkit` block.                                                                                                                   |
+| `--terms-url`         | conditional | `developer.termsOfUseUrl`. Required unless plugin.json carries an `x-microsoft-365-agents-toolkit` block.                                                                                                                |
+| `--website-url`       | no          | `developer.websiteUrl`. Falls back to plugin.json `homepage` then `author.url`.                                                                                                                                          |
+| `--app-id`            | no          | Override the deterministic UUIDv5 manifest id.                                                                                                                                                                           |
+| `--default-auth-type` | no          | `Auto` (default), `None`, `OAuthPluginVault`, or `ApiKeyPluginVault`. Auto probes remote HTTPS MCP endpoints and OAuth metadata, warns on inferred or fallback choices, and fails when the endpoint cannot be confirmed. |
+| `--package-name`      | no          | Full reverse-DNS packageName (omitted from manifest when absent).                                                                                                                                                        |
 
 ## CLI options — export
 
@@ -83,16 +83,17 @@ reconstructed manifest matches the original byte-for-byte where possible.
 `--default-auth-type Auto` performs network requests for each remote HTTPS MCP URL whose auth is
 not preserved in the ATK extension block. A confirmed endpoint with resolvable OAuth metadata maps
 to `OAuthPluginVault`. A confirmed unauthenticated `initialize` response with no resolved OAuth
-metadata maps to `None`. Both outcomes produce a warning because MCP servers can defer auth to
-individual tool calls or use auth mechanisms that discovery cannot identify.
+metadata maps to `None`. A confirmed auth challenge whose metadata cannot be resolved falls back to
+`OAuthPluginVault`. Every outcome produces a warning; the fallback warning tells the developer to
+verify the authentication type and register the placeholder reference before use.
 
 Auto visits MCP URLs supplied by the source plugin, then follows OAuth metadata URLs and redirects
 returned during discovery. It does not enforce an egress allowlist. For an untrusted plugin, verify
 the URLs first or use an explicit `--default-auth-type` to skip discovery requests.
 
-If the endpoint cannot be confirmed, or it challenges for auth without resolvable OAuth metadata,
-the import stops with `UnresolvedMcpAuth`. Re-run with an explicit `--default-auth-type` after
-verifying the server's requirements. `ApiKeyPluginVault` is never inferred automatically.
+If the endpoint cannot be confirmed, the import stops with `UnresolvedMcpAuth`. Re-run with an
+explicit `--default-auth-type` after verifying the server's requirements. `ApiKeyPluginVault` is
+never inferred automatically.
 
 ## Module structure
 

--- a/packages/fx-core/src/component/generator/openPlugin/authResolver.ts
+++ b/packages/fx-core/src/component/generator/openPlugin/authResolver.ts
@@ -99,9 +99,11 @@ export async function resolveOpenPluginMcpAuth(
       await mcpToolFetcher.resolveMCPOAuthMetadata(probe.authMetadataUrl, undefined, serverUrl);
       authTypes[serverName] = "OAuthPluginVault";
       warnings.push(getLocalizedString("core.openPluginImport.autoAuthOAuth", serverName));
-    } catch (error) {
+    } catch {
       if (probe.requiresAuth) {
-        return err(unresolvedAuth(serverName, error));
+        authTypes[serverName] = "OAuthPluginVault";
+        warnings.push(getLocalizedString("core.openPluginImport.authFallback", serverName));
+        continue;
       }
       authTypes[serverName] = "None";
       warnings.push(getLocalizedString("core.openPluginImport.autoAuthNone", serverName));

--- a/packages/fx-core/src/component/generator/openPlugin/authResolver.ts
+++ b/packages/fx-core/src/component/generator/openPlugin/authResolver.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { FxError, UserError } from "@microsoft/teamsfx-api";
+import { err, ok, Result } from "neverthrow";
+import { getLocalizedString } from "../../../common/localizeUtils";
+import * as mcpToolFetcher from "../../../common/mcpToolFetcher";
+import { AuthorizationType, DefaultAuthOption, ParsedOpenPlugin } from "./types";
+
+const SOURCE = "OpenPluginImport";
+
+export interface OpenPluginMcpAuthResolution {
+  authTypes: Readonly<Record<string, AuthorizationType>>;
+  warnings: string[];
+}
+
+type AuthProbeTarget = "invalid" | "noProbe" | "remote";
+
+function isLocalHostname(hostname: string): boolean {
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "[::1]" ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname)
+  ) {
+    return true;
+  }
+
+  const mappedIpv4 = /^\[::ffff:([0-9a-f]{1,4}):[0-9a-f]{1,4}\]$/.exec(hostname);
+  return mappedIpv4 !== null && Number.parseInt(mappedIpv4[1], 16) >> 8 === 0x7f;
+}
+
+function classifyAuthProbeTarget(serverUrl: string): AuthProbeTarget {
+  try {
+    const parsed = new URL(serverUrl);
+    const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
+    return parsed.protocol === "https:" && !isLocalHostname(hostname) ? "remote" : "noProbe";
+  } catch {
+    return "invalid";
+  }
+}
+
+function unresolvedAuth(serverName: string, error?: unknown): UserError {
+  const message = getLocalizedString("core.openPluginImport.unresolvedMcpAuth", serverName);
+  return new UserError({
+    source: SOURCE,
+    name: "UnresolvedMcpAuth",
+    message,
+    displayMessage: message,
+    error: error instanceof Error ? error : undefined,
+  });
+}
+
+/** Resolve every connector auth type before the pure manifest mapper runs. */
+export async function resolveOpenPluginMcpAuth(
+  parsed: ParsedOpenPlugin,
+  defaultAuth: DefaultAuthOption
+): Promise<Result<OpenPluginMcpAuthResolution, FxError>> {
+  const authTypes: Record<string, AuthorizationType> = {};
+  const warnings: string[] = [];
+
+  for (const serverName of Object.keys(parsed.mcpServers).sort()) {
+    const server = parsed.mcpServers[serverName];
+    const serverUrl = typeof server.url === "string" ? server.url.trim() : "";
+    if (!serverUrl) {
+      continue;
+    }
+
+    const override = parsed.atkExtension?.agentConnectors?.[serverName]?.authorization?.type;
+    if (override) {
+      authTypes[serverName] = override;
+      continue;
+    }
+    if (defaultAuth !== "Auto") {
+      authTypes[serverName] = defaultAuth;
+      continue;
+    }
+    const probeTarget = classifyAuthProbeTarget(serverUrl);
+    if (probeTarget === "invalid") {
+      return err(unresolvedAuth(serverName));
+    }
+    if (probeTarget === "noProbe") {
+      authTypes[serverName] = "None";
+      warnings.push(getLocalizedString("core.openPluginImport.autoAuthNone", serverName));
+      continue;
+    }
+
+    let probe: mcpToolFetcher.MCPAuthProbeResult;
+    try {
+      probe = await mcpToolFetcher.probeMCPServerAuth(serverUrl);
+    } catch (error) {
+      return err(unresolvedAuth(serverName, error));
+    }
+    if (probe.endpointStatus !== "confirmed") {
+      return err(unresolvedAuth(serverName));
+    }
+
+    try {
+      await mcpToolFetcher.resolveMCPOAuthMetadata(probe.authMetadataUrl, undefined, serverUrl);
+      authTypes[serverName] = "OAuthPluginVault";
+      warnings.push(getLocalizedString("core.openPluginImport.autoAuthOAuth", serverName));
+    } catch (error) {
+      if (probe.requiresAuth) {
+        return err(unresolvedAuth(serverName, error));
+      }
+      authTypes[serverName] = "None";
+      warnings.push(getLocalizedString("core.openPluginImport.autoAuthNone", serverName));
+    }
+  }
+
+  return ok({ authTypes, warnings });
+}

--- a/packages/fx-core/src/component/generator/openPlugin/importer.ts
+++ b/packages/fx-core/src/component/generator/openPlugin/importer.ts
@@ -8,8 +8,9 @@ import * as path from "path";
 import { createContext } from "../../../common/globalVars";
 import { Generator } from "../generator";
 import { TemplateNames } from "../templates/templateNames";
+import { resolveOpenPluginMcpAuth } from "./authResolver";
 import { applyIcons } from "./iconStrategy";
-import { mapToTtkProject } from "./mapper";
+import { mapToTtkProject, validateMcpServerCount } from "./mapper";
 import { readOpenPluginDir } from "./parser";
 import { ImportInputs } from "./types";
 
@@ -42,8 +43,6 @@ export async function importOpenPlugin(
       );
     }
     const parsed = await readOpenPluginDir(inputs.path);
-    const { manifest, copyOps, warnings } = mapToTtkProject(parsed, inputs);
-
     const defaultOutput = path.join(process.cwd(), parsed.manifest.name);
     const projectPath = path.resolve(inputs.output ?? defaultOutput);
 
@@ -59,6 +58,18 @@ export async function importOpenPlugin(
         );
       }
     }
+    validateMcpServerCount(parsed.mcpServers);
+
+    const authResolution = await resolveOpenPluginMcpAuth(parsed, inputs.defaultAuthType ?? "Auto");
+    if (authResolution.isErr()) {
+      return err(authResolution.error);
+    }
+    const { manifest, copyOps, warnings } = mapToTtkProject(
+      parsed,
+      inputs,
+      authResolution.value.authTypes
+    );
+    warnings.push(...authResolution.value.warnings);
 
     // 1. Scaffold the static baseline from the open-plugin-import template.
     const ctx = createContext();

--- a/packages/fx-core/src/component/generator/openPlugin/mapper.ts
+++ b/packages/fx-core/src/component/generator/openPlugin/mapper.ts
@@ -27,7 +27,22 @@ const DESC_SHORT_MAX = 80;
 const DESC_FULL_MAX = 4000;
 const MAX_AGENT_CONNECTORS = 10;
 
-export function mapToTtkProject(parsed: ParsedOpenPlugin, inputs: ImportInputs): MappedManifest {
+export function validateMcpServerCount(mcpServers: Record<string, OpenPluginMcpServerEntry>): void {
+  const connectorCount = Object.values(mcpServers).filter(
+    (server) => typeof server.url === "string" && server.url.trim().length > 0
+  ).length;
+  if (connectorCount > MAX_AGENT_CONNECTORS) {
+    throw new Error(
+      `Too many MCP servers: ${connectorCount}. The manifest caps agentConnectors at ${MAX_AGENT_CONNECTORS}.`
+    );
+  }
+}
+
+export function mapToTtkProject(
+  parsed: ParsedOpenPlugin,
+  inputs: ImportInputs,
+  resolvedAuthTypes: Readonly<Record<string, AuthorizationType>> = {}
+): MappedManifest {
   const warnings = [...parsed.warnings];
   const pj = parsed.manifest;
   const pluginName = pj.name;
@@ -71,19 +86,15 @@ export function mapToTtkProject(parsed: ParsedOpenPlugin, inputs: ImportInputs):
 
   const agentSkills = parsed.skills.map((folder) => ({ folder: `./skills/${folder}` }));
 
+  validateMcpServerCount(parsed.mcpServers);
   const agentConnectors = buildAgentConnectors(
     parsed.mcpServers,
     pluginName,
     inputs.defaultAuthType ?? "Auto",
     ext.agentConnectors,
-    warnings
+    warnings,
+    resolvedAuthTypes
   );
-
-  if (agentConnectors.length > MAX_AGENT_CONNECTORS) {
-    throw new Error(
-      `Too many MCP servers: ${agentConnectors.length}. The manifest caps agentConnectors at ${MAX_AGENT_CONNECTORS}.`
-    );
-  }
 
   const developer: Record<string, unknown> = {
     name: ext.developer?.name ?? author.name ?? "Unknown",
@@ -136,7 +147,8 @@ function buildAgentConnectors(
   pluginName: string,
   defaultAuth: "Auto" | AuthorizationType,
   extOverrides: Record<string, AtkAgentConnectorExt> | undefined,
-  warnings: string[]
+  warnings: string[],
+  resolvedAuthTypes: Readonly<Record<string, AuthorizationType>>
 ): Record<string, unknown>[] {
   const out: Record<string, unknown>[] = [];
   const serverNames = Object.keys(mcpServers).sort();
@@ -151,7 +163,7 @@ function buildAgentConnectors(
     }
     const override = extOverrides?.[name];
     const authType: AuthorizationType =
-      override?.authorization?.type ?? resolveAuthType(url, defaultAuth);
+      override?.authorization?.type ?? resolveAuthType(name, defaultAuth, resolvedAuthTypes);
     const authorization: Record<string, unknown> = { type: authType };
     if (authType !== "None") {
       authorization.referenceId =
@@ -177,14 +189,17 @@ function buildAgentConnectors(
   return out;
 }
 
-function resolveAuthType(url: string, defaultAuth: "Auto" | AuthorizationType): AuthorizationType {
+function resolveAuthType(
+  serverName: string,
+  defaultAuth: "Auto" | AuthorizationType,
+  resolvedAuthTypes: Readonly<Record<string, AuthorizationType>>
+): AuthorizationType {
   if (defaultAuth !== "Auto") {
     return defaultAuth;
   }
-  const isHttps = /^https:\/\//i.test(url);
-  const isLocal = /localhost|127\.0\.0\.1/.test(url);
-  if (isHttps && !isLocal) {
-    return "OAuthPluginVault";
+  const resolved = resolvedAuthTypes[serverName];
+  if (!resolved) {
+    throw new Error(`Missing resolved auth type for MCP server '${serverName}'.`);
   }
-  return "None";
+  return resolved;
 }

--- a/packages/fx-core/src/question/options/ImportOpenPluginOptions.ts
+++ b/packages/fx-core/src/question/options/ImportOpenPluginOptions.ts
@@ -45,7 +45,7 @@ export const ImportOpenPluginOptions: CLICommandOption[] = [
     name: "default-auth-type",
     type: "string",
     description:
-      "Default auth type for MCP connectors discovered in .mcp.json. 'Auto' picks OAuthPluginVault for non-localhost HTTPS, None otherwise.",
+      "Default auth type for MCP connectors discovered in .mcp.json. 'Auto' probes remote HTTPS MCP endpoints and OAuth metadata, warns on inferred choices, and requires an explicit type when auth is unresolved.",
     default: "Auto",
     choices: ["Auto", "None", "OAuthPluginVault", "ApiKeyPluginVault"],
   },

--- a/packages/fx-core/tests/component/generator/openPlugin/fixtures/contoso-helper/.plugin/plugin.json
+++ b/packages/fx-core/tests/component/generator/openPlugin/fixtures/contoso-helper/.plugin/plugin.json
@@ -9,5 +9,20 @@
   },
   "logo": "./assets/logo.png",
   "agents": "./agents-dir",
-  "hooks": "./hooks-dir"
+  "hooks": "./hooks-dir",
+  "x-microsoft-365-agents-toolkit": {
+    "agentConnectors": {
+      "contoso-tools": {
+        "authorization": {
+          "type": "OAuthPluginVault",
+          "referenceId": "contoso-helper-contoso-tools-auth"
+        }
+      },
+      "local-dev": {
+        "authorization": {
+          "type": "None"
+        }
+      }
+    }
+  }
 }

--- a/packages/fx-core/tests/component/generator/openPlugin/importer.test.ts
+++ b/packages/fx-core/tests/component/generator/openPlugin/importer.test.ts
@@ -213,23 +213,52 @@ describe("openPlugin.importOpenPlugin", () => {
     chai.expect(res.value.warnings.some((warning) => warning.includes("web"))).to.equal(true);
   });
 
+  it("OPI-AUTH-08 / SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-05: falls back to OAuth for a confirmed challenge without metadata", async () => {
+    vi.mocked(mcpToolFetcher.resolveMCPOAuthMetadata).mockRejectedValue(
+      new Error("No OAuth metadata")
+    );
+
+    const res = await importOpenPlugin({
+      path: pluginDir,
+      output: outDir,
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    });
+
+    if (res.isErr()) throw new Error(res.error.message);
+    const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+    chai
+      .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization)
+      .to.deep.equal({
+        type: "OAuthPluginVault",
+        referenceId: "demo-plugin-web-auth",
+      });
+    chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).toHaveBeenCalledOnce();
+    chai
+      .expect(
+        res.value.warnings.some(
+          (warning) =>
+            warning.includes("web") &&
+            warning.includes("could not be resolved") &&
+            warning.includes("Verify") &&
+            warning.includes("register")
+        )
+      )
+      .to.equal(true);
+  });
+
   it("OPI-AUTH-06: Auto stops before scaffolding when auth is unresolved", async () => {
     const probe = vi.mocked(mcpToolFetcher.probeMCPServerAuth);
-    const resolveMetadata = vi.mocked(mcpToolFetcher.resolveMCPOAuthMetadata);
     const cases = [
       async () =>
-        probe.mockResolvedValueOnce({ requiresAuth: false, endpointStatus: "undetermined" }),
+        probe.mockResolvedValueOnce({ requiresAuth: true, endpointStatus: "undetermined" }),
       async () =>
         probe.mockResolvedValueOnce({
-          requiresAuth: false,
+          requiresAuth: true,
           endpointStatus: "notEndpoint",
           responseStatus: 404,
         }),
       async () => probe.mockRejectedValueOnce(new Error("network unavailable")),
-      async () => {
-        probe.mockResolvedValueOnce({ requiresAuth: true, endpointStatus: "confirmed" });
-        resolveMetadata.mockRejectedValueOnce(new Error("No OAuth metadata"));
-      },
     ];
 
     for (const arrange of cases) {
@@ -246,6 +275,7 @@ describe("openPlugin.importOpenPlugin", () => {
 
       chai.expect(res.isErr()).to.equal(true);
       if (res.isErr()) chai.expect(res.error.name).to.equal("UnresolvedMcpAuth");
+      chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).not.toHaveBeenCalled();
       chai.expect(Generator.generateTemplate).not.toHaveBeenCalled();
       chai.expect(await fs.pathExists(outDir)).to.equal(false);
     }

--- a/packages/fx-core/tests/component/generator/openPlugin/importer.test.ts
+++ b/packages/fx-core/tests/component/generator/openPlugin/importer.test.ts
@@ -5,6 +5,7 @@ import { ok } from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
+import * as mcpToolFetcher from "../../../../src/common/mcpToolFetcher";
 import { setTools } from "../../../../src/common/globalVars";
 import { Generator } from "../../../../src/component/generator/generator";
 import { importOpenPlugin } from "../../../../src/component/generator/openPlugin/importer";
@@ -61,6 +62,16 @@ describe("openPlugin.importOpenPlugin", () => {
       await scaffoldOpenPluginTemplateFromSource(dest, { appName });
       return ok(undefined);
     });
+    vi.spyOn(mcpToolFetcher, "probeMCPServerAuth").mockResolvedValue({
+      requiresAuth: true,
+      endpointStatus: "confirmed",
+      authMetadataUrl: "https://web.example.com/.well-known/oauth-protected-resource",
+    });
+    vi.spyOn(mcpToolFetcher, "resolveMCPOAuthMetadata").mockResolvedValue({
+      authorizationUrl: "https://login.example.com/authorize",
+      tokenUrl: "https://login.example.com/token",
+      wellKnownUrl: "https://login.example.com/.well-known/oauth-authorization-server",
+    });
   });
 
   afterEach(async () => {
@@ -69,7 +80,7 @@ describe("openPlugin.importOpenPlugin", () => {
     await fs.remove(outDir);
   });
 
-  it("scaffolds the expected project tree", async () => {
+  it("SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-01: scaffolds an Auto-auth Toolkit project", async () => {
     const res = await importOpenPlugin({
       path: pluginDir,
       output: outDir,
@@ -99,6 +110,11 @@ describe("openPlugin.importOpenPlugin", () => {
     for (const rel of expected) {
       chai.expect(await fs.pathExists(path.join(outDir, rel)), `missing ${rel}`).to.equal(true);
     }
+    const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+    chai
+      .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization.type)
+      .to.equal("OAuthPluginVault");
+    chai.expect(res.value.warnings.some((warning) => warning.includes("web"))).to.equal(true);
   });
 
   it("emits the expected agentSkills and agentConnectors in manifest.json", async () => {
@@ -128,6 +144,319 @@ describe("openPlugin.importOpenPlugin", () => {
     chai
       .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization.type)
       .to.equal("OAuthPluginVault");
+  });
+
+  it("OPI-AUTH-03: Auto selects None for a confirmed public MCP endpoint", async () => {
+    vi.mocked(mcpToolFetcher.probeMCPServerAuth).mockResolvedValue({
+      requiresAuth: false,
+      endpointStatus: "confirmed",
+    });
+    vi.mocked(mcpToolFetcher.resolveMCPOAuthMetadata).mockRejectedValue(
+      new Error("No OAuth metadata")
+    );
+
+    const res = await importOpenPlugin({
+      path: pluginDir,
+      output: outDir,
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    });
+
+    if (res.isErr()) throw new Error(res.error.message);
+    const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+    chai
+      .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization)
+      .to.deep.equal({ type: "None" });
+    chai.expect(res.value.warnings.some((warning) => warning.includes("web"))).to.equal(true);
+  });
+
+  it("OPI-AUTH-04: Auto selects OAuth for a confirmed auth challenge", async () => {
+    const res = await importOpenPlugin({
+      path: pluginDir,
+      output: outDir,
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    });
+
+    if (res.isErr()) throw new Error(res.error.message);
+    const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+    chai
+      .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization)
+      .to.deep.equal({
+        type: "OAuthPluginVault",
+        referenceId: "demo-plugin-web-auth",
+      });
+    chai.expect(mcpToolFetcher.probeMCPServerAuth).toHaveBeenCalledOnce();
+    chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).toHaveBeenCalledOnce();
+    chai.expect(res.value.warnings.some((warning) => warning.includes("web"))).to.equal(true);
+  });
+
+  it("OPI-AUTH-05: Auto detects OAuth deferred until tool calls", async () => {
+    vi.mocked(mcpToolFetcher.probeMCPServerAuth).mockResolvedValue({
+      requiresAuth: false,
+      endpointStatus: "confirmed",
+    });
+
+    const res = await importOpenPlugin({
+      path: pluginDir,
+      output: outDir,
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    });
+
+    if (res.isErr()) throw new Error(res.error.message);
+    const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+    chai
+      .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization.type)
+      .to.equal("OAuthPluginVault");
+    chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).toHaveBeenCalledOnce();
+    chai.expect(res.value.warnings.some((warning) => warning.includes("web"))).to.equal(true);
+  });
+
+  it("OPI-AUTH-06: Auto stops before scaffolding when auth is unresolved", async () => {
+    const probe = vi.mocked(mcpToolFetcher.probeMCPServerAuth);
+    const resolveMetadata = vi.mocked(mcpToolFetcher.resolveMCPOAuthMetadata);
+    const cases = [
+      async () =>
+        probe.mockResolvedValueOnce({ requiresAuth: false, endpointStatus: "undetermined" }),
+      async () =>
+        probe.mockResolvedValueOnce({
+          requiresAuth: false,
+          endpointStatus: "notEndpoint",
+          responseStatus: 404,
+        }),
+      async () => probe.mockRejectedValueOnce(new Error("network unavailable")),
+      async () => {
+        probe.mockResolvedValueOnce({ requiresAuth: true, endpointStatus: "confirmed" });
+        resolveMetadata.mockRejectedValueOnce(new Error("No OAuth metadata"));
+      },
+    ];
+
+    for (const arrange of cases) {
+      await fs.remove(outDir);
+      vi.mocked(Generator.generateTemplate).mockClear();
+      await arrange();
+
+      const res = await importOpenPlugin({
+        path: pluginDir,
+        output: outDir,
+        privacyUrl: "https://example.com/privacy",
+        termsUrl: "https://example.com/terms",
+      });
+
+      chai.expect(res.isErr()).to.equal(true);
+      if (res.isErr()) chai.expect(res.error.name).to.equal("UnresolvedMcpAuth");
+      chai.expect(Generator.generateTemplate).not.toHaveBeenCalled();
+      chai.expect(await fs.pathExists(outDir)).to.equal(false);
+    }
+  });
+
+  it("OPI-AUTH-06: Auto rejects an invalid MCP URL without probing", async () => {
+    await fs.writeJSON(path.join(pluginDir, ".mcp.json"), {
+      mcpServers: {
+        invalid: { url: "not-a-valid-url" },
+      },
+    });
+
+    const res = await importOpenPlugin({
+      path: pluginDir,
+      output: outDir,
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    });
+
+    chai.expect(res.isErr()).to.equal(true);
+    if (res.isErr()) chai.expect(res.error.name).to.equal("UnresolvedMcpAuth");
+    chai.expect(mcpToolFetcher.probeMCPServerAuth).not.toHaveBeenCalled();
+    chai.expect(Generator.generateTemplate).not.toHaveBeenCalled();
+  });
+
+  it("OPI-AUTH-01: preserves an exported connector override without discovery", async () => {
+    const manifestPath = path.join(pluginDir, ".plugin", "plugin.json");
+    const sourceManifest = await fs.readJSON(manifestPath);
+    sourceManifest["x-microsoft-365-agents-toolkit"] = {
+      agentConnectors: {
+        web: {
+          authorization: {
+            type: "ApiKeyPluginVault",
+            referenceId: "existing-api-key-reference",
+          },
+        },
+      },
+    };
+    await fs.writeJSON(manifestPath, sourceManifest);
+
+    for (const defaultAuthType of [
+      "Auto",
+      "None",
+      "OAuthPluginVault",
+      "ApiKeyPluginVault",
+    ] as const) {
+      await fs.remove(outDir);
+      const res = await importOpenPlugin({
+        path: pluginDir,
+        output: outDir,
+        privacyUrl: "https://example.com/privacy",
+        termsUrl: "https://example.com/terms",
+        defaultAuthType,
+      });
+
+      if (res.isErr()) throw new Error(res.error.message);
+      const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+      chai
+        .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization)
+        .to.deep.equal({
+          type: "ApiKeyPluginVault",
+          referenceId: "existing-api-key-reference",
+        });
+      chai.expect(mcpToolFetcher.probeMCPServerAuth).not.toHaveBeenCalled();
+      chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).not.toHaveBeenCalled();
+    }
+  });
+
+  it("OPI-AUTH-02: applies every explicit default without discovery", async () => {
+    for (const defaultAuthType of ["None", "OAuthPluginVault", "ApiKeyPluginVault"] as const) {
+      await fs.remove(outDir);
+      const res = await importOpenPlugin({
+        path: pluginDir,
+        output: outDir,
+        privacyUrl: "https://example.com/privacy",
+        termsUrl: "https://example.com/terms",
+        defaultAuthType,
+      });
+
+      if (res.isErr()) throw new Error(res.error.message);
+      const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+      chai
+        .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization.type)
+        .to.equal(defaultAuthType);
+      chai.expect(mcpToolFetcher.probeMCPServerAuth).not.toHaveBeenCalled();
+      chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).not.toHaveBeenCalled();
+    }
+  });
+
+  it("OPI-AUTH-07: keeps localhost variants on None without discovery", async () => {
+    for (const serverUrl of [
+      "http://localhost:5050/sse",
+      "http://tools.example.com/mcp",
+      "https://[::1]/mcp",
+      "https://[::ffff:127.0.0.1]/mcp",
+      "https://tools.localhost./mcp",
+    ]) {
+      await fs.remove(outDir);
+      await fs.writeJSON(path.join(pluginDir, ".mcp.json"), {
+        mcpServers: {
+          local: { url: serverUrl },
+        },
+      });
+
+      const res = await importOpenPlugin({
+        path: pluginDir,
+        output: outDir,
+        privacyUrl: "https://example.com/privacy",
+        termsUrl: "https://example.com/terms",
+      });
+
+      if (res.isErr()) throw new Error(res.error.message);
+      const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+      chai
+        .expect(manifest.agentConnectors[0].toolSource.remoteMcpServer.authorization)
+        .to.deep.equal({ type: "None" });
+      chai.expect(mcpToolFetcher.probeMCPServerAuth).not.toHaveBeenCalled();
+      chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).not.toHaveBeenCalled();
+    }
+  });
+
+  it("OPI-AUTH-07: probes a public IPv6 MCP server", async () => {
+    const serverUrl = "https://[2001:db8::1]/mcp";
+    await fs.writeJSON(path.join(pluginDir, ".mcp.json"), {
+      mcpServers: {
+        remote: { url: serverUrl },
+      },
+    });
+
+    const res = await importOpenPlugin({
+      path: pluginDir,
+      output: outDir,
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    });
+
+    if (res.isErr()) throw new Error(res.error.message);
+    chai.expect(mcpToolFetcher.probeMCPServerAuth).toHaveBeenCalledWith(serverUrl);
+    chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).toHaveBeenCalledOnce();
+  });
+
+  it("OPI-AUTH-07: resolves mixed connectors in deterministic server-name order", async () => {
+    await fs.writeJSON(path.join(pluginDir, ".mcp.json"), {
+      mcpServers: {
+        secure: { url: "https://secure.example.com/mcp" },
+        stdio: { command: "node", args: ["server.js"] },
+        public: { url: "https://public.example.com/mcp" },
+        preserved: { url: "https://preserved.example.com/mcp" },
+        local: { url: "http://localhost:5050/sse" },
+      },
+    });
+    const manifestPath = path.join(pluginDir, ".plugin", "plugin.json");
+    const sourceManifest = await fs.readJSON(manifestPath);
+    sourceManifest["x-microsoft-365-agents-toolkit"] = {
+      agentConnectors: {
+        preserved: {
+          authorization: {
+            type: "ApiKeyPluginVault",
+            referenceId: "existing-api-key-reference",
+          },
+        },
+      },
+    };
+    await fs.writeJSON(manifestPath, sourceManifest);
+    vi.mocked(mcpToolFetcher.probeMCPServerAuth).mockImplementation(async (serverUrl) => ({
+      requiresAuth: serverUrl.includes("secure"),
+      endpointStatus: "confirmed",
+      authMetadataUrl: serverUrl.includes("secure")
+        ? "https://secure.example.com/.well-known/oauth-protected-resource"
+        : undefined,
+    }));
+    vi.mocked(mcpToolFetcher.resolveMCPOAuthMetadata).mockImplementation(
+      async (_authMetadataUrl, _wellKnownUrl, serverUrl) => {
+        if (!serverUrl?.includes("secure")) throw new Error("No OAuth metadata");
+        return {
+          authorizationUrl: "https://login.example.com/authorize",
+          tokenUrl: "https://login.example.com/token",
+          wellKnownUrl: "https://login.example.com/.well-known/oauth-authorization-server",
+        };
+      }
+    );
+
+    const res = await importOpenPlugin({
+      path: pluginDir,
+      output: outDir,
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    });
+
+    if (res.isErr()) throw new Error(res.error.message);
+    const manifest = await fs.readJSON(path.join(outDir, "appPackage", "manifest.json"));
+    chai
+      .expect(manifest.agentConnectors.map((connector: any) => connector.id))
+      .to.deep.equal(["local", "preserved", "public", "secure"]);
+    chai
+      .expect(
+        manifest.agentConnectors.map(
+          (connector: any) => connector.toolSource.remoteMcpServer.authorization.type
+        )
+      )
+      .to.deep.equal(["None", "ApiKeyPluginVault", "None", "OAuthPluginVault"]);
+    chai
+      .expect(vi.mocked(mcpToolFetcher.probeMCPServerAuth).mock.calls.map((call) => call[0]))
+      .to.deep.equal(["https://public.example.com/mcp", "https://secure.example.com/mcp"]);
+    chai
+      .expect(
+        res.value.warnings
+          .filter((warning) => warning.startsWith("Auto inferred"))
+          .map((warning) => warning.match(/server '([^']+)'/)?.[1])
+      )
+      .to.deep.equal(["local", "public", "secure"]);
   });
 
   it("surfaces a warning for stdio MCP servers", async () => {
@@ -179,7 +508,7 @@ describe("openPlugin.importOpenPlugin", () => {
     }
   });
 
-  it("refuses to write into a non-empty output directory", async () => {
+  it("SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-03: rejects non-empty output before discovery", async () => {
     await fs.ensureDir(outDir);
     await fs.writeFile(path.join(outDir, "preexisting.txt"), "hi");
     const res = await importOpenPlugin({
@@ -192,6 +521,31 @@ describe("openPlugin.importOpenPlugin", () => {
     if (res.isErr()) {
       chai.expect(res.error.name).to.equal("OutputDirectoryNotEmpty");
     }
+    chai.expect(mcpToolFetcher.probeMCPServerAuth).not.toHaveBeenCalled();
+    chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).not.toHaveBeenCalled();
+    chai.expect(Generator.generateTemplate).not.toHaveBeenCalled();
+    chai.expect(await fs.readFile(path.join(outDir, "preexisting.txt"), "utf8")).to.equal("hi");
+  });
+
+  it("SCN-TOOLKIT-IMPORT-OPEN-PLUGIN-04: rejects excess connectors before discovery", async () => {
+    const mcpServers: Record<string, { url: string }> = {};
+    for (let index = 0; index < 11; index++) {
+      mcpServers[`svc-${index}`] = { url: `https://svc-${index}.example.com/mcp` };
+    }
+    await fs.writeJSON(path.join(pluginDir, ".mcp.json"), { mcpServers });
+
+    const res = await importOpenPlugin({
+      path: pluginDir,
+      output: outDir,
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    });
+
+    chai.expect(res.isErr()).to.equal(true);
+    chai.expect(mcpToolFetcher.probeMCPServerAuth).not.toHaveBeenCalled();
+    chai.expect(mcpToolFetcher.resolveMCPOAuthMetadata).not.toHaveBeenCalled();
+    chai.expect(Generator.generateTemplate).not.toHaveBeenCalled();
+    chai.expect(await fs.pathExists(outDir)).to.equal(false);
   });
 
   it("returns an error when --path does not exist", async () => {

--- a/packages/fx-core/tests/component/generator/openPlugin/mapper.test.ts
+++ b/packages/fx-core/tests/component/generator/openPlugin/mapper.test.ts
@@ -78,14 +78,15 @@ describe("openPlugin.mapToTtkProject", () => {
       .to.deep.equal([{ folder: "./skills/alpha" }, { folder: "./skills/beta" }]);
   });
 
-  it("emits agentConnectors for http servers with OAuthPluginVault under Auto", () => {
+  it("uses a resolved OAuthPluginVault type under Auto", () => {
     const { manifest } = mapToTtkProject(
       baseParsed({
         mcpServers: {
           alpha: { url: "https://alpha.example.com/api", description: "alpha tools" },
         },
       }),
-      baseInputs()
+      baseInputs(),
+      { alpha: "OAuthPluginVault" }
     );
     chai.expect(manifest.agentConnectors).to.deep.equal([
       {
@@ -105,12 +106,13 @@ describe("openPlugin.mapToTtkProject", () => {
     ]);
   });
 
-  it("maps localhost http servers to None under Auto", () => {
+  it("uses a resolved None type under Auto", () => {
     const { manifest } = mapToTtkProject(
       baseParsed({
         mcpServers: { local: { url: "http://localhost:5050/sse" } },
       }),
-      baseInputs()
+      baseInputs(),
+      { local: "None" }
     );
     const connectors = manifest.agentConnectors as any[];
     chai.expect(connectors[0].toolSource.remoteMcpServer.authorization).to.deep.equal({
@@ -140,7 +142,8 @@ describe("openPlugin.mapToTtkProject", () => {
           http: { url: "https://http.example.com" },
         },
       }),
-      baseInputs()
+      baseInputs(),
+      { http: "OAuthPluginVault" }
     );
     const connectors = manifest.agentConnectors as any[];
     chai.expect(connectors.map((c) => c.id)).to.deep.equal(["http"]);
@@ -149,12 +152,25 @@ describe("openPlugin.mapToTtkProject", () => {
 
   it("throws when more than 10 MCP servers would be emitted", () => {
     const mcpServers: Record<string, { url: string }> = {};
+    const authTypes: Record<string, "OAuthPluginVault"> = {};
     for (let i = 0; i < 11; i++) {
       mcpServers[`svc-${i}`] = { url: `https://svc-${i}.example.com` };
+      authTypes[`svc-${i}`] = "OAuthPluginVault";
     }
     chai
-      .expect(() => mapToTtkProject(baseParsed({ mcpServers }), baseInputs()))
+      .expect(() => mapToTtkProject(baseParsed({ mcpServers }), baseInputs(), authTypes))
       .to.throw(/caps agentConnectors at 10/);
+  });
+
+  it("OPI-AUTH-07: does not guess when an Auto resolution is missing", () => {
+    chai
+      .expect(() =>
+        mapToTtkProject(
+          baseParsed({ mcpServers: { svc: { url: "https://svc.example.com" } } }),
+          baseInputs()
+        )
+      )
+      .to.throw(/Missing resolved auth type/);
   });
 
   it("does not emit contactInfo (not in devPreview schema)", () => {
@@ -212,7 +228,8 @@ describe("openPlugin.mapToTtkProject", () => {
       baseParsed({
         mcpServers: { svc: { url: "https://svc.example.com" } },
       }),
-      baseInputs()
+      baseInputs(),
+      { svc: "OAuthPluginVault" }
     );
     const connectors = manifest.agentConnectors as any[];
     chai.expect(connectors[0].description).to.include("Remote MCP server");

--- a/packages/fx-core/tests/component/utils/mcpToolFetcher.test.ts
+++ b/packages/fx-core/tests/component/utils/mcpToolFetcher.test.ts
@@ -555,6 +555,27 @@ describe("mcpToolFetcher", () => {
       assert.isTrue(getStub.mock.calls.length === 1);
     });
 
+    it("should bound every OAuth metadata request with a timeout", async () => {
+      const getStub = vi.spyOn(axios, "get");
+      getStub.mockResolvedValueOnce({
+        status: 200,
+        data: { authorization_servers: ["https://auth.example.com/oauth"] },
+      });
+      getStub.mockResolvedValueOnce({
+        data: {
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+        },
+      });
+
+      await resolveMCPOAuthMetadata("https://example.com/.well-known/oauth-protected-resource");
+
+      assert.equal(getStub.mock.calls.length, 2);
+      for (const call of getStub.mock.calls) {
+        assert.deepEqual(call[1], { timeout: 10000 });
+      }
+    });
+
     it("should throw when both authMetadataUrl and wellKnownUrl are undefined", async () => {
       try {
         await resolveMCPOAuthMetadata(undefined, undefined);


### PR DESCRIPTION
## Summary

- replace Open Plugin Auto auth's URL-shape guess with MCP `initialize` evidence plus OAuth metadata discovery
- preserve exported auth and explicit defaults, keep mapping pure, and fail when the MCP endpoint cannot be confirmed
- fall back to `OAuthPluginVault` with a verification/registration warning when a confirmed auth challenge has no resolvable OAuth metadata
- validate output/connector limits before network access and add operation + scenario contracts with AC-derived coverage

Related to #16606.

## Owner review focus

Please confirm the intended `Auto` policy: a verified public MCP endpoint maps to `None`; a confirmed auth challenge maps to `OAuthPluginVault` (with a warning when OAuth metadata cannot be resolved); and an invalid or unconfirmed endpoint blocks import. Explicit `--default-auth-type` values and preserved per-connector auth remain authoritative and skip discovery. This avoids treating every HTTPS URL as OAuth while retaining compatibility with servers such as Google Calendar/Contacts.

## Design

- [Operation spec](https://github.com/OfficeDev/microsoft-365-agents-toolkit/blob/feat/openplugin-auto-auth/docs/03-specs/operations/product/resolve-open-plugin-mcp-auth.md)
- [Scenario spec](https://github.com/OfficeDev/microsoft-365-agents-toolkit/blob/feat/openplugin-auto-auth/docs/03-specs/scenarios/toolkit/import-open-plugin.md)
- [Rendered product scenario](https://raw.githack.com/OfficeDev/microsoft-365-agents-toolkit/feat/openplugin-auto-auth/docs/01-product/scenarios/toolkit/import-open-plugin.html) (raw.githack shows an External Content Notice on first visit; select **Open the page** once.)

## Test plan

- `cd packages/fx-core && npm run build`
- `cd packages/fx-core && npm run test:unit:fast` - 293 passed files, 5,445 passed tests; 35 skipped, 1 todo
- focused Open Plugin importer suite - 21 tests
- real CLI Auto comparison: public DeepWiki MCP -> `None`; Google Calendar/Contacts auth challenge without metadata -> `OAuthPluginVault` plus fallback warning; non-MCP HTTPS URL -> `UnresolvedMcpAuth` with no output
- real CLI explicit-auth matrix: all three endpoint categories preserve `None`, `OAuthPluginVault`, or `ApiKeyPluginVault` exactly, with no inference warning
- scenario `render` + `check` - passes with existing unbound-template/fingerprint warnings
- changed-file ESLint error gate, Prettier, localization unused-string check, and `git diff --check`

## Risk

`Auto` is an explicit local-client discovery action. It follows MCP URLs from the imported plugin and OAuth metadata URLs/redirects returned by servers; it does not enforce an egress allowlist. Users importing an untrusted plugin can choose an explicit `--default-auth-type` to skip discovery. OAuth metadata requests are bounded to 10 seconds per hop.

A confirmed authentication challenge without resolvable OAuth metadata is treated as OAuth for compatibility and emits a warning to verify the type and register the generated reference ID. Invalid, unreachable, unconfirmed, and non-MCP endpoints still fail before scaffolding.