### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/ai-select-e2e-cases/action.yml
+++ b/.github/actions/ai-select-e2e-cases/action.yml
@@ -64,7 +64,7 @@ runs:
     # 2. Get PR changed files
     - name: Get PR changed files
       id: changed-files
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
       env:
         PR_NUMBER: ${{ inputs.pr-number }}
       with:
@@ -92,7 +92,7 @@ runs:
     # 3. Check PR comments for /e2e-run commands
     - name: Check PR comments for override commands
       id: comment-override
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
       env:
         PR_NUMBER: ${{ inputs.pr-number }}
       with:
@@ -283,7 +283,7 @@ runs:
 
     # 6. Post PR comment with selection summary
     - name: Post selection summary to PR
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
       env:
         PR_NUMBER: ${{ inputs.pr-number }}
         CASES: ${{ steps.merge.outputs.cases }}

--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -14,15 +14,15 @@ runs:
   using: "composite"
   steps:
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version: 22.17
 
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
     - name: Setup project
       if: ${{ inputs.setup == 'true' }}
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/FunctionExtensionCI.yml
+++ b/.github/workflows/FunctionExtensionCI.yml
@@ -18,13 +18,13 @@ jobs:
   Function-Extension:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 14
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
         with:
           dotnet-version: 3.1.x
       - name: Install Func CLI

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
       - name: Call Azure Function
         id: call_azure_function

--- a/.github/workflows/all-versions-upgrade-test.yml
+++ b/.github/workflows/all-versions-upgrade-test.yml
@@ -63,10 +63,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version: 16
 
@@ -75,7 +75,7 @@ jobs:
         npm config set legacy-peer-deps true
     
     - name: Setup project
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -155,10 +155,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version: 16
 
@@ -167,7 +167,7 @@ jobs:
         npm config set legacy-peer-deps true
     
     - name: Setup project
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 5

--- a/.github/workflows/app-studio-service-issue-assign.yml
+++ b/.github/workflows/app-studio-service-issue-assign.yml
@@ -15,9 +15,9 @@ jobs:
       issues: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Checkout github action repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
          repository: "microsoft/vscode-github-triage-actions"
          ref: stable 

--- a/.github/workflows/atk-copilot-test-generator.yml
+++ b/.github/workflows/atk-copilot-test-generator.yml
@@ -56,7 +56,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -67,7 +67,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/atk-copilot-test-label.yml
+++ b/.github/workflows/atk-copilot-test-label.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/atk-copilot-test-runner.yml
+++ b/.github/workflows/atk-copilot-test-runner.yml
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -151,7 +151,7 @@ jobs:
           echo "cd_run_id=$CD_RUN_ID" >> $GITHUB_OUTPUT
 
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -292,7 +292,7 @@ jobs:
           [ -f "$GIF_PATH" ] && echo "gif_path=$GIF_PATH" >> $GITHUB_OUTPUT || echo "gif_path=" >> $GITHUB_OUTPUT
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: atk-test-results-issue-${{ inputs.issue_number }}

--- a/.github/workflows/azdo-connector.yml
+++ b/.github/workflows/azdo-connector.yml
@@ -26,7 +26,7 @@ jobs:
       AZURE_DEVOPS_PROJECT: "DevDiv"
     steps:
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         with:
           client-id: ${{ secrets.DEVOPS_DEVDIV_CLIENT_ID }}
           tenant-id: ${{ secrets.DEVOPS_TENANT_ID }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: azdo-result
           path: result.json

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,20 +101,20 @@ jobs:
           exit 1
 
       - id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
           ref: ${{ github.ref }}
 
       - name: Set up Python for README image analysis
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.x'
 
@@ -134,7 +134,7 @@ jobs:
 
       - name: Checkout samples repo
         if: ${{ github.event.inputs.skipmarkdowncheck == 'false' || github.event.inputs.skipmarkdowncheck == ''}}
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/microsoft-365-agents-toolkit-samples
           path: samples-repo
@@ -147,12 +147,12 @@ jobs:
         run: |
           python -u .github/scripts/analyze_markdown.py --scan-directory "samples-repo" --file-patterns "**/README.md" "**/README.md.tpl"
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22.22
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: 📋 Check Results Summary
         if: ${{ always() && (github.event.inputs.skipmarkdowncheck == 'false' || github.event.inputs.skipmarkdowncheck == '') }}
@@ -262,7 +262,7 @@ jobs:
         run: node .github/scripts/v4/sync-v4-template-config.js
 
       - name: update template rc tag
-        uses: richardsimko/update-tag@v1.0.7
+        uses: richardsimko/update-tag@782c008c16efcff2a27f83238dc4b05ffd8f4b52 # v1.0.7
         if: ${{ (contains(steps.version-change.outputs.CHANGED, 'templates@') || contains(steps.version-change.outputs.CHANGED, '@microsoft/teamsfx')) && github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'rc' }}
         with:
           tag_name: "templates@0.0.0-rc"
@@ -271,7 +271,7 @@ jobs:
 
       - name: release templates' RC version to github
         if: ${{ (contains(steps.version-change.outputs.CHANGED, 'templates@') || contains(steps.version-change.outputs.CHANGED, '@microsoft/teamsfx')) && github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'rc' }}
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           prerelease: true
@@ -288,7 +288,7 @@ jobs:
 
       - name: Create Templates Stable Release
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'stable' }}
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         with:
           artifacts: |
             ${{ github.workspace }}/templates/build/fallback/common.zip
@@ -308,7 +308,7 @@ jobs:
 
       - name: Update Template Tag list Release
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'stable' }}
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         with:
           artifacts: ${{ runner.temp }}/template-tags.txt
           name: "Template Tag List"
@@ -340,7 +340,7 @@ jobs:
 
       - name: Release RC VS templates to GitHub
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' }}
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           tag: "templates-vs@0.0.0-rc"
@@ -362,7 +362,7 @@ jobs:
           echo "VSTAG=templates-vs@$VS_VERSION" >> $GITHUB_OUTPUT
 
       - name: Release stable VS Templates to GitHub
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -384,7 +384,7 @@ jobs:
 
       - name: Update Template Tag list Release (VS stable release)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         with:
           artifacts: ${{ runner.temp }}/template-tags.txt
           name: "Template Tag List"
@@ -421,7 +421,7 @@ jobs:
 
       - name: disable chat participant in package.json
         if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.preid != 'alpha') }}
-        uses: jossef/action-set-json-field@v2.1
+        uses: jossef/action-set-json-field@7ea163261afe43847c06afab44419845339a6be2 # v2.1
         with:
           file: packages/vscode-extension/package.json
           field: contributes.chatParticipants
@@ -436,7 +436,7 @@ jobs:
 
       - name: update cli ai key
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid != 'alpha' }}
-        uses: jossef/action-set-json-field@v1
+        uses: jossef/action-set-json-field@6e6d7e639f24b3955ef682815317b5613ac6ca12 # v1
         with:
           file: ./packages/cli/package.json
           field: aiKey
@@ -444,7 +444,7 @@ jobs:
 
       - name: update extension ai key
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid != 'alpha' }}
-        uses: jossef/action-set-json-field@v1
+        uses: jossef/action-set-json-field@6e6d7e639f24b3955ef682815317b5613ac6ca12 # v1
         with:
           file: ./packages/vscode-extension/package.json
           field: aiKey
@@ -478,7 +478,7 @@ jobs:
 
       - name: pack server bits
         if: ${{ contains(steps.version-change.outputs.CHANGED, '@microsoft/teamsfx-server') || (github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' ) }}
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           timeout_minutes: 10
           max_attempts: 10
@@ -493,7 +493,7 @@ jobs:
         if: ${{ github.event.inputs.pkgs == '' || contains(github.event.inputs.pkgs, 'vscode') }}
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           timeout_minutes: 10
           max_attempts: 10
@@ -510,7 +510,7 @@ jobs:
 
       - name: release stable VSCode extension to github
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'ms-teams-vscode-extension@') && github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'stable' }}
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           tag: ${{ steps.version-change.outputs.EXTENSION_VERSION }}
@@ -529,7 +529,7 @@ jobs:
           find ./packages/vscode-extension -type f -name '*.vsix' -exec mv {} . \;
 
       - name: upload release info to artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release
           path: |
@@ -546,7 +546,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Build failure message and subject
         id: build-message
@@ -605,7 +605,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/cd_trigger.yml
+++ b/.github/workflows/cd_trigger.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Download artifact
         id: downloadUrl
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -70,7 +70,7 @@ jobs:
 
       - name: Get teamsfx-server version
         id: version
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let rawData = require('fs').readFileSync('./versions.json', {encoding:'utf8', flag:'r'});
@@ -81,7 +81,7 @@ jobs:
 
       - name: Get stage input
         id: series
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let rawData = require('fs').readFileSync('./series.txt', {encoding:'utf8', flag:'r'});
@@ -92,7 +92,7 @@ jobs:
       - run: npm install semver
       - name: Get teamsfx-server preid
         id: preid
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let rawData = require('fs').readFileSync('./versions.json', {encoding:'utf8', flag:'r'});
@@ -112,19 +112,19 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 14
       - name: Setup project

--- a/.github/workflows/check-assignee.yml
+++ b/.github/workflows/check-assignee.yml
@@ -16,9 +16,9 @@ jobs:
       issues: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Checkout github action repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
          repository: "microsoft/vscode-github-triage-actions"
          ref: stable 

--- a/.github/workflows/check-wizard-nls.yml
+++ b/.github/workflows/check-wizard-nls.yml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22.17
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Install templates dependencies
         working-directory: templates

--- a/.github/workflows/code-cleanup--stage2-report.yml
+++ b/.github/workflows/code-cleanup--stage2-report.yml
@@ -11,7 +11,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
     - name: setup project
       uses: ./.github/actions/setup-project
@@ -36,7 +36,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
     - name: Find file with lines over 600
       run: |
@@ -53,7 +53,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
     - name: setup project
       uses: ./.github/actions/setup-project
@@ -80,7 +80,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
     - name: setup project
       uses: ./.github/actions/setup-project
@@ -115,7 +115,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
     - name: setup project
       uses: ./.github/actions/setup-project

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/${{ matrix.language }}-config.yml
@@ -54,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -15,16 +15,16 @@ jobs:
       contents: read
     steps:
       - name: 'Az CLI login'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:
           client-id: ${{secrets.DEVOPS_CLIENT_ID}}
           tenant-id: ${{secrets.DEVOPS_TENANT_ID}}
           subscription-id: ${{secrets.DEVOPS_SUB_ID}}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Checkout github action repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
          repository: "microsoft/vscode-github-triage-actions"
          ref: stable 

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -14,16 +14,16 @@ jobs:
     steps:
       - name: Get TeamsFx Renovate App Token
         id: teamsfx-renovate
-        uses: getsentry/action-github-app-token@v2
+        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
         with:
           app_id: ${{ secrets.RENOVATE_APP_ID }}
           private_key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v36.0.0
+        uses: renovatebot/github-action@aa150c86873c3e1326734d9c1390064fbc646148 # v36.0.0
         with:
           token: "${{ steps.teamsfx-renovate.outputs.token }}"
           configurationFile: .github/renovate.json

--- a/.github/workflows/dev-smoke-test-pipeline.yml
+++ b/.github/workflows/dev-smoke-test-pipeline.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Trigger CD pipeline
         id: trigger
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -87,7 +87,7 @@ jobs:
             console.log(`CD run ID: ${run.id}`);
 
       - name: Wait for CD pipeline to complete
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -120,14 +120,14 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Trigger Docker Build pipeline
         id: trigger
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -168,7 +168,7 @@ jobs:
             console.log(`Docker Build run ID: ${run.id}`);
 
       - name: Wait for Docker Build pipeline to complete
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -199,14 +199,14 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout repo to read smoke test cases (fallback)
         if: inputs.test_plan == ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: dev
           sparse-checkout: packages/tests/vscuse/smoking-test-cases.json
@@ -227,7 +227,7 @@ jobs:
 
       - name: Trigger UI Test pipeline
         id: trigger
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -270,7 +270,7 @@ jobs:
             core.setOutput('run_id', run.id.toString());
 
       - name: Wait for UI Test pipeline to complete
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           - TeamsFx-Samples
     steps:
       - name: Checkout TeamsFx.wiki
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/${{ matrix.repo }}
 
@@ -39,7 +39,7 @@ jobs:
           done <<< $links
 
       - name: Upload akas to artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.repo }}
           path: akas.data
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: aka-validation
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
       - name: List akas
@@ -90,7 +90,7 @@ jobs:
           done
 
       - name: upload result to artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: result
           path: artifacts/result.txt
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: aka-validation
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
@@ -172,7 +172,7 @@ jobs:
           echo "subject=$subject" >> $GITHUB_OUTPUT
           
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Send E-mail to the whole team
         uses: ./.github/actions/send-email-report

--- a/.github/workflows/dotnetsdk-ci.yml
+++ b/.github/workflows/dotnetsdk-ci.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
         with:
           dotnet-version: 8.x
       - name: Build

--- a/.github/workflows/duplicate-app-studio-service-issue.yml
+++ b/.github/workflows/duplicate-app-studio-service-issue.yml
@@ -15,9 +15,9 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Checkout github action repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
          repository: "microsoft/vscode-github-triage-actions"
          ref: stable 

--- a/.github/workflows/e2e-test-same-tenant.yml
+++ b/.github/workflows/e2e-test-same-tenant.yml
@@ -60,9 +60,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
-      - uses: azure/login@v1
+      - uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:
           client-id: ${{ secrets.DEVOPS_CLIENT_ID }}
           tenant-id: ${{ secrets.DEVOPS_TENANT_ID }}
@@ -147,27 +147,27 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
-      - uses: azure/login@v1
+      - uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:
           client-id: ${{ secrets.DEVOPS_CLIENT_ID }}
           tenant-id: ${{ secrets.DEVOPS_TENANT_ID }}
           subscription-id: ${{ secrets.DEVOPS_SUB_ID }}
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
 
       - name: Setup .NET
         if: contains(matrix.cases, '.dotnet.')
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
         with:
           dotnet-version: |
             8.0.x
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Setup project
         run: |
@@ -214,7 +214,7 @@ jobs:
           echo "name=$name" >> $GITHUB_OUTPUT
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ always() }}
         with:
           name: test-result-${{ steps.get-report-name.outputs.name }}
@@ -238,7 +238,7 @@ jobs:
       CI_ENABLED: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: setup project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -71,9 +71,9 @@ jobs:
       AUTO_TEST_PLAN_ID: ${{ github.event.inputs.target-testplan-id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
-      - uses: azure/login@v1
+      - uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:
           client-id: ${{secrets.DEVOPS_CLIENT_ID}}
           tenant-id: ${{secrets.DEVOPS_TENANT_ID}}
@@ -132,7 +132,7 @@ jobs:
   
       - name: Upload testplan to artifact
         if: ${{ github.event.inputs.target-testplan-name != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testplan
           path: |
@@ -176,9 +176,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
-      - uses: azure/login@v1
+      - uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:
           client-id: ${{secrets.DEVOPS_CLIENT_ID}}
           tenant-id: ${{secrets.DEVOPS_TENANT_ID}}
@@ -194,13 +194,13 @@ jobs:
           echo "M365_ACCOUNT_NAME=${users[index]}" >> $GITHUB_ENV
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
 
       - name: Setup node for Retail project
         if: contains(matrix.cases, 'Retail')
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
 
@@ -218,7 +218,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Setup .net
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
         with:
           dotnet-version: |
             8.0.x
@@ -226,11 +226,11 @@ jobs:
       # Python is not used in templates now
       - name: Setup Python
         if: contains(matrix.cases, 'samples')
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Setup project
         run: |
@@ -257,7 +257,7 @@ jobs:
 
       - name: Download samples(daily)
         if: (github.event_name == 'schedule'  || github.event_name == 'pull_request') && startsWith(matrix.cases, './samples/') && contains(matrix.cases, 'ProactiveMessage') == false
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/TeamsFx-Samples
           ref: dev
@@ -265,7 +265,7 @@ jobs:
 
       - name: Download samples(rc)
         if: github.event_name == 'workflow_dispatch' && startsWith(matrix.cases, './samples/') && contains(matrix.cases, 'ProactiveMessage') == false && contains(matrix.cases, 'SignatureOutlook') == false && contains(matrix.cases, 'ChefBot') == false
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/TeamsFx-Samples
           ref: ${{ github.event.inputs.sample-branch }}
@@ -273,7 +273,7 @@ jobs:
 
       - name: Download samples from another repo
         if: startsWith(matrix.cases, './samples/') && contains(matrix.cases, 'ProactiveMessage')
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/Microsoft-Teams-Samples
           ref: main
@@ -281,7 +281,7 @@ jobs:
       
       - name: Download samples from office repo
         if: startsWith(matrix.cases, './samples/') && contains(matrix.cases, 'SignatureOutlook')
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/Office-Add-in-samples
           ref: main
@@ -289,7 +289,7 @@ jobs:
 
       - name: Download samples from ai repo
         if: startsWith(matrix.cases, './samples/') && contains(matrix.cases, 'ChefBot')
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: microsoft/teams-ai
           ref: main
@@ -317,7 +317,7 @@ jobs:
           echo "name=$name" >> $GITHUB_OUTPUT
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ github.event_name != 'schedule' || success() || (failure() && github.run_attempt >= 5) }}
         with:
           name: test-result-${{ steps.get-report-name.outputs.name }}
@@ -326,7 +326,7 @@ jobs:
       
       - name: Download TestPlan
         if: ${{ always() && github.event.inputs.target-testplan-name != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: testplan
           path: ./packages/tests
@@ -356,7 +356,7 @@ jobs:
       M365_ACCOUNT_COLLABORATOR: ${{ secrets.TEST_COLLABORATOR_USER_NAME_2 }}
     steps:
       - name: Checkout (dev)
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: setup project
         uses: ./.github/actions/setup-project
@@ -389,13 +389,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Install Dateutils
         run: |
           sudo apt install dateutils
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ~/artifacts
 
@@ -572,11 +572,11 @@ jobs:
     if: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.get-coverage == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: mv files
         working-directory: packages/tests
@@ -585,7 +585,7 @@ jobs:
           mv src/e2e/commonUtils.ts.back src/e2e/commonUtils.ts
           mv src/utils/commonUtils.ts.back src/utils/commonUtils.ts
 
-      - uses: jossef/action-set-json-field@v1
+      - uses: jossef/action-set-json-field@6e6d7e639f24b3955ef682815317b5613ac6ca12 # v1
         with:
             file: ./packages/fx-core/.nycrc
             field: excludeAfterRemap
@@ -639,7 +639,7 @@ jobs:
           zip -r out1.zip .nyc_output/
           zip -r out2.zip coverage/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ always() }}
         with:
           name: coverage
@@ -650,7 +650,7 @@ jobs:
       - name: CodeCov report attempt
         if: ${{always()}}
         continue-on-error: true
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/env-checker-ci-pr.yml
+++ b/.github/workflows/env-checker-ci-pr.yml
@@ -42,21 +42,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
 
       # Use node 14 to setup project
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867 # v2.1.2
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       # https://github.com/marketplace/actions/retry-step
       - name: Setup project with Retry
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -66,7 +66,7 @@ jobs:
             npm run setup
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Setup .NET SDK
         if: ${{ matrix.dotnet-version != 'none' }}
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 

--- a/.github/workflows/env-checker-ci-schedule.yml
+++ b/.github/workflows/env-checker-ci-schedule.yml
@@ -28,21 +28,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
         with:
           fetch-depth: 0
 
       # Use node 22 to setup project
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867 # v2.1.2
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
   
       # https://github.com/marketplace/actions/retry-step
       - name: Setup project with Retry
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -53,7 +53,7 @@ jobs:
             npm run setup --legacy-peer-deps
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867 # v2.1.2
         with:
           node-version: ${{ matrix.node-version }}
     
@@ -94,21 +94,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
         with:
           fetch-depth: 0
 
       # Use node 22 to setup project
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867 # v2.1.2
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       # https://github.com/marketplace/actions/retry-step
       - name: Setup project with Retry
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -119,7 +119,7 @@ jobs:
             npm run setup --legacy-peer-deps
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867 # v2.1.2
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
         with:
           fetch-depth: 0
 
@@ -173,21 +173,21 @@ jobs:
 
       - name: Setup .NET SDK
         if: ${{ matrix.dotnet-version != 'none' }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
       # Use node 22 to setup project
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867 # v2.1.2
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
   
       # https://github.com/marketplace/actions/retry-step
       - name: Setup project with Retry
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           timeout_minutes: 15
           max_attempts: 3

--- a/.github/workflows/eval-microsoft-365-agents-toolkit-report.yml
+++ b/.github/workflows/eval-microsoft-365-agents-toolkit-report.yml
@@ -19,20 +19,20 @@ jobs:
       pull-requests: write
     steps:
       - id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout trusted reporting scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.pull_requests[0].base.sha || github.event.repository.default_branch }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Download raw evaluation results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: skill-eval-raw
           path: evals/results
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload evaluation results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: skill-eval-results
           path: |

--- a/.github/workflows/eval-microsoft-365-agents-toolkit.yml
+++ b/.github/workflows/eval-microsoft-365-agents-toolkit.yml
@@ -19,7 +19,7 @@ jobs:
     environment: skill-evaluation
     steps:
       - name: Checkout trusted evaluation harness
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -27,7 +27,7 @@ jobs:
 
       - name: Checkout PR skill
         if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -47,7 +47,7 @@ jobs:
           cp -R pr-source/packages/vscode-extension/skills/microsoft-365-agents-toolkit packages/vscode-extension/skills/
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload raw evaluation results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: skill-eval-raw
           path: |

--- a/.github/workflows/issue-milestoned.yml
+++ b/.github/workflows/issue-milestoned.yml
@@ -19,15 +19,15 @@ jobs:
       contents: read
     steps:
       - name: 'Az CLI login'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:
           client-id: ${{secrets.DEVOPS_CLIENT_ID}}
           tenant-id: ${{secrets.DEVOPS_TENANT_ID}}
           subscription-id: ${{secrets.DEVOPS_SUB_ID}}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Checkout github action repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
          repository: "microsoft/vscode-github-triage-actions"
          ref: stable 

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -38,10 +38,10 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v3.4.0
+      - uses: amannn/action-semantic-pull-request@db6e259b93f286e3416eef27aaae88935d16cf2e # v3.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const AZDO_TICKET_REGEX = 'https:\/\/(dev\.azure\.com\/msazure|msazure\.visualstudio\.com)\/Microsoft%20Teams%20Extensibility';
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted tooling
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -74,7 +74,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Checkout PR source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -83,11 +83,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.17
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 8.6.12
 
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -195,7 +195,7 @@ jobs:
           PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
         run: |
           echo "depth=$((PR_COMMIT_COUNT + 1))" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: ${{ github.event_name == 'pull_request'}}
         with:
           persist-credentials: false
@@ -208,7 +208,7 @@ jobs:
           extra_args: --only-verified
 
       - if: ${{ github.event_name == 'schedule' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
       - if: ${{ github.event_name == 'schedule' }}
@@ -229,7 +229,7 @@ jobs:
       GITHUB_ACTOR_NAME: ${{ github.actor }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manifest-schema-monitor.yml
+++ b/.github/workflows/manifest-schema-monitor.yml
@@ -20,19 +20,19 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create or update tracking issues
         if: ${{ steps.schema_check.outputs.drift_detected == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ISSUES_JSON: ${{ steps.schema_check.outputs.issues }}
           COPILOT_ASSIGNEE: ${{ vars.COPILOT_ASSIGNEE }}

--- a/.github/workflows/office-addin-manifest-drift-check.yml
+++ b/.github/workflows/office-addin-manifest-drift-check.yml
@@ -25,19 +25,19 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create or update tracking issue
         if: ${{ steps.drift_check.outputs.drift_detected == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ISSUE_TITLE: ${{ steps.drift_check.outputs.issue_title }}
           ISSUE_BODY: ${{ steps.drift_check.outputs.issue_body }}

--- a/.github/workflows/pack-npm-packages.yml
+++ b/.github/workflows/pack-npm-packages.yml
@@ -27,15 +27,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.17
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter "${{ inputs.filter }}"
@@ -77,7 +77,7 @@ jobs:
 
           ls -l "$GITHUB_WORKSPACE/npm-packages"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: npm-packages
           path: npm-packages/*.tgz
@@ -110,7 +110,7 @@ jobs:
       # vsix and templates releases are consumed today.
       - name: Attach to GitHub Release
         if: ${{ inputs.release_tag != '' }}
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # v1.10.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/pr-vscuse-test-comment-trigger.yml
+++ b/.github/workflows/pr-vscuse-test-comment-trigger.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Authorize commenter and extract hint
         id: authorize
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR'];
@@ -64,7 +64,7 @@ jobs:
 
       - name: React to triggering comment
         if: success()
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -76,7 +76,7 @@ jobs:
 
       - name: Post hidden hint marker comment
         if: steps.authorize.outputs.hint != ''
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           HINT:      ${{ steps.authorize.outputs.hint }}
           PR_NUMBER: ${{ steps.authorize.outputs.pr_number }}
@@ -105,7 +105,7 @@ jobs:
             });
 
       - name: Dispatch pr-vscuse-test.yml with the user's hint applied
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           PR_NUMBER: ${{ steps.authorize.outputs.pr_number }}
         with:

--- a/.github/workflows/pr-vscuse-test.yml
+++ b/.github/workflows/pr-vscuse-test.yml
@@ -57,7 +57,7 @@ jobs:
       # ── 0. Resolve PR context (supports both pull_request and workflow_dispatch) ──
       - name: Resolve PR context
         id: pr-context
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let prNumber, headRef, baseRef, prTitle, prBody;
@@ -90,7 +90,7 @@ jobs:
       # ── 0b. Fetch most recent user-supplied AI hint (posted by pr-vscuse-test-comment-trigger.yml) ──
       - name: Fetch latest user hint from PR comments
         id: user-hint
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           PR_NUMBER: ${{ steps.pr-context.outputs.pr_number }}
         with:
@@ -123,7 +123,7 @@ jobs:
 
       # ── 1. Checkout plans dir + full git history for diff ─────────────
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: refs/pull/${{ steps.pr-context.outputs.pr_number }}/head
           fetch-depth: 0
@@ -135,7 +135,7 @@ jobs:
       # ── 2. Get changed files via API (PR file list) ────────────────────
       - name: Get PR changed files
         id: changed-files
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           PR_NUMBER: ${{ steps.pr-context.outputs.pr_number }}
         with:
@@ -153,7 +153,7 @@ jobs:
       # ── 2b. Check if PR is non-code-only (test/doc/ci) — skip dispatch ──
       - name: Check if non-code-only PR
         id: code-check
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           PR_NUMBER: ${{ steps.pr-context.outputs.pr_number }}
           USER_HINT: ${{ steps.user-hint.outputs.hint }}
@@ -239,7 +239,7 @@ jobs:
       # ── 2c. Post skip comment when non-code-only ───────────────────────
       - name: Post skip comment (non-code-only PR)
         if: steps.code-check.outputs.skip_dispatch == 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           PR_NUMBER: ${{ steps.pr-context.outputs.pr_number }}
           HEAD_REF: ${{ steps.pr-context.outputs.head_ref }}
@@ -277,7 +277,7 @@ jobs:
           echo "EOF"            >> "$GITHUB_OUTPUT"
 
       # ── 3b. Install Copilot CLI ───────────────────────────────────────
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         if: steps.code-check.outputs.skip_dispatch != 'true' && steps.code-check.outputs.has_code_files == 'true'
         with:
           node-version: "22"
@@ -521,7 +521,7 @@ jobs:
       - name: Post PR comment with selected test plans
         id: post-comment
         if: steps.code-check.outputs.skip_dispatch != 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           TEST_PLANS: ${{ steps.ai-select.outputs.test_plans }}
           REASON: ${{ steps.ai-select.outputs.reason }}
@@ -579,7 +579,7 @@ jobs:
       - name: Dispatch dev-smoke-test-pipeline.yml
         id: dispatch
         if: steps.code-check.outputs.skip_dispatch != 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           TEST_PLANS: ${{ steps.ai-select.outputs.test_plans }}
           HEAD_BRANCH: ${{ steps.pr-context.outputs.head_ref }}
@@ -648,7 +648,7 @@ jobs:
       # Update comment: pipeline now running
       - name: Update PR comment — pipeline dispatched
         if: steps.code-check.outputs.skip_dispatch != 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           COMMENT_ID: ${{ steps.post-comment.outputs.comment_id }}
           TEST_PLANS: ${{ steps.ai-select.outputs.test_plans }}
@@ -698,7 +698,7 @@ jobs:
       - name: Wait for smoke pipeline to complete
         id: wait-smoke
         if: steps.code-check.outputs.skip_dispatch != 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           SMOKE_RUN_ID: ${{ steps.dispatch.outputs.smoke_run_id }}
         with:
@@ -845,7 +845,7 @@ jobs:
       # ── 8. Resolve PR comment with final result ────────────────────────
       - name: Resolve PR comment with test results
         if: always() && steps.code-check.outputs.skip_dispatch != 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           COMMENT_ID: ${{ steps.post-comment.outputs.comment_id }}
           TEST_PLANS: ${{ steps.ai-select.outputs.test_plans }}

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - id: generate-token
         if: ${{ env.APP_GITHUB_APP_ID != '' && env.APP_GITHUB_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ env.APP_GITHUB_APP_ID }}
           private-key: ${{ env.APP_GITHUB_APP_PRIVATE_KEY }}
@@ -74,13 +74,13 @@ jobs:
             Microsoft-365-Agents-Toolkit-Release-Schedule
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
 
       - name: Checkout release schedule repo
         if: ${{ env.LOCAL_SCHEDULE_FILE == '' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: ${{ env.SCHEDULE_REPO }}
           token: ${{ steps.generate-token.outputs.token || github.token }}
@@ -90,7 +90,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.x'
 
@@ -127,7 +127,7 @@ jobs:
           echo "Found $RELEASES_COUNT pending release(s)"
 
       - name: Upload releases configuration
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: releases-config
           path: releases.json
@@ -149,7 +149,7 @@ jobs:
       vsrelease: ${{ steps.select.outputs.vsrelease }}
     steps:
       - name: Download releases configuration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: releases-config
 
@@ -253,7 +253,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && needs.parse-schedule.outputs.releases_count > 0 }}
     steps:
       - name: Download releases configuration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: releases-config
 
@@ -298,19 +298,19 @@ jobs:
     steps:
       - id: generate-token
         if: ${{ env.APP_GITHUB_APP_ID != '' && env.APP_GITHUB_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ env.APP_GITHUB_APP_ID }}
           private-key: ${{ env.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token || github.token }}
 
       - name: Download releases configuration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: releases-config
 
@@ -404,7 +404,7 @@ jobs:
       - name: Create PR to merge dev into existing release branch
         id: sync_pr
         if: ${{ steps.check_branch.outputs.exists == 'true' && env.DRY_RUN == 'false' && env.RERUN_CD_ONLY == 'false' && steps.config.outputs.is_prerelease == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ steps.generate-token.outputs.token || github.token }}
           script: |
@@ -517,7 +517,7 @@ jobs:
       - id: generate-samples-token
         if: ${{ env.APP_GITHUB_APP_ID != '' && env.APP_GITHUB_APP_PRIVATE_KEY != '' }}
         continue-on-error: true
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ env.APP_GITHUB_APP_ID }}
           private-key: ${{ env.APP_GITHUB_APP_PRIVATE_KEY }}
@@ -527,7 +527,7 @@ jobs:
 
       - name: Create PR in samples repo (merge dev into main)
         if: ${{ env.DRY_RUN == 'false' && env.RERUN_CD_ONLY == 'false' && steps.config.outputs.is_hotfix != 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ steps.generate-samples-token.outputs.token || github.token }}
           script: |
@@ -610,7 +610,7 @@ jobs:
       - name: Bump versions and create PR for stable release
         id: version_bump_pr
         if: ${{ steps.create_branch.outputs.created == 'true' && steps.config.outputs.is_stable == 'true' && env.DRY_RUN == 'false' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const { execSync } = require('child_process');
@@ -670,7 +670,7 @@ jobs:
 
       - name: Create version bump PR
         if: ${{ steps.version_bump_pr.outputs.bump_branch != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ steps.generate-token.outputs.token || github.token }}
           script: |
@@ -896,13 +896,13 @@ jobs:
     steps:
       - id: generate-token
         if: ${{ env.APP_GITHUB_APP_ID != '' && env.APP_GITHUB_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ env.APP_GITHUB_APP_ID }}
           private-key: ${{ env.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Trigger CD on dev with defaults
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ steps.generate-token.outputs.token || github.token }}
           script: |
@@ -948,13 +948,13 @@ jobs:
     steps:
       - id: generate-token
         if: ${{ env.APP_GITHUB_APP_ID != '' && env.APP_GITHUB_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ env.APP_GITHUB_APP_ID }}
           private-key: ${{ env.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Trigger CD workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ steps.generate-token.outputs.token || github.token }}
           script: |
@@ -1015,14 +1015,14 @@ jobs:
     steps:
       - id: generate-token
         if: ${{ env.APP_GITHUB_APP_ID != '' && env.APP_GITHUB_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ env.APP_GITHUB_APP_ID }}
           private-key: ${{ env.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Trigger CD on automation sync PR merge
         id: trigger
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ steps.generate-token.outputs.token || github.token }}
           script: |
@@ -1188,7 +1188,7 @@ jobs:
         uses: ./.github/actions/send-email-report
 
       - name: Post completion comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PRODUCT: ${{ (needs.trigger-cd.result == 'success' && needs.trigger-cd.outputs.product) || needs.trigger-cd-on-pr-merge.outputs.product }}
           VERSION: ${{ (needs.trigger-cd.result == 'success' && needs.trigger-cd.outputs.version) || needs.trigger-cd-on-pr-merge.outputs.version }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -144,16 +144,16 @@ jobs:
       matrix: ${{ fromJson(needs.build-clean-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.ref_name }}
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Setup project
         working-directory: ./

--- a/.github/workflows/sdk-e2e-test.yml
+++ b/.github/workflows/sdk-e2e-test.yml
@@ -20,13 +20,13 @@ jobs:
       SDK_INTEGRATION_TEST_API_CERTPROVIDER: ${{ secrets.SDK_INTEGRATION_TEST_API_CERTPROVIDER }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: setup project
         uses: ./.github/actions/setup-project
 
       - name: setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
 
       - name: install xq
         run: |
@@ -47,7 +47,7 @@ jobs:
       - name: get job id
         id: get-job-id
         if: ${{ always() }}
-        uses: ayachensiyuan/get-action-job-id@v1.5
+        uses: ayachensiyuan/get-action-job-id@209f0d92c5955407851afc2b173f3bf0481d4297 # v1.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/sync-knowledge.yml
+++ b/.github/workflows/sync-knowledge.yml
@@ -22,7 +22,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -180,7 +180,7 @@ jobs:
       # --- Generate experts for sources that need it ---
       - name: Setup Node.js
         if: steps.sync.outputs.has_changes == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -405,7 +405,7 @@ jobs:
       # --- Create Pull Request ---
       - name: Create Pull Request
         if: steps.sync.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'sync: update knowledge from upstream sources'

--- a/.github/workflows/templates-dependencies-released.yml
+++ b/.github/workflows/templates-dependencies-released.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
 

--- a/.github/workflows/ui-test-vscuse-common.yml
+++ b/.github/workflows/ui-test-vscuse-common.yml
@@ -86,7 +86,7 @@ jobs:
       email-receiver: ${{ steps.set-email.outputs.email_receiver }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set email receiver
         id: set-email
@@ -237,17 +237,17 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ github.ref_name }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
 
@@ -296,7 +296,7 @@ jobs:
           echo "M365_ACCOUNT_NAME=${users[index]}" >> $GITHUB_ENV
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -405,7 +405,7 @@ jobs:
 
       - name: Upload error file
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: error-file-${{ matrix.test_plan }}-${{ github.run_id }}
           path: error-${{ matrix.test_plan }}-${{ github.run_id }}.txt
@@ -447,7 +447,7 @@ jobs:
 
       - name: Upload encrypted test report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: test-report-${{ matrix.test_plan }}-${{ github.run_number }}
           path: packages/tests/vscuse/vscode-test-cases/test_report/${{ env.ZIP_FILE }}
@@ -456,7 +456,7 @@ jobs:
 
       - name: Login to Azure
         if: always()
-        uses: azure/login@v2
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         with:
           client-id: ${{secrets.DEVOPS_CLIENT_ID}}
           tenant-id: ${{secrets.DEVOPS_TENANT_ID}}
@@ -488,7 +488,7 @@ jobs:
 
       - name: Upload storage URL artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: storage-url-${{ matrix.test_plan }}-${{ github.run_id }}
           path: storage_url-${{ matrix.test_plan }}-${{ github.run_id }}.txt
@@ -548,9 +548,9 @@ jobs:
         working-directory: packages/tests/vscuse
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: azure/login@v2
+      - uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         with:
           client-id: ${{secrets.DEVOPS_CLIENT_ID}}
           tenant-id: ${{secrets.DEVOPS_TENANT_ID}}
@@ -558,14 +558,14 @@ jobs:
           enable-AzPSSession: true
 
       - name: Download storage URLs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: storage-url-*
           path: /tmp/storage-urls
           merge-multiple: true
 
       - name: Download error files
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: error-file-*
           path: /tmp/error-files

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -98,16 +98,16 @@ jobs:
           echo "target_cli_version=alpha" >> $GITHUB_ENV
 
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: ${{ steps.bvt.outputs.branch || steps.pvt.outputs.branch }}
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
       
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: add sample cases into pvt file
         if: ${{ github.event.schedule == '0 18 * * *' || github.event.inputs.test-case == '' }}
@@ -145,7 +145,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Upload TTK to artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ttk
           path: |
@@ -253,29 +253,29 @@ jobs:
           echo "AZURE_OPENAI_ENDPOINT=" >> $env:GITHUB_ENV
       
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: ${{ needs.setup.outputs.branch }}
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup node for Retail project
         if: contains(matrix.cases, 'Retail')
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
         with:
           dotnet-version: 6.0.x
 
       - name: Setup Python
         if: contains(matrix.test-case,  'py')
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -361,7 +361,7 @@ jobs:
           npx playwright install
 
       - name: Download TTK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ttk
           path: packages/tests
@@ -373,7 +373,7 @@ jobs:
 
       - name: Download samples
         if: startsWith(matrix.test-case, 'sample-') && contains(matrix.test-case, 'proactive-message') == false && contains(matrix.test-case, 'reddit-link') == false && contains(matrix.test-case, 'chef-bot') == false && contains(matrix.test-case, 'food-catalog') == false && contains(matrix.test-case, 'outlook-signature') == false
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/TeamsFx-Samples
           ref: ${{ needs.setup.outputs.sample-ref }}
@@ -381,7 +381,7 @@ jobs:
 
       - name: Download samples from another repo
         if: contains(matrix.test-case, 'proactive-message') || contains(matrix.test-case, 'reddit-link')
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/Microsoft-Teams-Samples
           ref: main
@@ -389,7 +389,7 @@ jobs:
 
       - name: Download samples chef bot
         if: contains(matrix.test-case, 'chef-bot')
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: microsoft/teams-ai
           ref: js-1.7.4
@@ -397,7 +397,7 @@ jobs:
 
       - name: Download samples food catalog
         if: contains(matrix.test-case, 'food-catalog')
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: pnp/graph-connectors-samples
           ref: main
@@ -405,7 +405,7 @@ jobs:
 
       - name: Download samples outlook signature
         if: contains(matrix.test-case, 'outlook-signature')
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: OfficeDev/Office-Add-in-samples
           ref: main
@@ -481,21 +481,21 @@ jobs:
           npx extest run-tests --storage .test-resources --extensions_dir .test-resources --type stable --code_settings ./settings.json ./out/ui-test/**/${{ matrix.test-case }}.test.js
       
       - name: Upload test result json file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ github.event_name != 'schedule' || success() || (failure() && github.run_attempt >= 5) }}
         with:
           name: test-result-${{ matrix.test-case }}-${{ matrix.os }}
           path: packages/tests/mochawesome-report/mochawesome.json
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure() || cancelled()
         with:
           name: screenshots ${{ matrix.test-case }} ${{ matrix.os }}
           path: packages/tests/.test-resources/screenshots/
 
       - name: Upload telemetry
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always() && startsWith(matrix.test-case, 'telemetry')
         with:
           name: telemetry ${{ matrix.test-case }} ${{ matrix.os }}
@@ -513,15 +513,15 @@ jobs:
     env:
       AUTO_TEST_PLAN_ID: ${{ github.event.inputs.source-testplan-id }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - name: setup project
         run: |
           pnpm --filter=@microsoft/teamsfx-test install
-      - uses: azure/login@v2
+      - uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         with:
           client-id: ${{secrets.DEVOPS_CLIENT_ID}}
           tenant-id: ${{secrets.DEVOPS_TENANT_ID}}
@@ -536,7 +536,7 @@ jobs:
           npx ts-node src/scripts/testPlan.ts archive $testplanid
       
       - name: Download TestPlan
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: packages/tests/mocha-results
 
@@ -571,7 +571,7 @@ jobs:
         working-directory: packages/tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Install Dateutils
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout-pr
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
@@ -26,7 +26,7 @@ jobs:
 
       - name: Checkout
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
@@ -55,7 +55,7 @@ jobs:
       - name: CodeCov report attempt 1
         id: codecov1
         continue-on-error: true
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.CODECOV_FILES }}
@@ -72,7 +72,7 @@ jobs:
         id: codecov2
         if: steps.codecov1.outcome == 'failure'
         continue-on-error: true
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.CODECOV_FILES }}
@@ -89,7 +89,7 @@ jobs:
         id: codecov3
         if: steps.codecov2.outcome == 'failure'
         continue-on-error: true
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.CODECOV_FILES }}
@@ -106,7 +106,7 @@ jobs:
         id: codecov4
         if: steps.codecov3.outcome == 'failure'
         continue-on-error: true
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.CODECOV_FILES }}
@@ -122,7 +122,7 @@ jobs:
       - name: CodeCov report attempt 5
         id: codecov5
         if: steps.codecov4.outcome == 'failure'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.CODECOV_FILES }}
@@ -134,7 +134,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/vscuse-atk-docker-build.yml
+++ b/.github/workflows/vscuse-atk-docker-build.yml
@@ -64,7 +64,7 @@ jobs:
           df -h
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.inputs.source_ref || github.ref }}
 
@@ -141,10 +141,10 @@ jobs:
           rm -rf temp-release
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -165,7 +165,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: ./packages/tests/vscuse/docker/vscuse-atk
           # platforms: linux/amd64,linux/arm64

--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -25,20 +25,20 @@ jobs:
       scan-vs-result: ${{ steps.scan-vs.outcome }}
     steps:
       - id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
           ref: ${{ github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.x'
 
@@ -47,14 +47,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install python-dateutil requests
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Setup .NET for NuGet security check
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '8.0.x'
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload scan artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vuln-scan-output
           path: |
@@ -117,28 +117,28 @@ jobs:
       has-changes: ${{ steps.fix.outputs.has_changes }}
     steps:
       - id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_GITHUB_APP_ID }}
           private-key: ${{ secrets.APP_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
           ref: ${{ github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.x'
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: 🔍 Scan & fix tracked pnpm lockfiles
         id: fix
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload pnpm scan artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vuln-scan-output-pnpm
           path: |
@@ -187,18 +187,18 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.x'
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vuln-scan-output
           path: artifacts
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vuln-scan-output-pnpm
           path: artifacts


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
