### PR TITLE
fix(tests): preserve keep-prefixed Entra apps

### DIFF
--- a/packages/tests/src/scripts/clean.ts
+++ b/packages/tests/src/scripts/clean.ts
@@ -6,6 +6,7 @@ import {
   AppStudioCleanHelper,
   filterResourceGroupByName,
   deleteResourceGroupByName,
+  resourceGroupHasTag,
   GraphApiCleanHelper,
   SharePointApiCleanHelper,
   DevTunnelCleanHelper,
@@ -25,26 +26,65 @@ const adminMicrosoftEntraAppName = [
   "Test SP",
 ];
 const excludePrefix: string = getAppNamePrefix();
+const keepNamePrefix = "keep-";
+const notDeleteTag = "NOT_DELETE";
 
-function shouldSkipAadApp(displayName?: string): boolean {
+function hasNotDeleteTag(tags?: unknown): boolean {
+  if (Array.isArray(tags)) {
+    return tags.includes(notDeleteTag);
+  }
+
+  if (typeof tags === "string") {
+    return tags.split(/[\s,;]+/).includes(notDeleteTag);
+  }
+
+  if (typeof tags === "object" && tags !== null) {
+    return Object.prototype.hasOwnProperty.call(tags, notDeleteTag);
+  }
+
+  return false;
+}
+
+function hasGeneratedNamePrefix(displayName?: string): boolean {
+  return displayName?.startsWith(excludePrefix) === true;
+}
+
+function hasKeepNamePrefix(displayName?: string): boolean {
+  return displayName?.startsWith(keepNamePrefix) === true;
+}
+
+function shouldSkipAadApp(displayName?: string, tags?: unknown): boolean {
   if (!displayName) {
     return true;
   }
 
   return (
     adminMicrosoftEntraAppName.some((name) => displayName.startsWith(name)) ||
-    displayName.startsWith(excludePrefix)
+    hasGeneratedNamePrefix(displayName) ||
+    hasNotDeleteTag(tags)
   );
 }
 
-function shouldCleanByPrefix(displayName?: string): boolean {
+function shouldCleanByPrefix(displayName?: string, tags?: unknown): boolean {
   if (!displayName) {
     return false;
   }
 
   return (
     appNamePrefixList.some((name) => displayName.startsWith(name)) &&
-    !displayName.startsWith(excludePrefix)
+    !hasGeneratedNamePrefix(displayName) &&
+    !hasNotDeleteTag(tags)
+  );
+}
+
+function shouldCleanAgentResource(
+  displayName?: string,
+  tags?: unknown,
+): boolean {
+  return (
+    !hasGeneratedNamePrefix(displayName) &&
+    !hasKeepNamePrefix(displayName) &&
+    !hasNotDeleteTag(tags)
   );
 }
 
@@ -63,7 +103,7 @@ async function main() {
     if (teamsAppList) {
       for (const app of teamsAppList) {
         const displayName = app?.teamsAppDefinition?.displayName;
-        if (shouldCleanByPrefix(displayName)) {
+        if (shouldCleanByPrefix(displayName, app?.teamsAppDefinition?.tags)) {
           console.log(displayName);
           try {
             await cleanService.uninstallTeamsApp(teamsUserId, app?.id ?? "");
@@ -100,7 +140,7 @@ async function main() {
     const aadList = await cleanService.listAad();
     if (aadList) {
       for (const aad of aadList) {
-        if (!shouldSkipAadApp(aad.displayName)) {
+        if (!shouldSkipAadApp(aad.displayName, aad.tags)) {
           console.log(aad.displayName);
           try {
             await cleanService.deleteAad(aad.id!);
@@ -121,7 +161,9 @@ async function main() {
     const enterpriseAppList = await cleanService.listEnterpriseApplications();
     if (enterpriseAppList) {
       for (const enterpriseApp of enterpriseAppList) {
-        if (shouldCleanByPrefix(enterpriseApp.displayName)) {
+        if (
+          shouldCleanByPrefix(enterpriseApp.displayName, enterpriseApp.tags)
+        ) {
           console.log(enterpriseApp.displayName);
           try {
             await cleanService.deleteEnterpriseApplication(enterpriseApp.id!);
@@ -144,7 +186,7 @@ async function main() {
     const deletedAadList = await cleanService.listDeletedAad();
     if (deletedAadList) {
       for (const aad of deletedAadList) {
-        if (!shouldSkipAadApp(aad.displayName)) {
+        if (!shouldSkipAadApp(aad.displayName, aad.tags)) {
           console.log(aad.displayName);
           try {
             await cleanService.deleteDeletedItem(aad.id!);
@@ -168,7 +210,9 @@ async function main() {
       await cleanService.listDeletedEnterpriseApplications();
     if (deletedEnterpriseAppList) {
       for (const enterpriseApp of deletedEnterpriseAppList) {
-        if (shouldCleanByPrefix(enterpriseApp.displayName)) {
+        if (
+          shouldCleanByPrefix(enterpriseApp.displayName, enterpriseApp.tags)
+        ) {
           console.log(enterpriseApp.displayName);
           try {
             await cleanService.deleteDeletedItem(enterpriseApp.id!);
@@ -195,7 +239,7 @@ async function main() {
     const appStudioAppList = await addStudioCleanService.getAppsInAppStudio();
     if (appStudioAppList) {
       for (const app of appStudioAppList) {
-        if (!app?.displayName?.startsWith(excludePrefix)) {
+        if (shouldCleanAgentResource(app?.displayName, app?.tags)) {
           console.log(app?.displayName);
           try {
             await addStudioCleanService.deleteAppInAppStudio(
@@ -215,6 +259,10 @@ async function main() {
       await addStudioCleanService.getApiKeyRegistration();
     if (apiKeyRegistrationList) {
       for (const apiKey of apiKeyRegistrationList) {
+        if (hasNotDeleteTag(apiKey?.tags)) {
+          continue;
+        }
+
         try {
           await addStudioCleanService.deleteApiKeyRegistration(apiKey?.id);
           console.log(apiKey?.id, " is deleted");
@@ -239,7 +287,11 @@ async function main() {
     if (rgNameList.length > 0) {
       for (const rgName of rgNameList) {
         for (const name of rgNamePrefixList) {
-          if (rgName.startsWith(name) && !rgName.startsWith(excludePrefix)) {
+          if (
+            rgName.startsWith(name) &&
+            !hasGeneratedNamePrefix(rgName) &&
+            !(await resourceGroupHasTag(rgName, notDeleteTag))
+          ) {
             await deleteResourceGroupByName(rgName);
           }
         }
@@ -265,7 +317,8 @@ async function main() {
         for (const name of appNamePrefixList) {
           if (
             app.Title?.startsWith(name) &&
-            !app.Title?.startsWith(excludePrefix)
+            !hasGeneratedNamePrefix(app.Title) &&
+            !hasNotDeleteTag(app.Tags ?? app.tags)
           ) {
             console.log(app.Title);
             try {
@@ -290,7 +343,10 @@ async function main() {
       Env.username,
       Env.password,
     );
-    await devTunnelCleanHelper.deleteAll();
+    await devTunnelCleanHelper.deleteAll(
+      "TeamsToolkitCreatedTag",
+      notDeleteTag,
+    );
   } catch (e: any) {
     console.log(`Failed to clean dev tunnel`);
   }
@@ -312,8 +368,11 @@ async function main() {
       const acquisitions = await m365TitleCleanService.listAcquisitions();
       if (acquisitions) {
         for (const acquisition of acquisitions) {
-          if (!acquisition.titleDefinition.name.startsWith(excludePrefix)) {
-            console.log(acquisition.titleDefinition.name);
+          const titleName = acquisition.titleDefinition?.name;
+          const titleTags =
+            acquisition.tags ?? acquisition.titleDefinition?.tags;
+          if (shouldCleanAgentResource(titleName, titleTags)) {
+            console.log(titleName);
             console.log(acquisition.titleId);
             const result = await m365TitleCleanService.unacquire(
               acquisition.titleId,

--- a/packages/tests/src/scripts/clean.ts
+++ b/packages/tests/src/scripts/clean.ts
@@ -6,7 +6,6 @@ import {
   AppStudioCleanHelper,
   filterResourceGroupByName,
   deleteResourceGroupByName,
-  resourceGroupHasTag,
   GraphApiCleanHelper,
   SharePointApiCleanHelper,
   DevTunnelCleanHelper,
@@ -27,23 +26,6 @@ const adminMicrosoftEntraAppName = [
 ];
 const excludePrefix: string = getAppNamePrefix();
 const keepNamePrefix = "keep-";
-const notDeleteTag = "NOT_DELETE";
-
-function hasNotDeleteTag(tags?: unknown): boolean {
-  if (Array.isArray(tags)) {
-    return tags.includes(notDeleteTag);
-  }
-
-  if (typeof tags === "string") {
-    return tags.split(/[\s,;]+/).includes(notDeleteTag);
-  }
-
-  if (typeof tags === "object" && tags !== null) {
-    return Object.prototype.hasOwnProperty.call(tags, notDeleteTag);
-  }
-
-  return false;
-}
 
 function hasGeneratedNamePrefix(displayName?: string): boolean {
   return displayName?.startsWith(excludePrefix) === true;
@@ -53,7 +35,7 @@ function hasKeepNamePrefix(displayName?: string): boolean {
   return displayName?.startsWith(keepNamePrefix) === true;
 }
 
-function shouldSkipAadApp(displayName?: string, tags?: unknown): boolean {
+function shouldSkipAadApp(displayName?: string): boolean {
   if (!displayName) {
     return true;
   }
@@ -61,30 +43,18 @@ function shouldSkipAadApp(displayName?: string, tags?: unknown): boolean {
   return (
     adminMicrosoftEntraAppName.some((name) => displayName.startsWith(name)) ||
     hasGeneratedNamePrefix(displayName) ||
-    hasNotDeleteTag(tags)
+    hasKeepNamePrefix(displayName)
   );
 }
 
-function shouldCleanByPrefix(displayName?: string, tags?: unknown): boolean {
+function shouldCleanByPrefix(displayName?: string): boolean {
   if (!displayName) {
     return false;
   }
 
   return (
     appNamePrefixList.some((name) => displayName.startsWith(name)) &&
-    !hasGeneratedNamePrefix(displayName) &&
-    !hasNotDeleteTag(tags)
-  );
-}
-
-function shouldCleanAgentResource(
-  displayName?: string,
-  tags?: unknown,
-): boolean {
-  return (
-    !hasGeneratedNamePrefix(displayName) &&
-    !hasKeepNamePrefix(displayName) &&
-    !hasNotDeleteTag(tags)
+    !hasGeneratedNamePrefix(displayName)
   );
 }
 
@@ -103,7 +73,7 @@ async function main() {
     if (teamsAppList) {
       for (const app of teamsAppList) {
         const displayName = app?.teamsAppDefinition?.displayName;
-        if (shouldCleanByPrefix(displayName, app?.teamsAppDefinition?.tags)) {
+        if (shouldCleanByPrefix(displayName)) {
           console.log(displayName);
           try {
             await cleanService.uninstallTeamsApp(teamsUserId, app?.id ?? "");
@@ -140,7 +110,7 @@ async function main() {
     const aadList = await cleanService.listAad();
     if (aadList) {
       for (const aad of aadList) {
-        if (!shouldSkipAadApp(aad.displayName, aad.tags)) {
+        if (!shouldSkipAadApp(aad.displayName)) {
           console.log(aad.displayName);
           try {
             await cleanService.deleteAad(aad.id!);
@@ -161,9 +131,7 @@ async function main() {
     const enterpriseAppList = await cleanService.listEnterpriseApplications();
     if (enterpriseAppList) {
       for (const enterpriseApp of enterpriseAppList) {
-        if (
-          shouldCleanByPrefix(enterpriseApp.displayName, enterpriseApp.tags)
-        ) {
+        if (shouldCleanByPrefix(enterpriseApp.displayName)) {
           console.log(enterpriseApp.displayName);
           try {
             await cleanService.deleteEnterpriseApplication(enterpriseApp.id!);
@@ -186,7 +154,7 @@ async function main() {
     const deletedAadList = await cleanService.listDeletedAad();
     if (deletedAadList) {
       for (const aad of deletedAadList) {
-        if (!shouldSkipAadApp(aad.displayName, aad.tags)) {
+        if (!shouldSkipAadApp(aad.displayName)) {
           console.log(aad.displayName);
           try {
             await cleanService.deleteDeletedItem(aad.id!);
@@ -210,9 +178,7 @@ async function main() {
       await cleanService.listDeletedEnterpriseApplications();
     if (deletedEnterpriseAppList) {
       for (const enterpriseApp of deletedEnterpriseAppList) {
-        if (
-          shouldCleanByPrefix(enterpriseApp.displayName, enterpriseApp.tags)
-        ) {
+        if (shouldCleanByPrefix(enterpriseApp.displayName)) {
           console.log(enterpriseApp.displayName);
           try {
             await cleanService.deleteDeletedItem(enterpriseApp.id!);
@@ -239,7 +205,7 @@ async function main() {
     const appStudioAppList = await addStudioCleanService.getAppsInAppStudio();
     if (appStudioAppList) {
       for (const app of appStudioAppList) {
-        if (shouldCleanAgentResource(app?.displayName, app?.tags)) {
+        if (!app?.displayName?.startsWith(excludePrefix)) {
           console.log(app?.displayName);
           try {
             await addStudioCleanService.deleteAppInAppStudio(
@@ -259,10 +225,6 @@ async function main() {
       await addStudioCleanService.getApiKeyRegistration();
     if (apiKeyRegistrationList) {
       for (const apiKey of apiKeyRegistrationList) {
-        if (hasNotDeleteTag(apiKey?.tags)) {
-          continue;
-        }
-
         try {
           await addStudioCleanService.deleteApiKeyRegistration(apiKey?.id);
           console.log(apiKey?.id, " is deleted");
@@ -287,11 +249,7 @@ async function main() {
     if (rgNameList.length > 0) {
       for (const rgName of rgNameList) {
         for (const name of rgNamePrefixList) {
-          if (
-            rgName.startsWith(name) &&
-            !hasGeneratedNamePrefix(rgName) &&
-            !(await resourceGroupHasTag(rgName, notDeleteTag))
-          ) {
+          if (rgName.startsWith(name) && !rgName.startsWith(excludePrefix)) {
             await deleteResourceGroupByName(rgName);
           }
         }
@@ -317,8 +275,7 @@ async function main() {
         for (const name of appNamePrefixList) {
           if (
             app.Title?.startsWith(name) &&
-            !hasGeneratedNamePrefix(app.Title) &&
-            !hasNotDeleteTag(app.Tags ?? app.tags)
+            !app.Title?.startsWith(excludePrefix)
           ) {
             console.log(app.Title);
             try {
@@ -343,10 +300,7 @@ async function main() {
       Env.username,
       Env.password,
     );
-    await devTunnelCleanHelper.deleteAll(
-      "TeamsToolkitCreatedTag",
-      notDeleteTag,
-    );
+    await devTunnelCleanHelper.deleteAll();
   } catch (e: any) {
     console.log(`Failed to clean dev tunnel`);
   }
@@ -368,11 +322,8 @@ async function main() {
       const acquisitions = await m365TitleCleanService.listAcquisitions();
       if (acquisitions) {
         for (const acquisition of acquisitions) {
-          const titleName = acquisition.titleDefinition?.name;
-          const titleTags =
-            acquisition.tags ?? acquisition.titleDefinition?.tags;
-          if (shouldCleanAgentResource(titleName, titleTags)) {
-            console.log(titleName);
+          if (!acquisition.titleDefinition.name.startsWith(excludePrefix)) {
+            console.log(acquisition.titleDefinition.name);
             console.log(acquisition.titleId);
             const result = await m365TitleCleanService.unacquire(
               acquisition.titleId,

--- a/packages/tests/src/utils/cleanHelper.ts
+++ b/packages/tests/src/utils/cleanHelper.ts
@@ -189,7 +189,11 @@ export class GraphApiCleanHelper extends CleanHelper {
 
   public async listAad(): Promise<any[]> {
     const result: any[] = [];
-    const response = await this.execute("get", `/applications`, undefined);
+    const response = await this.execute(
+      "get",
+      `/applications?$select=id,appId,displayName,tags`,
+      undefined,
+    );
     if (response?.data?.value) {
       result.push(...(response?.data?.value as any[]));
     }
@@ -269,7 +273,11 @@ export class GraphApiCleanHelper extends CleanHelper {
 
   public async listEnterpriseApplications(): Promise<any[]> {
     const result: any[] = [];
-    const response = await this.execute("get", `/servicePrincipals`, undefined);
+    const response = await this.execute(
+      "get",
+      `/servicePrincipals?$select=id,displayName,tags`,
+      undefined,
+    );
     if (response?.data?.value) {
       result.push(...(response?.data?.value as any[]));
     }
@@ -703,10 +711,16 @@ export class DevTunnelCleanHelper {
     });
   }
 
-  public async deleteAll(tag = "TeamsToolkitCreatedTag"): Promise<void> {
+  public async deleteAll(
+    tag = "TeamsToolkitCreatedTag",
+    preserveTag = "NOT_DELETE",
+  ): Promise<void> {
     const tunnels = await this.tunnelManagementClientImpl.listTunnels();
     for (const tunnel of tunnels) {
-      if (tunnel?.labels?.includes(tag)) {
+      if (
+        tunnel?.labels?.includes(tag) &&
+        !tunnel.labels.includes(preserveTag)
+      ) {
         console.log(`clean dev tunnel ${tunnel.tunnelId}`);
         await this.tunnelManagementClientImpl.deleteTunnel(tunnel);
       }
@@ -790,6 +804,22 @@ export async function deleteResourceGroupByName(
     return result;
   }
   return false;
+}
+
+export async function resourceGroupHasTag(
+  name: string,
+  tagName: string,
+): Promise<boolean> {
+  const manager = await ResourceGroupManager.init();
+  if (!(await manager.hasResourceGroup(name))) {
+    return false;
+  }
+
+  const resourceGroup = await manager.getResourceGroup(name);
+  return Object.prototype.hasOwnProperty.call(
+    resourceGroup.tags ?? {},
+    tagName,
+  );
 }
 
 export async function filterResourceGroupByName(contains: string) {

--- a/packages/tests/src/utils/cleanHelper.ts
+++ b/packages/tests/src/utils/cleanHelper.ts
@@ -189,11 +189,7 @@ export class GraphApiCleanHelper extends CleanHelper {
 
   public async listAad(): Promise<any[]> {
     const result: any[] = [];
-    const response = await this.execute(
-      "get",
-      `/applications?$select=id,appId,displayName,tags`,
-      undefined,
-    );
+    const response = await this.execute("get", `/applications`, undefined);
     if (response?.data?.value) {
       result.push(...(response?.data?.value as any[]));
     }
@@ -273,11 +269,7 @@ export class GraphApiCleanHelper extends CleanHelper {
 
   public async listEnterpriseApplications(): Promise<any[]> {
     const result: any[] = [];
-    const response = await this.execute(
-      "get",
-      `/servicePrincipals?$select=id,displayName,tags`,
-      undefined,
-    );
+    const response = await this.execute("get", `/servicePrincipals`, undefined);
     if (response?.data?.value) {
       result.push(...(response?.data?.value as any[]));
     }
@@ -711,16 +703,10 @@ export class DevTunnelCleanHelper {
     });
   }
 
-  public async deleteAll(
-    tag = "TeamsToolkitCreatedTag",
-    preserveTag = "NOT_DELETE",
-  ): Promise<void> {
+  public async deleteAll(tag = "TeamsToolkitCreatedTag"): Promise<void> {
     const tunnels = await this.tunnelManagementClientImpl.listTunnels();
     for (const tunnel of tunnels) {
-      if (
-        tunnel?.labels?.includes(tag) &&
-        !tunnel.labels.includes(preserveTag)
-      ) {
+      if (tunnel?.labels?.includes(tag)) {
         console.log(`clean dev tunnel ${tunnel.tunnelId}`);
         await this.tunnelManagementClientImpl.deleteTunnel(tunnel);
       }
@@ -804,22 +790,6 @@ export async function deleteResourceGroupByName(
     return result;
   }
   return false;
-}
-
-export async function resourceGroupHasTag(
-  name: string,
-  tagName: string,
-): Promise<boolean> {
-  const manager = await ResourceGroupManager.init();
-  if (!(await manager.hasResourceGroup(name))) {
-    return false;
-  }
-
-  const resourceGroup = await manager.getResourceGroup(name);
-  return Object.prototype.hasOwnProperty.call(
-    resourceGroup.tags ?? {},
-    tagName,
-  );
 }
 
 export async function filterResourceGroupByName(contains: string) {


### PR DESCRIPTION
## Summary
- Preserve Entra app registrations whose display name starts with `keep-` during test tenant cleanup
- Keep the existing generated-prefix and admin app exclusions unchanged
- Remove the broader tag/resource cleanup protections from this PR scope

## Validation
- `npx prettier --write packages\tests\src\scripts\clean.ts packages\tests\src\utils\cleanHelper.ts`
- `cd packages\tests && npm run build`