### PR TITLE
fix(fx-core): clarify DCR app ID binding guidance

### DIFF
--- a/packages/fx-core/resource/yaml-schema/v1.13/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/v1.13/yaml.schema.json
@@ -1969,7 +1969,7 @@
             },
             "appId": {
               "type": "string",
-              "description": "The Teams app id associated with this configuration. Only takes effect when applicableToApps is SpecificApp."
+              "description": "The Microsoft 365 app ID (MOSAppId), not the Teams manifest ID or Microsoft Entra client ID. Required only when applicableToApps is SpecificApp; ignored for AnyApp. For declarative agents, use the appId returned by copilotAgent/publish for the intended publication scope."
             },
             "wellKnownAuthorizationServer": {
               "type": "string",
@@ -1982,7 +1982,7 @@
             },
             "applicableToApps": {
               "type": "string",
-              "description": "Which app can use this DCR configuration. Default is \"AnyApp\".",
+              "description": "Which app can use this DCR configuration. Default is \"AnyApp\". Keep AnyApp during declarative agent creation and sideloading because the Microsoft 365 app ID can change. To restrict usage after publishing, use SpecificApp with that publication's Microsoft 365 app ID.",
               "enum": ["SpecificApp", "AnyApp"]
             },
             "targetAudience": {
@@ -1999,7 +1999,7 @@
           "required": ["configurationId"],
           "properties": {
             "configurationId": {
-              "description": "Required. The configuration id of the created DCR registration.",
+              "description": "Required. The configuration id of the created DCR registration. If the mapped environment variable already has a value, dcr/register skips registration and does not update the existing configuration. To change the app binding, create a new registration, update the plugin's auth.reference_id, and rebuild and republish the app package.",
               "$ref": "#/definitions/envVarName"
             }
           }

--- a/packages/fx-core/resource/yaml-schema/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/yaml.schema.json
@@ -1969,7 +1969,7 @@
             },
             "appId": {
               "type": "string",
-              "description": "The Teams app id associated with this configuration. Only takes effect when applicableToApps is SpecificApp."
+              "description": "The Microsoft 365 app ID (MOSAppId), not the Teams manifest ID or Microsoft Entra client ID. Required only when applicableToApps is SpecificApp; ignored for AnyApp. For declarative agents, use the appId returned by copilotAgent/publish for the intended publication scope."
             },
             "wellKnownAuthorizationServer": {
               "type": "string",
@@ -1982,7 +1982,7 @@
             },
             "applicableToApps": {
               "type": "string",
-              "description": "Which app can use this DCR configuration. Default is \"AnyApp\".",
+              "description": "Which app can use this DCR configuration. Default is \"AnyApp\". Keep AnyApp during declarative agent creation and sideloading because the Microsoft 365 app ID can change. To restrict usage after publishing, use SpecificApp with that publication's Microsoft 365 app ID.",
               "enum": ["SpecificApp", "AnyApp"]
             },
             "targetAudience": {
@@ -1999,7 +1999,7 @@
           "required": ["configurationId"],
           "properties": {
             "configurationId": {
-              "description": "Required. The configuration id of the created DCR registration.",
+              "description": "Required. The configuration id of the created DCR registration. If the mapped environment variable already has a value, dcr/register skips registration and does not update the existing configuration. To change the app binding, create a new registration, update the plugin's auth.reference_id, and rebuild and republish the app package.",
               "$ref": "#/definitions/envVarName"
             }
           }

--- a/packages/fx-core/src/component/driver/dcr/interface/createDcrArgs.ts
+++ b/packages/fx-core/src/component/driver/dcr/interface/createDcrArgs.ts
@@ -3,7 +3,7 @@
 
 export interface CreateDcrArgs {
   name: string; // The display name of the DCR config; becomes clientName; max 128 chars
-  appId?: string; // Teams app id; required only when applicableToApps is "SpecificApp"
+  appId?: string; // Published Microsoft 365 app ID (MOSAppId), not Teams manifest ID; required for "SpecificApp".
   wellKnownAuthorizationServer: string; // URL to the AS's RFC 8414 metadata document; required
   targetUrlsShouldStartWith?: string[]; // URL prefixes allowed as outbound destinations
   applicableToApps?: string; // Which apps can use this config. Values: "SpecificApp" | "AnyApp". Default: "AnyApp".


### PR DESCRIPTION
## Summary

Related to #16643.

Correct the misleading `dcr/register` parameter guidance for declarative agents. An app-scoped DCR configuration must use the Microsoft 365 app identity for the intended publication, not the Teams manifest ID or Microsoft Entra client ID.

- Clarify the `appId` description in the TypeScript argument interface and both current/v1.13 YAML schemas.
- Recommend retaining `AnyApp` during agent creation and sideloading, when the Microsoft 365 app ID may change, and applying `SpecificApp` only after publication using its returned app ID.
- Document that an existing `configurationId` causes registration to be skipped: changing YAML alone does not update the binding. A new registration requires updating the plugin reference, rebuilding, and republishing.

This is a documentation/IntelliSense correction only. It does not change generated defaults (`AnyApp` + `HomeTenant`), registration behavior, or publication ordering. It does not claim to resolve the separate unauthenticated-runtime symptoms reported in #16643.

## Validation

- [x] DCR driver tests: 16 passed using the locally installed Vitest (`node node_modules/vitest/vitest.mjs run --config vitest.config.ts tests/component/driver/dcr/create.test.ts --reporter=verbose --maxWorkers=1`, from `packages/fx-core`).
- [x] Both YAML schemas parse and are identical; compared with the baseline, only the three intended DCR descriptions changed in each schema.
- [x] No editor diagnostics in the three modified files; focused code review found no blocking issues.
- [x] TypeScript argument file formatting checked.

The two full schema files already have Prettier formatting differences in the baseline. This change introduces no additional formatting differences and deliberately avoids unrelated reformatting. No runtime code changed; full build and service E2E were not run.