### PR TITLE
refactor: fix smoke test

### DIFF
--- a/.github/workflows/dev-smoke-test-pipeline.yml
+++ b/.github/workflows/dev-smoke-test-pipeline.yml
@@ -59,6 +59,7 @@ jobs:
               ref: sourceBranch,
               inputs: {
                 preid: 'alpha',
+                publishnpm: 'false',
                 skipmarkdowncheck: 'true',
                 SkipBranchCheck: 'true',
                 skipdockerbuild: 'true'


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by disabling npm publishing during the smoke test pipeline.