### PR TITLE
fix(fx-core): propagate add knowledge errors

### DIFF
--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -2320,7 +2320,7 @@ export class FxCore extends FxCoreOpenPluginPart {
         return err(new UserCancelError());
       }
       await context.userInteraction.showMessage("warn", result.error.message, true);
-      return ok(undefined);
+      return err(result.error);
     }
 
     this.showAddKnowledgeSuccessMessage(context, inputs, agentManifestPath, knowledgeSource);

--- a/packages/fx-core/tests/core/FxCore.knowledge.test.ts
+++ b/packages/fx-core/tests/core/FxCore.knowledge.test.ts
@@ -62,11 +62,18 @@ describe("addKnowledge", async () => {
       actions: [{}],
       capabilities: [],
     });
+    await fs.writeJson("test1.json", {
+      actions: [{}],
+      capabilities: [],
+    });
   });
 
   afterEach(async () => {
     if (await fs.pathExists("fakeAgentManifest.json")) {
       await fs.unlink("fakeAgentManifest.json");
+    }
+    if (await fs.pathExists("test1.json")) {
+      await fs.unlink("test1.json");
     }
     vi.restoreAllMocks();
   });
@@ -886,14 +893,12 @@ describe("addKnowledge", async () => {
       ok("fakeAgentManifest.json")
     );
     vi.spyOn(MockUserInteraction.prototype, "showMessage").mockResolvedValue(ok("Add"));
-    vi.spyOn(copilotGptManifestUtils, "readCopilotGptManifestFile").mockResolvedValue(
-      err(new UserError("test", "test", "test"))
-    );
+    await fs.remove("test1.json");
 
     const core = new FxCore(tools);
     for (const inputs of inputsList) {
       const result = await core.addKnowledge(inputs);
-      assert.isTrue(result.isOk());
+      assert.isTrue(result.isErr());
     }
   });
 

--- a/packages/fx-core/tests/core/FxCore.knowledge.test.ts
+++ b/packages/fx-core/tests/core/FxCore.knowledge.test.ts
@@ -605,12 +605,14 @@ describe("addKnowledge", async () => {
       } as DeclarativeCopilotManifestSchema)
     );
 
+    const expectedError = new UserError("test", "test", "test");
     vi.spyOn(copilotGptManifestUtils, "addWebSearchCapability").mockResolvedValue(
-      err(new UserError("test", "test", "test"))
+      err(expectedError)
     );
     const core = new FxCore(tools);
     const result = await core.addKnowledge(inputs);
-    assert.isTrue(result.isOk());
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr(), expectedError);
   });
 
   it("error path: add OneDrive & Sharepoint capability", async () => {
@@ -644,12 +646,14 @@ describe("addKnowledge", async () => {
       } as DeclarativeCopilotManifestSchema)
     );
 
+    const expectedError = new UserError("test", "test", "test");
     vi.spyOn(copilotGptManifestUtils, "addOneDriveSharePointCapability").mockResolvedValue(
-      err(new UserError("test", "test", "test"))
+      err(expectedError)
     );
     const core = new FxCore(tools);
     const result = await core.addKnowledge(inputs);
-    assert.isTrue(result.isOk());
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr(), expectedError);
   });
 
   it("error path: undefined projectPath", async () => {
@@ -1152,12 +1156,12 @@ describe("addKnowledge", async () => {
       } as DeclarativeCopilotManifestSchema)
     );
 
-    vi.spyOn(copilotGptManifestUtils, "addGCCapability").mockResolvedValue(
-      err(new UserError("test", "test", "test"))
-    );
+    const expectedError = new UserError("test", "test", "test");
+    vi.spyOn(copilotGptManifestUtils, "addGCCapability").mockResolvedValue(err(expectedError));
     const core = new FxCore(tools);
     const result = await core.addKnowledge(inputs);
-    assert.isTrue(result.isOk());
+    assert.isTrue(result.isErr());
+    assert.strictEqual(result._unsafeUnwrapErr(), expectedError);
   });
 
   it("happy path: add OneDrive & Sharepoint(search all)", async () => {


### PR DESCRIPTION
## Summary
- propagate capability mutation errors from addKnowledge after displaying the warning
- preserve cancellation handling
- update web search, OneDrive/SharePoint, and Graph connector regression tests

## Validation
- pnpm exec tsc -p tsconfig.json --noEmit --incremental false
- Unit tests could not start because the local install is missing the Vite package entry point.
- ESLint could not start because the local install is missing the unrs-resolver optional native binding.