### PR TITLE
fix(ci): isolate PR content from trusted workflow tooling

### DIFF
--- a/.github/scripts/lint-pr.sh
+++ b/.github/scripts/lint-pr.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
-VAR=$(git diff --diff-filter=MARC $1...HEAD --name-only --relative -- .| grep -E '.js$|.ts$|.jsx$|.tsx$' | xargs)
-echo $VAR
-if [ ! -z "$VAR" ]
-then 
-    # Format check: Prettier rewrites the changed files; the workflow's follow-up
-    # "Check if there are changes" step fails the job if any file was not already
-    # formatted (git diff is non-empty).
-    npx prettier --write $VAR
-    # Quality gate: ESLint checks code quality. --quiet ignores warnings so this
-    # fails the job only on ESLint errors (e.g. import cycles). No --fix: quality
-    # issues must be fixed by the author, not silently auto-applied. Runs full
-    # (type-aware) since ESLINT_FAST is not set in CI.
-    npx eslint --quiet $VAR
+
+set -euo pipefail
+
+if [ "${1:-}" = "--working-tree" ]; then
+    mapfile -d '' files < <(git diff --diff-filter=MARC --name-only --relative -z -- . | grep -zE '\.(js|ts|jsx|tsx)$' || true)
+else
+    mapfile -d '' files < <(git diff --diff-filter=MARC "${1:?base ref is required}"...HEAD --name-only --relative -z -- . | grep -zE '\.(js|ts|jsx|tsx)$' || true)
 fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+printf '%s\n' "${files[@]}"
+npx prettier --check -- "${files[@]}"
+npx eslint --quiet -- "${files[@]}"

--- a/.github/workflows/eval-microsoft-365-agents-toolkit-report.yml
+++ b/.github/workflows/eval-microsoft-365-agents-toolkit-report.yml
@@ -78,10 +78,10 @@ jobs:
           always() &&
           (github.event.workflow_run.event == 'pull_request' ||
           github.event.workflow_run.event == 'pull_request_target') &&
-          github.event.workflow_run.head_repository.full_name == github.repository
+          github.event.workflow_run.pull_requests[0].head.repo.full_name == github.repository
         env:
-          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
         run: |
           if [ ! -f evals/results/latest.json ]; then
             echo "No latest evaluation result to commit."

--- a/.github/workflows/eval-microsoft-365-agents-toolkit.yml
+++ b/.github/workflows/eval-microsoft-365-agents-toolkit.yml
@@ -18,12 +18,33 @@ jobs:
     timeout-minutes: 120
     environment: skill-evaluation
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout trusted evaluation harness
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.ref }}
+
+      - name: Checkout PR skill
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          path: pr-source
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
+          sparse-checkout: packages/vscode-extension/skills/microsoft-365-agents-toolkit
+
+      - name: Overlay PR skill onto trusted harness
+        if: ${{ github.event_name == 'pull_request_target' }}
+        run: |
+          if find pr-source/packages/vscode-extension/skills/microsoft-365-agents-toolkit -type l -print -quit | grep -q .; then
+            echo "Symbolic links are not allowed in the evaluated skill."
+            exit 1
+          fi
+          rm -rf packages/vscode-extension/skills/microsoft-365-agents-toolkit
+          cp -R pr-source/packages/vscode-extension/skills/microsoft-365-agents-toolkit packages/vscode-extension/skills/
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -65,54 +65,84 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout branch
-        uses: actions/checkout@v3
+      - name: Checkout trusted tooling
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
+          path: trusted
+          ref: ${{ github.event.pull_request.base.sha }}
 
-      - name: setup project
-        uses: ./.github/actions/setup-project
+      - name: Checkout PR source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          path: pr-source
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: lint and format check files in PR on Fork
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.17
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install trusted tooling
+        working-directory: trusted
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm run build
+
+      - name: Prepare PR source for trusted linting
         env:
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git remote add upstream "https://github.com/${{ github.repository }}.git"
-          git fetch upstream "$BASE_BRANCH"
-          VAR=$(realpath .github/scripts/lint-pr.sh)
-          pnpm -r exec -- bash "$VAR" "upstream/$BASE_BRANCH"
+          git -C pr-source remote add upstream "https://github.com/$BASE_REPOSITORY.git"
+          git -C pr-source fetch --no-tags upstream "$BASE_SHA"
+          while IFS= read -r -d '' file; do
+            case "$file" in
+              .github/*|*eslint.config.*|*.prettierrc.*|*prettier.config.*|eslint-local-rules.js|commitlint.config.js)
+                continue
+                ;;
+            esac
+            if [ -L "pr-source/$file" ] || [ ! -f "pr-source/$file" ]; then
+              echo "Refusing to lint non-regular file: $file"
+              exit 1
+            fi
+            is_new_file=false
+            if [ ! -e "trusted/$file" ]; then
+              is_new_file=true
+            fi
+            mkdir -p "trusted/$(dirname "$file")"
+            cp -- "pr-source/$file" "trusted/$file"
+            if [ "$is_new_file" = true ]; then
+              git -C trusted add --intent-to-add -- "$file"
+            fi
+          done < <(git -C pr-source diff --diff-filter=MARC --name-only -z "$BASE_SHA...HEAD" -- '*.js' '*.ts' '*.jsx' '*.tsx')
 
-      - name: lint and format check files in PR on local
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        env:
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+      - name: Lint and format check PR source with trusted tooling
+        working-directory: trusted
         run: |
           VAR=$(realpath .github/scripts/lint-pr.sh)
-          pnpm -r exec -- bash "$VAR" "origin/$BASE_BRANCH"
-
-      - name: Check if there are changes
-        id: changes
-        run: |
-          git add .
-          VAR=$(git diff --cached --name-only)
-          if [ ! -z "$VAR" ]
-          then 
-            echo $VAR
-            echo '======================================= Prompt Information ==============================================='
-            echo 'There may be some unformatted files in your PR, please run these commands on Git Bash terminal: '
-            echo '1. npm run setup'
-            echo '2. VAR=$(realpath .github/scripts/lint-pr.sh) '
-            echo '3. pnpm -r exec -- bash $VAR ${your-PR-target-branch}'
-            echo 'please replace the ${your-PR-target-branch} as the target branch of your PR, such as origin/dev or upstream/dev'
-            exit 1
-          fi
+          pnpm -r exec -- bash "$VAR" --working-tree
 
       - name: Check unused strings
-        working-directory: ./packages/fx-core
-        run: npm run checkUnusedStrings
+        run: |
+          if find \
+            pr-source/packages/fx-core/resource/package.nls.json \
+            pr-source/packages/fx-core/src \
+            pr-source/packages/fx-core/templates/ui \
+            -type l -print -quit | grep -q .; then
+            echo "Symbolic links are not allowed in unused-string scan inputs."
+            exit 1
+          fi
+          node trusted/packages/fx-core/scripts/find-unused-strings.js \
+            pr-source/packages/fx-core/resource/package.nls.json \
+            pr-source/packages/fx-core/src \
+            pr-source/packages/fx-core/templates/ui
         shell: bash
         env:
           CI: true
@@ -122,11 +152,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install Yaml lint and mustache
         run: |
@@ -134,34 +165,23 @@ jobs:
           npm install mustache -g
           echo '{"appName":"test"}'>test.json
 
-      - name: check origin or remote
-        id: remote
+      - name: Fetch trusted base revision
         env:
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          CURRENT_REPOSITORY: ${{ github.repository }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          if [ "$HEAD_REPOSITORY" = "$CURRENT_REPOSITORY" ]
-          then
-            echo "target=origin" >> $GITHUB_OUTPUT
-          else
-            echo "target=remote" >> $GITHUB_OUTPUT
-          fi
+          git remote add upstream "https://github.com/$BASE_REPOSITORY.git"
+          git fetch --no-tags upstream "$BASE_SHA"
 
       - name: check yaml lint origin
         env:
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
-          TARGET_REMOTE: ${{ steps.remote.outputs.target }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          TARGET="$TARGET_REMOTE/$BASE_BRANCH"
-          YMLTPL=$(git diff --diff-filter=MARC "$TARGET...HEAD" --name-only -- templates | grep -E '.yml.tpl$'|xargs)
-          echo "$YMLTPL"
-          if [ ! -z "$YMLTPL" ]
-          then
-              for obj in "$YMLTPL"
-              do
-                mustache test.json $obj | yamllint -d "{extends: relaxed, rules: {line-length: {max: 100}}}" -
-              done
-          fi
+          mapfile -d '' templates < <(git diff --diff-filter=MARC --name-only -z "$BASE_SHA...HEAD" -- 'templates/*.yml.tpl')
+          printf '%s\n' "${templates[@]}"
+          for template in "${templates[@]}"; do
+            mustache test.json "$template" | yamllint -d "{extends: relaxed, rules: {line-length: {max: 100}}}" -
+          done
 
   check-sensitive-content:
     if: ${{ (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'schedule' }}
@@ -171,14 +191,13 @@ jobs:
         if: ${{ github.event_name == 'pull_request'}}
         env:
           PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           echo "depth=$((PR_COMMIT_COUNT + 1))" >> "$GITHUB_ENV"
-          echo "branch=$PR_HEAD_REF" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
         if: ${{ github.event_name == 'pull_request'}}
         with:
-          ref: ${{env.branch}}
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: ${{env.depth}}
       - uses: trufflesecurity/trufflehog@main
@@ -188,6 +207,8 @@ jobs:
 
       - if: ${{ github.event_name == 'schedule' }}
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - if: ${{ github.event_name == 'schedule' }}
         uses: trufflesecurity/trufflehog@main
         with:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -88,6 +88,8 @@ jobs:
           node-version: 22.17
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 8.6.12
 
       - name: Install trusted tooling
         working-directory: trusted


### PR DESCRIPTION
## Summary

https://github.com/OfficeDev/microsoft-365-agents-toolkit-test/issues/32673

Harden the skill evaluation and PR lint workflows by separating trusted base-branch tooling from untrusted pull request content.

This addresses the remaining arbitrary code execution, checkout credential exposure, and PR-controlled tooling risks while preserving the workflows' primary functionality.

## Changes

### Skill evaluation workflow

- Use `pull_request_target` so the workflow definition is loaded from the trusted base branch.
- Require approval through the `skill-evaluation` environment.
- Check out the evaluation harness from the exact PR base SHA.
- Sparse-checkout only the skill under test from the exact PR head SHA.
- Overlay only the PR skill onto the trusted evaluation harness.
- Keep `eval.yaml`, `setup.sh`, task definitions, and reporting scripts base-controlled.
- Disable persisted Git credentials on both checkouts.
- Reject symbolic links in the PR skill before overlaying it.
- Keep the evaluation runner read-only.

### Trusted reporting workflow

- Process raw evaluation results on a separate `workflow_run` runner.
- Execute comparison and PR-comment scripts from the trusted base SHA.
- Keep write permissions and the GitHub App credential isolated to this workflow.
- Continue generating JSON, Markdown, and HTML reports.
- Continue posting PR comments and updating same-repository PR baselines.
- Use the actual PR head repository, SHA, and branch for `pull_request_target` runs.
- Skip baseline updates when the PR branch no longer matches the evaluated SHA.

### PR lint workflow

- Check out trusted tooling from the exact base SHA.
- Check out PR source separately from the exact head SHA.
- Remove execution of the PR-controlled `setup-project` action.
- Remove execution of PR-controlled shell and package scripts.
- Install trusted dependencies with `--ignore-scripts`.
- Build only trusted base-branch tooling.
- Copy changed JavaScript and TypeScript source files into the trusted tree for validation.
- Exclude PR-owned workflow, ESLint, Prettier, and other executable configuration files.
- Run trusted Prettier and ESLint configurations against PR source.
- Invoke the trusted unused-string scanner directly instead of an npm script.
- Cover both newly added and modified source files.
- Reject symbolic links before recursively scanning PR content.
- Disable persisted credentials on all PR-head checkouts.
- Use immutable SHAs instead of mutable branch references.

### Shell injection and permissions

- Pass GitHub event values through environment variables instead of embedding them in shell source.
- Quote shell expansions and use null-delimited filename handling.
- Reduce PR jobs to read-only permissions.
- Scope write access only to trusted reporting and manual changelog jobs.

## Functionality Impact

The primary workflow behavior is preserved:

- Matching PRs still trigger skill evaluation.
- Evaluation reports, dashboards, artifacts, PR comments, and baseline updates remain available.
- Formatting, ESLint, YAML, unused-string, and sensitive-content checks continue to run.
- Manual changelog generation remains available.

Intentional changes:

- PR changes to evaluation definitions, setup hooks, package scripts, or lint configuration are not executed during the PR run.
- Evaluation harness changes take effect after they are merged into the base branch.
- PR source is checked using the current trusted base-branch tooling.
- Prettier now uses check mode rather than rewriting files.
- Baseline updates are skipped if the evaluated PR revision is stale.

## Security Impact

Previously, pull requests could modify local actions, shell scripts, package scripts, lifecycle scripts, evaluation hooks, and lint configuration that the workflows executed directly.

The workflows now use separate trust domains:

- Base SHA: executable workflow tooling and configuration.
- PR head SHA: untrusted source or skill data being evaluated.

PR-controlled executable files are no longer invoked with workflow credentials. PR checkouts do not persist Git credentials, and write permissions are isolated from runners processing PR content.

## Required Setup

Create a GitHub environment named `skill-evaluation` and configure required reviewers.

Existing repository and organization secrets can remain in their current locations.

## Validation

- GitHub Actions workflow diagnostics passed.
- Bash syntax validation passed.
- Prettier checks passed.
- `git diff --check` passed.
- The trusted lint helper passed a package-context smoke test.