### PR TITLE
fix(ci): prevent code and shell injection in PR workflows

### DIFF
--- a/.github/workflows/eval-microsoft-365-agents-toolkit-report.yml
+++ b/.github/workflows/eval-microsoft-365-agents-toolkit-report.yml
@@ -1,0 +1,109 @@
+name: Report Microsoft 365 Agents Toolkit Skill Evaluation
+
+on:
+  workflow_run:
+    workflows: ["Evaluate Microsoft 365 Agents Toolkit Skill"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_GITHUB_APP_ID }}
+          private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Checkout trusted reporting scripts
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.pull_requests[0].base.sha || github.event.repository.default_branch }}
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Download raw evaluation results
+        uses: actions/download-artifact@v4
+        with:
+          name: skill-eval-raw
+          path: evals/results
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Compare with baseline
+        continue-on-error: true
+        run: node evals/results/generate-compare-json.js
+
+      - name: Generate comparison Markdown
+        if: always()
+        run: node evals/results/generate-compare-markdown.js
+
+      - name: Generate comparison dashboard
+        if: always()
+        run: node evals/results/generate-compare-dashboard.js
+
+      - name: Post comparison comment on PR
+        if: >-
+          always() &&
+          (github.event.workflow_run.event == 'pull_request' ||
+          github.event.workflow_run.event == 'pull_request_target')
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: node evals/results/post-pr-comment.js
+
+      - name: Upload evaluation results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-eval-results
+          path: |
+            ./evals/results/latest.json
+            ./evals/results/compare.json
+            ./evals/results/compare.md
+            ./evals/results/compare-dashboard.html
+          retention-days: 30
+
+      - name: Update baseline on PR branch
+        if: >-
+          always() &&
+          (github.event.workflow_run.event == 'pull_request' ||
+          github.event.workflow_run.event == 'pull_request_target') &&
+          github.event.workflow_run.head_repository.full_name == github.repository
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ ! -f evals/results/latest.json ]; then
+            echo "No latest evaluation result to commit."
+            exit 0
+          fi
+
+          git check-ref-format "refs/heads/$HEAD_BRANCH"
+          remote_head=$(git ls-remote origin "refs/heads/$HEAD_BRANCH" | cut -f1)
+          if [ "$remote_head" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "The PR branch changed after this evaluation; skipping the stale baseline update."
+            exit 0
+          fi
+
+          git fetch origin "$HEAD_BRANCH"
+          git checkout -B "$HEAD_BRANCH" "origin/$HEAD_BRANCH"
+          cp evals/results/latest.json evals/results/baseline.json
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add evals/results/baseline.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: update baseline from latest eval results (PR sync)"
+          git push origin "HEAD:refs/heads/$HEAD_BRANCH"

--- a/.github/workflows/eval-microsoft-365-agents-toolkit.yml
+++ b/.github/workflows/eval-microsoft-365-agents-toolkit.yml
@@ -2,38 +2,33 @@ name: Evaluate Microsoft 365 Agents Toolkit Skill
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths:
-      - 'packages/vscode-extension/skills/microsoft-365-agents-toolkit/**'
-      - 'evals/microsoft-365-agents-toolkit/**'
-      - '.github/workflows/eval-microsoft-365-agents-toolkit.yml'
+      - "packages/vscode-extension/skills/microsoft-365-agents-toolkit/**"
+      - "evals/microsoft-365-agents-toolkit/**"
+      - ".github/workflows/eval-microsoft-365-agents-toolkit.yml"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   evaluate:
     if: ${{ !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    environment: skill-evaluation
     steps:
-      - id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.APP_GITHUB_APP_ID }}
-          private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.generate-token.outputs.token }}
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+          persist-credentials: false
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: "24"
 
       - name: Install GitHub Copilot CLI
         run: |
@@ -57,70 +52,16 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         run: waza run -o evals/results/latest.json
 
-      - name: Fetch baseline.json from PR target branch
-        if: always() && github.event_name == 'pull_request'
-        run: |
-          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
-          git fetch origin $BASE_BRANCH
-          git show origin/$BASE_BRANCH:evals/results/baseline.json > evals/results/baseline.json || echo "No baseline.json in base branch"
-
-      - name: Compare with baseline
+      - name: Record evaluation completion
         if: always()
-        run: |
-          if [ -f evals/results/baseline.json ] && [ -f evals/results/latest.json ]; then
-            node evals/results/generate-compare-json.js
-          else
-            echo "## Waza Comparison Report" > evals/results/compare.md
-            echo >> evals/results/compare.md
-            echo "Comparison skipped because baseline or latest result file was not found." >> evals/results/compare.md
-            echo >> evals/results/compare.md
-            echo "- baseline: evals/results/baseline.json" >> evals/results/compare.md
-            echo "- latest: evals/results/latest.json" >> evals/results/compare.md
-          fi
+        run: echo "Evaluation run $GITHUB_RUN_ID completed." > evals/results/evaluation-complete.txt
 
-      - name: Generate comparison Markdown
-        if: always()
-        run: node evals/results/generate-compare-markdown.js
-
-      - name: Generate comparison dashboard
-        if: always()
-        run: node evals/results/generate-compare-dashboard.js
-
-      - name: Post comparison comment on PR
-        if: always() && github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node evals/results/post-pr-comment.js
-
-      - name: Upload evaluation results
+      - name: Upload raw evaluation results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: skill-eval-results
+          name: skill-eval-raw
           path: |
             ./evals/results/latest.json
-            ./evals/results/compare.json
-            ./evals/results/compare-dashboard.html
+            ./evals/results/evaluation-complete.txt
           retention-days: 30
-
-      - name: Update baseline on PR branch
-        if: always() && github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          if [ -f evals/results/latest.json ]; then
-            BRANCH="${{ github.head_ref }}"
-            git fetch origin $BRANCH
-            git checkout $BRANCH
-            cp evals/results/latest.json evals/results/baseline.json
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add evals/results/baseline.json
-            if git diff --cached --quiet; then
-              echo "No changes to commit"
-              exit 0
-            fi
-            git commit -m "chore: update baseline from latest eval results (PR sync)"
-            git pull --rebase origin $BRANCH
-            git push origin HEAD:$BRANCH
-          fi

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -27,12 +27,11 @@ on:
       - completed
 
 permissions:
-  contents: write
+  contents: read
   actions: read
-  pull-requests: write
-  id-token: write
+  pull-requests: read
 
-jobs: 
+jobs:
   pr-title:
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
@@ -72,23 +71,27 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      
+
       - name: setup project
         uses: ./.github/actions/setup-project
 
       - name: lint and format check files in PR on Fork
-        if: ${{ github.event.pull_request.head.repo.full_name != 'OfficeDev/TeamsFx' }}
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
-          git remote add upstream https://github.com/OfficeDev/TeamsFx.git
-          git fetch upstream ${{ github.event.pull_request.base.ref }}
+          git remote add upstream "https://github.com/${{ github.repository }}.git"
+          git fetch upstream "$BASE_BRANCH"
           VAR=$(realpath .github/scripts/lint-pr.sh)
-          pnpm -r exec -- bash $VAR upstream/${{ github.event.pull_request.base.ref }}
+          pnpm -r exec -- bash "$VAR" "upstream/$BASE_BRANCH"
 
       - name: lint and format check files in PR on local
-        if: ${{ github.event.pull_request.head.repo.full_name == 'OfficeDev/TeamsFx' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
           VAR=$(realpath .github/scripts/lint-pr.sh)
-          pnpm -r exec -- bash $VAR origin/${{ github.event.pull_request.base.ref }}
+          pnpm -r exec -- bash "$VAR" "origin/$BASE_BRANCH"
 
       - name: Check if there are changes
         id: changes
@@ -113,7 +116,7 @@ jobs:
         shell: bash
         env:
           CI: true
-          
+
   check-yaml-lint:
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
@@ -130,22 +133,28 @@ jobs:
           pip install yamllint
           npm install mustache -g
           echo '{"appName":"test"}'>test.json
-      
+
       - name: check origin or remote
         id: remote
+        env:
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          CURRENT_REPOSITORY: ${{ github.repository }}
         run: |
-          if [ ${{ github.event.pull_request.head.repo.full_name == 'OfficeDev/TeamsFx' }} ]
+          if [ "$HEAD_REPOSITORY" = "$CURRENT_REPOSITORY" ]
           then
             echo "target=origin" >> $GITHUB_OUTPUT
           else
             echo "target=remote" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: check yaml lint origin
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          TARGET_REMOTE: ${{ steps.remote.outputs.target }}
         run: |
-          TRAGET=${{steps.remote.outputs.target}}/${{ github.event.pull_request.base.ref }}
-          YMLTPL=$(git diff --diff-filter=MARC $TRAGET...HEAD --name-only -- templates | grep -E '.yml.tpl$'|xargs)
-          echo $YMLTPL
+          TARGET="$TARGET_REMOTE/$BASE_BRANCH"
+          YMLTPL=$(git diff --diff-filter=MARC "$TARGET...HEAD" --name-only -- templates | grep -E '.yml.tpl$'|xargs)
+          echo "$YMLTPL"
           if [ ! -z "$YMLTPL" ]
           then
               for obj in "$YMLTPL"
@@ -160,15 +169,12 @@ jobs:
     steps:
       - shell: bash
         if: ${{ github.event_name == 'pull_request'}}
+        env:
+          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "depth=$(($(jq length <<< '${{ toJson(github.event.commits) }}') + 1))" >> $GITHUB_ENV
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "depth=$((${{ github.event.pull_request.commits }} + 1))" >> $GITHUB_ENV
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
-          fi
+          echo "depth=$((PR_COMMIT_COUNT + 1))" >> "$GITHUB_ENV"
+          echo "branch=$PR_HEAD_REF" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
         if: ${{ github.event_name == 'pull_request'}}
         with:
@@ -192,6 +198,12 @@ jobs:
   generate-changelog:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: write
+    env:
+      TARGET_BRANCH: ${{ github.event.inputs.target-branch }}
+      SOURCE_BRANCH: ${{ github.event.inputs.source-branch }}
+      GITHUB_ACTOR_NAME: ${{ github.actor }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -204,8 +216,8 @@ jobs:
         id: update-changelog
         working-directory: ./
         run: |
-          git fetch origin ${{ github.event.inputs.source-branch }}:${{ github.event.inputs.source-branch }}
-          head=$(git merge-base ${{ github.event.inputs.target-branch }} ${{ github.event.inputs.source-branch }})
+          git fetch origin "$SOURCE_BRANCH:$SOURCE_BRANCH"
+          head=$(git merge-base "$TARGET_BRANCH" "$SOURCE_BRANCH")
           tempfile=$(mktemp)
           REPO_URL="https://github.com/OfficeDev/Teams-toolkit"
 
@@ -218,7 +230,7 @@ jobs:
           history_dotnet_sdk_feat=$(git log --pretty=format:"- [%s]($REPO_URL/commit/%h)" $head...HEAD -- ./packages/dotnet-sdk | grep "feat:" || true)
 
           cat <<EOF > "$tempfile"
-          ### RELEASE ${{ github.event.inputs.source-branch }}...${{ github.event.inputs.target-branch }}
+          ### RELEASE $SOURCE_BRANCH...$TARGET_BRANCH
           ### Feature Commits
 
           #### Fx-core
@@ -273,14 +285,14 @@ jobs:
           cat "$tempfile"
           cat ./packages/vscode-extension/PRERELEASE.md >> "$tempfile"
           mv "$tempfile" ./packages/vscode-extension/PRERELEASE.md
-          git checkout -b changelog/${{ github.event.inputs.target-branch }}
+          git checkout -b "changelog/$TARGET_BRANCH"
           echo "=== changelog file path ==="
-          echo "https://github.com/OfficeDev/teams-toolkit/blob/changelog/${{ github.event.inputs.source-branch }}/packages/vscode-extension/PRERELEASE.md"
+          echo "https://github.com/OfficeDev/teams-toolkit/blob/changelog/$SOURCE_BRANCH/packages/vscode-extension/PRERELEASE.md"
 
-          body="<h2>CHANGELOG ${{ github.event.inputs.source-branch }} ... ${{ github.event.inputs.target-branch }}</h2><h3><a href='https:\/\/github.com\/OfficeDev\/teams-toolkit\/blob\/changelog\/${{ github.event.inputs.target-branch }}\/packages\/vscode-extension\/PRERELEASE.md'>Click Here to Open Changelog File</a></h3>"
-          subject="[Changelog] ${{ github.event.inputs.source-branch }} ... ${{ github.event.inputs.target-branch }}"
+          body="<h2>CHANGELOG $SOURCE_BRANCH ... $TARGET_BRANCH</h2><h3><a href='https:\/\/github.com\/OfficeDev\/teams-toolkit\/blob\/changelog\/$TARGET_BRANCH\/packages\/vscode-extension\/PRERELEASE.md'>Click Here to Open Changelog File</a></h3>"
+          subject="[Changelog] $SOURCE_BRANCH ... $TARGET_BRANCH"
 
-          github_user=${{ github.actor }}
+          github_user="$GITHUB_ACTOR_NAME"
           echo "github_user=$github_user"
           accounts_file="./.github/accounts.json"
           email=$(jq -r --arg user "$github_user" '.[$user]' "$accounts_file")
@@ -293,14 +305,16 @@ jobs:
 
       - name: setup user info
         working-directory: ./
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          user_info=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/users/${{ github.actor }})
-          git config --global user.email $(echo $user_info | jq -r '.name')
-          git config --global user.name $(echo $user_info | jq -r '.name')
+          user_info=$(curl -s -H "Authorization: token $GH_TOKEN" "https://api.github.com/users/$GITHUB_ACTOR_NAME")
+          git config --global user.email "$(echo "$user_info" | jq -r '.name')"
+          git config --global user.name "$(echo "$user_info" | jq -r '.name')"
           git add ./packages/vscode-extension/PRERELEASE.md
           git commit -m "dosc: update changelog for release"
-          git push --force origin changelog/${{ github.event.inputs.target-branch }}
-          
+          git push --force origin "changelog/$TARGET_BRANCH"
+
       - name: Send E-mail
         uses: ./.github/actions/send-email-report
         env:

--- a/evals/results/post-pr-comment.js
+++ b/evals/results/post-pr-comment.js
@@ -34,6 +34,15 @@ function getRepoInfo() {
 }
 
 function getIssueNumber() {
+  const issueNumberFromEnvironment = process.env.PR_NUMBER;
+  if (issueNumberFromEnvironment) {
+    const issueNumber = Number(issueNumberFromEnvironment);
+    if (Number.isInteger(issueNumber) && issueNumber > 0) {
+      return issueNumber;
+    }
+    throw new Error("PR_NUMBER is invalid");
+  }
+
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath || !fs.existsSync(eventPath)) {
     throw new Error("GITHUB_EVENT_PATH is missing or invalid");


### PR DESCRIPTION
## Summary

https://github.com/OfficeDev/microsoft-365-agents-toolkit-test/issues/32673

Harden the skill evaluation and PR lint workflows against untrusted code execution and shell injection while preserving automatic PR evaluation, comparison reports, PR comments, artifacts, and baseline updates.

## Changes

### Skill evaluation

- Use `pull_request_target` so the workflow definition comes from the trusted base branch.
- Require approval through the `skill-evaluation` environment before evaluating PR content.
- Check out the exact PR head SHA without persisting Git credentials.
- Reduce the evaluation runner to read-only repository permissions.
- Remove GitHub App write credentials from the runner that executes PR content.
- Upload raw evaluation results for processing on a separate trusted runner.

### Trusted reporting

- Add a `workflow_run` workflow that executes from the default branch on a fresh runner.
- Check out comparison and reporting scripts from the trusted PR base SHA.
- Generate JSON, Markdown, and HTML comparison reports.
- Post or update the evaluation comment on the PR.
- Upload the final evaluation artifacts.
- Update baselines only for same-repository PRs.
- Skip stale baseline updates when the PR branch no longer matches the evaluated SHA.
- Keep write permissions and the GitHub App credential isolated to this trusted workflow.

### PR lint workflow

- Reduce default permissions to read-only.
- Scope `contents: write` exclusively to manual changelog generation.
- Remove the unused global OIDC permission.
- Pass PR metadata and workflow inputs through environment variables.
- Quote shell expansions to prevent command injection.
- Replace the obsolete hard-coded repository comparison with `github.repository`.

## Security Impact

PR-controlled versions of the four evaluation reporting scripts no longer execute with privileged credentials. The privileged reporting workflow runs trusted code from the base branch and treats evaluation artifacts as data.

Attacker-controlled branch names and other GitHub context values are no longer interpolated directly into shell source. PR lint jobs also no longer receive unnecessary write or OIDC permissions.

The evaluation itself remains PR-controlled and therefore requires explicit approval through a protected GitHub environment.

## Required Setup

Create a GitHub environment named `skill-evaluation` and configure required reviewers.

Existing repository and organization secrets remain in their current locations; they do not need to be migrated into the environment.

The evaluation workflow should not be configured as a required status check if maintainers need the option to reject or skip evaluation for a PR.

## Validation

- GitHub Actions workflow diagnostics passed.
- Prettier checks passed.
- Node.js syntax checks passed for reporting scripts.
- `git diff --check` passed.