### PR TITLE
fix(vscuse): Auto-fix Feature_Check_Copilot_License_Enabled

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -234,20 +234,16 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 703,
-        "y": 100
+        "x": 975,
+        "y": 710
       },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the top of the Visual Studio Code interface to access a Microsoft 365 account.",
+      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the bottom right of the Visual Studio Code interface to access a Microsoft 365 account.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:703:100:16:5:0000000000000000",
-        "dhash:703:100:96:5:00000042b2474971",
-        "dhash:703:100:0:10:9cb89590b0717d7f"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_47935ca7",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -234,10 +234,10 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 975,
-        "y": 710
+        "x": 762,
+        "y": 97
       },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the bottom right of the Visual Studio Code interface to access a Microsoft 365 account.",
+      "description": "Click the \"Sign in\" button within the Microsoft 365 developer sandbox modal.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 17,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -27,6 +27,7 @@
       "step_a0026de5",
       "step_fa6d6cb1",
       "step_78a597ab",
+      "step_5f5e5f2a",
       "step_47935ca7",
       "step_ed29b905",
       "step_b16aa4f5",
@@ -37,7 +38,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-06-17T02:28:59.615382"
+    "updated_at": "2026-08-22T02:22:17.579000"
   },
   "steps": [
     {
@@ -222,6 +223,28 @@
       "tags": [],
       "screenshot": "step_78a597ab",
       "created_at": "2026-06-17T02:28:51.067052",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_5f5e5f2a",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 975,
+        "y": 456
+      },
+      "description": "Click the \"Sign in\" button in the Microsoft 365 account notification at the bottom right of Visual Studio Code.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-08-22T02:22:17.579000",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -191,11 +191,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fa6d6cb1",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -192,7 +192,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:512:431:16:5:d2d46667c4da2854",
+        "dhash:512:431:96:5:0000a45951aa949a",
+        "dhash:512:431:0:10:2c78747470717035"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fa6d6cb1",
@@ -262,7 +266,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:762:97:16:5:24b9a72ba9aba343",
+        "dhash:762:97:96:5:0008304b4fe04848",
+        "dhash:762:97:0:10:94b8959090b9797b"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_47935ca7",


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Feature_Check_Copilot_License_Enabled`
**Status:** :white_check_mark: FIXED (attempt 4/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/10bf7497-50f6-48ae-83ad-4ac41937543d/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/47587499-df0a-4e12-a141-07f6dfceb098/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Updated the stale M365 sign-in selector to click the current bottom-right notifi | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/70930eb3-5cee-451c-aa30-07fef8948f68/test_report.html) |
| 2 | Redirected the stale M365 sign-in click from the unrelated MCP “Skip” notificati | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/32a13082-b290-41fb-8737-33d44f74e58c/test_report.html) |
| 3 | Removed stale dhash preconditions blocking the correctly positioned “Set up your | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/a3184cab-0a92-43c4-91aa-26e38fe460b7/test_report.html) |
| 4 | Added an explicit click for the current bottom-right Microsoft 365 sign-in notif | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/47587499-df0a-4e12-a141-07f6dfceb098/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Feature_Check_Copilot_License_Enabled.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../Feature_Check_Copilot_License_Enabled.json     | 45 ++++++++++++++++------
 1 file changed, 34 insertions(+), 11 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
index 6395c68..30fc83e 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 17,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -27,6 +27,7 @@
       "step_a0026de5",
       "step_fa6d6cb1",
       "step_78a597ab",
+      "step_5f5e5f2a",
       "step_47935ca7",
       "step_ed29b905",
       "step_b16aa4f5",
@@ -37,7 +38,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-06-17T02:28:59.615382"
+    "updated_at": "2026-08-22T02:22:17.579000"
   },
   "steps": [
     {
@@ -192,9 +193,9 @@
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
+        "dhash:512:431:16:5:d2d46667c4da2854",
+        "dhash:512:431:96:5:0000a45951aa949a",
+        "dhash:512:431:0:10:2c78747470717035"
       ],
       "postconditions": [],
       "tags": [],
@@ -228,25 +229,47 @@
       "created_at": "2026-06-17T02:28:51.067052",
       "plan_id": "plan_80b368dd"
     },
+    {
+      "step_id": "step_5f5e5f2a",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 975,
+        "y": 456
+      },
+      "description": "Click the \"Sign in\" button in the Microsoft 365 account notification at the bottom right of Visual Studio Code.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-08-22T02:22:17.579000",
+      "plan_id": "plan_80b368dd"
+    },
     {
       "step_id": "step_47935ca7",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 703,
-        "y": 100
+        "x": 762,
+        "y": 97
       },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the top of the Visual Studio Code interface to access a Microsoft 365 account.",
+      "description": "Click the \"Sign in\" button within the Microsoft 365 developer sandbox modal.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:703:100:16:5:0000000000000000
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>