### PR TITLE
feat(vscode-extension): add Share command palette entry

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -532,6 +532,10 @@
           "when": "false"
         },
         {
+          "command": "fx-extension.share",
+          "when": "fx-extension.isDeclarativeCopilotApp"
+        },
+        {
           "command": "fx-extension.selectAndDebug",
           "when": "false"
         },
@@ -701,6 +705,12 @@
         "command": "fx-extension.publish",
         "title": "%teamstoolkit.commands.publish.title%",
         "enablement": "fx-extension.isTeamsFx && isWorkspaceTrusted && !fx-extension.commandLocked",
+        "category": "Microsoft 365 Agents"
+      },
+      {
+        "command": "fx-extension.share",
+        "title": "%teamstoolkit.commands.share.title%",
+        "enablement": "fx-extension.isTeamsFx && fx-extension.isDeclarativeCopilotApp && isWorkspaceTrusted && !fx-extension.commandLocked",
         "category": "Microsoft 365 Agents"
       },
       {

--- a/packages/vscode-extension/test/extension/packageContributions.test.ts
+++ b/packages/vscode-extension/test/extension/packageContributions.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import fs from "fs-extra";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+interface CommandContribution {
+  command: string;
+  title: string;
+  category?: string;
+  enablement?: string;
+}
+
+interface CommandPaletteContribution {
+  command: string;
+  when?: string;
+}
+
+interface ExtensionManifest {
+  contributes: {
+    commands: CommandContribution[];
+    menus: {
+      commandPalette: CommandPaletteContribution[];
+    };
+  };
+}
+
+describe("package contributions", () => {
+  it("AC-01: exposes Share in the command palette only for declarative agent projects", () => {
+    const manifest: ExtensionManifest = fs.readJsonSync(
+      path.resolve(__dirname, "../../package.json")
+    );
+
+    expect(
+      manifest.contributes.commands.find((command) => command.command === "fx-extension.share")
+    ).toEqual({
+      command: "fx-extension.share",
+      title: "%teamstoolkit.commands.share.title%",
+      category: "Microsoft 365 Agents",
+      enablement:
+        "fx-extension.isTeamsFx && fx-extension.isDeclarativeCopilotApp && isWorkspaceTrusted && !fx-extension.commandLocked",
+    });
+    expect(
+      manifest.contributes.menus.commandPalette.find(
+        (command) => command.command === "fx-extension.share"
+      )
+    ).toEqual({
+      command: "fx-extension.share",
+      when: "fx-extension.isDeclarativeCopilotApp",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expose the existing Share action in the VS Code Command Palette
- show it only for declarative agent projects
- add regression coverage for the command contribution

## Test Plan
- npm run test:unit
- npm run check-types
- npm run lint (0 errors; existing warnings remain)
- changed-file Prettier check