### PR TITLE
fix(vscuse): Auto-fix Feature_Check_Copilot_License_Enabled (progress 10→16 steps, not a plan issue)

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 15,
+    "total_steps": 16,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -27,6 +27,7 @@
       "step_a0026de5",
       "step_78a597ab",
       "step_47935ca7",
+      "step_6b12e8d4",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -36,7 +37,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-03T02:43:47.577000"
+    "updated_at": "2026-09-03T02:50:05.808000"
   },
   "steps": [
     {
@@ -48,7 +49,7 @@
         "x": 951,
         "y": 130
       },
-      "description": "Click the language selection button (flag icon) in the top right corner of the VS Code welcome screen to open the language options.",
+      "description": "Click the Close (X) button in the top-right corner of the VS Code welcome sign-in dialog to dismiss it.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -210,7 +211,7 @@
         "x": 976,
         "y": 457
       },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the bottom right of the Visual Studio Code interface to open the Microsoft authentication browser.",
+      "description": "Click the \"Sign in\" button in the Microsoft 365 notification to open the Microsoft 365 developer sandbox prompt.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -221,6 +222,32 @@
       "tags": [],
       "screenshot": "step_47935ca7",
       "created_at": "2026-06-17T02:19:55.488096",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_6b12e8d4",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 762,
+        "y": 97
+      },
+      "description": "Click the \"Sign in\" button in the Microsoft 365 developer sandbox prompt to launch and activate the Microsoft authentication browser.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [
+        "dhash:762:97:16:5:24b1a72ba9aba343",
+        "dhash:762:97:96:5:0008304b0f344900",
+        "dhash:762:97:0:10:9c68332223232421"
+      ],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-03T02:50:05.808000",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 17,
+    "total_steps": 16,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -28,7 +28,6 @@
       "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
-      "step_48c6f7a1",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -235,34 +234,10 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 703,
-        "y": 100
+        "x": 980,
+        "y": 758
       },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the top of the Visual Studio Code interface to access a Microsoft 365 account.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:703:100:16:5:0000000000000000",
-        "dhash:703:100:96:5:00000042b2474971",
-        "dhash:703:100:0:10:9cb89590b0717d7f"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_47935ca7",
-      "created_at": "2026-06-17T02:19:55.488096",
-      "plan_id": "plan_80b368dd"
-    },
-    {
-      "step_id": "step_48c6f7a1",
-      "agent": "interaction",
-      "tool": "keyboard_shortcut",
-      "parameters": {
-        "keys": "alt+tab"
-      },
-      "description": "Press Alt+Tab to activate the Microsoft authentication browser window opened in the background.",
+      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the bottom right of the Visual Studio Code interface to open the Microsoft authentication browser.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -270,11 +245,9 @@
       "depends_on": [],
       "preconditions": [],
       "postconditions": [],
-      "tags": [
-        "delay:5"
-      ],
-      "screenshot": "",
-      "created_at": "2026-09-03T02:15:02.293000",
+      "tags": [],
+      "screenshot": "step_47935ca7",
+      "created_at": "2026-06-17T02:19:55.488096",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 15,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -27,7 +27,6 @@
       "step_a0026de5",
       "step_78a597ab",
       "step_47935ca7",
-      "step_8f4a9c21",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -37,7 +36,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-03T02:38:12.271000"
+    "updated_at": "2026-09-03T02:43:47.577000"
   },
   "steps": [
     {
@@ -208,8 +207,8 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 980,
-        "y": 758
+        "x": 976,
+        "y": 457
       },
       "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the bottom right of the Visual Studio Code interface to open the Microsoft authentication browser.",
       "content_refs": [],
@@ -222,30 +221,6 @@
       "tags": [],
       "screenshot": "step_47935ca7",
       "created_at": "2026-06-17T02:19:55.488096",
-      "plan_id": "plan_80b368dd"
-    },
-    {
-      "step_id": "step_8f4a9c21",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 944,
-        "y": 17
-      },
-      "description": "After the Microsoft authentication browser opens in the background, click the VS Code Minimize button to reveal and activate the browser window.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [
-        "delay:10"
-      ],
-      "screenshot": "",
-      "created_at": "2026-09-03T02:32:43.261000",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 17,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -28,6 +28,7 @@
       "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
+      "step_8f4a9c21",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -37,7 +38,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-06-17T02:28:59.615382"
+    "updated_at": "2026-09-03T02:32:43.261000"
   },
   "steps": [
     {
@@ -248,6 +249,30 @@
       "tags": [],
       "screenshot": "step_47935ca7",
       "created_at": "2026-06-17T02:19:55.488096",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_8f4a9c21",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 944,
+        "y": 17
+      },
+      "description": "After the Microsoft authentication browser opens in the background, click the VS Code Minimize button to reveal and activate the browser window.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:10"
+      ],
+      "screenshot": "",
+      "created_at": "2026-09-03T02:32:43.261000",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 17,
+    "total_steps": 16,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -25,7 +25,6 @@
       "step_f0d7ba3e",
       "step_436b1f61",
       "step_a0026de5",
-      "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
       "step_8f4a9c21",
@@ -38,7 +37,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-03T02:32:43.261000"
+    "updated_at": "2026-09-03T02:38:12.271000"
   },
   "steps": [
     {
@@ -175,32 +174,6 @@
       "tags": [],
       "screenshot": "step_a0026de5",
       "created_at": "2026-06-17T02:19:55.474845",
-      "plan_id": "plan_80b368dd"
-    },
-    {
-      "step_id": "step_fa6d6cb1",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 512,
-        "y": 431
-      },
-      "description": "Click the \"Set up your environment\" option in the guided tutorial list under the \"Build a Declarative Agent\" section of the Microsoft 365 Agents Toolkit welcome screen in Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_fa6d6cb1",
-      "created_at": "2026-06-17T02:24:33.865380",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 17,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -28,6 +28,7 @@
       "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
+      "step_48c6f7a1",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -252,6 +253,28 @@
       "tags": [],
       "screenshot": "step_47935ca7",
       "created_at": "2026-06-17T02:19:55.488096",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_48c6f7a1",
+      "agent": "interaction",
+      "tool": "keyboard_shortcut",
+      "parameters": {
+        "keys": "alt+tab"
+      },
+      "description": "Press Alt+Tab to activate the Microsoft authentication browser window opened in the background.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:5"
+      ],
+      "screenshot": "",
+      "created_at": "2026-09-03T02:15:02.293000",
       "plan_id": "plan_80b368dd"
     },
     {


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Feature_Check_Copilot_License_Enabled`
**Status:** :mag: NOT A PLAN ISSUE (AI diagnosis after 7 attempt(s))
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/c72ac973-46e6-49fe-98c6-2547879d5fa3/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/af6089a0-70c7-46c3-8528-08be020ed573/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Added a delayed Alt+Tab step after clicking “Sign in” to activate the background | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/5f4030cd-83e7-4cda-a544-2fbb789373da/test_report.html) |
| 2 | Corrected the stale Sign in click to target the lower-right notification action  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/2413cfa9-0b45-4998-a564-1aaf3345a467/test_report.html) |
| 3 | Added a delayed step that minimizes foreground VS Code at its recorded title-bar | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/ef5b6f07-d8f3-43d5-a6c2-8d36e1ef5098/test_report.html) |
| 4 | Removed the obsolete “Set up your environment” expansion step because the sectio | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/000d9d86-c4a3-490a-88a0-7326e099410f/test_report.html) |
| 5 | Corrected the false-positive Sign in click from the bottom status control at (98 | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/8fb4494f-f9b4-41e1-a36c-efd161c5cc85/test_report.html) |
| 6 | Added the missing click on the intermediate Microsoft 365 developer sandbox “Sig | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/af6089a0-70c7-46c3-8528-08be020ed573/test_report.html) |
| 7 | NOT_PLAN_ISSUE: The authentication browser activated and credentials were submit | :mag: Not a plan issue | — |

### AI Diagnosis

> :mag: **This failure is NOT caused by the test plan.** The AI identified an external issue:
> 
> The authentication browser activated and credentials were submitted successfully, but Microsoft Entra rejected the extension-generated OAuth request with AADSTS70007, so localhost received no authorization code or refresh token; no UI plan change can recover this extension/auth configuration failure.

> :point_right: **Action needed:** Investigate the root cause above. No plan changes will fix this.

### How to Review
- Each commit represents one fix attempt for `plans/Feature_Check_Copilot_License_Enabled.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../Feature_Check_Copilot_License_Enabled.json     | 60 ++++++++++------------
 1 file changed, 28 insertions(+), 32 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
index 6395c68..4166292 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -25,9 +25,9 @@
       "step_f0d7ba3e",
       "step_436b1f61",
       "step_a0026de5",
-      "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
+      "step_6b12e8d4",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -37,7 +37,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-06-17T02:28:59.615382"
+    "updated_at": "2026-09-03T02:50:05.808000"
   },
   "steps": [
     {
@@ -49,7 +49,7 @@
         "x": 951,
         "y": 130
       },
-      "description": "Click the language selection button (flag icon) in the top right corner of the VS Code welcome screen to open the language options.",
+      "description": "Click the Close (X) button in the top-right corner of the VS Code welcome sign-in dialog to dismiss it.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -177,81 +177,77 @@
       "plan_id": "plan_80b368dd"
     },
     {
-      "step_id": "step_fa6d6cb1",
+      "step_id": "step_78a597ab",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 512,
-        "y": 431
+        "x": 516,
+        "y": 447
       },
-      "description": "Click the \"Set up your environment\" option in the guided tutorial list under the \"Build a Declarative Agent\" section of the Microsoft 365 Agents Toolkit welcome screen in Visual Studio Code.",
+      "description": "Click the \"Check Copilot License\" button in the \"Set up your environment\" section of the Microsoft 365 Agents Toolkit welcome screen in Visual Studio Code.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
+        "dhash:516:447:16:5:2493f3ec6b936ad2",
+        "dhash:516:447:96:5:75622a1d99660000",
+        "dhash:516:447:0:10:24b0949090b17075"
       ],
       "postconditions": [],
       "tags": [],
-      "screenshot": "step_fa6d6cb1",
-      "created_at": "2026-06-17T02:24:33.865380",
+      "screenshot": "step_78a597ab",
+      "created_at": "2026-06-17T02:28:51.067052",
       "plan_id": "plan_80b368dd"
     },
     {
-      "step_id": "step_78a597ab",
+      "step_id": "step_47935ca7",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 516,
-        "y": 447
+        "x": 976,
+        "y": 45
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>