### PR TITLE
fix(fx-core): update local YAML for MCP auth

### DIFF
--- a/packages/fx-core/src/core/FxCore.declarativeAgent.ts
+++ b/packages/fx-core/src/core/FxCore.declarativeAgent.ts
@@ -817,8 +817,7 @@ export class FxCoreDeclarativeAgentPart {
           try {
             const ymlPath = pathUtils.getYmlFilePath(inputs.projectPath);
             if (ymlPath) {
-              const injectResult = await injectMCPAuthActionToYml({
-                ymlPath,
+              const injectArgs = {
                 authType,
                 authName: namespace,
                 registrationId,
@@ -827,7 +826,12 @@ export class FxCoreDeclarativeAgentPart {
                 persistCredentialEnvRefs: true,
                 serverName,
                 scopes: inputs[QuestionNames.MCPForDAScopes],
-              });
+              };
+              const injectResult = await injectMCPAuthActionToYml({ ...injectArgs, ymlPath });
+              const localYmlPath = pathUtils.getYmlFilePath(inputs.projectPath, "local", true);
+              if (localYmlPath && localYmlPath !== ymlPath && (await fs.pathExists(localYmlPath))) {
+                await injectMCPAuthActionToYml({ ...injectArgs, ymlPath: localYmlPath });
+              }
               if (injectResult.wellKnownUrlPlaceholderUsed) {
                 mcpWarnings.push({
                   type: "mcpAuthDcrWellKnownUrlPlaceholder",
@@ -1063,14 +1067,22 @@ export class FxCoreDeclarativeAgentPart {
               const endpoints = await resolveMCPAuthEndpoints(authType, inputs);
               const ymlPath = pathUtils.getYmlFilePath(inputs.projectPath);
               if (ymlPath) {
-                const injectResult = await injectMCPAuthActionToYml({
-                  ymlPath,
+                const injectArgs = {
                   authType,
                   authName: actionId,
                   registrationId,
                   mcpServerUrl,
                   endpoints,
-                });
+                };
+                const injectResult = await injectMCPAuthActionToYml({ ...injectArgs, ymlPath });
+                const localYmlPath = pathUtils.getYmlFilePath(inputs.projectPath, "local", true);
+                if (
+                  localYmlPath &&
+                  localYmlPath !== ymlPath &&
+                  (await fs.pathExists(localYmlPath))
+                ) {
+                  await injectMCPAuthActionToYml({ ...injectArgs, ymlPath: localYmlPath });
+                }
                 if (injectResult.wellKnownUrlPlaceholderUsed) {
                   mcpWarnings.push({
                     type: "mcpAuthDcrWellKnownUrlPlaceholder",

--- a/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
+++ b/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
@@ -3182,7 +3182,10 @@ describe("addPlugin", async () => {
       .spyOn(actionInjectorModule.ActionInjector, "injectCreateDcrActionForMCP")
       .mockResolvedValue();
 
-    vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue("m365agents.yml");
+    vi.spyOn(pathUtils, "getYmlFilePath").mockImplementation((_projectPath, env) =>
+      env === "local" ? "m365agents.local.yml" : "m365agents.yml"
+    );
+    vi.spyOn(fs, "pathExists").mockResolvedValue(true);
     vi.spyOn(fs, "ensureFile").mockResolvedValue();
     const writeJSONStub = vi.spyOn(fs, "writeJSON").mockResolvedValue();
 
@@ -3193,7 +3196,10 @@ describe("addPlugin", async () => {
     assert.equal(modifyFrontDoorStub.mock.calls.length, 0);
 
     // oauth-dynamic reuses the DCR injector (dcr/register) — not the OAuth one.
-    assert.equal(dcrInjectStub.mock.calls.length, 1);
+    assert.deepEqual(
+      dcrInjectStub.mock.calls.map((call) => call[0]),
+      ["m365agents.yml", "m365agents.local.yml"]
+    );
     assert.equal(dcrInjectStub.mock.calls[0][1], "examplecom");
     assert.equal(dcrInjectStub.mock.calls[0][2], "MCP_DA_AUTH_ID_EXAMPLECOM");
     assert.equal(oauthInjectStub.mock.calls.length, 0);

--- a/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
+++ b/packages/fx-core/tests/core/FxCore.declarativeAgent.test.ts
@@ -2641,7 +2641,10 @@ describe("addPlugin", async () => {
       .spyOn(actionInjectorModule.ActionInjector, "injectCreateOAuthActionForMCP")
       .mockResolvedValue();
 
-    vi.spyOn(pathUtils, "getYmlFilePath").mockReturnValue("m365agents.yml");
+    vi.spyOn(pathUtils, "getYmlFilePath").mockImplementation((_projectPath, env) =>
+      env === "local" ? "m365agents.local.yml" : "m365agents.yml"
+    );
+    vi.spyOn(fs, "pathExists").mockResolvedValue(true);
     vi.spyOn(fs, "ensureFile").mockResolvedValue();
     vi.spyOn(fs, "writeJSON").mockResolvedValue();
 
@@ -2649,7 +2652,10 @@ describe("addPlugin", async () => {
     const result = await core.addPlugin(inputs);
 
     assert.isTrue(result.isOk());
-    assert.isTrue(injectStub.mock.calls.length === 1);
+    assert.deepEqual(
+      injectStub.mock.calls.map((call) => call[0]),
+      ["m365agents.yml", "m365agents.local.yml"]
+    );
     // Verify registration ID pattern
     const registrationId = injectStub.mock.calls[0][3];
     assert.equal(registrationId, "MCP_DA_AUTH_ID_ACTION_1");


### PR DESCRIPTION
## Description

When adding an authenticated MCP action to a declarative agent, update `m365agents.local.yml` when it exists in addition to the primary `m365agents.yml`. This matches the existing add-auth behavior while avoiding duplicate writes when both paths resolve to the same file.

## Changes

- Reuse the MCP auth injection arguments for the primary and local workflow files.
- Skip local injection when the local YAML does not exist or resolves to the primary path.
- Extend the existing MCP DCR test to verify both YAML files are updated.

## Validation

- `pnpm run build` in `packages/fx-core`
- `pnpm run build` in `packages/cli`
- `pnpm exec vitest run tests/core/FxCore.declarativeAgent.test.ts --config vitest.config.ts --maxWorkers=75%`
  - 72 passed, 6 skipped
- Real CLI E2E:
  - Scaffolded a declarative agent with `node cli.js new`.
  - Added a static OAuth MCP action with `node cli.js add action`.
  - Verified matching `oauth/register` actions in `m365agents.yml` and `m365agents.local.yml`.
  - Verified the declarative-agent action, `RemoteMCPServer` runtime, OAuth reference, and dev/local environment values.

The E2E project is preserved locally under `e2e-output/mcp-local-yaml-e2e-20260821-1608` for manual inspection.