### PR TITLE
fix(vscuse): Auto-fix Feature_DA_Add_Embedded_Knowledge

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Embedded_Knowledge.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Embedded_Knowledge.json
@@ -683,7 +683,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:974:743:16:5:224598a9a3a3293c",
+        "dhash:974:743:96:5:00000061968e8a21",
+        "dhash:974:743:0:10:30a1c0c0c0c0c0c0"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_08dc097f",
@@ -1083,7 +1087,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:974:743:16:5:224598a9a3a3293c",
+        "dhash:974:743:96:5:00000061968e8a21",
+        "dhash:974:743:0:10:300080c0c0c0c0c0"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_ec67a74c",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Embedded_Knowledge.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Embedded_Knowledge.json
@@ -603,7 +603,7 @@
         "x": 260,
         "y": 109
       },
-      "description": "Click on the \"addtional-files\" folder entry in the file picker dialog under the \"Home\" directory, within the application’s open file interface.",
+      "description": "Click on the \"addtional-files\" folder entry in the file picker dialog under the \"Home\" directory, within the application\u2019s open file interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -671,19 +671,19 @@
     {
       "step_id": "step_08dc097f",
       "agent": "interaction",
-      "tool": "key_press",
+      "tool": "click",
       "parameters": {
-        "key": "enter"
+        "button": "left",
+        "x": 974,
+        "y": 743
       },
-      "description": "Press the Enter key to open the selected file \"azure.json\" in the Linux file chooser dialog.",
+      "description": "Click the \"Open\" button in the bottom-right corner of the Linux file chooser dialog to confirm opening the selected file \"azure.json\".",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:30a1c0c0c0c0c0c0"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_08dc097f",
@@ -777,7 +777,7 @@
         "x": 331,
         "y": 78
       },
-      "description": "Click the “dev” environment option in the “Select an environment” dropdown within the Microsoft Visual Studio Code interface, targeting the Microsoft 365 Agents extension.",
+      "description": "Click the \u201cdev\u201d environment option in the \u201cSelect an environment\u201d dropdown within the Microsoft Visual Studio Code interface, targeting the Microsoft 365 Agents extension.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -1071,19 +1071,19 @@
     {
       "step_id": "step_ec67a74c",
       "agent": "interaction",
-      "tool": "key_press",
+      "tool": "click",
       "parameters": {
-        "key": "enter"
+        "button": "left",
+        "x": 974,
+        "y": 743
       },
-      "description": "Press the Enter key to select and open the highlighted file \"azure.parameters.test.json\" in the Linux file picker dialog within a vscode workspace directory.",
+      "description": "Click the \"Open\" button in the bottom-right corner of the Linux file chooser dialog to confirm opening the selected file \"azure.parameters.test.json\".",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:384:0:20:300080c0c0c0c0c0"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_ec67a74c",


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Feature_DA_Add_Embedded_Knowledge`
**Status:** :white_check_mark: FIXED (attempt 1/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/e9154fad-e6f7-41fc-9121-b0828240a5de/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/60ca4a6d-9877-48f7-9a77-4d85bfda8bdb/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Replaced both Linux file chooser Enter submissions with clicks on the recorded O | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/60ca4a6d-9877-48f7-9a77-4d85bfda8bdb/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Feature_DA_Add_Embedded_Knowledge.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../plans/Feature_DA_Add_Embedded_Knowledge.json   | 30 ++++++++++++++--------
 1 file changed, 19 insertions(+), 11 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Embedded_Knowledge.json b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Embedded_Knowledge.json
index 9cd2184..01e61fb 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Embedded_Knowledge.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_DA_Add_Embedded_Knowledge.json
@@ -603,7 +603,7 @@
         "x": 260,
         "y": 109
       },
-      "description": "Click on the \"addtional-files\" folder entry in the file picker dialog under the \"Home\" directory, within the application’s open file interface.",
+      "description": "Click on the \"addtional-files\" folder entry in the file picker dialog under the \"Home\" directory, within the application\u2019s open file interface.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -671,18 +671,22 @@
     {
       "step_id": "step_08dc097f",
       "agent": "interaction",
-      "tool": "key_press",
+      "tool": "click",
       "parameters": {
-        "key": "enter"
+        "button": "left",
+        "x": 974,
+        "y": 743
       },
-      "description": "Press the Enter key to open the selected file \"azure.json\" in the Linux file chooser dialog.",
+      "description": "Click the \"Open\" button in the bottom-right corner of the Linux file chooser dialog to confirm opening the selected file \"azure.json\".",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:384:0:20:30a1c0c0c0c0c0c0"
+        "dhash:974:743:16:5:224598a9a3a3293c",
+        "dhash:974:743:96:5:00000061968e8a21",
+        "dhash:974:743:0:10:30a1c0c0c0c0c0c0"
       ],
       "postconditions": [],
       "tags": [],
@@ -777,7 +781,7 @@
         "x": 331,
         "y": 78
       },
-      "description": "Click the “dev” environment option in the “Select an environment” dropdown within the Microsoft Visual Studio Code interface, targeting the Microsoft 365 Agents extension.",
+      "description": "Click the \u201cdev\u201d environment option in the \u201cSelect an environment\u201d dropdown within the Microsoft Visual Studio Code interface, targeting the Microsoft 365 Agents extension.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -1071,18 +1075,22 @@
     {
       "step_id": "step_ec67a74c",
       "agent": "interaction",
-      "tool": "key_press",
+      "tool": "click",
       "parameters": {
-        "key": "enter"
+        "button": "left",
+        "x": 974,
+        "y": 743
       },
-      "description": "Press the Enter key to select and open the highlighted file \"azure.parameters.test.json\" in the Linux file picker dialog within a vscode workspace directory.",
+      "description": "Click the \"Open\" button in the bottom-right corner of the Linux file chooser dialog to confirm opening the selected
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>