### PR TITLE
fix(fx-core): propagate non-interactive question mode

### DIFF
--- a/packages/fx-core/src/common/utils.ts
+++ b/packages/fx-core/src/common/utils.ts
@@ -20,6 +20,7 @@ export function generateDriverContext(ctx: Context, inputs: InputsWithProjectPat
     telemetryReporter: ctx.telemetryReporter,
     projectPath: inputs.projectPath,
     platform: inputs.platform,
+    nonInteractive: inputs.nonInteractive,
   };
 }
 

--- a/packages/fx-core/src/component/driver/interface/commonArgs.ts
+++ b/packages/fx-core/src/component/driver/interface/commonArgs.ts
@@ -21,6 +21,7 @@ export interface DriverContext {
   telemetryReporter?: TelemetryReporter;
   projectPath: string;
   platform: Platform;
+  nonInteractive?: boolean;
 }
 
 export type AzureResourceInfo = {

--- a/packages/fx-core/src/component/driver/util/utils.ts
+++ b/packages/fx-core/src/component/driver/util/utils.ts
@@ -47,6 +47,7 @@ export function createDriverContext(inputs: Inputs): DriverContext {
     telemetryReporter: TOOLS.telemetryReporter,
     projectPath: inputs.projectPath!,
     platform: inputs.platform,
+    nonInteractive: inputs.nonInteractive,
   };
   return driverContext;
 }

--- a/packages/fx-core/src/component/middleware/questionMW.ts
+++ b/packages/fx-core/src/component/middleware/questionMW.ts
@@ -5,6 +5,7 @@ import { HookContext, Middleware, NextFunction } from "@feathersjs/hooks/lib";
 import { Inputs, err } from "@microsoft/teamsfx-api";
 import { throwIfAborted } from "../../common/cancellation";
 import { TOOLS } from "../../common/globalVars";
+import { DriverContext } from "../driver/interface/commonArgs";
 import { QuestionNodes, questionNodes } from "../../question";
 import { traverse } from "../../ui/visitor";
 
@@ -14,6 +15,8 @@ export function QuestionMW(key: keyof QuestionNodes, fromAction = false): Middle
     throwIfAborted(inputs);
     if (fromAction) {
       inputs.outputEnvVarNames = ctx.arguments[2];
+      const driverContext = ctx.arguments[1] as DriverContext;
+      inputs.nonInteractive = driverContext.nonInteractive;
     }
     const node = questionNodes[key](inputs.platform);
     const askQuestionRes = await traverse(node, inputs, TOOLS.ui, TOOLS.telemetryReporter);

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -1783,6 +1783,7 @@ export class FxCore extends FxCoreOpenPluginPart {
       telemetryReporter: TOOLS.telemetryReporter,
       projectPath: projectPath,
       platform: inputs.platform,
+      nonInteractive: inputs.nonInteractive,
     };
     const lifecycle = projectModel[lifecycleName_];
     if (lifecycle) {

--- a/packages/fx-core/tests/component/driver/oauth/create.test.ts
+++ b/packages/fx-core/tests/component/driver/oauth/create.test.ts
@@ -691,7 +691,7 @@ describe("CreateOauthDriver", () => {
     }
   });
 
-  it("provision handoff: missing Custom OAuth credentials are prompted and consumed", async () => {
+  it("provision handoff: interactive Custom OAuth prompts for a missing scope", async () => {
     envRestore = mockedEnv({
       [QuestionNames.OauthClientId]: undefined,
       [QuestionNames.OauthClientSecret]: undefined,
@@ -734,7 +734,123 @@ describe("CreateOauthDriver", () => {
       QuestionNames.OauthClientSecret,
       QuestionNames.OAuthScope,
     ]);
-    expect(confirm).toHaveBeenCalledOnce();
+    expect(confirm.mock.calls).to.have.length(1);
+  });
+
+  it("provision handoff: non-interactive Custom OAuth preserves an omitted scope", async () => {
+    envRestore = mockedEnv({
+      [QuestionNames.OauthClientId]: undefined,
+      [QuestionNames.OauthClientSecret]: undefined,
+      [QuestionNames.OAuthScope]: undefined,
+      [outputKeys.configurationId]: undefined,
+    });
+    const { promptNames, confirm } = setProvisionQuestionAnswers({});
+    vi.spyOn(teamsGraphClient, "createOauthRegistration").mockImplementation(
+      async (_token, oauthRegistration) => {
+        expect(oauthRegistration.clientId).to.equal("suppliedClientId");
+        expect(oauthRegistration.clientSecret).to.equal("suppliedClientSecret");
+        expect(oauthRegistration.scopes).to.be.empty;
+        return {
+          configurationRegistrationId: { oAuthConfigId: "mockedRegistrationId" },
+          resourceIdentifierUri: "mockedResourceIdentifierUri",
+        };
+      }
+    );
+
+    const args: CreateOauthArgs = {
+      name: "test",
+      appId: "mockedAppId",
+      clientId: "suppliedClientId",
+      clientSecret: "suppliedClientSecret",
+      flow: "authorizationCode",
+      identityProvider: "Custom",
+      isPKCEEnabled: false,
+      baseUrl: "https://test",
+      authorizationUrl: "https://auth.example.com/authorize",
+      tokenUrl: "https://auth.example.com/token",
+    };
+    const result = await createOauthDriver.execute(
+      args,
+      { ...mockedDriverContext, nonInteractive: true },
+      outputEnvVarNames
+    );
+
+    expect(result.result.isOk()).to.be.true;
+    expect(promptNames).to.be.empty;
+    expect(confirm.mock.calls).to.be.empty;
+  });
+
+  it("provision handoff: non-interactive Custom OAuth preserves an explicit scope", async () => {
+    envRestore = mockedEnv({
+      [QuestionNames.OauthClientId]: undefined,
+      [QuestionNames.OauthClientSecret]: undefined,
+      [QuestionNames.OAuthScope]: undefined,
+      [outputKeys.configurationId]: undefined,
+    });
+    const { promptNames, confirm } = setProvisionQuestionAnswers({});
+    vi.spyOn(teamsGraphClient, "createOauthRegistration").mockImplementation(
+      async (_token, oauthRegistration) => {
+        expect(oauthRegistration.scopes).to.deep.equal(["scope.read"]);
+        return {
+          configurationRegistrationId: { oAuthConfigId: "mockedRegistrationId" },
+          resourceIdentifierUri: "mockedResourceIdentifierUri",
+        };
+      }
+    );
+
+    const args: CreateOauthArgs = {
+      name: "test",
+      appId: "mockedAppId",
+      clientId: "suppliedClientId",
+      clientSecret: "suppliedClientSecret",
+      scope: "scope.read",
+      flow: "authorizationCode",
+      identityProvider: "Custom",
+      isPKCEEnabled: false,
+      baseUrl: "https://test",
+      authorizationUrl: "https://auth.example.com/authorize",
+      tokenUrl: "https://auth.example.com/token",
+    };
+    const result = await createOauthDriver.execute(
+      args,
+      { ...mockedDriverContext, nonInteractive: true },
+      outputEnvVarNames
+    );
+
+    expect(result.result.isOk()).to.be.true;
+    expect(promptNames).to.be.empty;
+    expect(confirm.mock.calls).to.be.empty;
+  });
+
+  it("provision handoff: non-interactive Custom OAuth does not prompt for a missing client id", async () => {
+    envRestore = mockedEnv({
+      [QuestionNames.OauthClientId]: undefined,
+      [QuestionNames.OauthClientSecret]: undefined,
+      [QuestionNames.OAuthScope]: undefined,
+      [outputKeys.configurationId]: undefined,
+    });
+    const { promptNames, confirm } = setProvisionQuestionAnswers({});
+
+    const args: CreateOauthArgs = {
+      name: "test",
+      appId: "mockedAppId",
+      clientSecret: "suppliedClientSecret",
+      flow: "authorizationCode",
+      identityProvider: "Custom",
+      isPKCEEnabled: false,
+      baseUrl: "https://test",
+      authorizationUrl: "https://auth.example.com/authorize",
+      tokenUrl: "https://auth.example.com/token",
+    };
+    const result = await createOauthDriver.execute(
+      args,
+      { ...mockedDriverContext, nonInteractive: true },
+      outputEnvVarNames
+    );
+
+    expect(result.result.isErr()).to.be.true;
+    expect(promptNames).to.be.empty;
+    expect(confirm.mock.calls).to.be.empty;
   });
 
   it("provision handoff: missing Entra client id is the only prompted credential", async () => {
@@ -771,7 +887,7 @@ describe("CreateOauthDriver", () => {
 
     expect(result.result.isOk()).to.be.true;
     expect(promptNames).to.deep.equal([QuestionNames.OauthClientId]);
-    expect(confirm).not.toHaveBeenCalled();
+    expect(confirm.mock.calls).to.be.empty;
   });
 
   it("happy path: read clientSecret from input and refreshurl from spec", async () => {

--- a/packages/fx-core/tests/component/driver/util/utils.test.ts
+++ b/packages/fx-core/tests/component/driver/util/utils.test.ts
@@ -1,13 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { Platform } from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
 import mockedEnv, { RestoreFn } from "mocked-env";
 import { chai, vi } from "vitest";
+import { setTools } from "../../../../src/common/globalVars";
 import {
+  createDriverContext,
   loadStateFromEnv,
   mapStateToEnv,
   updateVersionForTeamsAppYamlFile,
 } from "../../../../src/component/driver/util/utils";
+import { MockedAzureAccountProvider, MockedM365Provider } from "../../../core/utils";
+import { MockedLogProvider, MockedUserInteraction } from "../../../plugins/solution/util";
+
+describe("createDriverContext", () => {
+  it("propagates non-interactive mode to lifecycle drivers", () => {
+    setTools({
+      ui: new MockedUserInteraction(),
+      logProvider: new MockedLogProvider(),
+      tokenProvider: {
+        azureAccountProvider: new MockedAzureAccountProvider(),
+        m365TokenProvider: new MockedM365Provider(),
+      },
+    });
+
+    const context = createDriverContext({
+      platform: Platform.CLI,
+      projectPath: "test-project",
+      nonInteractive: true,
+    });
+
+    chai.expect(context.nonInteractive).to.be.true;
+  });
+});
 
 describe("loadStateFromEnv", () => {
   let envRestore: RestoreFn | undefined;


### PR DESCRIPTION
## Summary

Propagate non-interactive mode from FxCore lifecycle inputs into driver-owned question handling.

This ensures lifecycle actions such as `oauth/register` and `apiKey/register` apply the same non-interactive question semantics as the rest of FxCore.

## Problem

`Inputs.nonInteractive` was available at the FxCore entry point but was not copied into `DriverContext`. When `QuestionMW` handled questions owned by a lifecycle action, it therefore treated the action as interactive.

For Custom OAuth registration with an omitted optional scope, this could cause FxCore to invoke the UI instead of skipping the optional question.

## Impact

The impact depends on the calling surface:

- **Direct FxCore consumers or UI implementations without their own non-interactive safeguard:** an unexpected prompt or UI invocation can occur during non-interactive provisioning.
- **ATK CLI:** the issue is mostly masked because the CLI independently disables its UI when `--interactive false` is used. The CLI returns an empty answer without displaying a prompt, but FxCore still follows the wrong question path and relies on CLI-specific behavior.
- **Explicit OAuth scopes:** remain unchanged and are preserved.
- **Interactive provisioning:** remains unchanged and continues prompting for an omitted scope.

This is primarily a consistency and integration bug in FxCore rather than a currently visible ATK CLI regression.

## Root cause

Lifecycle actions receive an internal `DriverContext`, but its construction paths did not preserve `Inputs.nonInteractive`. `QuestionMW` consequently traversed driver questions without knowing the operation was non-interactive.

## Changes

- Add optional `nonInteractive` state to `DriverContext`.
- Propagate it through all FxCore driver-context construction paths.
- Forward it to driver-owned question traversal.
- Add regression coverage verifying:
  - omitted OAuth scope is skipped in non-interactive mode;
  - an explicitly supplied scope is preserved;
  - interactive mode still prompts for a missing scope;
  - missing required credentials do not trigger UI in non-interactive mode;
  - context factories preserve non-interactive mode.

## Validation

- Repository build passed.
- FxCore build passed.
- 57 focused FxCore tests passed.
- Formatting passed.
- Lint completed with zero errors.

## Notes

The full FxCore unit suite reports 11 existing dependency-checker failures that reproduce independently of this change.