### PR TITLE
fix(scaffold): apply project name to upgraded add-ins

### DIFF
--- a/docs/03-specs/scenarios/da/create-metaos-upgrade-project.md
+++ b/docs/03-specs/scenarios/da/create-metaos-upgrade-project.md
@@ -18,6 +18,7 @@ This is the vertical contract for the native v4 Declarative Agent with Office Ad
 | SCN-CREATE-METAOS-UPGRADE-05 | L1   | copied manifest and env are present or env is absent                                                                        | upgrade step finishes | manifest `id` and `env/.env.dev` `TEAMS_APP_ID` are set to the same generated UUID                                                              |
 | SCN-CREATE-METAOS-UPGRADE-06 | L1   | empty target                                                                                                                | scaffold              | `m365agents.yml` and `env/.env.dev` lifecycle baseline files are rendered, then the package runs only `metaos/upgrade-existing-project`         |
 | SCN-CREATE-METAOS-UPGRADE-07 | L1   | the target already contains `declarativeAgent.json` and the copied manifest already references the `declarativeAgentAlc` id | upgrade step runs     | the generated agent uses the collision-free filename `declarativeAgent1.json`, and the existing manifest reference is updated to that same file |
+| SCN-CREATE-METAOS-UPGRADE-08 | L1   | the copied manifest and package contain the existing project name                                                           | upgrade step runs     | manifest short/full names and the normalized `package.json` name use the user-entered app name                                                   |
 
 ## Composed operations
 

--- a/packages/fx-core/src/v4/runtime/steps/metaOs.ts
+++ b/packages/fx-core/src/v4/runtime/steps/metaOs.ts
@@ -7,6 +7,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import { Result, err, ok } from "neverthrow";
 import { RegisteredStep, StepContext, StepParams } from "../../pipeline/runScaffoldPipeline";
+import { safeProjectNameLowerCase } from "../whitelist";
 
 /** MetaOS post-render steps. */
 
@@ -204,7 +205,11 @@ interface CommandNames {
   powerpoint: string;
 }
 
-function updateManifestForDa(ctx: StepContext, daFilename: string): Result<CommandNames, FxError> {
+function updateManifestForDa(
+  ctx: StepContext,
+  daFilename: string,
+  appName: string
+): Result<CommandNames, FxError> {
   const manifestContents = readRequired(ctx, MANIFEST_PATH, "MetaOsManifestMissing");
   if (manifestContents.isErr()) {
     return err(manifestContents.error);
@@ -217,6 +222,7 @@ function updateManifestForDa(ctx: StepContext, daFilename: string): Result<Comma
   }
   manifest
     .setId(DEFAULT_MANIFEST_ID)
+    .setName(appName, `Full name for ${appName}`)
     .removeDeclarativeAgent(DEFAULT_DA_ID)
     .addDeclarativeAgent(DEFAULT_DA_ID, daFilename);
   if (!manifest.hasExtensions()) {
@@ -427,7 +433,7 @@ function appendCommandHandlers(
   return ok(undefined);
 }
 
-function upgradeOfficeAddinDebugging(ctx: StepContext): Result<void, FxError> {
+function updatePackageJson(ctx: StepContext, appName: string): Result<void, FxError> {
   const packageJson = readRequiredJsonObject(
     ctx,
     PACKAGE_JSON_PATH,
@@ -437,6 +443,7 @@ function upgradeOfficeAddinDebugging(ctx: StepContext): Result<void, FxError> {
   if (packageJson.isErr()) {
     return err(packageJson.error);
   }
+  packageJson.value.name = safeProjectNameLowerCase(appName);
   let devDependencies = nestedRecord(packageJson.value, "devDependencies");
   if (devDependencies === undefined) {
     devDependencies = {};
@@ -450,7 +457,7 @@ function upgradeOfficeAddinDebugging(ctx: StepContext): Result<void, FxError> {
 function extendToDeclarativeAgent(ctx: StepContext, appName: string): Result<void, FxError> {
   const daFilename = uniqueFileName(ctx, "declarativeAgent", ".json");
   const actionFilename = uniqueFileName(ctx, "alchemy-plugin", ".json");
-  const commandNames = updateManifestForDa(ctx, daFilename);
+  const commandNames = updateManifestForDa(ctx, daFilename, appName);
   if (commandNames.isErr()) {
     return err(commandNames.error);
   }
@@ -466,7 +473,7 @@ function extendToDeclarativeAgent(ctx: StepContext, appName: string): Result<voi
   if (appended.isErr()) {
     return err(appended.error);
   }
-  return upgradeOfficeAddinDebugging(ctx);
+  return updatePackageJson(ctx, appName);
 }
 
 /** Registered step for mirroring v3 MetaOSHelper.unifyProjectID. */

--- a/packages/fx-core/tests/v4/scenarios/createMetaOsUpgradeProject.test.ts
+++ b/packages/fx-core/tests/v4/scenarios/createMetaOsUpgradeProject.test.ts
@@ -37,6 +37,10 @@ function sourceManifest(withExistingDaReference = false): string {
   return JSON.stringify(
     {
       id: "source-id",
+      name: {
+        short: "Existing Add-in",
+        full: "Existing Add-in Full Name",
+      },
       ...(withExistingDaReference
         ? {
             copilotAgents: {
@@ -63,6 +67,7 @@ function sourceManifest(withExistingDaReference = false): string {
 function sourcePackageJson(): string {
   return JSON.stringify(
     {
+      name: "existing-add-in",
       devDependencies: {
         "office-addin-debugging": "5.0.0",
       },
@@ -179,5 +184,18 @@ describe("SCN-DA-CREATE-METAOS-UPGRADE-PROJECT (v4, T3 InMemoryRuntime)", () => 
     assert.deepEqual(manifest.copilotAgents, {
       declarativeAgents: [{ id: "declarativeAgentAlc", file: "declarativeAgent1.json" }],
     });
+  });
+
+  it("SCN-CREATE-METAOS-UPGRADE-08: applies the user-entered project name to manifest.json and package.json", async () => {
+    const { files } = await run();
+
+    const manifest = readJsonObject(files, "appPackage/manifest.json");
+    assert.deepEqual(manifest.name, {
+      short: "MetaOS Upgrade",
+      full: "Full name for MetaOS Upgrade",
+    });
+
+    const packageJson = readJsonObject(files, "package.json");
+    assert.strictEqual(packageJson.name, "metaosupgrade");
   });
 });


### PR DESCRIPTION
Use the entered app name for the copied manifest and normalize it for package.json when extending an Office Add-in with Declarative Agent actions.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>