### PR TITLE
fix(cli): disable Application Insights internal console logging

### DIFF
--- a/packages/cli/src/telemetry/telemetryReporter.ts
+++ b/packages/cli/src/telemetry/telemetryReporter.ts
@@ -67,6 +67,11 @@ export default class TelemetryReporter {
   }
 
   private createAppInsightsClient(key: string) {
+    // The SDK's internal logging writes straight to the console (console.warn -> stderr) by
+    // default, including when the telemetry endpoint itself is unreachable. Telemetry transport
+    // failures are never actionable for CLI users and must not be mistaken for command output,
+    // so keep an undeliverable telemetry beacon silent.
+    appInsights.Configuration.setInternalLogging(false, false);
     if (appInsights.defaultClient) {
       this.appInsightsClient = new appInsights.TelemetryClient(key);
       this.appInsightsClient.channel.setUseDiskRetryCaching(true);

--- a/packages/cli/tests/unit/telemetry/telemetryReporter.tests.ts
+++ b/packages/cli/tests/unit/telemetry/telemetryReporter.tests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { featureFlagManager, FeatureFlags } from "@microsoft/teamsfx-core";
-import { TelemetryClient } from "applicationinsights";
+import { Configuration, TelemetryClient } from "applicationinsights";
 import log4js from "log4js";
 import os from "os";
 import { vi } from "vitest";
@@ -64,6 +64,13 @@ describe("Telemetry Reporter", function () {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("disables ApplicationInsights internal console logging", () => {
+    const setInternalLoggingSpy = vi.spyOn(Configuration, "setInternalLogging");
+    new Reporter("real", "real", "real", "real");
+    expect(setInternalLoggingSpy.mock.calls.length > 0).to.be.true;
+    expect(setInternalLoggingSpy.mock.lastCall).deep.equals([false, false]);
   });
 
   it("getCommonProperties", () => {


### PR DESCRIPTION
Fixes #16631

## Problem

When the Application Insights endpoint is unreachable — e.g. a DNS-level blocker (Pi-hole, NextDNS, corporate DNS policy, or a `hosts` sinkhole) resolves it to `0.0.0.0` — the CLI writes Application Insights **internal SDK warnings to stderr**, even on commands that succeed:

```
ApplicationInsights:CorrelationIdManager [
  Error: connect ECONNREFUSED 0.0.0.0:443
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1607:16) {
    errno: -111,
    code: 'ECONNREFUSED',
    syscall: 'connect',
    address: '0.0.0.0',
    port: 443
  }
]
```

Telemetry delivery is optional and unrelated to the command being run, but the failure lands on the CLI's diagnostic stream. This is especially disruptive for anything consuming `atk` output programmatically: the rendered line begins with `Error:` and describes a refused TCP connection, so it is indistinguishable from a real, actionable network failure against a service the command genuinely needs. A wrapper that surfaces the CLI's error output therefore reports a spurious failure whenever telemetry happens to be blocked.

## Root cause

`applicationinsights@1.8.10` → `out/Library/CorrelationIdManager.js` (lines 62-66):

```js
req.on('error', function (error) {
    // Unable to contact endpoint.
    // Do nothing for now.
    Logging.warn(CorrelationIdManager.TAG, error);
});
```

The comment says "Do nothing for now", but `Logging.warn` is not a no-op — `out/Library/Logging.js`:

```js
Logging.warn = function (message) {
    var optionalParams = [];
    for (var _i = 1; _i < arguments.length; _i++) {
        optionalParams[_i - 1] = arguments[_i];
    }
    if (!Logging.disableWarnings) {
        console.warn(Logging.TAG + message, optionalParams);
    }
};

Logging.enableDebug = false;
Logging.disableWarnings = false;   // <-- default
Logging.TAG = "ApplicationInsights:";
```

`disableWarnings` defaults to `false`, so the warning always fires. `console.warn` writes to **stderr**, and Node renders the `Error` passed through `optionalParams` as a multi-line inspected object — which is why the diagnostic spans several lines and why one of them reads exactly `Error: connect ECONNREFUSED 0.0.0.0:443`.

No user setting, verbosity flag, or telemetry opt-out is involved: any unreachable ingestion endpoint produces this by default.

## Fix

Disable the SDK's internal console logging when the CLI creates its Application Insights client:

```ts
appInsights.Configuration.setInternalLogging(false, false);
```

`Configuration.setInternalLogging(enableDebugLogging?: boolean, enableWarningLogging?: boolean)` is a public typed API in 1.8.10 (`applicationinsights.d.ts` line 148). In 1.x it sets the module-level `Logging.enableDebug` / `Logging.disableWarnings` directly, with no `defaultClient` guard, so it takes effect immediately.

**Why it is placed before the `if`, rather than chained onto the `setup(...)` chain:**

- It covers **both** construction paths. Chaining `.setInternalLogging(false, false)` onto the `appInsights.setup(key)...` chain would only cover the `else` branch, leaving the `new appInsights.TelemetryClient(key)` branch able to emit the warning.
- It must run **before** a client is constructed, since the correlation-ID request is issued during client construction/start.
- It avoids touching the existing unit-test mock, which stubs the fluent chain method-by-method. A new chained call would have thrown `TypeError: ...setInternalLogging is not a function` and broken the existing tests.

This only silences the SDK's own internal console diagnostics. Telemetry collection and delivery are unchanged, and users keep the existing `--telemetry` opt-out — nobody has to disable telemetry to get clean CLI output.

## Testing

Added a unit test in `packages/cli/tests/unit/telemetry/telemetryReporter.tests.ts` asserting that constructing a `TelemetryReporter` calls `Configuration.setInternalLogging` with `(false, false)`.

Because the existing `vi.mock("applicationinsights", ...)` factory spreads `...actual`, the mocked module's `Configuration` is the same class object the source calls into, so the spy intercepts the real call.

> Note for reviewers: I was not able to run the `packages/cli` suite locally (the workspace install was not available to me), so please let CI validate. The change itself was verified directly against the installed `applicationinsights@1.8.10` `.d.ts` and compiled sources rather than by inference.

## Alternative considered

Passing `--telemetry false` — rejected. It is the wrong lever: users should not have to opt out of telemetry to get clean output, and doing so discards usage signal that is genuinely useful to the Toolkit team. It is also unclear that it would even suppress this particular diagnostic, since the correlation-ID lookup is issued at client construction (see #16631).
