### PR TITLE
fix(vscuse): Auto-fix Feature_Check_Copilot_License_Enabled

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -192,7 +192,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:512:431:16:5:d65466e3cc314000",
+        "dhash:512:431:96:5:00402459512a949a",
+        "dhash:512:431:0:10:2c78747470717035"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fa6d6cb1",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 17,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -27,6 +27,7 @@
       "step_a0026de5",
       "step_fa6d6cb1",
       "step_78a597ab",
+      "step_5f1d8a70",
       "step_47935ca7",
       "step_ed29b905",
       "step_b16aa4f5",
@@ -37,7 +38,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-06-17T02:28:59.615382"
+    "updated_at": "2026-09-09T02:05:24.466000"
   },
   "steps": [
     {
@@ -226,6 +227,30 @@
       "tags": [],
       "screenshot": "step_78a597ab",
       "created_at": "2026-06-17T02:28:51.067052",
+      "plan_id": "plan_80b368dd"
+    },
+    {
+      "step_id": "step_5f1d8a70",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 974,
+        "y": 572
+      },
+      "description": "Click the \"Sign in\" button in the bottom-right Microsoft 365 account notification to open the Microsoft 365 developer sandbox sign-in dialog.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:3"
+      ],
+      "screenshot": "",
+      "created_at": "2026-09-09T02:05:24.466000",
       "plan_id": "plan_80b368dd"
     },
     {

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -38,7 +38,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-09-09T02:05:24.466000"
+    "updated_at": "2026-09-09T02:10:33.427000"
   },
   "steps": [
     {
@@ -192,11 +192,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_fa6d6cb1",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -232,7 +232,7 @@
       "parameters": {
         "button": "left",
         "x": 974,
-        "y": 572
+        "y": 457
       },
       "description": "Click the \"Sign in\" button in the bottom-right Microsoft 365 account notification to open the Microsoft 365 developer sandbox sign-in dialog.",
       "content_refs": [],


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Feature_Check_Copilot_License_Enabled`
**Status:** :white_check_mark: FIXED (attempt 3/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/04080335-b3df-403a-af3a-e6bb33f7ba3e/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/df3f9793-1359-481e-837c-b01d461a039d/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Added the missing click on the bottom-right Microsoft 365 “Sign in” notification | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/eaf25161-60fd-4d19-9ff0-05cf9ad4eddb/test_report.html) |
| 2 | Preserved the notification Sign in step needed to launch browser authentication  | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/fb15cdfc-d2b4-40d3-b8ed-867ee7cf3e82/test_report.html) |
| 3 | Corrected the Microsoft 365 notification “Sign in” click from `(974,572)`, which | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/df3f9793-1359-481e-837c-b01d461a039d/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Feature_Check_Copilot_License_Enabled.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../Feature_Check_Copilot_License_Enabled.json     | 35 ++++++++++++++++++----
 1 file changed, 30 insertions(+), 5 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
index 6395c68..d43c47c 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Feature_Check_Copilot_License_Enabled.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0.0
     },
-    "total_steps": 16,
+    "total_steps": 17,
     "created_at": "2026-06-17T02:10:05.016638",
     "name": "Feature Check Copilot License Enabled",
     "description": {
@@ -27,6 +27,7 @@
       "step_a0026de5",
       "step_fa6d6cb1",
       "step_78a597ab",
+      "step_5f1d8a70",
       "step_47935ca7",
       "step_ed29b905",
       "step_b16aa4f5",
@@ -37,7 +38,7 @@
       "step_35bc35cf"
     ],
     "tags": [],
-    "updated_at": "2026-06-17T02:28:59.615382"
+    "updated_at": "2026-09-09T02:10:33.427000"
   },
   "steps": [
     {
@@ -192,9 +193,9 @@
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:512:431:16:5:d2d46667c4d328a0",
-        "dhash:512:431:96:5:0000a4595128d59a",
-        "dhash:512:431:0:10:24b0949490b17075"
+        "dhash:512:431:16:5:d65466e3cc314000",
+        "dhash:512:431:96:5:00402459512a949a",
+        "dhash:512:431:0:10:2c78747470717035"
       ],
       "postconditions": [],
       "tags": [],
@@ -228,6 +229,30 @@
       "created_at": "2026-06-17T02:28:51.067052",
       "plan_id": "plan_80b368dd"
     },
+    {
+      "step_id": "step_5f1d8a70",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 974,
+        "y": 457
+      },
+      "description": "Click the \"Sign in\" button in the bottom-right Microsoft 365 account notification to open the Microsoft 365 developer sandbox sign-in dialog.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:3"
+      ],
+      "screenshot": "",
+      "created_at": "2026-09-09T02:05:24.466000",
+      "plan_id": "plan_80b368dd"
+    },
     {
       "step_id": "step_47935ca7",
       "agent": "interaction",
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>