### PR TITLE
fix(vscuse): Auto-fix Feature_Check_Copilot_License_Enabled (progress 10→19 steps)

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -37,7 +37,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-06-17T02:28:59.615382"
+    "updated_at": "2026-09-06T02:07:15.086000"
   },
   "steps": [
     {
@@ -234,22 +234,20 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 703,
-        "y": 100
+        "x": 976,
+        "y": 715
       },
-      "description": "Click the \"Sign in\" button in the Microsoft 365 notification at the top of the Visual Studio Code interface to access a Microsoft 365 account.",
+      "description": "Click the \"Sign in\" action in the Microsoft 365 notification at the bottom right of Visual Studio Code to launch the Microsoft sign-in page.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:703:100:16:5:0000000000000000",
-        "dhash:703:100:96:5:00000042b2474971",
-        "dhash:703:100:0:10:9cb89590b0717d7f"
-      ],
+      "preconditions": [],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "delay:2"
+      ],
       "screenshot": "step_47935ca7",
       "created_at": "2026-06-17T02:19:55.488096",
       "plan_id": "plan_80b368dd"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 21,
+    "total_steps": 20,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -28,7 +28,6 @@
       "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
-      "step_4db6b876",
       "step_81e9c4a2",
       "step_b7f2d630",
       "step_5c14a9e8",
@@ -42,7 +41,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-06T02:28:42.113000"
+    "updated_at": "2026-09-06T02:33:37.021000"
   },
   "steps": [
     {
@@ -250,35 +249,13 @@
       "plan_id": "plan_80b368dd"
     },
     {
-      "step_id": "step_4db6b876",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 512,
-        "y": 27
-      },
-      "description": "Click the Visual Studio Code Command Palette input to restore keyboard focus before filtering for the Microsoft 365 Accounts command.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "",
-      "created_at": "2026-09-06T02:28:42.113000",
-      "plan_id": "plan_80b368dd"
-    },
-    {
       "step_id": "step_81e9c4a2",
       "agent": "interaction",
       "tool": "type_text",
       "parameters": {
-        "text": "Microsoft 365 Agents: Accounts"
+        "text": " Agents: Accounts"
       },
-      "description": "Type \"Microsoft 365 Agents: Accounts\" into the Visual Studio Code Command Palette.",
+      "description": "Type the abbreviated query \" Agents: Accounts\" into the Visual Studio Code Command Palette to filter to the Microsoft 365 Agents Accounts commands.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -297,8 +274,8 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 423,
-        "y": 75
+        "x": 461,
+        "y": 80
       },
       "description": "Click the second Command Palette result labeled \"Microsoft 365 Agents: Accounts\", below the similarly named Accounts View command.",
       "content_refs": [],

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -41,7 +41,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-06T02:33:37.021000"
+    "updated_at": "2026-09-06T02:39:54.778000"
   },
   "steps": [
     {
@@ -275,9 +275,9 @@
       "parameters": {
         "button": "left",
         "x": 461,
-        "y": 80
+        "y": 54
       },
-      "description": "Click the second Command Palette result labeled \"Microsoft 365 Agents: Accounts\", below the similarly named Accounts View command.",
+      "description": "Click the first Command Palette result labeled \"Microsoft 365 Agents: Accounts\", above the unrelated \"Accounts: Manage Accounts\" command.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 20,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -28,6 +28,10 @@
       "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
+      "step_81e9c4a2",
+      "step_b7f2d630",
+      "step_5c14a9e8",
+      "step_d26f803b",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -37,7 +41,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-06T02:17:45.859000"
+    "updated_at": "2026-09-06T02:22:45.882000"
   },
   "steps": [
     {
@@ -191,11 +195,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fa6d6cb1",
@@ -231,13 +231,11 @@
     {
       "step_id": "step_47935ca7",
       "agent": "interaction",
-      "tool": "click",
+      "tool": "key_press",
       "parameters": {
-        "button": "left",
-        "x": 974,
-        "y": 572
+        "key": "f1"
       },
-      "description": "Click the \"Sign in\" action in the upper Microsoft 365 notification at the bottom right of Visual Studio Code, above the MCP configuration notification, to launch the Microsoft sign-in page.",
+      "description": "Press the F1 key to open the Visual Studio Code Command Palette instead of relying on the variable position of the Microsoft 365 sign-in notification.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -245,11 +243,95 @@
       "depends_on": [],
       "preconditions": [],
       "postconditions": [],
-      "tags": [
-        "delay:2"
-      ],
-      "screenshot": "step_47935ca7",
+      "tags": [],
+      "screenshot": "",
       "created_at": "2026-06-17T02:19:55.488096",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_81e9c4a2",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Microsoft 365 Agents: Accounts"
+      },
+      "description": "Type \"Microsoft 365 Agents: Accounts\" into the Visual Studio Code Command Palette.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-06T02:22:45.882000",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_b7f2d630",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 423,
+        "y": 75
+      },
+      "description": "Click the second Command Palette result labeled \"Microsoft 365 Agents: Accounts\", below the similarly named Accounts View command.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-06T02:22:45.882000",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_5c14a9e8",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 379,
+        "y": 52
+      },
+      "description": "Click the \"Sign in to Microsoft 365\" option in the Microsoft 365 Agents account picker.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-06T02:22:45.882000",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_d26f803b",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 762,
+        "y": 97
+      },
+      "description": "Click the \"Sign in\" button in the Microsoft 365 developer sandbox modal to launch the Microsoft sign-in page.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-06T02:22:45.882000",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -40,7 +40,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-06T02:39:54.778000"
+    "updated_at": "2026-09-06T02:51:40.298000"
   },
   "steps": [
     {
@@ -216,7 +216,9 @@
       "depends_on": [],
       "preconditions": [],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "delay:30"
+      ],
       "screenshot": "",
       "created_at": "2026-06-17T02:19:55.488096",
       "plan_id": "plan_80b368dd"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 20,
+    "total_steps": 19,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -26,7 +26,6 @@
       "step_436b1f61",
       "step_a0026de5",
       "step_fa6d6cb1",
-      "step_78a597ab",
       "step_47935ca7",
       "step_81e9c4a2",
       "step_b7f2d630",
@@ -200,32 +199,6 @@
       "tags": [],
       "screenshot": "step_fa6d6cb1",
       "created_at": "2026-06-17T02:24:33.865380",
-      "plan_id": "plan_80b368dd"
-    },
-    {
-      "step_id": "step_78a597ab",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 516,
-        "y": 447
-      },
-      "description": "Click the \"Check Copilot License\" button in the \"Set up your environment\" section of the Microsoft 365 Agents Toolkit welcome screen in Visual Studio Code.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:516:447:16:5:2493f3ec6b936ad2",
-        "dhash:516:447:96:5:75622a1d99660000",
-        "dhash:516:447:0:10:24b0949090b17075"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_78a597ab",
-      "created_at": "2026-06-17T02:28:51.067052",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -37,7 +37,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-06T02:07:15.086000"
+    "updated_at": "2026-09-06T02:17:45.859000"
   },
   "steps": [
     {
@@ -49,7 +49,7 @@
         "x": 951,
         "y": 130
       },
-      "description": "Click the language selection button (flag icon) in the top right corner of the VS Code welcome screen to open the language options.",
+      "description": "Click the close button in the top-right corner of the \"Welcome to VS Code\" sign-in overlay to dismiss it.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -234,10 +234,10 @@
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 976,
-        "y": 715
+        "x": 974,
+        "y": 572
       },
-      "description": "Click the \"Sign in\" action in the Microsoft 365 notification at the bottom right of Visual Studio Code to launch the Microsoft sign-in page.",
+      "description": "Click the \"Sign in\" action in the upper Microsoft 365 notification at the bottom right of Visual Studio Code, above the MCP configuration notification, to launch the Microsoft sign-in page.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 20,
+    "total_steps": 21,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -28,6 +28,7 @@
       "step_fa6d6cb1",
       "step_78a597ab",
       "step_47935ca7",
+      "step_4db6b876",
       "step_81e9c4a2",
       "step_b7f2d630",
       "step_5c14a9e8",
@@ -41,7 +42,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-06T02:22:45.882000"
+    "updated_at": "2026-09-06T02:28:42.113000"
   },
   "steps": [
     {
@@ -246,6 +247,28 @@
       "tags": [],
       "screenshot": "",
       "created_at": "2026-06-17T02:19:55.488096",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_4db6b876",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 512,
+        "y": 27
+      },
+      "description": "Click the Visual Studio Code Command Palette input to restore keyboard focus before filtering for the Microsoft 365 Accounts command.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-06T02:28:42.113000",
       "plan_id": "plan_80b368dd"
     },
     {


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Feature_Check_Copilot_License_Enabled`
**Status:** :x: FAILED (8/8 attempts exhausted)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/fb6b4627-1170-44c8-850f-88d63b171a2e/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/db3115bc-8858-480a-a788-79d27aebcb36/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Updated `step_47935ca7` to click the current bottom-right Microsoft 365 sign-in  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/ffa021a8-af11-4dc2-ad03-69ecafa93c76/test_report.html) |
| 2 | Corrected the false-positive sign-in click from `(976,715)`, which selected “Ski | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/a0a74686-b534-47fc-a1ec-15c1cad029c9/test_report.html) |
| 3 | Removed stale walkthrough preconditions and replaced the unreliable notification | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/18faf1ec-cfe4-423d-beb9-ea7bb5248a31/test_report.html) |
| 4 | Added an explicit click on the Command Palette input before typing the Accounts  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/bfbca0f2-e88a-417d-ab15-b266bbeaf86f/test_report.html) |
| 5 | Removed the ineffective palette-focus click and aligned the Accounts command seq | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/48548a5b-e2e9-4248-8848-e1097ce6ca11/test_report.html) |
| 6 | Corrected the upstream false-positive click in `step_b7f2d630` from y=80, which  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/111f2789-a312-4706-81f6-28603d3c3f6b/test_report.html) |
| 7 | Removed the redundant pre-login Copilot license check that left a pending sign-i | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/8bc36eaa-eae9-4f73-8b18-36237753a4d5/test_report.html) |
| 8 | Delayed the Accounts command flow by 30 seconds so Microsoft 365 Agents Toolkit  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/db3115bc-8858-480a-a788-79d27aebcb36/test_report.html) |

> :warning: **AI could not fix this plan automatically. Human review needed.**
> Each commit represents one fix attempt — review the history to understand what was tried.

### How to Review
- Each commit represents one fix attempt for `plans/Feature_Check_Copilot_License_Enabled.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../Feature_Check_Copilot_License_Enabled.json     | 117 +++++++++++++++------
 1 file changed, 86 insertions(+), 31 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
index 6395c68..3a34c53 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 19,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -26,8 +26,11 @@
       "step_436b1f61",
       "step_a0026de5",
       "step_fa6d6cb1",
-      "step_78a597ab",
       "step_47935ca7",
+      "step_81e9c4a2",
+      "step_b7f2d630",
+      "step_5c14a9e8",
+      "step_d26f803b",
       "step_ed29b905",
       "step_b16aa4f5",
       "step_c51b1af7",
@@ -37,7 +40,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-06-17T02:28:59.615382"
+    "updated_at": "2026-09-06T02:51:40.298000"
   },
   "steps": [
     {
@@ -49,7 +52,7 @@
         "x": 951,
         "y": 130
       },
-      "description": "Click the language selection button (flag icon) in the top right corner of the VS Code welcome screen to open the language options.",
+      "description": "Click the close button in the top-right corner of the \"Welcome to VS Code\" sign-in overlay to dismiss it.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -191,11 +194,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fa6d6cb1",
@@ -203,55 +202,111 @@
       "plan_id": "plan_80b368dd"
     },
     {
-      "step_id": "step_78a597ab",
+      "step_id": "step_47935ca7",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f1"
+      },
+      "description": "Press the F1 key to open the Visual Studio Code Command Palette instead of relying on the variable position of the Microsoft 365 sign-in notification.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:30"
+      ],
+      "screenshot": "",
+      "created_at": "2026-06-17T02:19:55.488096",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_81e9c4a2",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": " Agents: Accounts"
+      },
+      "description": "Type th
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>