### PR TITLE
fix(vscuse): Auto-fix Sample_Copilot_Connection_Local_Debug

### DIFF
--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
@@ -400,7 +400,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the Microsoft Teams app details page for an app whose name starts with ${{var:app_name}} is visible.",
+      "description": "@assertion the Microsoft Teams app details page for the graph-connector-applocal sample is visible.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 60,
       "precondition_retry_interval": 2
     },
-    "total_steps": 13,
+    "total_steps": 10,
     "created_at": "2026-06-05T07:17:53.766103",
     "name": "group: debug_in_teams_local",
     "description": {
@@ -27,10 +27,7 @@
       "step_abda900e",
       "step_a527f679",
       "step_7f03643c",
-      "step_afa29596",
-      "step_31620d1e",
-      "step_7f090e7d",
-      "step_22db8609"
+      "step_afa29596"
     ],
     "tags": [
       "group"
@@ -252,7 +249,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion there's \"Add\" or \"Open\" blue button exist.",
+      "description": "@assertion the Microsoft Teams chat interface is visible with a \"Type a message\" input.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -265,80 +262,6 @@
       ],
       "screenshot": null,
       "created_at": "2026-06-05T09:07:45.987858",
-      "plan_id": "plan_r_0930_083113"
-    },
-    {
-      "step_id": "step_31620d1e",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 288,
-        "y": 214
-      },
-      "description": "Click the \"Open\" or \"Add\" button on the app details popup for the ${{var:app_name}}local app within the Microsoft Teams interface.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:288:214:16:5:05100a0511030b12",
-        "dhash:288:214:96:5:2616011c1c01005b",
-        "dhash:288:214:0:10:00b4b0d8f8fcf0d8"
-      ],
-      "postconditions": [],
-      "tags": [],
-      "screenshot": "step_31620d1e",
-      "created_at": "2026-06-05T09:07:45.996452",
-      "plan_id": "plan_r_0930_083113"
-    },
-    {
-      "step_id": "step_7f090e7d",
-      "agent": "assertion",
-      "tool": "",
-      "parameters": {},
-      "description": "@assertion there's \"open\" blue button exist.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [],
-      "postconditions": [],
-      "tags": [
-        "step_retry_timeout: 180"
-      ],
-      "screenshot": null,
-      "created_at": "2026-06-05T09:07:46.005866",
-      "plan_id": "plan_r_0930_083113"
-    },
-    {
-      "step_id": "step_22db8609",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 533,
-        "y": 508
-      },
-      "description": "Click the \"Open\" button in the \"Let's go\" or \"Added successfully!\" dialog for the ${{var:app_name}}local app within Microsoft Teams web interface.",
-      "content_refs": [],
-      "timeout": 30,
-      "retry_count": 0,
-      "continue_on_error": "false",
-      "depends_on": [],
-      "preconditions": [
-        "dhash:533:508:16:5:00987494ca4acacc",
-        "dhash:533:508:96:5:000058a48598e36b",
-        "dhash:533:508:0:10:1669696969696979"
-      ],
-      "postconditions": [],
-      "tags": [
-        "precondition_wait_timeout: 120"
-      ],
-      "screenshot": "step_22db8609",
-      "created_at": "2026-06-05T09:07:46.013714",
       "plan_id": "plan_r_0930_083113"
     }
   ],

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
@@ -8,7 +8,7 @@
       "precondition_wait_timeout": 60,
       "precondition_retry_interval": 2
     },
-    "total_steps": 10,
+    "total_steps": 17,
     "created_at": "2026-06-05T07:17:53.766103",
     "name": "group: debug_in_teams_local",
     "description": {
@@ -27,12 +27,19 @@
       "step_abda900e",
       "step_a527f679",
       "step_7f03643c",
-      "step_afa29596"
+      "step_afa29596",
+      "step_3c7a2e91",
+      "step_742f5c18",
+      "step_c12e8a74",
+      "step_91b0dce3",
+      "step_67da40be",
+      "step_f4a21d68",
+      "step_2be730c9"
     ],
     "tags": [
       "group"
     ],
-    "updated_at": "2026-06-05T09:08:12.655697"
+    "updated_at": "2026-09-13T03:09:08.148000"
   },
   "steps": [
     {
@@ -249,7 +256,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the Microsoft Teams app details page for an app whose name starts with ${{var:app_name}} is visible.",
+      "description": "@assertion the signed-in Microsoft Teams web app is visible, either on the target app details page or an existing chat.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -262,6 +269,150 @@
       ],
       "screenshot": null,
       "created_at": "2026-06-05T09:07:45.987858",
+      "plan_id": "plan_r_0930_083113"
+    },
+    {
+      "step_id": "step_3c7a2e91",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 1004,
+        "y": 19
+      },
+      "description": "Close the authenticated Microsoft Teams Chrome debug window so Visual Studio Code regains focus before relaunching the app details deep link.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "delay:3"
+      ],
+      "screenshot": "",
+      "created_at": "2026-09-13T03:09:08.148001",
+      "plan_id": "plan_r_0930_083113"
+    },
+    {
+      "step_id": "step_742f5c18",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "f1"
+      },
+      "description": "Press F1 in Visual Studio Code to open the command palette after closing the authenticated Chrome debug window.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-13T03:09:08.148002",
+      "plan_id": "plan_r_0930_083113"
+    },
+    {
+      "step_id": "step_c12e8a74",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Debug: Select and Start Debugging"
+      },
+      "description": "Type 'Debug: Select and Start Debugging' into the Visual Studio Code command palette.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-13T03:09:08.148003",
+      "plan_id": "plan_r_0930_083113"
+    },
+    {
+      "step_id": "step_91b0dce3",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to select \"Debug: Select and Start Debugging\" from the Visual Studio Code command palette.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-13T03:09:08.148004",
+      "plan_id": "plan_r_0930_083113"
+    },
+    {
+      "step_id": "step_67da40be",
+      "agent": "interaction",
+      "tool": "type_text",
+      "parameters": {
+        "text": "Debug in Teams (Chrome)"
+      },
+      "description": "Type 'Debug in Teams (Chrome)' into the Visual Studio Code launch configuration dropdown.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-13T03:09:08.148005",
+      "plan_id": "plan_r_0930_083113"
+    },
+    {
+      "step_id": "step_f4a21d68",
+      "agent": "interaction",
+      "tool": "key_press",
+      "parameters": {
+        "key": "enter"
+      },
+      "description": "Press Enter to relaunch \"Debug in Teams (Chrome)\" with the authenticated Microsoft Teams session.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [],
+      "screenshot": "",
+      "created_at": "2026-09-13T03:09:08.148006",
+      "plan_id": "plan_r_0930_083113"
+    },
+    {
+      "step_id": "step_2be730c9",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion the Microsoft Teams app details page for an app whose name starts with ${{var:app_name}} is visible.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 180"
+      ],
+      "screenshot": null,
+      "created_at": "2026-09-13T03:09:08.148007",
       "plan_id": "plan_r_0930_083113"
     }
   ],

--- a/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
+++ b/packages/tests/vscuse/vscode-test-cases/groups/group__debug_in_teams_local.json
@@ -249,7 +249,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the Microsoft Teams chat interface is visible with a \"Type a message\" input.",
+      "description": "@assertion the Microsoft Teams app details page for an app whose name starts with ${{var:app_name}} is visible.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
@@ -141,7 +141,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the page title contains 'Copilot connector app'",
+      "description": "@assertion the README preview title contains 'Getting Started with Copilot connector App'",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -215,7 +215,7 @@
         "x": 294,
         "y": 21
       },
-      "description": "Click the “+\"  browser tab in Microsoft Teams  to open the new page",
+      "description": "Click the \u201c+\"  browser tab in Microsoft Teams  to open the new page",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0
     },
-    "total_steps": 19,
+    "total_steps": 23,
     "created_at": "2026-05-14T01:57:51.379181",
     "name": "Sample Copilot Connection Local Debug",
     "description": {
@@ -35,8 +35,12 @@
       "step_e6f65939",
       "step_160facb6",
       "step_11e4ca89",
-      "step_19e4652a",
-      "step_1852dd3d",
+      "step_5e462c1a",
+      "step_46eb37d8",
+      "step_98fba04c",
+      "step_23d511aa",
+      "step_f3d089dc",
+      "step_96cb45e1",
       "step_f6f51246",
       "step_b391f22e",
       "step_868e410e",
@@ -340,7 +344,7 @@
         "x": 141,
         "y": 19
       },
-      "description": "Click the browser tab titled \"graph-connector-applocal | Microsoft Teams\" (teams.cloud.microsoft) at coordinates (141, 19) to switch context.",
+      "description": "Click the Microsoft Teams browser tab containing the ${{var:app_name}}local app details page to switch back from the localhost certificate tab.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -354,55 +358,131 @@
       "plan_id": "plan_a0fbdb40"
     },
     {
-      "step_id": "step_19e4652a",
-      "agent": "interaction",
-      "tool": "click",
-      "parameters": {
-        "button": "left",
-        "x": 997,
-        "y": 198
-      },
-      "description": "Click the \"...\" (more options) button in the top-right of the Microsoft Teams web interface to open its dropdown menu.",
+      "step_id": "step_5e462c1a",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion the app details popup is visible with its primary action button below the app name.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:997:198:16:5:0112a88269696916",
-        "dhash:997:198:96:5:c62a400626000200",
-        "dhash:997:198:0:10:18b836412c4c5040"
-      ],
+      "preconditions": [],
       "postconditions": [],
-      "tags": [],
-      "screenshot": "step_19e4652a",
-      "created_at": "2026-05-14T01:57:51.476482",
+      "tags": [
+        "step_retry_timeout: 180"
+      ],
+      "screenshot": null,
+      "created_at": "2026-09-13T02:50:08.439000",
       "plan_id": "plan_a0fbdb40"
     },
     {
-      "step_id": "step_1852dd3d",
+      "step_id": "step_46eb37d8",
       "agent": "interaction",
       "tool": "click",
       "parameters": {
         "button": "left",
-        "x": 961,
-        "y": 238
+        "x": 288,
+        "y": 214
       },
-      "description": "Click the \"Reload app\" option in the dropdown menu within the Microsoft Teams web application interface.",
+      "description": "Click the visible blue \"Add\" or \"Open\" button in the Microsoft Teams app details dialog.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:961:238:16:5:98e618092d2d09c9",
-        "dhash:961:238:96:5:010112b6a6004f45",
-        "dhash:961:238:0:10:18b833432c4c5040"
-      ],
+      "preconditions": [],
       "postconditions": [],
-      "tags": [],
-      "screenshot": "step_1852dd3d",
-      "created_at": "2026-05-14T01:57:51.482736",
+      "tags": [
+        "ocr:true"
+      ],
+      "screenshot": "",
+      "created_at": "2026-09-13T02:50:08.439001",
+      "plan_id": "plan_a0fbdb40"
+    },
+    {
+      "step_id": "step_98fba04c",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion the dialog opened from the app details popup is visible with its blue \"Open\" button.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 180"
+      ],
+      "screenshot": null,
+      "created_at": "2026-09-13T02:50:08.439002",
+      "plan_id": "plan_a0fbdb40"
+    },
+    {
+      "step_id": "step_23d511aa",
+      "agent": "interaction",
+      "tool": "click",
+      "parameters": {
+        "button": "left",
+        "x": 533,
+        "y": 508
+      },
+      "description": "Click the blue \"Open\" button in the \"Added successfully!\" or \"Let's go\" dialog for the app in Microsoft Teams.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "ocr:true"
+      ],
+      "screenshot": "",
+      "created_at": "2026-09-13T02:50:08.439003",
+      "plan_id": "plan_a0fbdb40"
+    },
+    {
+      "step_id": "step_f3d089dc",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion the Microsoft Teams tab page for an app whose name starts with ${{var:app_name}} is open.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 180"
+      ],
+      "screenshot": null,
+      "created_at": "2026-09-13T02:50:08.439004",
+      "plan_id": "plan_a0fbdb40"
+    },
+    {
+      "step_id": "step_96cb45e1",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion Google Chrome is displaying a teams.cloud.microsoft permission prompt that asks to access other apps and services on this device and its \"Allow\" button is available.",
+      "content_refs": [],
+      "timeout": 30,
+      "retry_count": 0,
+      "continue_on_error": "false",
+      "depends_on": [],
+      "preconditions": [],
+      "postconditions": [],
+      "tags": [
+        "step_retry_timeout: 120"
+      ],
+      "screenshot": null,
+      "created_at": "2026-09-13T02:50:08.439005",
       "plan_id": "plan_a0fbdb40"
     },
     {
@@ -420,13 +500,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:373:240:16:5:a1ae4e465292b329",
-        "dhash:373:240:96:5:3900c9c7c3c90000",
-        "dhash:373:240:0:10:38e8948080808080"
-      ],
+      "preconditions": [],
       "postconditions": [],
-      "tags": [],
+      "tags": [
+        "ocr:true"
+      ],
       "screenshot": "step_f6f51246",
       "created_at": "2026-05-14T01:57:51.489880",
       "plan_id": "plan_a0fbdb40"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
@@ -344,7 +344,7 @@
         "x": 141,
         "y": 19
       },
-      "description": "Click the Microsoft Teams browser tab containing the ${{var:app_name}}local app details page to switch back from the localhost certificate tab.",
+      "description": "Click the Microsoft Teams browser tab containing the graph-connector-applocal app details page to switch back from the localhost certificate tab.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -450,7 +450,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the Microsoft Teams tab page for an app whose name starts with ${{var:app_name}} is open.",
+      "description": "@assertion the Microsoft Teams tab page for the graph-connector-applocal sample is open.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
@@ -350,7 +350,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:141:19:16:5:3843565356565351",
+        "dhash:141:19:96:5:804a2424ca00cfcf",
+        "dhash:141:19:0:10:7020282e32233eb0"
+      ],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_11e4ca89",
@@ -500,7 +504,11 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [],
+      "preconditions": [
+        "dhash:373:240:16:5:2b5626aa4b4b9995",
+        "dhash:373:240:96:5:0000c9c7c3c90000",
+        "dhash:373:240:0:10:38e8908080808080"
+      ],
       "postconditions": [],
       "tags": [
         "ocr:true"

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
@@ -575,7 +575,8 @@
       "preconditions": [],
       "postconditions": [],
       "tags": [
-        "delay:3"
+        "delay:3",
+        "step_retry_timeout: 180"
       ],
       "screenshot": null,
       "created_at": "2026-05-14T01:57:51.509892",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
@@ -346,11 +346,7 @@
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
-      "preconditions": [
-        "dhash:141:19:16:5:404689c3d657e31c",
-        "dhash:141:19:96:5:a85135a44100c995",
-        "dhash:141:19:0:10:74c8768e6c948080"
-      ],
+      "preconditions": [],
       "postconditions": [],
       "tags": [],
       "screenshot": "step_11e4ca89",

--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
@@ -215,7 +215,7 @@
         "x": 294,
         "y": 21
       },
-      "description": "Click the \u201c+\"  browser tab in Microsoft Teams  to open the new page",
+      "description": "Click the \u201c+\" browser tab in Microsoft Teams to open the new page",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,


### PR DESCRIPTION
## VscUse Auto-Fix Results

**Plan:** `Sample_Copilot_Connection_Local_Debug`
**Status:** :white_check_mark: FIXED (attempt 7/8)
**Initial Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/71897258-9944-4e4c-9f85-cc096a9db07f/index.html)
**Final Report:** [Link](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/b8d3c14b-02c5-4023-b9bc-c1c6be10857d/test_report.html)

### Iteration Summary

| # | Fix Applied | Result | Report |
|---|-------------|--------|--------|
| 1 | Updated the case-sensitive README assertion to target the visible heading, `Gett | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/fbe85c26-4bd2-4cc3-afbc-e029be542a18/test_report.html) |
| 2 | Verified the case-sensitive README heading now matches the visible `Getting Star | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/e4ac2c9b-38f1-4fd0-bfaf-3fb9cef372e0/test_report.html) |
| 3 | Verified the case-sensitive README assertion now passes and all audited menu/lis | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/ea06269d-03c6-4b8d-97d8-0d3a3b0f56ba/test_report.html) |
| 4 | Preserved the corrected case-sensitive README title, made the shared debug group | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/c4089bb3-747c-4b66-8223-028baf8e5cd5/test_report.html) |
| 5 | Preserved the corrected case-sensitive README heading and updated the shared loc | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/544939e2-cc18-4d71-b89a-aa4ce218ac28/test_report.html) |
| 6 | Preserved the corrected case-sensitive README heading and updated the shared deb | :x: Failed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/591e2274-5eab-4076-a7df-a13b436b6be8/test_report.html) |
| 7 | Preserved the corrected case-sensitive README heading assertion and added a 180- | :white_check_mark: Passed | [Report](https://storproxy-app-voazuxhhvtgiq.azurewebsites.net/b8d3c14b-02c5-4023-b9bc-c1c6be10857d/test_report.html) |

### How to Review
- Each commit represents one fix attempt for `plans/Sample_Copilot_Connection_Local_Debug.json`
- Compare the initial report with the final report to verify the fix
- Check that coordinate/dhash changes are reasonable for the current VS Code layout

### Changes Made to Test Plan

```
.../Sample_Copilot_Connection_Local_Debug.json     | 157 ++++++++++++++++-----
 1 file changed, 120 insertions(+), 37 deletions(-)
```

<details>
<summary>View diff</summary>

```diff
diff --git a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
index 2cdbee6..ec5afd9 100644
--- a/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
+++ b/packages/tests/vscuse/vscode-test-cases/plans/Sample_Copilot_Connection_Local_Debug.json
@@ -9,7 +9,7 @@
       "precondition_retry_interval": 2,
       "step_retry_timeout": 0
     },
-    "total_steps": 19,
+    "total_steps": 23,
     "created_at": "2026-05-14T01:57:51.379181",
     "name": "Sample Copilot Connection Local Debug",
     "description": {
@@ -35,8 +35,12 @@
       "step_e6f65939",
       "step_160facb6",
       "step_11e4ca89",
-      "step_19e4652a",
-      "step_1852dd3d",
+      "step_5e462c1a",
+      "step_46eb37d8",
+      "step_98fba04c",
+      "step_23d511aa",
+      "step_f3d089dc",
+      "step_96cb45e1",
       "step_f6f51246",
       "step_b391f22e",
       "step_868e410e",
@@ -141,7 +145,7 @@
       "agent": "assertion",
       "tool": "",
       "parameters": {},
-      "description": "@assertion the page title contains 'Copilot connector app'",
+      "description": "@assertion the README preview title contains 'Getting Started with Copilot connector App'",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -215,7 +219,7 @@
         "x": 294,
         "y": 21
       },
-      "description": "Click the “+\"  browser tab in Microsoft Teams  to open the new page",
+      "description": "Click the \u201c+\" browser tab in Microsoft Teams to open the new page",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
@@ -340,16 +344,16 @@
         "x": 141,
         "y": 19
       },
-      "description": "Click the browser tab titled \"graph-connector-applocal | Microsoft Teams\" (teams.cloud.microsoft) at coordinates (141, 19) to switch context.",
+      "description": "Click the Microsoft Teams browser tab containing the graph-connector-applocal app details page to switch back from the localhost certificate tab.",
       "content_refs": [],
       "timeout": 30,
       "retry_count": 0,
       "continue_on_error": "false",
       "depends_on": [],
       "preconditions": [
-        "dhash:141:19:16:5:404689c3d657e31c",
-        "dhash:141:19:96:5:a85135a44100c995",
-        "dhash:141:19:0:10:74c8768e6c948080"
+        "dhash:141:19:16:5:3843565356565351",
+        "dhash:141:19:96:5:804a2424ca00cfcf",
+        "dhash:141:19:0:10:7020282e32233eb0"
       ],
       "postconditions": [],
       "tags": [],
@@ -358,55 +362,131 @@
       "plan_id": "plan_a0fbdb40"
     },
     {
-      "step_id": "step_19e4652a",
+      "step_id": "step_5e462c1a",
+      "agent": "assertion",
+      "tool": "",
+      "parameters": {},
+      "description": "@assertion the app details popup is visible with its primary action button below the app name.",
+      "content_refs": 
... (truncated, see commit diff for full changes)
```

</details>

---
<sub>Generated by `vscuse-auto-fix.yml` | model: `gpt-5.6-sol`</sub>