### PR TITLE
fix(manifest): discriminate api-plugin v2.4 runtime.spec by runtime type

### DIFF
--- a/packages/manifest/src/json-schemas/copilot/plugin/v2.4/schema.json
+++ b/packages/manifest/src/json-schemas/copilot/plugin/v2.4/schema.json
@@ -341,18 +341,8 @@
                     }
                 },
                 "spec": {
-                    "description": "Runtime-specific configuration object.",
-                    "oneOf": [
-                        {
-                            "$ref": "#/$defs/open-api-spec"
-                        },
-                        {
-                            "$ref": "#/$defs/local-plugin-spec"
-                        },
-                        {
-                            "$ref": "#/$defs/mcp-execution-spec"
-                        }
-                    ]
+                    "type": "object",
+                    "description": "Runtime-specific configuration object. Its exact shape is determined by the sibling `type` member (see the `oneOf` on this runtime object): `OpenApi` uses `open-api-spec`, `LocalPlugin` uses `local-plugin-spec`, and `RemoteMCPServer` uses `mcp-execution-spec`."
                 },
                 "output_template": {
                     "type": "string",
@@ -362,7 +352,46 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {}
-            }
+            },
+            "oneOf": [
+                {
+                    "$comment": "Discriminate `spec` by the sibling `type`. draft-04 has no if/then, so this is expressed as a `oneOf` where each branch pins `type` and the matching `spec` schema. Without this, a bare RemoteMCPServer spec of `{ \"url\": \"...\" }` (dynamic tool discovery) matches BOTH `open-api-spec` and `mcp-execution-spec` and fails a `oneOf` placed directly on `spec`.",
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "OpenApi"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/open-api-spec"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "LocalPlugin"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/local-plugin-spec"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "RemoteMCPServer"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/mcp-execution-spec"
+                        }
+                    }
+                }
+            ]
         },
         "auth-object": {
             "type": "object",
@@ -551,7 +580,13 @@
         "mcp-tool-inline": {
             "type": "object",
             "title": "MCP Tool Inline Definitions",
-            "description": "Inline tool definitions matching the format returned by the MCP server's tools/list method."
+            "description": "Inline tool definitions matching the format returned by the MCP server's tools/list method.",
+            "$comment": "Excludes a top-level `file` key so this branch is mutually exclusive with `mcp-tool-file-reference` under `mcp_tool_description`'s `oneOf`. Without it, this open object also matches the file-reference form, so `{ \"file\": \"...\" }` matches both branches and fails the `oneOf`.",
+            "not": {
+                "required": [
+                    "file"
+                ]
+            }
         },
         "function-parameters": {
             "type": "object",

--- a/packages/manifest/test/copilotPluginV24RuntimeSpec.test.ts
+++ b/packages/manifest/test/copilotPluginV24RuntimeSpec.test.ts
@@ -1,0 +1,156 @@
+import { assert } from "chai";
+import "mocha";
+import fs from "fs-extra";
+import path from "path";
+import { AppManifestUtils } from "../src";
+
+/**
+ * Guards the v2.4 API-plugin schema's discriminated `runtime.spec` union.
+ *
+ * `runtime.spec` is selected by the sibling `runtime.type` (OpenApi -> open-api-spec,
+ * LocalPlugin -> local-plugin-spec, RemoteMCPServer -> mcp-execution-spec). Before the fix the
+ * `spec` schemas were combined in a single undiscriminated `oneOf`, so a bare RemoteMCPServer
+ * dynamic-tool-discovery spec `{ "url": "..." }` matched BOTH `open-api-spec` and
+ * `mcp-execution-spec` and failed `oneOf`. This suite pins the intended behavior for every runtime
+ * type, plus the `mcp_tool_description` file/inline disambiguation.
+ */
+describe("Copilot plugin v2.4 runtime spec discrimination", () => {
+  const schema = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, "../src/json-schemas/copilot/plugin/v2.4/schema.json"),
+      "utf8"
+    )
+  );
+
+  const noneAuth = { type: "None" };
+
+  function manifestWithRuntime(runtime: unknown): unknown {
+    return {
+      $schema: "https://developer.microsoft.com/json-schemas/copilot/plugin/v2.4/schema.json",
+      schema_version: "v2.4",
+      name_for_human: "Test",
+      namespace: "test",
+      description_for_human: "Test",
+      contact_email: "publisher@example.com",
+      functions: [],
+      runtimes: [runtime],
+    };
+  }
+
+  async function validate(runtime: unknown): Promise<string[]> {
+    return AppManifestUtils.validateAgainstSchema(manifestWithRuntime(runtime) as any, schema);
+  }
+
+  describe("valid runtimes", () => {
+    it("accepts a RemoteMCPServer with a bare url spec (dynamic tool discovery)", async () => {
+      const errors = await validate({
+        type: "RemoteMCPServer",
+        auth: noneAuth,
+        spec: { url: "https://api.contoso.com/mcp" },
+        run_for_functions: ["*"],
+      });
+      assert.deepEqual(errors, []);
+    });
+
+    it("accepts a RemoteMCPServer with a file-reference mcp_tool_description (static tools)", async () => {
+      const errors = await validate({
+        type: "RemoteMCPServer",
+        auth: noneAuth,
+        spec: {
+          url: "https://api.contoso.com/mcp",
+          mcp_tool_description: { file: "mcp-tools.json" },
+        },
+        run_for_functions: ["*"],
+      });
+      assert.deepEqual(errors, []);
+    });
+
+    it("accepts a RemoteMCPServer with inline mcp_tool_description (static tools)", async () => {
+      const errors = await validate({
+        type: "RemoteMCPServer",
+        auth: noneAuth,
+        spec: {
+          url: "https://api.contoso.com/mcp",
+          mcp_tool_description: { tools: [] },
+        },
+        run_for_functions: ["*"],
+      });
+      assert.deepEqual(errors, []);
+    });
+
+    it("accepts an OpenApi runtime with a url spec", async () => {
+      const errors = await validate({
+        type: "OpenApi",
+        auth: noneAuth,
+        spec: { url: "https://api.contoso.com/openapi.yaml" },
+        run_for_functions: ["*"],
+      });
+      assert.deepEqual(errors, []);
+    });
+
+    it("accepts an OpenApi runtime with an api_description spec", async () => {
+      const errors = await validate({
+        type: "OpenApi",
+        auth: noneAuth,
+        spec: { api_description: "openapi: 3.0.0" },
+        run_for_functions: ["*"],
+      });
+      assert.deepEqual(errors, []);
+    });
+
+    it("accepts a LocalPlugin runtime", async () => {
+      const errors = await validate({
+        type: "LocalPlugin",
+        auth: noneAuth,
+        spec: { local_endpoint: "Microsoft.Office.Addin" },
+        run_for_functions: ["myFunction"],
+      });
+      assert.deepEqual(errors, []);
+    });
+  });
+
+  describe("invalid runtimes", () => {
+    it("rejects an OpenApi runtime whose spec carries mcp_tool_description", async () => {
+      const errors = await validate({
+        type: "OpenApi",
+        auth: noneAuth,
+        spec: {
+          url: "https://api.contoso.com/openapi.yaml",
+          mcp_tool_description: { file: "mcp-tools.json" },
+        },
+        run_for_functions: ["*"],
+      });
+      assert.isTrue(errors.length > 0);
+    });
+
+    it("rejects a RemoteMCPServer runtime whose spec is missing url", async () => {
+      const errors = await validate({
+        type: "RemoteMCPServer",
+        auth: noneAuth,
+        spec: {},
+        run_for_functions: ["*"],
+      });
+      assert.isTrue(errors.length > 0);
+    });
+
+    it("rejects a RemoteMCPServer runtime carrying a local_endpoint spec", async () => {
+      const errors = await validate({
+        type: "RemoteMCPServer",
+        auth: noneAuth,
+        spec: { local_endpoint: "Microsoft.Office.Addin" },
+        run_for_functions: ["*"],
+      });
+      assert.isTrue(errors.length > 0);
+    });
+
+    it("rejects a LocalPlugin runtime carrying a url spec", async () => {
+      const errors = await validate({
+        type: "LocalPlugin",
+        auth: noneAuth,
+        spec: { local_endpoint: "Microsoft.Office.Addin", url: "https://api.contoso.com" },
+        run_for_functions: ["myFunction"],
+      });
+      assert.isTrue(errors.length > 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #16664.

The v2.4 API-plugin schema (`packages/manifest/src/json-schemas/copilot/plugin/v2.4/schema.json`) combined `open-api-spec`, `local-plugin-spec`, and `mcp-execution-spec` in a single undiscriminated `oneOf` directly on `runtime.spec`. Because `open-api-spec` and `mcp-execution-spec` are both `{ url }`-shaped, a bare `RemoteMCPServer` runtime using MCP **dynamic tool discovery** (spec `{ "url": "https://..." }`, no `mcp_tool_description`) matched **two** branches. `oneOf` then failed with the confusing errors:

```
/runtimes/0/spec must have required property 'local_endpoint'
/runtimes/0/spec must NOT have additional properties (additionalProperty: "url")
/runtimes/0/spec must match exactly one schema in oneOf (passingSchemas: [0,2])
```

This blocks the documented [MCP dynamic tool discovery](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/plugin-dynamic-tool-discovery) shape from validating.

## Fix

Because this schema is JSON Schema **draft-04** (no `if/then/else`, no `const`), the discriminated union is expressed as a runtime-level `oneOf` where each branch pins the discriminator `type` (via `enum`) to its matching `spec` `$ref`:

- `type: OpenApi`      -> `spec: open-api-spec`
- `type: LocalPlugin`  -> `spec: local-plugin-spec`
- `type: RemoteMCPServer` -> `spec: mcp-execution-spec`

`runtime.spec` itself becomes a generic `{ type: object }` whose shape is selected by the sibling `type`.

### Second fix (pre-existing)

While validating, I found a related pre-existing ambiguity in `mcp_tool_description`'s `oneOf`: `mcp-tool-inline` was an open object, so the file-reference shape `{ "file": "..." }` matched **both** `mcp-tool-file-reference` and `mcp-tool-inline` (`passingSchemas: [0,1]`). This affects the toolkit's own `materializeRemoteMcpTools` output. Added `"not": { "required": ["file"] }` to `mcp-tool-inline` so the two branches are mutually exclusive.

## Tests

Adds `packages/manifest/test/copilotPluginV24RuntimeSpec.test.ts`, which validates real manifests through `AppManifestUtils.validateAgainstSchema` for every runtime type plus the file/inline disambiguation (valid + negative cases). Verified the new test fails against the pre-fix schema (reproducing the exact `passingSchemas: [0,2]` errors) and passes after the fix. Full `packages/manifest` unit suite: 186 passing.