### PR TITLE
fix(vscuse): Auto-fix Feature_Check_Copilot_License_Enabled (progress 10→13 steps)

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -239,7 +239,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:762:97:16:5:24b1a72ba9aba343",
+        "dhash:762:97:96:5:0008304b0f344900",
+        "dhash:762:97:0:10:9c68332223232421"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 18,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -27,6 +27,8 @@
       "step_a0026de5",
       "step_78a597ab",
       "step_47935ca7",
+      "step_1e6b47a2",
+      "step_4d9a830c",
       "step_8e9d1c42",
       "step_ed29b905",
       "step_b16aa4f5",
@@ -179,39 +181,11 @@
     {
       "step_id": "step_78a597ab",
       "agent": "interaction",
-      "tool": "click",
+      "tool": "key_press",
       "parameters": {
-        "button": "left",
-        "x": 516,
-        "y": 447
+        "key": "f1"
       },
-      "description": "Click the \"Check Copilot License\" button in the \"Set up your environment\" section of the Microsoft 365 Agents Toolkit welcome screen in Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:516:447:16:5:2493f3ec6b936ad2",
-        "dhash:516:447:96:5:75622a1d99660000",
-        "dhash:516:447:0:10:24b0949090b17075"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_78a597ab",
-      "created_at": "2026-06-17T02:28:51.067052",
-      "plan_id": "plan_80b368dd"
-    },
-    {
-      "step_id": "step_47935ca7",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 978,
-        "y": 758
-      },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the bottom right of the Visual Studio Code interface to access a Microsoft 365 account.",
+      "description": "Press F1 to open the Visual Studio Code command palette before signing in to Microsoft 365.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -220,8 +194,72 @@
       "preconditions": [],
       "postconditions": [],
       "tags": [],
-      "screenshot": "step_47935ca7",
+      "screenshot": null,
+      "created_at": "2026-06-17T02:28:51.067052",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_47935ca7",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Microsoft 365 Agents: Accounts"
+      },
+      "description": "Type 'Microsoft 365 Agents: Accounts' into the Visual Studio Code command palette.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
       "created_at": "2026-06-17T02:19:55.488096",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_1e6b47a2",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 461,
+        "y": 70
+      },
+      "description": "Click the exact 'Microsoft 365 Agents: Accounts' command below the similarly named Accounts View command.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-08-21T02:40:11.181000",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_4d9a830c",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 379,
+        "y": 52
+      },
+      "description": "Click the 'Sign in to Microsoft 365' option in the Accounts menu.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-08-21T02:40:11.181000",
       "plan_id": "plan_80b368dd"
     },
     {
@@ -233,20 +271,16 @@
         "x": 762,
         "y": 97
       },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 developer sandbox modal to open the Microsoft sign-in page.",
+      "description": "Click the Microsoft 365 sign-in confirmation button to open the Microsoft sign-in page.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:762:97:16:5:24b1a72ba9aba343",
-        "dhash:762:97:96:5:0008304b0f344900",
-        "dhash:762:97:0:10:9c68332223232421"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
-      "screenshot": "",
+      "screenshot": null,
       "created_at": "2026-08-21T02:05:41.223000",
       "plan_id": "plan_80b368dd"
     },

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 17,
+    "total_steps": 16,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -25,7 +25,6 @@
       "step_f0d7ba3e",
       "step_436b1f61",
       "step_a0026de5",
-      "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
       "step_8e9d1c42",
@@ -175,28 +174,6 @@
       "tags": [],
       "screenshot": "step_a0026de5",
       "created_at": "2026-06-17T02:19:55.474845",
-      "plan_id": "plan_80b368dd"
-    },
-    {
-      "step_id": "step_fa6d6cb1",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 512,
-        "y": 431
-      },
-      "description": "Click the \"Set up your environment\" option in the guided tutorial list under the \"Build a Declarative Agent\" section of the Microsoft 365 Agents Toolkit welcome screen in Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_fa6d6cb1",
-      "created_at": "2026-06-17T02:24:33.865380",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 17,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -28,6 +28,7 @@
       "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
+      "step_8e9d1c42",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -252,6 +253,28 @@
       "tags": [],
       "screenshot": "step_47935ca7",
       "created_at": "2026-06-17T02:19:55.488096",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_8e9d1c42",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 762,
+        "y": 97
+      },
+      "description": "Click the \"Sign in\" button in the Microsoft 365 developer sandbox modal to open the Microsoft sign-in page.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-08-21T02:05:41.223000",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -192,11 +192,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fa6d6cb1",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 18,
+    "total_steps": 19,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -26,6 +26,7 @@
       "step_436b1f61",
       "step_a0026de5",
       "step_78a597ab",
+      "step_6f23b48d",
       "step_47935ca7",
       "step_1e6b47a2",
       "step_4d9a830c",
@@ -196,6 +197,30 @@
       "tags": [],
       "screenshot": null,
       "created_at": "2026-06-17T02:28:51.067052",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_6f23b48d",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 512,
+        "y": 25
+      },
+      "description": "Click the Visual Studio Code command palette input to restore keyboard focus before typing the Microsoft 365 Accounts command.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:2"
+      ],
+      "screenshot": null,
+      "created_at": "2026-08-21T02:51:27.784000",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -225,7 +225,7 @@
       "parameters": {
         "button": "left",
         "x": 461,
-        "y": 70
+        "y": 80
       },
       "description": "Click the exact 'Microsoft 365 Agents: Accounts' command below the similarly named Accounts View command.",
       "content_refs": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -235,20 +235,16 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 703,
-        "y": 100
+        "x": 978,
+        "y": 758
       },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the top of the Visual Studio Code interface to access a Microsoft 365 account.",
+      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the bottom right of the Visual Studio Code interface to access a Microsoft 365 account.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:703:100:16:5:0000000000000000",
-        "dhash:703:100:96:5:00000042b2474971",
-        "dhash:703:100:0:10:9cb89590b0717d7f"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_47935ca7",


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Feature_Check_Copilot_License_Enabled`
**Status:** :x: FAILED (8/8 attempts exhausted)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/de395ff6-f4d9-4fd3-aee8-d207a2c0b488/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/93128f29-1c07-4baa-9090-54cafabe5e1c/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Added the missing second “Sign in” click on the Microsoft 365 developer sandbox  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/73d76f62-98ea-462a-9b93-13e92734832d/test_report.html) |
| 2 | Corrected the first Microsoft 365 “Sign in” click to target the visible bottom-r | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/4b4bc3a0-1130-4051-a9ff-8a3e74836258/test_report.html) |
| 3 | Removed stale dHash preconditions blocking “Set up your environment,” allowing t | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/1011b87e-e5b3-47d9-b6d9-b7c5877e3b45/test_report.html) |
| 4 | Removed the obsolete “Set up your environment” click that prematurely triggered  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/9cca0fca-0d83-4c12-94a9-0405621630d8/test_report.html) |
| 5 | Added modal dHash preconditions so the second sign-in click waits for the Micros | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/dad592c5-dc94-41a6-a7cb-836a90dfa272/test_report.html) |
| 6 | Replaced the disappearing notification flow with the recorded Accounts → Sign in | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/5eafb587-22f2-441c-95fb-1a4978af65a8/test_report.html) |
| 7 | Corrected the false-positive Accounts menu click from y=70 to y=80 so it selects | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/1e9d351d-8246-43d6-9fb4-16f0358a3898/test_report.html) |
| 8 | Added an explicit command-palette focus step so the Accounts command is typed an | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/93128f29-1c07-4baa-9090-54cafabe5e1c/test_report.html) |

> :warning: **AI could not fix this plan automatically. Human review needed.**
> Each commit represents one fix attempt — review the history to understand what was tried.

### How to Review
- Each commit represents one fix attempt for `plans/Feature_Check_Copilot_License_Enabled.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../Feature_Check_Copilot_License_Enabled.json     | 121 +++++++++++++++------
 1 file changed, 88 insertions(+), 33 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
index 6395c68..9a27860 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 19,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -25,9 +25,12 @@
       "step_f0d7ba3e",
       "step_436b1f61",
       "step_a0026de5",
-      "step_fa6d6cb1",
       "step_78a597ab",
+      "step_6f23b48d",
       "step_47935ca7",
+      "step_1e6b47a2",
+      "step_4d9a830c",
+      "step_8e9d1c42",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -177,81 +180,133 @@
       "plan_id": "plan_80b368dd"
     },
     {
-      "step_id": "step_fa6d6cb1",
+      "step_id": "step_78a597ab",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f1"
+      },
+      "description": "Press F1 to open the Visual Studio Code command palette before signing in to Microsoft 365.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": null,
+      "created_at": "2026-06-17T02:28:51.067052",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_6f23b48d",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
         "button": "left",
         "x": 512,
-        "y": 431
+        "y": 25
       },
-      "description": "Click the \"Set up your environment\" option in the guided tutorial list under the \"Build a Declarative Agent\" section of the Microsoft 365 Agents Toolkit welcome screen in Visual Studio Code.",
+      "description": "Click the Visual Studio Code command palette input to restore keyboard focus before typing the Microsoft 365 Accounts command.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:2"
       ],
+      "screenshot": null,
+      "created_at": "2026-08-21T02:51:27.784000",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_47935ca7",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Microsoft 365 Agents: Accoun
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>